### PR TITLE
fix(#5101): extract tojos lifecycle from MjSafe into each mojo

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ConcurrentCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ConcurrentCache.java
@@ -20,7 +20,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * as it differs from file to file.</p>
  *
  * <p>Guards are per-instance and {@link Parsing} is built by both
- * {@link MjParse} and {@link MjSafe#assembling()}, which is enough within one
+ * {@link MjParse} and {@link MjSafe#assembling(TjsForeign)}, which is enough within one
  * module, as those mojos never overlap. Modules built in parallel still share
  * the machine-wide cache directory (#2857), which no in-process lock covers.</p>
  *

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAssemble.java
@@ -44,6 +44,8 @@ public final class MjAssemble extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        this.assembling().exec();
+        try (TjsForeign tojos = this.tojos()) {
+            this.assembling(tojos).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -35,49 +35,55 @@ public final class MjCompile extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Timed(
-            new Compiling(
-                new Timed(this.assembling()),
-                new Timed(
-                    new Linting(
-                        this.scopedTojos(),
-                        this.compileTojos(),
-                        this.targetDir.toPath(),
-                        this.cache.toPath(),
-                        this.cacheEnabled,
-                        this.plugin.getVersion(),
-                        this.skipSourceLints,
-                        this.skipProgramLints,
-                        this.skipExperimental,
-                        this.failOnWarning,
-                        this.lintAsPackage,
-                        this.skipLinting
-                    )
-                ),
-                new Timed(
-                    new Resolving(
-                        this.scopedTojos(),
-                        this.targetDir.toPath().resolve(MjResolve.DIR),
-                        new CentralMaven(this.system),
-                        this.discoverSelf,
-                        this.skipZeroVersions,
-                        this.resolveJna,
-                        this.ignoreRuntime,
-                        this.runtime(),
-                        this.ignoreConflicts
-                    )
-                ),
-                new Timed(
-                    new Placing(
-                        this.placedTojos,
-                        this.targetDir.toPath().resolve(MjResolve.DIR),
-                        this.classesDir.toPath(),
-                        this.placeBinaries,
-                        this.skipBinaries,
-                        this.rewriteBinaries
+        try (
+            TjsForeign tojos = this.tojos();
+            TjsForeign compile = this.compileTojos();
+            TjsPlaced placed = this.placed()
+        ) {
+            new Timed(
+                new Compiling(
+                    new Timed(this.assembling(tojos)),
+                    new Timed(
+                        new Linting(
+                            tojos,
+                            compile,
+                            this.targetDir.toPath(),
+                            this.cache.toPath(),
+                            this.cacheEnabled,
+                            this.plugin.getVersion(),
+                            this.skipSourceLints,
+                            this.skipProgramLints,
+                            this.skipExperimental,
+                            this.failOnWarning,
+                            this.lintAsPackage,
+                            this.skipLinting
+                        )
+                    ),
+                    new Timed(
+                        new Resolving(
+                            tojos,
+                            this.targetDir.toPath().resolve(MjResolve.DIR),
+                            new CentralMaven(this.system),
+                            this.discoverSelf,
+                            this.skipZeroVersions,
+                            this.resolveJna,
+                            this.ignoreRuntime,
+                            this.runtime(),
+                            this.ignoreConflicts
+                        )
+                    ),
+                    new Timed(
+                        new Placing(
+                            placed,
+                            this.targetDir.toPath().resolve(MjResolve.DIR),
+                            this.classesDir.toPath(),
+                            this.placeBinaries,
+                            this.skipBinaries,
+                            this.rewriteBinaries
+                        )
                     )
                 )
-            )
-        ).exec();
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -119,12 +119,14 @@ public final class MjFormat extends MjSafe {
     @Override
     void exec() throws IOException {
         final long start = System.currentTimeMillis();
-        final Collection<TjForeign> sources = this.scopedTojos().withSources();
-        this.report(
-            sources.size(),
-            new Threaded<>(sources, tojo -> this.reformat(tojo.source())).total(),
-            System.currentTimeMillis() - start
-        );
+        try (TjsForeign tojos = this.tojos()) {
+            final Collection<TjForeign> sources = tojos.withSources();
+            this.report(
+                sources.size(),
+                new Threaded<>(sources, tojo -> this.reformat(tojo.source())).total(),
+                System.currentTimeMillis() - start
+            );
+        }
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLint.java
@@ -39,19 +39,24 @@ public final class MjLint extends MjSafe {
 
     @Override
     void exec() throws IOException {
-        new Linting(
-            this.scopedTojos(),
-            this.compileTojos(),
-            this.targetDir.toPath(),
-            this.cache.toPath(),
-            this.cacheEnabled,
-            this.plugin.getVersion(),
-            this.skipSourceLints,
-            this.skipProgramLints,
-            this.skipExperimental,
-            this.failOnWarning,
-            this.lintAsPackage,
-            this.skipLinting
-        ).exec();
+        try (
+            TjsForeign tojos = this.tojos();
+            TjsForeign compile = this.compileTojos()
+        ) {
+            new Linting(
+                tojos,
+                compile,
+                this.targetDir.toPath(),
+                this.cache.toPath(),
+                this.cacheEnabled,
+                this.plugin.getVersion(),
+                this.skipSourceLints,
+                this.skipProgramLints,
+                this.skipExperimental,
+                this.failOnWarning,
+                this.lintAsPackage,
+                this.skipLinting
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
@@ -53,12 +53,14 @@ public final class MjMerge extends MjSafe {
 
     @Override
     void exec() throws IOException {
-        new Timed(
-            new Merging(
-                this.scopedTojos(),
-                this.targetDir.toPath().resolve(Merging.DIR),
-                this.mergedPackages
-            )
-        ).exec();
+        try (TjsForeign tojos = this.tojos()) {
+            new Timed(
+                new Merging(
+                    tojos,
+                    this.targetDir.toPath().resolve(Merging.DIR),
+                    this.mergedPackages
+                )
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjParse.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.maven;
 
+import java.io.IOException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.ResolutionScope;
@@ -38,12 +39,14 @@ public final class MjParse extends MjSafe {
     }
 
     @Override
-    public void exec() {
-        new Parsing(
-            this.scopedTojos(),
-            this.targetDir.toPath(),
-            this.sourcesDir.toPath(),
-            this.caching(Parsing.CACHE)
-        ).exec();
+    public void exec() throws IOException {
+        try (TjsForeign tojos = this.tojos()) {
+            new Parsing(
+                tojos,
+                this.targetDir.toPath(),
+                this.sourcesDir.toPath(),
+                this.caching(Parsing.CACHE)
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPlace.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPlace.java
@@ -34,13 +34,15 @@ public final class MjPlace extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Placing(
-            this.placedTojos,
-            this.targetDir.toPath().resolve(MjResolve.DIR),
-            this.classesDir.toPath(),
-            this.placeBinaries,
-            this.skipBinaries,
-            this.rewriteBinaries
-        ).exec();
+        try (TjsPlaced placed = this.placed()) {
+            new Placing(
+                placed,
+                this.targetDir.toPath().resolve(MjResolve.DIR),
+                this.classesDir.toPath(),
+                this.placeBinaries,
+                this.skipBinaries,
+                this.rewriteBinaries
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjProbe.java
@@ -38,6 +38,8 @@ public final class MjProbe extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Probing(this.scopedTojos(), this.objectionary(), !this.offline).exec();
+        try (TjsForeign tojos = this.tojos()) {
+            new Probing(tojos, this.objectionary(), !this.offline).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -33,16 +33,18 @@ public final class MjPull extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Pulling(
-            this.scopedTojos(),
-            this.targetDir.toPath().resolve(Pulling.DIR),
-            this.hash,
-            this.objectionary(),
-            this.cache.toPath().resolve(Pulling.CACHE),
-            this.plugin.getVersion(),
-            this.overWrite,
-            this.cacheEnabled,
-            this.offline
-        ).exec();
+        try (TjsForeign tojos = this.tojos()) {
+            new Pulling(
+                tojos,
+                this.targetDir.toPath().resolve(Pulling.DIR),
+                this.hash,
+                this.objectionary(),
+                this.cache.toPath().resolve(Pulling.CACHE),
+                this.plugin.getVersion(),
+                this.overWrite,
+                this.cacheEnabled,
+                this.offline
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -6,6 +6,7 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -81,41 +82,46 @@ public final class MjRegister extends MjSafe {
     }
 
     @Override
-    public void exec() {
+    public void exec() throws IOException {
         if (this.sourcesDir == null) {
             throw new IllegalArgumentException(
                 String.format("sourcesDir is null. Please specify a valid sourcesDir for %s", this)
             );
         }
-        this.removeOldFiles();
-        final int before = this.scopedTojos().size();
-        if (before > 0) {
-            Logger.info(this, "There are %d EO sources registered already", before);
+        try (TjsForeign tojos = this.tojos()) {
+            this.removeOldFiles();
+            final int before = tojos.size();
+            if (before > 0) {
+                Logger.info(this, "There are %d EO sources registered already", before);
+            }
+            final Unplace unplace = new Unplace(this.sourcesDir);
+            Logger.info(
+                this,
+                "Registered %d EO sources from %[file]s to %[file]s, included %s, excluded %s",
+                new Threaded<>(
+                    new Walk(this.sourcesDir.toPath())
+                        .includes(this.includeSources)
+                        .excludes(this.excludeSources),
+                    file -> this.register(file, unplace, tojos)
+                ).total(),
+                this.sourcesDir,
+                this.foreign,
+                this.includeSources,
+                this.excludeSources
+            );
         }
-        final Unplace unplace = new Unplace(this.sourcesDir);
-        Logger.info(
-            this,
-            "Registered %d EO sources from %[file]s to %[file]s, included %s, excluded %s",
-            new Threaded<>(
-                new Walk(this.sourcesDir.toPath())
-                    .includes(this.includeSources)
-                    .excludes(this.excludeSources),
-                file -> this.register(file, unplace)
-            ).total(),
-            this.sourcesDir,
-            this.foreign,
-            this.includeSources,
-            this.excludeSources
-        );
     }
 
     /**
      * Register a single EO source file.
      * @param file Source file
      * @param unplace Unplace builder for naming
+     * @param tojos The foreign catalog to register into
      * @return Always 1, to count the registered files
      */
-    private int register(final Path file, final Unplace unplace) {
+    private int register(
+        final Path file, final Unplace unplace, final TjsForeign tojos
+    ) {
         if (
             this.strictFileNames
                 && !MjRegister.PATTERN.matcher(file.getFileName().toString()).matches()
@@ -129,10 +135,10 @@ public final class MjRegister extends MjSafe {
             );
         }
         final String name = unplace.make(file);
-        if (this.scopedTojos().contains(name)) {
+        if (tojos.contains(name)) {
             Logger.debug(this, "EO source %s already registered", name);
         } else {
-            this.scopedTojos()
+            tojos
                 .add(name)
                 .withSource(file.toAbsolutePath())
                 .withHash(new ChSource(file));

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.maven;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
@@ -52,20 +53,22 @@ public final class MjResolve extends MjSafe {
     }
 
     @Override
-    public void exec() {
+    public void exec() throws IOException {
         if (this.central == null) {
             this.central = new CentralMaven(this.system);
         }
-        new Resolving(
-            this.scopedTojos(),
-            this.targetDir.toPath().resolve(MjResolve.DIR),
-            this.central,
-            this.discoverSelf,
-            this.skipZeroVersions,
-            this.resolveJna,
-            this.ignoreRuntime,
-            this.runtime(),
-            this.ignoreConflicts
-        ).exec();
+        try (TjsForeign tojos = this.tojos()) {
+            new Resolving(
+                tojos,
+                this.targetDir.toPath().resolve(MjResolve.DIR),
+                this.central,
+                this.discoverSelf,
+                this.skipZeroVersions,
+                this.resolveJna,
+                this.ignoreRuntime,
+                this.runtime(),
+                this.ignoreConflicts
+            ).exec();
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -5,7 +5,6 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
@@ -390,15 +389,6 @@ abstract class MjSafe extends AbstractMojo {
     protected Settings settings = new Settings();
 
     /**
-     * Placed tojos.
-     * @checkstyle MemberNameCheck (7 lines)
-     * @checkstyle VisibilityModifierCheck (5 lines)
-     */
-    protected final TjsPlaced placedTojos = new TjsPlaced(
-        () -> Catalogs.INSTANCE.make(this.placed.toPath(), this.placedFormat)
-    );
-
-    /**
      * The Git hash to pull objects from.
      * If not set, will be computed from {@code tag} field.
      * @checkstyle VisibilityModifierCheck (5 lines)
@@ -430,20 +420,6 @@ abstract class MjSafe extends AbstractMojo {
     );
 
     /**
-     * Cached tojos.
-     * @todo #5098:90min Extract tojos lifecycle out of MjSafe.
-     *  TjsForeign and TjsPlaced are created, scoped, and closed here,
-     *  mixing Maven plumbing with catalog state management. Move their
-     *  construction and closing into each Mojo (or a dedicated owner)
-     *  so MjSafe is not responsible for their lifecycle. Ensure that
-     *  close() is still guaranteed even when exec() throws.
-     */
-    private final TjsForeign tojos = new TjsForeign(
-        () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignFormat),
-        () -> this.scope
-    );
-
-    /**
      * Whether we should skip goal execution.
      */
     @Parameter(property = "eo.skip", defaultValue = "false")
@@ -469,39 +445,45 @@ abstract class MjSafe extends AbstractMojo {
                 );
             }
         } else {
-            try {
-                final long start = System.nanoTime();
-                new Deadline(this, this.timeout, this.unrollExitError).spent(
-                    () -> {
-                        this.exec();
-                        return new Object();
-                    }
+            final long start = System.nanoTime();
+            new Deadline(this, this.timeout, this.unrollExitError).spent(
+                () -> {
+                    this.exec();
+                    return new Object();
+                }
+            );
+            if (Logger.isDebugEnabled(this)) {
+                Logger.debug(
+                    this,
+                    "Execution of %s took %[nano]s",
+                    this.getClass().getSimpleName(),
+                    System.nanoTime() - start
                 );
-                if (Logger.isDebugEnabled(this)) {
-                    Logger.debug(
-                        this,
-                        "Execution of %s took %[nano]s",
-                        this.getClass().getSimpleName(),
-                        System.nanoTime() - start
-                    );
-                }
-            } finally {
-                if (this.foreign != null) {
-                    MjSafe.closeTojos(this.tojos);
-                }
-                if (this.placed != null) {
-                    MjSafe.closeTojos(this.placedTojos);
-                }
             }
         }
     }
 
     /**
-     * Tojos to use, in my scope only.
-     * @return Tojos to use
+     * A fresh foreign catalog in this mojo's scope, to be closed by the
+     * caller once the mojo is done with it.
+     * @return The catalog
      */
-    protected final TjsForeign scopedTojos() {
-        return this.tojos;
+    protected final TjsForeign tojos() {
+        return new TjsForeign(
+            () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignFormat),
+            () -> this.scope
+        );
+    }
+
+    /**
+     * A fresh placed catalog, to be closed by the caller once the mojo is
+     * done with it.
+     * @return The catalog
+     */
+    protected final TjsPlaced placed() {
+        return new TjsPlaced(
+            () -> Catalogs.INSTANCE.make(this.placed.toPath(), this.placedFormat)
+        );
     }
 
     /**
@@ -535,25 +517,26 @@ abstract class MjSafe extends AbstractMojo {
 
     /**
      * Build the assembling step from this mojo's configuration.
+     * @param tojos The foreign catalog to assemble through
      * @return Configured Assembling instance
      */
-    Assembling assembling() {
+    Assembling assembling(final TjsForeign tojos) {
         return new Assembling(
-            this.scopedTojos(),
+            tojos,
             new Timed(
                 new Parsing(
-                    this.scopedTojos(),
+                    tojos,
                     this.targetDir.toPath(),
                     this.sourcesDir.toPath(),
                     this.caching(Parsing.CACHE)
                 )
             ),
             new Timed(
-                new Probing(this.scopedTojos(), this.objectionary(), !this.offline)
+                new Probing(tojos, this.objectionary(), !this.offline)
             ),
             new Timed(
                 new Pulling(
-                    this.scopedTojos(),
+                    tojos,
                     this.targetDir.toPath().resolve(Pulling.DIR),
                     this.hash,
                     this.objectionary(),
@@ -576,18 +559,5 @@ abstract class MjSafe extends AbstractMojo {
      */
     GlobalCache caching(final String sub) {
         return new Caching(this.cache, this.cacheEnabled, this.plugin.getVersion()).forStep(sub);
-    }
-
-    /**
-     * Close it safely.
-     * @param res The resource
-     * @throws MojoFailureException If fails
-     */
-    private static void closeTojos(final Closeable res) throws MojoFailureException {
-        try {
-            res.close();
-        } catch (final IOException ex) {
-            throw new MojoFailureException(ex);
-        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -145,22 +145,24 @@ public final class MjTranspile extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Timed(
-            new Transpiling(
-                this.scopedTojos().standalone(),
-                this.targetDir.toPath(),
-                this.generatedDir.toPath(),
-                this.cache.toPath(),
-                this.cacheEnabled,
-                this.plugin.getVersion(),
-                this.transpileTests,
-                this.xslMeasures.toPath(),
-                new Tracking(this.trackSteps, this.trackLocations),
-                this.coverageTracking,
-                this.base(),
-                this.roots()
-            )
-        ).exec();
+        try (TjsForeign tojos = this.tojos()) {
+            new Timed(
+                new Transpiling(
+                    tojos.standalone(),
+                    this.targetDir.toPath(),
+                    this.generatedDir.toPath(),
+                    this.cache.toPath(),
+                    this.cacheEnabled,
+                    this.plugin.getVersion(),
+                    this.transpileTests,
+                    this.xslMeasures.toPath(),
+                    new Tracking(this.trackSteps, this.trackLocations),
+                    this.coverageTracking,
+                    this.base(),
+                    this.roots()
+                )
+            ).exec();
+        }
         if (this.addSourcesRoot) {
             this.project.addCompileSourceRoot(
                 this.generatedDir.toPath().toAbsolutePath().toString()

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnplace.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjUnplace.java
@@ -29,12 +29,14 @@ public final class MjUnplace extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        new Timed(
-            new Unplacing(
-                this.placedTojos,
-                this.classesDir.toPath(),
-                this.keepBinaries
-            )
-        ).exec();
+        try (TjsPlaced placed = this.placed()) {
+            new Timed(
+                new Unplacing(
+                    placed,
+                    this.classesDir.toPath(),
+                    this.keepBinaries
+                )
+            ).exec();
+        }
     }
 }


### PR DESCRIPTION
Fixes #5101 (resolves the `@todo #5098` puzzle).

## Problem

`MjSafe` created, scoped, and closed the `TjsForeign`/`TjsPlaced` catalogs as instance fields and in `execute()`'s `finally`, mixing Maven plumbing with catalog state management. Every mojo inherited a catalog it may not need, and the lifecycle was implicit.

## Solution

Move the catalog lifecycle into each mojo that actually uses a catalog:

- `MjSafe` no longer holds `tojos`/`placedTojos` fields and no longer closes anything. It exposes two factories — `tojos()` (the mojo's `eo.scope`) and `placed()` — and `assembling(TjsForeign)` now receives the catalog as a parameter instead of pulling it from a shared field.
- Each affected mojo (`MjParse`, `MjLint`, `MjMerge`, `MjProbe`, `MjPull`, `MjRegister`, `MjResolve`, `MjTranspile`, `MjFormat`, `MjCompile`, `MjAssemble`, `MjPlace`, `MjUnplace`) creates the catalogs it needs at the top of its `exec()` and closes them with `try-with-resources`, so `close()` is guaranteed even when `exec()` throws.
- `MjLint` and `MjCompile` use both `tojos()` and the existing `compileTojos()` factory; `MjCompile` also owns its placed catalog.

## Changes

15 files: `MjSafe.java` (removed fields/close logic, added factories, `assembling(TjsForeign)`), the 13 mojos above, and a javadoc link fix in `ConcurrentCache.java`. The `@todo #5098` puzzle text is removed.

## Tests

- `mvn -pl eo-maven-plugin test` — 631 of 633 pass. The 2 failures (`MjFormatTest.doesNotOverwriteDroppedBindingRecoveryWhenAutoFixIsOn`, `...failsWhenErrorRecoveredByDroppingABinding`) are **pre-existing on master** — verified by stashing this branch's changes and observing the identical 2 failures.
- `mvn -pl eo-maven-plugin -Pqulice verify -PskipTests` — clean.

@yegor256 please take a look.
