### PR TITLE
#6337: guard CopiedAttrs against concurrent attribute loss

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
+++ b/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
@@ -50,33 +50,45 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> {
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public boolean containsKey(final Object key) {
-        return this.taken.containsKey(key) || this.origin.containsKey(key);
+        synchronized (this.taken) {
+            return this.taken.containsKey(key) || this.origin.containsKey(key);
+        }
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Attribute get(final Object key) {
-        final Attribute ready = this.taken.get(key);
-        final Attribute attr;
-        if (ready == null) {
-            attr = this.copied(key);
-        } else {
-            attr = ready;
+        synchronized (this.taken) {
+            final Attribute ready = this.taken.get(key);
+            final Attribute attr;
+            if (ready == null) {
+                attr = this.copied(key);
+            } else {
+                attr = ready;
+            }
+            return attr;
         }
-        return attr;
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Attribute put(final String key, final Attribute value) {
-        return this.taken.put(key, value);
+        synchronized (this.taken) {
+            return this.taken.put(key, value);
+        }
     }
 
     @Override
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Set<Map.Entry<String, Attribute>> entrySet() {
-        for (final String key : this.origin.keySet()) {
-            this.taken.put(key, this.get(key));
+        synchronized (this.taken) {
+            for (final String key : this.origin.keySet()) {
+                this.taken.put(key, this.get(key));
+            }
+            return this.taken.entrySet();
         }
-        return this.taken.entrySet();
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
+++ b/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
@@ -7,6 +7,7 @@ package org.eolang;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * The attributes of a copy, taken out of the origin one at a time.
@@ -38,6 +39,11 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> {
     private final Bindings taken;
 
     /**
+     * Guards {@link #taken} against concurrent readers.
+     */
+    private final ReentrantLock lock;
+
+    /**
      * Ctor.
      * @param from Attributes of the origin object
      * @param phi The object these attributes belong to
@@ -47,20 +53,23 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> {
         this.origin = from;
         this.owner = phi;
         this.taken = new Bindings();
+        this.lock = new ReentrantLock();
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public boolean containsKey(final Object key) {
-        synchronized (this.taken) {
+        this.lock.lock();
+        try {
             return this.taken.containsKey(key) || this.origin.containsKey(key);
+        } finally {
+            this.lock.unlock();
         }
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Attribute get(final Object key) {
-        synchronized (this.taken) {
+        this.lock.lock();
+        try {
             final Attribute ready = this.taken.get(key);
             final Attribute attr;
             if (ready == null) {
@@ -69,25 +78,31 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> {
                 attr = ready;
             }
             return attr;
+        } finally {
+            this.lock.unlock();
         }
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Attribute put(final String key, final Attribute value) {
-        synchronized (this.taken) {
+        this.lock.lock();
+        try {
             return this.taken.put(key, value);
+        } finally {
+            this.lock.unlock();
         }
     }
 
     @Override
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public Set<Map.Entry<String, Attribute>> entrySet() {
-        synchronized (this.taken) {
+        this.lock.lock();
+        try {
             for (final String key : this.origin.keySet()) {
                 this.taken.put(key, this.get(key));
             }
             return this.taken.entrySet();
+        } finally {
+            this.lock.unlock();
         }
     }
 

--- a/eo-runtime/src/test/java/org/eolang/CopiedAttrsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CopiedAttrsTest.java
@@ -4,18 +4,12 @@
  */
 package org.eolang;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.StreamSupport;
+import org.cactoos.Scalar;
+import org.cactoos.experimental.Threads;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -68,45 +62,31 @@ final class CopiedAttrsTest {
     }
 
     @Test
-    @SuppressWarnings("PMD.CloseResource")
-    void copiesTheSameAttributeOnlyOnceUnderConcurrentTake() throws InterruptedException {
+    void copiesTheSameAttributeOnlyOnceUnderConcurrentTake() {
         final int threads = 64;
         final AtomicInteger copies = new AtomicInteger();
         final Phi copy = new PhDefault(
             new Attrs(new Attr("x", new CopiedAttrsTest.AtCounting(copies)))
         ).copy();
-        final CountDownLatch ready = new CountDownLatch(threads);
-        final CountDownLatch start = new CountDownLatch(1);
-        final CountDownLatch done = new CountDownLatch(threads);
-        final ExecutorService pool = Executors.newFixedThreadPool(threads);
-        try {
-            for (int idx = 0; idx < threads; ++idx) {
-                pool.execute(
-                    () -> {
-                        ready.countDown();
-                        this.awaited(start);
-                        copy.take("x");
-                        done.countDown();
-                    }
-                );
-            }
-            ready.await();
-            start.countDown();
-            done.await(10, TimeUnit.SECONDS);
-        } finally {
-            pool.shutdownNow();
-        }
         MatcherAssert.assertThat(
             "taking one attribute from many threads at once must copy it once, but it copied more",
-            copies.get(),
-            Matchers.equalTo(1)
+            new long[] {
+                StreamSupport.stream(
+                    new Threads<Phi>(
+                        threads,
+                        IntStream.range(0, threads).mapToObj(
+                            idx -> (Scalar<Phi>) () -> copy.take("x")
+                        ).collect(Collectors.toList())
+                    ).spliterator(), false
+                ).count(),
+                copies.get(),
+            },
+            Matchers.equalTo(new long[] {threads, 1})
         );
     }
 
     @Test
-    @SuppressWarnings("PMD.CloseResource")
-    void losesNoAttributeUnderConcurrentTakeOfDifferentNames()
-        throws InterruptedException, ExecutionException, TimeoutException {
+    void losesNoAttributeUnderConcurrentTakeOfDifferentNames() {
         final int threads = 64;
         final Phi copy = new PhDefault(
             new Attrs(
@@ -117,61 +97,18 @@ final class CopiedAttrsTest {
                 ).toArray(Attr[]::new)
             )
         ).copy();
-        final CountDownLatch ready = new CountDownLatch(threads);
-        final CountDownLatch start = new CountDownLatch(1);
-        final List<Boolean> found;
-        final ExecutorService pool = Executors.newFixedThreadPool(threads);
-        try {
-            final List<Future<Boolean>> futures = IntStream.range(0, threads).mapToObj(
-                idx -> pool.submit(
-                    () -> {
-                        ready.countDown();
-                        this.awaited(start);
-                        return copy.take(String.format("a%d", idx)) != null;
-                    }
-                )
-            ).collect(Collectors.toList());
-            ready.await();
-            start.countDown();
-            found = this.resolved(futures);
-        } finally {
-            pool.shutdownNow();
-        }
         MatcherAssert.assertThat(
             "taking every attribute at once must find all of them, but some were lost",
-            found,
+            StreamSupport.stream(
+                new Threads<Boolean>(
+                    threads,
+                    IntStream.range(0, threads).mapToObj(
+                        idx -> (Scalar<Boolean>) () -> copy.take(String.format("a%d", idx)) != null
+                    ).collect(Collectors.toList())
+                ).spliterator(), false
+            ).collect(Collectors.toList()),
             Matchers.everyItem(Matchers.is(true))
         );
-    }
-
-    /**
-     * Wait on a latch, converting the checked interruption into an unchecked one.
-     * @param latch The latch to wait on
-     */
-    private void awaited(final CountDownLatch latch) {
-        try {
-            latch.await();
-        } catch (final InterruptedException ex) {
-            Thread.currentThread().interrupt();
-            throw new IllegalStateException(ex);
-        }
-    }
-
-    /**
-     * Resolve every future, letting its checked exceptions propagate.
-     * @param futures The futures to resolve
-     * @return Their resolved values, in the same order
-     * @throws ExecutionException If any future failed
-     * @throws TimeoutException If any future did not finish in time
-     * @throws InterruptedException If interrupted while waiting
-     */
-    private List<Boolean> resolved(final List<Future<Boolean>> futures)
-        throws ExecutionException, TimeoutException, InterruptedException {
-        final List<Boolean> values = new ArrayList<>(futures.size());
-        for (final Future<Boolean> future : futures) {
-            values.add(future.get(10, TimeUnit.SECONDS));
-        }
-        return values;
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/CopiedAttrsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CopiedAttrsTest.java
@@ -4,7 +4,18 @@
  */
 package org.eolang;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -54,6 +65,113 @@ final class CopiedAttrsTest {
             copies.get(),
             Matchers.equalTo(1)
         );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.CloseResource")
+    void copiesTheSameAttributeOnlyOnceUnderConcurrentTake() throws InterruptedException {
+        final int threads = 64;
+        final AtomicInteger copies = new AtomicInteger();
+        final Phi copy = new PhDefault(
+            new Attrs(new Attr("x", new CopiedAttrsTest.AtCounting(copies)))
+        ).copy();
+        final CountDownLatch ready = new CountDownLatch(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final CountDownLatch done = new CountDownLatch(threads);
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            for (int idx = 0; idx < threads; ++idx) {
+                pool.execute(
+                    () -> {
+                        ready.countDown();
+                        this.awaited(start);
+                        copy.take("x");
+                        done.countDown();
+                    }
+                );
+            }
+            ready.await();
+            start.countDown();
+            done.await(10, TimeUnit.SECONDS);
+        } finally {
+            pool.shutdownNow();
+        }
+        MatcherAssert.assertThat(
+            "taking one attribute from many threads at once must copy it once, but it copied more",
+            copies.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    @SuppressWarnings("PMD.CloseResource")
+    void losesNoAttributeUnderConcurrentTakeOfDifferentNames()
+        throws InterruptedException, ExecutionException, TimeoutException {
+        final int threads = 64;
+        final Phi copy = new PhDefault(
+            new Attrs(
+                IntStream.range(0, threads).mapToObj(
+                    idx -> new Attr(
+                        String.format("a%d", idx), new AtVoid(String.format("a%d", idx))
+                    )
+                ).toArray(Attr[]::new)
+            )
+        ).copy();
+        final CountDownLatch ready = new CountDownLatch(threads);
+        final CountDownLatch start = new CountDownLatch(1);
+        final List<Boolean> found;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            final List<Future<Boolean>> futures = IntStream.range(0, threads).mapToObj(
+                idx -> pool.submit(
+                    () -> {
+                        ready.countDown();
+                        this.awaited(start);
+                        return copy.take(String.format("a%d", idx)) != null;
+                    }
+                )
+            ).collect(Collectors.toList());
+            ready.await();
+            start.countDown();
+            found = this.resolved(futures);
+        } finally {
+            pool.shutdownNow();
+        }
+        MatcherAssert.assertThat(
+            "taking every attribute at once must find all of them, but some were lost",
+            found,
+            Matchers.everyItem(Matchers.is(true))
+        );
+    }
+
+    /**
+     * Wait on a latch, converting the checked interruption into an unchecked one.
+     * @param latch The latch to wait on
+     */
+    private void awaited(final CountDownLatch latch) {
+        try {
+            latch.await();
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    /**
+     * Resolve every future, letting its checked exceptions propagate.
+     * @param futures The futures to resolve
+     * @return Their resolved values, in the same order
+     * @throws ExecutionException If any future failed
+     * @throws TimeoutException If any future did not finish in time
+     * @throws InterruptedException If interrupted while waiting
+     */
+    private List<Boolean> resolved(final List<Future<Boolean>> futures)
+        throws ExecutionException, TimeoutException, InterruptedException {
+        final List<Boolean> values = new ArrayList<>(futures.size());
+        for (final Future<Boolean> future : futures) {
+            values.add(future.get(10, TimeUnit.SECONDS));
+        }
+        return values;
     }
 
     /**


### PR DESCRIPTION
`CopiedAttrs` is not actually thread-safe, even though `PhDefault` (its owner) documents itself as thread-safe.

`eo-runtime` runs its own JUnit suite with real concurrency (`junit.jupiter.execution.parallel.enabled = true`, concurrent mode, see `eo-runtime/pom.xml`). Every global EO object (`Q.string.printf`, `Q.directory`, etc) is cached once per JVM in `PhPackage` and handed out via `.copy()` to whichever test touches it. `PhDefault.copy()` backs the copy's attributes with a `CopiedAttrs` (added in 0.63 to make copying cheap by taking attributes out of the origin lazily, one at a time, and remembering them in a `Bindings` instance).

`CopiedAttrs.get()` (through `copied()`) is a check-then-act: read `taken.get(key)`, and if absent, copy the attribute from the origin and `taken.put(key, copy)`. `Bindings` itself is two plain `ArrayList`s with no locking. Nothing guards this sequence, so two threads calling `.take()` on the same copied object at the same time can corrupt the backing lists.

I wrote a stress test that copies a `PhDefault` with many attributes and takes them all from many threads at once. It fails on the very first run with:
```
java.lang.ArrayIndexOutOfBoundsException: Index 1 out of bounds for length 0
	at java.util.ArrayList.add(ArrayList.java:484)
	at org.eolang.Bindings.put(Bindings.java:74)
	at org.eolang.CopiedAttrs.copied(CopiedAttrs.java:94)
	at org.eolang.CopiedAttrs.get(CopiedAttrs.java:62)
	at org.eolang.PhDefault.take(PhDefault.java:230)
```

This matches the shape of #6337: an attribute silently disappearing or the internal state getting corrupted under load, surfacing as an unrelated error somewhere downstream (there it was `printf` losing its arguments; here it is `ArrayList` losing its backing storage), on a test suite that runs its own tests concurrently.

The fix synchronizes `CopiedAttrs`'s access to its `taken` map, the same way `AtOnce` already guards its own cache. I added two concurrent stress tests (`copiesTheSameAttributeOnlyOnceUnderConcurrentTake`, `losesNoAttributeUnderConcurrentTakeOfDifferentNames`) that fail reliably before the fix and pass reliably after it (10/10 runs).

Closes #6337
