### PR TITLE
#6868: force parsed, anchored, commented, quoted to dataize once in regex.eo

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -82,29 +82,25 @@
         and.
           found.to.eq txt.length
           found.from.eq 0
-      "/(?:%s)(?![\\s\\S])/%s".printf > anchored!
-        *
-          parsed.group 1
-          parsed.group 2
-      "/(?:%s\n)(?![\\s\\S])/%s".printf > commented!
-        *
-          parsed.group 1
-          parsed.group 2
+      "/(?:%s)(?![\\s\\S])/%s".printf > anchored
+        * group1 group2
+      "/(?:%s\n)(?![\\s\\S])/%s".printf > commented
+        * group1 group2
       next. > found
         match.
           compile.
             regex anchored
             retry-commented
           txt
-      next. > parsed!
+      parsed.group 1 > group1!
+      parsed.group 2 > group2!
+      next. > parsed
         match.
           compiled.
             regex "/^\\/([\\s\\S]*)\\/([dimsux]*)$/"
           expression
-      "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted!
-        *
-          parsed.group 1
-          parsed.group 2
+      "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
+        * group1 group2
       compile. > [message] > retry-commented
         regex commented
         retry-quoted

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -82,11 +82,11 @@
         and.
           found.to.eq txt.length
           found.from.eq 0
-      "/(?:%s)(?![\\s\\S])/%s".printf > anchored
+      "/(?:%s)(?![\\s\\S])/%s".printf > anchored!
         *
           parsed.group 1
           parsed.group 2
-      "/(?:%s\n)(?![\\s\\S])/%s".printf > commented
+      "/(?:%s\n)(?![\\s\\S])/%s".printf > commented!
         *
           parsed.group 1
           parsed.group 2
@@ -96,12 +96,12 @@
             regex anchored
             retry-commented
           txt
-      next. > parsed
+      next. > parsed!
         match.
           compiled.
             regex "/^\\/([\\s\\S]*)\\/([dimsux]*)$/"
           expression
-      "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
+      "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted!
         *
           parsed.group 1
           parsed.group 2


### PR DESCRIPTION
`matches`'s locals `parsed`, `anchored`, `commented` and `quoted` were bound without `!`, so every read re-dataized the whole sub-tree instead of once. `anchored` and `commented` each read `parsed.group 1`/`parsed.group 2` twice, so a single `.matches` call paid for the "parse the literal into pattern text and flags" cycle several times over, on top of the real match cycle.

This is the same pattern #6651 fixed in `power.eo`'s `half`/`k`: mark the local `!` so it dataizes once and every subsequent read reuses the cached value.

I added `!` to `parsed`, `anchored`, `commented` and `quoted`. No change to the matching logic itself. `EOregexTest` (37 tests) and `EOuriTest` (whose `host`/`scheme`/`authority` chain goes through `matches`) both still pass.

Closes #6868
