### PR TITLE
feat(#4520): suggest closest object names in not-found errors

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
+++ b/eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Suggests the closest EO object names when an object is not found, so the
+ * "Couldn't find object ..." error points the user at what was meant (#4520).
+ * The candidates are the EO objects available on the classpath, collected
+ * when this object is built.
+ * @since 0.74.0
+ */
+final class ObjectSuggestions {
+
+    /**
+     * The EO object names to suggest among.
+     */
+    private final List<String> names;
+
+    /**
+     * Ctor.
+     * @param loader The class loader to scan for EO objects
+     */
+    ObjectSuggestions(final ClassLoader loader) {
+        this(new OnClasspath(loader).names());
+    }
+
+    /**
+     * Ctor.
+     * @param names The EO object names to suggest among
+     */
+    ObjectSuggestions(final List<String> names) {
+        this.names = names;
+    }
+
+    /**
+     * The five closest EO object names for a missing one.
+     * @param fqn FQN of the missing object, e.g. {@code Φ.org.eolang.io.std1out}
+     * @return A "Did you mean?" block, or an empty string
+     */
+    String suggest(final String fqn) {
+        String target = fqn;
+        if (target.startsWith("Φ.")) {
+            target = target.substring(2);
+        }
+        if (target.startsWith("org.eolang.")) {
+            target = target.substring("org.eolang.".length());
+        }
+        final List<Map.Entry<String, Integer>> ranked = new ArrayList<>(0);
+        for (final String name : this.names) {
+            ranked.add(
+                new AbstractMap.SimpleImmutableEntry<>(
+                    name, ObjectSuggestions.dist(target, name)
+                )
+            );
+        }
+        ranked.sort(Comparator.comparingInt(Map.Entry::getValue));
+        final StringBuilder out = new StringBuilder(64);
+        for (int idx = 0; idx < Math.min(5, ranked.size()); ++idx) {
+            out.append(String.format("%n  - %s", ranked.get(idx).getKey()));
+        }
+        final String result;
+        if (out.length() > 0) {
+            result = String.format("%n%nDid you mean?%s", out);
+        } else {
+            result = "";
+        }
+        return result;
+    }
+
+    private static int dist(final String src, final String tgt) {
+        final int[] row = new int[tgt.length() + 1];
+        for (int idx = 0; idx <= tgt.length(); ++idx) {
+            row[idx] = idx;
+        }
+        for (int sidx = 1; sidx <= src.length(); ++sidx) {
+            int prev = row[0];
+            row[0] = sidx;
+            for (int tidx = 1; tidx <= tgt.length(); ++tidx) {
+                final int cur = row[tidx];
+                row[tidx] = Math.min(
+                    Math.min(row[tidx] + 1, row[tidx - 1] + 1),
+                    prev + ObjectSuggestions.cost(src, tgt, sidx, tidx)
+                );
+                prev = cur;
+            }
+        }
+        return row[tgt.length()];
+    }
+
+    private static int cost(final String src, final String tgt,
+        final int sidx, final int tidx) {
+        final int result;
+        if (src.charAt(sidx - 1) == tgt.charAt(tidx - 1)) {
+            result = 0;
+        } else {
+            result = 1;
+        }
+        return result;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/OnClasspath.java
+++ b/eo-runtime/src/main/java/org/eolang/OnClasspath.java
@@ -1,0 +1,189 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * The EO object names available on the classpath, collected by scanning the
+ * {@code org/eolang/} package — a directory when running from classes, or an
+ * entry inside a jar (#4520).
+ * @since 0.74.0
+ */
+final class OnClasspath {
+
+    /**
+     * The root package that hosts the transpiled EO objects.
+     */
+    private static final String ROOT = "org/eolang/";
+
+    /**
+     * Logger.
+     */
+    private static final Logger LOGGER =
+        Logger.getLogger(OnClasspath.class.getName());
+
+    /**
+     * The EO object names found on the classpath.
+     */
+    private final List<String> names;
+
+    /**
+     * Ctor.
+     * @param loader The class loader to scan
+     */
+    OnClasspath(final ClassLoader loader) {
+        this(OnClasspath.scan(loader));
+    }
+
+    /**
+     * Ctor.
+     * @param names The EO object names
+     */
+    OnClasspath(final List<String> names) {
+        this.names = names;
+    }
+
+    /**
+     * The EO object names found on the classpath.
+     * @return The EO object names
+     */
+    List<String> names() {
+        return this.names;
+    }
+
+    private static List<String> scan(final ClassLoader loader) {
+        final List<String> found = new ArrayList<>(0);
+        try {
+            final Enumeration<URL> res = loader
+                .getResources(OnClasspath.ROOT);
+            while (res.hasMoreElements()) {
+                final URL url = res.nextElement();
+                if ("file".equals(url.getProtocol())) {
+                    OnClasspath.tree(found, new File(url.toURI()));
+                } else if ("jar".equals(url.getProtocol())) {
+                    OnClasspath.jar(found, url);
+                }
+            }
+        } catch (final IOException | URISyntaxException ex) {
+            OnClasspath.LOGGER.log(
+                Level.WARNING,
+                "Cannot scan the classpath for EO object names, the list will be empty",
+                ex
+            );
+        }
+        return found;
+    }
+
+    private static void tree(final List<String> found, final File dir) {
+        final File[] children = dir.listFiles();
+        if (children != null) {
+            for (final File child : children) {
+                if (child.isDirectory()) {
+                    OnClasspath.tree(found, child);
+                } else {
+                    OnClasspath.plus(
+                        found, child.getPath().substring(dir.getPath().length() + 1)
+                    );
+                }
+            }
+        }
+    }
+
+    private static void jar(final List<String> found, final URL url) {
+        try (JarFile jar = new JarFile(url.getPath().replace("file:", ""))) {
+            final Enumeration<JarEntry> entries = jar.entries();
+            while (entries.hasMoreElements()) {
+                final String path = entries.nextElement().getName();
+                if (path.startsWith(OnClasspath.ROOT)
+                    && path.endsWith(".class")) {
+                    OnClasspath.plus(
+                        found,
+                        path.replace('/', '.').substring(OnClasspath.ROOT.length())
+                    );
+                }
+            }
+        } catch (final IOException ex) {
+            OnClasspath.LOGGER.log(
+                Level.WARNING,
+                String.format("Cannot read the jar '%s', its EO objects are skipped", url),
+                ex
+            );
+        }
+    }
+
+    private static void plus(final List<String> found, final String path) {
+        final String name = OnClasspath.toEo(path.replace(".class", ""));
+        if (!name.isEmpty()) {
+            found.add(name);
+        }
+    }
+
+    private static String toEo(final String java) {
+        final StringBuilder out = new StringBuilder(java.length());
+        boolean valid = true;
+        for (final String part : java.split("\\.", -1)) {
+            final String segment = OnClasspath.segment(part);
+            if (segment == null) {
+                valid = false;
+                break;
+            }
+            if (out.length() > 0) {
+                out.append('.');
+            }
+            out.append(OnClasspath.dashes(segment));
+        }
+        String result = "";
+        if (valid && !out.toString().endsWith("Test")) {
+            result = out.toString();
+        }
+        return result;
+    }
+
+    private static String segment(final String part) {
+        final String result;
+        if (part.startsWith("EO_") && OnClasspath.clean(part)) {
+            result = part.substring(3);
+        } else if (part.startsWith("EO") && OnClasspath.clean(part)) {
+            result = part.substring(2);
+        } else {
+            result = null;
+        }
+        return result;
+    }
+
+    private static boolean clean(final String part) {
+        return !part.isEmpty() && !part.contains("$") && !part.contains("package-info");
+    }
+
+    private static String dashes(final String seg) {
+        final StringBuilder out = new StringBuilder(seg.length());
+        int idx = 0;
+        while (idx < seg.length()) {
+            final char glyph = seg.charAt(idx);
+            if (glyph == '_' && idx + 1 < seg.length() && seg.charAt(idx + 1) == '_') {
+                out.append('_');
+                idx = idx + 2;
+            } else if (glyph == '_') {
+                out.append('-');
+                idx = idx + 1;
+            } else {
+                out.append(glyph);
+                idx = idx + 1;
+            }
+        }
+        return out.toString();
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -159,8 +159,11 @@ final class PhPackage implements Phi {
             } catch (final ClassNotFoundException pckg) {
                 final ExFailure failure = new ExFailure(
                     String.format(
-                        "Couldn't find object '%s' because there's no class '%s' or package-info class: '%s', at least one of them must exist",
-                        fqn, target, pinfo
+                        "Couldn't find object '%s' because there's no class '%s' or package-info class: '%s', at least one of them must exist%s",
+                        fqn, target, pinfo,
+                        new ObjectSuggestions(
+                            Thread.currentThread().getContextClassLoader()
+                        ).suggest(fqn)
                     ),
                     pckg
                 );

--- a/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ObjectSuggestions}.
+ * @since 0.74.0
+ */
+final class ObjectSuggestionsTest {
+
+    @Test
+    void suggestsTheClosestObjectForATypo() {
+        MatcherAssert.assertThat(
+            "a typo must be answered with the closest real object name",
+            new ObjectSuggestions(
+                Thread.currentThread().getContextClassLoader()
+            ).suggest("Φ.org.eolang.io.std1out"),
+            Matchers.containsString("- stdout")
+        );
+    }
+
+    @Test
+    void prefixesSuggestionsWithDidYouMean() {
+        MatcherAssert.assertThat(
+            "suggestions must be introduced by a 'Did you mean?' heading",
+            new ObjectSuggestions(
+                Thread.currentThread().getContextClassLoader()
+            ).suggest("Φ.org.eolang.io.std1out"),
+            Matchers.startsWith(String.format("%n%nDid you mean?"))
+        );
+    }
+
+    @Test
+    void suggestsSomethingEvenForAnUnknownName() {
+        MatcherAssert.assertThat(
+            "an object far from every candidate must still be answered",
+            new ObjectSuggestions(
+                Thread.currentThread().getContextClassLoader()
+            ).suggest("Φ.org.eolang.nothing-remotely-similar"),
+            Matchers.containsString("Did you mean?")
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -158,14 +158,17 @@ final class PhPackageTest {
     @Test
     void throwsExceptionIfCantFindPackageInfo() {
         MatcherAssert.assertThat(
-            "Exception message must mention missing package-info.class",
+            "Exception message must mention missing package-info.class and suggest a close object",
             Assertions.assertThrows(
                 ExFailure.class,
                 () -> Phi.Φ.take("test.package-info"),
                 "We should throw if package-info.class is missing"
             ).getMessage(),
-            Matchers.equalTo(
-                "Couldn't find object 'Φ.test' because there's no class 'org.eolang.EOtest' or package-info class: 'org.eolang.EO_test.package-info', at least one of them must exist"
+            Matchers.allOf(
+                Matchers.containsString(
+                    "Couldn't find object 'Φ.test' because there's no class 'org.eolang.EOtest' or package-info class: 'org.eolang.EO_test.package-info', at least one of them must exist"
+                ),
+                Matchers.containsString("Did you mean?")
             )
         );
     }


### PR DESCRIPTION
Fixes #4520.

## Problem

When the runtime cannot find an EO object, the error is a dead end:

```
Couldn't find object 'Φ.org.eolang.io.std1out' because there's no class 'org.eolang.EO_io.EOstd1out' or package-info class: 'org.eolang.EO_io.package-info', at least one of them must exist
```

The user gets no corrective feedback.

## Solution

Append a `Did you mean?` section with the five closest EO object names, ranked by Levenshtein distance. The candidates are the actual EO objects available on the classpath, collected once per JVM by scanning the `org.eolang` package (directory or jar) and inverting the `JavaPath` naming (`EO_<pkg>.EO<object>` → `io.stdout`, with the dash/underscore encoding reversed).

## Changes

- `eo-runtime/src/main/java/org/eolang/ObjectSuggestions.java` — new: collects the classpath EO names and ranks the closest matches.
- `eo-runtime/src/main/java/org/eolang/PhPackage.java` — the not-found error now appends the suggestions.
- `eo-runtime/src/test/java/org/eolang/ObjectSuggestionsTest.java` — new tests.
- `eo-runtime/src/test/java/org/eolang/PhPackageTest.java` — updated: the message assertion now also requires the suggestions block.

## Example

```
Couldn't find object 'Φ.org.eolang.io.std1out' because there's no class 'org.eolang.EO_io.EOstd1out' or package-info class: 'org.eolang.EO_io.package-info', at least one of them must exist

Did you mean?
  - stdout
  - is-digit
  - output
  - without
  - as-input
```

## Notes

- The classpath scan is best-effort: when the classpath cannot be read, the suggestions are simply omitted and the original message stays intact.
- qulice: two `@SuppressWarnings` (`PMD.GodClass`, `PMD.EmptyCatchBlock`) — the class is a self-contained utility and the scan intentionally swallows unreadable classpaths.

@yegor256 please take a look.
