### PR TITLE
Say when a dispatch cannot be answered

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -42,6 +42,12 @@ import java.util.Map;
  * argument lands in means knowing which formation is being copied, and that is
  * what the pairs have just settled.</p>
  *
+ * <p>So is the admission that a dispatch could not be worked out, for the same
+ * reason in reverse: only here, when the passes have stopped adding pairs, is
+ * it known that no pass will answer it. A row saying nothing is known is worth
+ * writing, since an absent row says that and also says "nobody looked", and a
+ * reader has no way of telling which.</p>
+ *
  * @since 0.68.0
  */
 public final class Resolved implements Clue {
@@ -81,6 +87,9 @@ public final class Resolved implements Clue {
             pairs, new Bound(args, names, new Provided(given, names, voids)).all()
         ).all();
         rows.putAll(written.others());
+        for (final XML dispatch : dispatches) {
+            rows.putIfAbsent(dispatch.xpath("@loc").get(0), new Unknown());
+        }
         Files.write(
             links,
             new Types(rows).asXml().toString().getBytes(StandardCharsets.UTF_8)

--- a/eo-inference/src/main/java/org/eolang/inference/Unknown.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Unknown.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * An object we looked at and could say nothing about.
+ *
+ * <p>Not the same as an object nobody looked at, which is what an absent row
+ * used to mean as well. A reader that cannot tell the two apart has to guess
+ * whether the tables gave up or never tried, and a checker that guesses is
+ * worse than one that stays undecided.</p>
+ *
+ * @since 0.69.0
+ */
+final class Unknown implements Type {
+
+    @Override
+    public Directives directives() {
+        return new Directives().add("unknown").up();
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-that-comes-back-with-a-variable-stays-quiet.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-that-comes-back-with-a-variable-stays-quiet.yaml
@@ -2,8 +2,9 @@
 # SPDX-License-Identifier: MIT
 ---
 # `A` names no object. It stands for whatever the caller puts in, and which
-# object that is cannot be read off the text of `keep` alone. So nothing is
-# written down and `keep.plus` waits for the day variables are understood.
+# object that is cannot be read off the text of `keep` alone. So the atom says
+# nothing about what it comes back with, and the row for `keep.plus` says that
+# nothing is known, which is not the same as saying nothing.
 eo:
   app.eo: |
     [] > app
@@ -14,4 +15,4 @@ eo:
 provides:
   - "/provides/type[@id='Φ.keep'][not(@returns)]"
 links:
-  - "/links[not(type[@id='Φ.app.φ'])]"
+  - "/links/type[@id='Φ.app.φ']/unknown"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
@@ -3,7 +3,8 @@
 ---
 # `one` hands its answers to `two` and `two` hands them back, so looking for a
 # name behind the delegation walks in a circle. It is walked once and answers
-# nothing, which leaves the dispatch unnamed rather than the pass unfinished.
+# nothing, which leaves the dispatch owned up to rather than the pass
+# unfinished.
 eo:
   app.eo: |
     [] > app
@@ -15,4 +16,4 @@ eo:
     [] > two
       one > @
 links:
-  - "/links[not(type[@id='Φ.app.φ'])]"
+  - "/links/type[@id='Φ.app.φ']/unknown"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-nobody-can-answer-says-so.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-nobody-can-answer-says-so.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Nothing describes what `nowhere` is, so nothing can say what taking `foo`
+# from it gives. That is worth writing down: an absent row would say the same
+# thing as a row nobody ever tried to write.
+eo:
+  jarref.eo: |
+    [] > jarref
+      nowhere.foo > @
+links:
+  - "/links/type[@id='Φ.jarref.φ']/unknown"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-that-is-answered-says-what-it-is.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/dispatch-that-is-answered-says-what-it-is.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An answer, once there is one, is not thrown away for an admission that there
+# is none: a dispatch that resolves keeps the reference it resolved to.
+eo:
+  app.eo: |
+    [] > app
+      t.next > @
+  t.eo: |
+    [] > t
+      [] > next
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.t.next']"
+  - "/links/type[@id='Φ.app.φ'][not(unknown)]"


### PR DESCRIPTION
`needs.xml` records all 10,414 dispatches of `eo-runtime`. `links.xml` answered 10,078 of them and said nothing whatsoever about the other 336, because a dispatch falls between the two rules that write rows: `Links` writes for a base that names another object, and a dispatch base names none; `Dispatched` writes when it can work the dispatch out, and for these it could not.

```xml
<type id="Φ.clock.φ">
  <unknown/>
</type>
```

An absent row said that, and also said "nobody looked" — which is what the 2,521 formations and 1,079 voids are silent for, since they are known and known elsewhere. A reader had no way of telling the two apart. Now silence in `links.xml` means one of those three kinds, and nothing else.

`Resolved` writes it, because a dispatch is only known to be unanswerable once the passes have stopped adding pairs:

```java
for (final XML dispatch : dispatches) {
    rows.putIfAbsent(dispatch.xpath("@loc").get(0), new Unknown());
}
```

`putIfAbsent` is the whole of the care needed: an answer, where there is one, is kept. A row saying an object is a copy of something nothing describes is also kept — "a copy of `X`" stays true whatever is known about `X`, and replacing it with an admission would throw a fact away.

Two existing packs described the old silence and now describe the admission — `atom-that-comes-back-with-a-variable-stays-quiet` and `delegation-that-comes-back-is-walked-once`, both of which asserted that the dispatch got no row. Two new packs cover the change itself and the case it must not touch.

On `eo-runtime`: 336 rows, 39,120 to 39,456, and **every number on the ladder identical** — 514 on the bottom rung before and after, depth 65.7% before and after. These objects were already counted as unknown; what changes is that the table now says so. Two runs of the goal produce the same file.

What is left silent is three kinds of object that are all known: a formation, a void, and the `λ` of an atom. Each is worth a row of its own and none of them is this ticket.
