### PR TITLE
fix(#6125): group Transpiling constructor parameters into PhiSettings and Outputs

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -148,16 +148,17 @@ public final class MjTranspile extends MjSafe {
         new Timed(
             new Transpiling(
                 this.scopedTojos().standalone(),
-                this.targetDir.toPath(),
-                this.generatedDir.toPath(),
-                this.cache.toPath(),
+                new Outputs(
+                    this.targetDir.toPath(),
+                    this.generatedDir.toPath(),
+                    this.cache.toPath(),
+                    this.xslMeasures.toPath()
+                ),
                 this.cacheEnabled,
                 this.plugin.getVersion(),
                 this.transpileTests,
-                this.xslMeasures.toPath(),
                 new Tracking(this.trackSteps, this.trackLocations),
-                this.coverageTracking,
-                this.base(),
+                new PhiSettings(this.coverageTracking, this.base()),
                 this.roots()
             )
         ).exec();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Outputs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Outputs.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Path;
+
+/**
+ * The paths the transpiler writes into: where the parsed XMIR goes, where
+ * the generated Java lands, the base cache directory, and the file where
+ * XSL measurements are stored. They travel together, so they are passed
+ * as one value instead of four {@code Path} parameters.
+ * @since 0.62.0
+ */
+@SuppressWarnings("PMD.DataClass")
+final class Outputs {
+
+    /**
+     * Target directory of the build.
+     */
+    private final Path target;
+
+    /**
+     * Generated sources directory.
+     */
+    private final Path generated;
+
+    /**
+     * Base cache directory.
+     */
+    private final Path cache;
+
+    /**
+     * File where XSL measurements are stored.
+     */
+    private final Path measures;
+
+    /**
+     * Ctor.
+     * @param target Target directory of the build
+     * @param generated Generated sources directory
+     * @param cache Base cache directory
+     * @param measures File where XSL measurements are stored
+     */
+    Outputs(
+        final Path target, final Path generated, final Path cache, final Path measures
+    ) {
+        this.target = target;
+        this.generated = generated;
+        this.cache = cache;
+        this.measures = measures;
+    }
+
+    /**
+     * Target directory of the build.
+     * @return The directory
+     */
+    Path target() {
+        return this.target;
+    }
+
+    /**
+     * Generated sources directory.
+     * @return The directory
+     */
+    Path generated() {
+        return this.generated;
+    }
+
+    /**
+     * Base cache directory.
+     * @return The directory
+     */
+    Path cache() {
+        return this.cache;
+    }
+
+    /**
+     * File where XSL measurements are stored.
+     * @return The file
+     */
+    Path measures() {
+        return this.measures;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PhiSettings.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PhiSettings.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+/**
+ * The settings that change what the transpiler writes into the generated
+ * Java: whether located objects get wrapped into {@code PhCoverage}, and
+ * which class a generated class extends instead of {@code PhDefault}.
+ * Both are read only by {@code to-java.xsl} and are folded into the
+ * transpile cache key, so they travel together.
+ * @since 0.62.0
+ */
+final class PhiSettings {
+
+    /**
+     * Whether located objects are wrapped into {@code PhCoverage}.
+     */
+    private final boolean coverage;
+
+    /**
+     * The class a generated class extends instead of {@code PhDefault}.
+     */
+    private final String superclass;
+
+    /**
+     * Ctor.
+     * @param coverage Whether located objects are wrapped into {@code PhCoverage}
+     * @param superclass The class a generated class extends instead of {@code PhDefault}
+     */
+    PhiSettings(final boolean coverage, final String superclass) {
+        this.coverage = coverage;
+        this.superclass = superclass;
+    }
+
+    /**
+     * Whether located objects are wrapped into {@code PhCoverage}.
+     * @return True when they are
+     */
+    boolean coverage() {
+        return this.coverage;
+    }
+
+    /**
+     * The class a generated class extends instead of {@code PhDefault}.
+     * @return The class name
+     */
+    String superclass() {
+        return this.superclass;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -95,50 +95,32 @@ final class Transpilation {
     private final Tracking tracking;
 
     /**
-     * Whether located objects are wrapped into {@code PhCoverage}.
+     * What the transpiler writes into the generated Java.
      */
-    private final boolean coverage;
+    private final PhiSettings settings;
 
     /**
-     * The class that a generated class extends instead of {@code PhDefault},
-     * where {@code to-java.xsl} writes an {@code extends} clause of its own.
+     * Where the transpiler writes.
      */
-    private final String superclass;
-
-    /**
-     * File where XSL measurements are stored.
-     * @checkstyle MemberNameCheck (5 lines)
-     */
-    private final Path xslMeasures;
-
-    /**
-     * The target directory of the build, where tracked steps leave their XMIRs.
-     */
-    private final Path target;
+    private final Outputs outputs;
 
     /**
      * Ctor.
      * @param ver Plugin version string
      * @param diagnostics Which diagnostic artifacts to emit while transpiling
-     * @param cvrg Whether located objects are wrapped into {@code PhCoverage}
-     * @param base The class that a generated class extends instead of {@code PhDefault}
-     * @param measures Path to the file where XSL measurements are stored
-     * @param dir The target directory of the build
+     * @param settings What the transpiler writes into the generated Java
+     * @param outputs Where the transpiler writes
      */
     Transpilation(
         final String ver,
         final Tracking diagnostics,
-        final boolean cvrg,
-        final String base,
-        final Path measures,
-        final Path dir
+        final PhiSettings settings,
+        final Outputs outputs
     ) {
         this.version = ver;
         this.tracking = diagnostics;
-        this.coverage = cvrg;
-        this.superclass = base;
-        this.xslMeasures = measures;
-        this.target = dir;
+        this.settings = settings;
+        this.outputs = outputs;
     }
 
     /**
@@ -166,7 +148,7 @@ final class Transpilation {
                     Arrays.stream(Transpilation.XSLS), Arrays.stream(Transpilation.IMPORTS)
                 ).toArray(String[]::new)
             ).get(),
-            this.tracking.locations(), this.coverage, this.superclass
+            this.tracking.locations(), this.settings.coverage(), this.settings.superclass()
         );
     }
 
@@ -181,7 +163,9 @@ final class Transpilation {
         final Train<Shift> measured = this.measured(this.train());
         final Function<XML, XML> func;
         if (this.tracking.steps()) {
-            final Path dir = new Place(name).make(this.target.resolve(Transpiling.PRE), "");
+            final Path dir = new Place(name).make(
+                this.outputs.target().resolve(Transpiling.PRE), ""
+            );
             func = xml -> new Xsline(new TrSpy(measured, dir)).pass(xml);
         } else {
             func = new Xsline(measured)::pass;
@@ -195,30 +179,30 @@ final class Transpilation {
      * @return Measured train
      */
     private Train<Shift> measured(final Train<Shift> base) {
-        final Path parent = this.xslMeasures.toAbsolutePath().getParent();
+        final Path parent = this.outputs.measures().toAbsolutePath().getParent();
         if (parent.toFile().mkdirs()) {
-            Logger.debug(this, "Directory created for %[file]s", this.xslMeasures);
+            Logger.debug(this, "Directory created for %[file]s", this.outputs.measures());
         }
         if (!Files.exists(parent)) {
             throw new IllegalArgumentException(
                 String.format(
                     "For some reason, the directory %s is absent, can't write measures to %s",
                     parent,
-                    this.xslMeasures
+                    this.outputs.measures()
                 )
             );
         }
-        if (Files.isDirectory(this.xslMeasures)) {
+        if (Files.isDirectory(this.outputs.measures())) {
             throw new IllegalArgumentException(
                 String.format(
                     "This is not a file but a directory, can't write to it: %s",
-                    this.xslMeasures
+                    this.outputs.measures()
                 )
             );
         }
         return new TrLambda(
             base,
-            shift -> new StMeasured(shift, this.xslMeasures)
+            shift -> new StMeasured(shift, this.outputs.measures())
         );
     }
 
@@ -228,8 +212,8 @@ final class Transpilation {
      */
     private Train<Shift> train() {
         final boolean track = this.tracking.locations();
-        final boolean instrument = this.coverage;
-        final String base = this.superclass;
+        final boolean instrument = this.settings.coverage();
+        final String base = this.settings.superclass();
         return Transpilation.TRAINS.get().computeIfAbsent(
             String.format("%b|%b|%s", track, instrument, base),
             ignored -> Transpilation.compiled(track, instrument, base)

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -57,22 +57,9 @@ final class Transpiling implements Step {
     private final Collection<TjForeign> sources;
 
     /**
-     * Target directory.
-     * @checkstyle MemberNameCheck (5 lines)
+     * Where the transpiler writes.
      */
-    private final Path targetDir;
-
-    /**
-     * Generated sources directory.
-     * @checkstyle MemberNameCheck (5 lines)
-     */
-    private final Path generatedDir;
-
-    /**
-     * Base cache directory.
-     * @checkstyle MemberNameCheck (5 lines)
-     */
-    private final Path cacheDir;
+    private final Outputs outputs;
 
     /**
      * Whether caching is enabled.
@@ -109,51 +96,39 @@ final class Transpiling implements Step {
     /**
      * Constructor.
      * @param srcs XMIR sources to transpile
-     * @param target Target directory
-     * @param generated Generated sources directory
-     * @param cache Base cache directory
+     * @param outputs Where the transpiler writes
      * @param enabled Whether caching is enabled
      * @param ver Plugin version string
      * @param tests Whether to transpile tests
-     * @param measures Path to the file where XSL measurements are stored
      * @param diagnostics Which diagnostic artifacts to emit while transpiling
-     * @param cvrg Whether located objects are wrapped into {@code PhCoverage}
-     * @param base The class that a generated class extends instead of {@code PhDefault}
+     * @param settings What the transpiler writes into the generated Java
      * @param java Directories with the Java sources a human wrote
-     * @checkstyle ParameterNumberCheck (22 lines)
      */
-    @SuppressWarnings("PMD.ExcessiveParameterList")
     Transpiling(
         final Collection<TjForeign> srcs,
-        final Path target,
-        final Path generated,
-        final Path cache,
+        final Outputs outputs,
         final boolean enabled,
         final String ver,
         final boolean tests,
-        final Path measures,
         final Tracking diagnostics,
-        final boolean cvrg,
-        final String base,
+        final PhiSettings settings,
         final Collection<Path> java
     ) {
         this.sources = srcs;
-        this.targetDir = target;
-        this.generatedDir = generated;
-        this.cacheDir = cache;
+        this.outputs = outputs;
         this.cacheEnabled = enabled;
         this.transpileTests = tests;
         this.version = ver;
         this.roots = java;
-        this.train = new Transpilation(ver, diagnostics, cvrg, base, measures, target);
+        this.train = new Transpilation(ver, diagnostics, settings, outputs);
         this.guard = new ConcurrentCache();
     }
 
     @Override
     public void exec() throws IOException {
         final JavaFiles files = new JavaFiles(
-            this.generatedDir,
-            this.cacheDir.resolve(Transpiling.CACHE).resolve(this.version()),
+            this.outputs.generated(),
+            this.outputs.cache().resolve(Transpiling.CACHE).resolve(this.version()),
             this.cacheEnabled
         );
         final int transpiled = new Threaded<>(
@@ -164,8 +139,8 @@ final class Transpiling implements Step {
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(),
-            transpiled + new PackageInfos(this.generatedDir, this.roots).create(),
-            this.generatedDir
+            transpiled + new PackageInfos(this.outputs.generated(), this.roots).create(),
+            this.outputs.generated()
         );
     }
 
@@ -187,13 +162,13 @@ final class Transpiling implements Step {
     private int transpiled(final TjForeign tojo, final JavaFiles files) throws IOException {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
-        final Path base = this.targetDir.resolve(Transpiling.DIR);
+        final Path base = this.outputs.target().resolve(Transpiling.DIR);
         final String name = new OnDetailed(new OnDefault(new Xnav(xmir.inner())), source).get();
         final Path target = new Place(name).make(base, MjAssemble.XMIR);
         final Supplier<String> hsh = new TojoHash(tojo);
         final AtomicBoolean rewrite = new AtomicBoolean(false);
         final Function<XML, XML> transform = this.train.forSource(name);
-        final Path cdir = this.cacheDir.resolve(Transpiling.CACHE);
+        final Path cdir = this.outputs.cache().resolve(Transpiling.CACHE);
         final Path tail = base.relativize(target);
         if (this.cacheEnabled) {
             this.guard.apply(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
@@ -20,10 +20,13 @@ final class TranspilationTest {
             () -> new Transpilation(
                 "1.0-SNAPSHOT",
                 new Tracking(false, false),
-                false,
-                "PhDefault",
-                Paths.get("xsl-measures.csv"),
-                Paths.get("target")
+                new PhiSettings(false, "PhDefault"),
+                new Outputs(
+                    Paths.get("target"),
+                    Paths.get("target/generated"),
+                    Paths.get("target/cache"),
+                    Paths.get("xsl-measures.csv")
+                )
             ).forSource("foo"),
             "forSource() must not throw when eo.xslMeasuresFile is a bare relative path with no parent directory"
         );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
@@ -38,16 +38,17 @@ final class TranspilingTest {
     private static Transpiling transpiling() {
         return new Transpiling(
             Collections.emptyList(),
-            Paths.get("target"),
-            Paths.get("target/generated"),
-            Paths.get("target/cache"),
+            new Outputs(
+                Paths.get("target"),
+                Paths.get("target/generated"),
+                Paths.get("target/cache"),
+                Paths.get("target/xsl-measures.csv")
+            ),
             true,
             "1.0-SNAPSHOT",
             false,
-            Paths.get("target/xsl-measures.csv"),
             new Tracking(false, false),
-            false,
-            "PhDefault",
+            new PhiSettings(false, "PhDefault"),
             Collections.singleton(Paths.get("src/main/java"))
         );
     }


### PR DESCRIPTION
Fixes #6125.

## Problem

`Transpiling` took 12 positional parameters, several of the same type (4 `Path`, 3 `boolean`, 2 `String`), so two slots could be swapped at the call site with no compiler or lint catching it. The class carried `@checkstyle ParameterNumberCheck` and `@SuppressWarnings("PMD.ExcessiveParameterList")` to stay green.

## Solution

Group the related parameters behind named types, as the issue suggests:

- **`PhiSettings`** — bundles the two values that describe what the transpiler writes into the generated Java: whether located objects are wrapped into `PhCoverage` and which class a generated class extends. Both were already folded together into the transpile cache key, so they travel as one value through `Transpiling` and `Transpilation`.
- **`Outputs`** — bundles the four paths the transpiler writes into: target, generated sources, base cache, and the XSL measures file. `Transpiling` stores it as a field (no constructor method calls), and `Transpilation` receives it too.

The constructor goes from 12 parameters to 8, and both `ParameterNumberCheck`/`ExcessiveParameterList` suppressions are removed.

## Changes

- `eo-maven-plugin/.../PhiSettings.java` — new value object (coverage + superclass).
- `eo-maven-plugin/.../Outputs.java` — new value object (target, generated, cache, measures).
- `eo-maven-plugin/.../Transpiling.java` — constructor takes `Outputs` + `PhiSettings`; stores `Outputs` as a field.
- `eo-maven-plugin/.../Transpilation.java` — takes `PhiSettings` + `Outputs`; suppressions removed.
- `eo-maven-plugin/.../MjTranspile.java` — builds the two value objects at the call site.
- Tests updated.

## Tests

- `mvn -pl eo-maven-plugin test` — 631 of 633 pass (the 2 `MjFormatTest` failures are pre-existing on master, verified separately).
- `mvn -pl eo-maven-plugin -Pqulice verify -PskipTests` — clean.

@yegor256 please take a look.
