### PR TITLE
#6883: force normalized to dataize once in path.eo

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -92,7 +92,7 @@
             normalized.size.eq 0
             "."
             string normalized
-      as-bytes. > normalized
+      as-bytes. > normalized!
         if.
           driveless.size.eq 0
           if.


### PR DESCRIPTION
`path.eo`'s inner `normalized` attribute (the split/fold-`..`/join pipeline) is read three times from its own formation's `@`, without `!`, so every `.normalized` call redoes the full pipeline three times. Every other similar local in this same file (`pth!`, `index!`, `len!`, `base!`) is already `!`-forced; this one was missed.

Added `!`. `EOpathTest` (58 tests, including 19 `can-normalize-*` cases) passes.

Closes #6883
