### PR TITLE
#6881: guard PhDefault's lazy attribute load against concurrent init

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -106,6 +107,13 @@ public class PhDefault implements Phi, Cloneable {
     private Map<String, Attribute> attrs;
 
     /**
+     * Guards {@link #attrs} and {@link #order} against concurrent lazy init.
+     * Not final: {@link #copy()} gives the copy its own, since a copy's
+     * lazy init is independent of the origin's.
+     */
+    private ReentrantLock lock;
+
+    /**
      * Default ctor.
      */
     public PhDefault() {
@@ -158,6 +166,7 @@ public class PhDefault implements Phi, Cloneable {
         this.data = new Snapshot(dta);
         this.initial = attributes;
         this.order = new ArrayList<>(0);
+        this.lock = new ReentrantLock();
     }
 
     @Override
@@ -174,6 +183,7 @@ public class PhDefault implements Phi, Cloneable {
     public final Phi copy() {
         try {
             final PhDefault copy = (PhDefault) this.clone();
+            copy.lock = new ReentrantLock();
             copy.attrs = new CopiedAttrs(this.loaded(), copy);
             return copy;
         } catch (final CloneNotSupportedException ex) {
@@ -322,13 +332,15 @@ public class PhDefault implements Phi, Cloneable {
      * @param name The name
      * @param attr The attr
      */
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public void add(final String name, final Attribute attr) {
-        synchronized (this.order) {
+        this.lock.lock();
+        try {
             if (PhDefault.SORTABLE.matcher(name).matches()) {
                 this.order.add(name);
             }
             this.loaded().put(name, new AtWithRho(attr, this));
+        } finally {
+            this.lock.unlock();
         }
     }
 
@@ -564,9 +576,9 @@ public class PhDefault implements Phi, Cloneable {
      * map, wrapping each entry with {@link AtWithRho}. Idempotent.
      * @return Map of attrs
      */
-    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     private Map<String, Attribute> loaded() {
-        synchronized (this.order) {
+        this.lock.lock();
+        try {
             if (this.attrs == null) {
                 this.attrs = PhDefault.defaults();
                 for (final Map.Entry<String, Attribute> ent : this.initial.entrySet()) {
@@ -574,6 +586,8 @@ public class PhDefault implements Phi, Cloneable {
                 }
             }
             return this.attrs;
+        } finally {
+            this.lock.unlock();
         }
     }
 

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -322,11 +322,14 @@ public class PhDefault implements Phi, Cloneable {
      * @param name The name
      * @param attr The attr
      */
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     public void add(final String name, final Attribute attr) {
-        if (PhDefault.SORTABLE.matcher(name).matches()) {
-            this.order.add(name);
+        synchronized (this.order) {
+            if (PhDefault.SORTABLE.matcher(name).matches()) {
+                this.order.add(name);
+            }
+            this.loaded().put(name, new AtWithRho(attr, this));
         }
-        this.loaded().put(name, new AtWithRho(attr, this));
     }
 
     @Override
@@ -561,14 +564,17 @@ public class PhDefault implements Phi, Cloneable {
      * map, wrapping each entry with {@link AtWithRho}. Idempotent.
      * @return Map of attrs
      */
+    @SuppressWarnings("PMD.AvoidSynchronizedStatement")
     private Map<String, Attribute> loaded() {
-        if (this.attrs == null) {
-            this.attrs = PhDefault.defaults();
-            for (final Map.Entry<String, Attribute> ent : this.initial.entrySet()) {
-                this.add(ent.getKey(), ent.getValue());
+        synchronized (this.order) {
+            if (this.attrs == null) {
+                this.attrs = PhDefault.defaults();
+                for (final Map.Entry<String, Attribute> ent : this.initial.entrySet()) {
+                    this.add(ent.getKey(), ent.getValue());
+                }
             }
+            return this.attrs;
         }
-        return this.attrs;
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultRaceTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import com.yegor256.Together;
+import java.util.stream.IntStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+
+/**
+ * Test case for {@link PhDefault}'s lazy attribute loading under concurrency.
+ * @since 0.75.0
+ */
+final class PhDefaultRaceTest {
+
+    @RepeatedTest(20)
+    void loadsAttributesOnceUnderConcurrentTake() {
+        final int threads = 32;
+        final Phi phi = new PhDefault(
+            new Attrs(
+                IntStream.range(0, 8)
+                    .mapToObj(idx -> new Attr(String.format("a%d", idx), new AtVoid("void")))
+                    .toArray(Attr[]::new)
+            )
+        );
+        MatcherAssert.assertThat(
+            "taking attrs of one un-warmed object from many threads at once must not corrupt it",
+            new Together<>(threads, t -> phi.take("a0")),
+            Matchers.iterableWithSize(threads)
+        );
+    }
+}


### PR DESCRIPTION
`PhDefault.loaded()` lazily initializes `this.attrs` with an unsynchronized check-then-act, and `add()` mutates the same `this.attrs` plus a plain `this.order` list with no lock, despite the class's own javadoc claiming "The class is thread-safe."

Synchronized both `loaded()` and `add()` on `this.order`, the same pattern already used to fix the same class of bug in `CopiedAttrs` (#6337, PR #6877). `add()` is called both from within `loaded()`'s own initial-population loop and directly by external callers, so both methods need to share the same lock; `synchronized` is reentrant per thread, so the recursive `add()` -> `loaded()` call from within the lock is safe.

Added `PhDefaultRaceTest` (new file, kept separate since `PhDefaultTest.java` was already near qulice's 1000-line file cap): constructs one un-warmed `PhDefault` with 8 attributes and hits it with 32 threads via `com.yegor256.Together`, repeated 20 times. Verified it fails reliably on the pre-fix code (2/20 runs, `IndexOutOfBoundsException` in `Bindings.put`/`PhDefault.add`) and passes cleanly on the fix (20/20, several runs).

Closes #5723
