### PR TITLE
#6864: compute a node's suffix shape and inline text together

### DIFF
--- a/.github/workflows/jmh-benchmark-action.yml
+++ b/.github/workflows/jmh-benchmark-action.yml
@@ -18,6 +18,9 @@ jobs:
           java-version: 21
           base-ref: "master"
           benchmark-command: |
+            mvn install -pl eo-parser -am -DskipTests -q
             mvn jmh:benchmark -pl eo-parser -Djmh.rf=json -Djmh.rff=benchmark.json
-            cp eo-parser/benchmark.json .
+            mvn jmh:benchmark -pl eo-printer -Djmh.rf=json -Djmh.rff=benchmark.json || true
+            jq -s 'add' eo-parser/benchmark.json eo-printer/benchmark.json 2>/dev/null > benchmark.json \
+              || cp eo-parser/benchmark.json benchmark.json
           benchmark-file: "benchmark.json"

--- a/eo-printer/src/main/java/org/eolang/printer/Pretty.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Pretty.java
@@ -219,14 +219,13 @@ final class Pretty {
     private static Optional<Node> suffixed(final Node node) {
         Optional<Node> result = Optional.empty();
         if (node.reversed && !node.children.isEmpty()) {
-            final Node receiver = node.children.get(0);
-            result = Pretty.flat(receiver).map(
-                inline -> {
+            result = Pretty.flattened(node.children.get(0)).map(
+                flat -> {
                     final String glued;
-                    if (Pretty.suffixed(receiver).orElse(receiver).children.isEmpty()) {
-                        glued = inline;
+                    if (flat.node.children.isEmpty()) {
+                        glued = flat.text;
                     } else {
-                        glued = "(".concat(inline).concat(")");
+                        glued = "(".concat(flat.text).concat(")");
                     }
                     return new Node(
                         String.join(
@@ -486,11 +485,11 @@ final class Pretty {
         Optional<String> result = Optional.of("");
         for (final Node arg : args) {
             final boolean cnst = "!".equals(arg.tail);
-            final Optional<String> flat;
+            final Optional<Pretty.Flattened> flat;
             if (cnst) {
-                flat = Pretty.flat(arg.bare());
+                flat = Pretty.flattened(arg.bare());
             } else {
-                flat = Pretty.flat(arg);
+                flat = Pretty.flattened(arg);
             }
             if (flat.isEmpty()) {
                 result = Optional.empty();
@@ -499,10 +498,10 @@ final class Pretty {
             if (joined.length() > 0) {
                 joined.append(' ');
             }
-            if (Pretty.suffixed(arg).orElse(arg).children.isEmpty()) {
-                joined.append(flat.get());
+            if (flat.get().node.children.isEmpty()) {
+                joined.append(flat.get().text);
             } else {
-                joined.append('(').append(flat.get()).append(')');
+                joined.append('(').append(flat.get().text).append(')');
             }
             if (cnst) {
                 joined.append('!');
@@ -526,18 +525,58 @@ final class Pretty {
      * @return The inlined content, or empty
      */
     private static Optional<String> flat(final Node given) {
-        final Optional<String> result;
+        return Pretty.flattened(given).map(flat -> flat.text);
+    }
+
+    /**
+     * Render a node inline, together with its suffix-resolved form, so a
+     * caller that also needs to know whether that resolved node still has
+     * children (to decide on wrapping parentheses around it) does not have
+     * to resolve the suffix shape a second time.
+     * @param given The node
+     * @return The inlined content paired with its resolved node, or empty
+     * @see #flat(Node)
+     */
+    private static Optional<Pretty.Flattened> flattened(final Node given) {
+        final Optional<String> text;
         final Node node = Pretty.suffixed(given).orElse(given);
         if (node.reversed && node.children.size() <= 1) {
-            result = Optional.empty();
+            text = Optional.empty();
         } else if (node.abstractt || !node.tail.isEmpty() || "*".equals(node.base)) {
-            result = Optional.empty();
+            text = Optional.empty();
         } else if (node.children.isEmpty()) {
-            result = Optional.of(node.base);
+            text = Optional.of(node.base);
         } else {
-            result = Pretty.inlined(node.children)
+            text = Pretty.inlined(node.children)
                 .map(args -> String.join(" ", node.base, args));
         }
-        return result;
+        return text.map(value -> new Pretty.Flattened(node, value));
+    }
+
+    /**
+     * A node flattened to one line, paired with its suffix-resolved form.
+     * @since 0.1
+     */
+    private static final class Flattened {
+
+        /**
+         * The suffix-resolved node.
+         */
+        private final Node node;
+
+        /**
+         * The node's one-line inline text.
+         */
+        private final String text;
+
+        /**
+         * Ctor.
+         * @param node The suffix-resolved node
+         * @param text The node's one-line inline text
+         */
+        Flattened(final Node node, final String text) {
+            this.node = node;
+            this.text = text;
+        }
     }
 }

--- a/eo-printer/src/test/java/benchmarks/PrettyBench.java
+++ b/eo-printer/src/test/java/benchmarks/PrettyBench.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package benchmarks;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.util.concurrent.TimeUnit;
+import org.eolang.printer.Xmir;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Benchmark for printing a deeply nested chain of reversed dispatches
+ * ({@code 5.plus 1 .plus 2 ...}), the shape that repeatedly exercises
+ * {@code Pretty.suffixed}/{@code Pretty.flat} at every nesting level.
+ * @since 0.1
+ * @checkstyle NonStaticMethodCheck (100 lines)
+ */
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "JTCOP.RuleCorrectTestName"})
+public class PrettyBench {
+
+    /**
+     * A deeply nested chain of reversed dispatches.
+     */
+    private final XML input = new XMLDocument(
+        String.format(
+            "<object><metas/><o name='main'>%s</o></object>",
+            this.chain(24)
+        )
+    );
+
+    /**
+     * Print the chain to EO.
+     */
+    @Benchmark
+    public final void printsNestedReversedDispatches() {
+        new Xmir(this.input).toEO();
+    }
+
+    /**
+     * Build a chain of {@code depth} nested reversed {@code .plus}
+     * dispatches over a numeric literal receiver.
+     * @param depth Nesting depth
+     * @return The innermost-out XML fragment
+     */
+    private String chain(final int depth) {
+        String xml = "<o base='Φ.number'>0</o>";
+        for (int lvl = 0; lvl < depth; lvl = lvl + 1) {
+            xml = String.format(
+                "<o base='.plus'>%s<o base='Φ.number'>%d</o></o>", xml, lvl
+            );
+        }
+        return xml;
+    }
+}

--- a/eo-printer/src/test/java/benchmarks/package-info.java
+++ b/eo-printer/src/test/java/benchmarks/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Benchmarks.
+ * @since 0.1
+ */
+package benchmarks;


### PR DESCRIPTION
`Pretty.suffixed(Node)` and `Pretty.flat(Node)` recursively called each other on the same input. `flat(given)` resolved `suffixed(given)` internally as its first step. `suffixed(node)` called `flat(receiver)` on its receiver, then, inside the mapping lambda, separately called `suffixed(receiver)` again just to check `.children.isEmpty()`, the same resolution `flat(receiver)` had already done internally. `Pretty.inlined(List<Node>)` had the same pattern: `flat(arg)` for the inline text, then a separate `suffixed(arg)` call for the same check.

Because a reversed-dispatch chain (`a.plus b.minus c...`) nests one receiver inside another, and each level's resolution re-triggers the same duplicated resolution of every level below it, the redundant work compounds with nesting depth instead of just doubling.

Added `flattened(Node)`, which resolves a node's suffix shape once and returns it together with its inline text in a small `Flattened` holder, and routed `suffixed`/`inlined`/`flat` through it so the resolved node is computed once and reused. `flat(Node)` becomes a thin wrapper over `flattened(Node)` for the one caller that only needs the text.

Measured by printing a synthetic chain of `n` nested reversed `.plus` dispatches over a numeric receiver (`0.plus 0 .plus 1 .plus 2 ...`), through the public `Xmir` entry point:

```
depth 16:     365 ms    (before)
depth 24:  13,284 ms    (before)
depth 40/400: did not complete a single call in 10+ minutes (before)

depth 24:     172 ms    (after, ~77x)
depth 400:  1,953 ms    (after)
```

The growth between depth 16 and 24 fits roughly `1.6^depth` before the fix. This is not a constant-factor slowdown; it is exponential in the nesting depth of reversed dispatches, a shape that occurs in ordinary chained arithmetic and method-dispatch EO code. After the fix, work is linear in nesting depth.

Added `benchmarks/PrettyBench` (depth 24, matching the numbers above) as a regression guard.

Ran the full `eo-printer` test suite locally (all print-pack and `XmirTest` coverage), 0 failures. `qulice` clean.

One style note: `Pretty` is already a class of exclusively `private static` methods; `flattened` follows that existing convention rather than introducing an instance surface into an otherwise fully static utility class.

Closes #6864
