### PR TITLE
#6827: use 64-bit _ftime64_s for the Windows clock

### DIFF
--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -1,5 +1,5 @@
 # Wall-clock time source backed by the operating system.
-# Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime32_s` on Windows.
+# Reads the underlying syscall: `gettimeofday` on POSIX, `_ftime64_s` on Windows.
 # Decorates an `i64` holding the current time in milliseconds since the Unix epoch.
 
 +architect yegor256@gmail.com
@@ -16,7 +16,7 @@
         millitm.
           output. >> timeb
             win32
-              "_ftime32_s"
+              "_ftime64_s"
               *
       plus.
         times.

--- a/eo-runtime/src/main/java/org/eolang/win32/FtimeFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FtimeFuncCall.java
@@ -12,7 +12,7 @@ import org.eolang.Phi;
 import org.eolang.Syscall;
 
 /**
- * The msvcrt _ftime32_s function call.
+ * The msvcrt _ftime64_s function call.
  * @since 0.74.0
  */
 public final class FtimeFuncCall implements Syscall {
@@ -34,7 +34,7 @@ public final class FtimeFuncCall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
         final FtimeFuncCall.Timeb timeb = new FtimeFuncCall.Timeb();
-        result.put(0, new Data.ToPhi(Msvcrt.INSTANCE._ftime32_s(timeb)));
+        result.put(0, new Data.ToPhi(Msvcrt.INSTANCE._ftime64_s(timeb)));
         final Phi struct = this.win.take("timeb");
         struct.put(0, new Data.ToPhi(timeb.time));
         struct.put(1, new Data.ToPhi(timeb.millitm));
@@ -43,7 +43,7 @@ public final class FtimeFuncCall implements Syscall {
     }
 
     /**
-     * The {@code struct __timeb32} filled by {@code _ftime32_s}.
+     * The {@code struct __timeb64} filled by {@code _ftime64_s}.
      * @since 0.74.0
      * @checkstyle VisibilityModifierCheck (100 lines)
      */
@@ -52,7 +52,7 @@ public final class FtimeFuncCall implements Syscall {
         /**
          * Seconds since the Unix epoch.
          */
-        public int time;
+        public long time;
 
         /**
          * Fraction of a second, in milliseconds.

--- a/eo-runtime/src/main/java/org/eolang/win32/Msvcrt.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Msvcrt.java
@@ -166,14 +166,16 @@ public interface Msvcrt extends Library {
 
     /**
      * Gets the current time as seconds and milliseconds since the Unix epoch,
-     * filling a {@code struct __timeb32}. It replaces Kernel32's wall-clock
+     * filling a {@code struct __timeb64}. It replaces Kernel32's wall-clock
      * {@code GetSystemTime}, lining the win32 clock up with the posix
      * {@code gettimeofday}: like {@code gettimeofday} it hands back the raw
      * status code, unlike the older {@code _ftime} that returns {@code void}.
+     * The 64-bit variant is used because the 32-bit {@code _ftime32_s} can
+     * only represent dates through 18 January 2038.
      * @param timeb Structure to fill with the current time
      * @return Zero on success, an errno value on failure
      */
-    int _ftime32_s(Structure timeb);
+    int _ftime64_s(Structure timeb);
 
     /**
      * Duplicates a file descriptor.

--- a/eo-runtime/src/main/java/org/eolang/win32/NamedFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/NamedFuncCall.java
@@ -41,7 +41,7 @@ public final class NamedFuncCall implements Syscall {
         NamedFuncCall.ALL.put("_write", WriteFuncCall::new);
         NamedFuncCall.ALL.put("_close", CloseFuncCall::new);
         NamedFuncCall.ALL.put("getenv", GetenvFuncCall::new);
-        NamedFuncCall.ALL.put("_ftime32_s", FtimeFuncCall::new);
+        NamedFuncCall.ALL.put("_ftime64_s", FtimeFuncCall::new);
         NamedFuncCall.ALL.put("WSAStartup", WSAStartupFuncCall::new);
         NamedFuncCall.ALL.put("WSACleanup", WSACleanupFuncCall::new);
         NamedFuncCall.ALL.put("WSAGetLastError", WSAGetLastErrorFuncCall::new);


### PR DESCRIPTION
`clock`'s Windows branch fills a `struct _timeb` via `_ftime32_s`, which Microsoft documents as only representing dates through 23:59:59 UTC on 18 January 2038. The POSIX branch already uses `gettimeofday`, which has no such limit.

Switched to the 64-bit CRT API: `_ftime64_s` filling a `struct __timeb64`, whose `time` field is a 64-bit `__time64_t`. The JNA structure's `time` field changed from `int` to `long` to match, and the dispatch table in `NamedFuncCall` was updated to route the new syscall name to the same `FtimeFuncCall`. No change to the millisecond calculation itself, or to the POSIX branch.

`EOclockTest` and the eo-runtime build pass. The Windows-specific code path only actually runs on the `windows-2022` CI leg, since JNA structures compile on every platform but the syscall itself is Windows-only.

Closes #6827
