### PR TITLE
Say that a void is a variable

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -45,11 +45,11 @@ import java.util.Map;
  *
  * <p>Which is why a row carries what an object is as an element of its own
  * rather than as a cell, and what {@link Types} makes of it. Being a copy is
- * one of the things an object turns out to be, and two more arrive here as
- * well, both of them copies of nothing: a datum, the bytes of a literal being
- * the ground the program stands on, and a termination, which comes back with
- * no value at all. Those are the rows this clue writes without a reference to
- * look at.</p>
+ * one of the things an object turns out to be, and three more arrive here as
+ * well, none of them a copy of anything: a datum, the bytes of a literal being
+ * the ground the program stands on; a termination, which comes back with no
+ * value at all; and a void, which comes back with whatever a caller puts in
+ * it. Those are the rows this clue writes without a reference to look at.</p>
  *
  * <p>A name that resolves to nothing gets no row and no complaint: a
  * missing row makes a later check stay undecided, while a wrong row would
@@ -84,6 +84,9 @@ final class Links implements Clue {
         }
         for (final XML dead : world.bottoms()) {
             found.put(dead.xpath("@loc").get(0), new Bottom());
+        }
+        for (final XML hollow : world.voids()) {
+            found.put(hollow.xpath("@loc").get(0), new Var());
         }
         Files.createDirectories(tables);
         Files.write(

--- a/eo-inference/src/main/java/org/eolang/inference/Var.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Var.java
@@ -1,0 +1,30 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * An object whose type only a caller can say.
+ *
+ * <p>A void is the one thing in a program that is deliberately left open, and
+ * what it holds is decided by whoever fills it. So the row says that and
+ * nothing more, and says it under the locator of the void, which is the name
+ * every mention of that variable is written with: {@code Φ.inc.x.next} is the
+ * {@code next} of whatever fills {@code x}, true of every caller and concrete
+ * for none.</p>
+ *
+ * <p>Nothing is carried here, not even the name, since the row is keyed by the
+ * locator and the locator is the name.</p>
+ *
+ * @since 0.69.0
+ */
+final class Var implements Type {
+
+    @Override
+    public Directives directives() {
+        return new Directives().add("var").up();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -90,6 +90,20 @@ final class Xmirs {
     }
 
     /**
+     * Every void of the program.
+     *
+     * <p>An object with nothing behind it, written as a base of its own in
+     * the text. It names no other object, since what it holds is not decided
+     * here but by whoever fills it.</p>
+     *
+     * @return The voids, file by file, in the order they appear in the code
+     * @throws IOException If a file cannot be read
+     */
+    Collection<XML> voids() throws IOException {
+        return this.matching("//o[@loc and @base='∅']");
+    }
+
+    /**
      * The object every file of the program is about.
      *
      * <p>A file carries one object at the top and the package it declares

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-that-lands-on-a-void-stays-in-the-table.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/chain-that-lands-on-a-void-stays-in-the-table.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The phi of `inc` is a copy of its `x`, and following that reference used to
+# arrive at a locator no row was keyed by. Both ends of the step are in the
+# table now, so a reader never has to leave it to find out where a chain
+# stopped.
+eo:
+  inc.eo: |
+    [x] > inc
+      x > @
+links:
+  - "/links/type[@id='Φ.inc.φ']/ref[@loc='Φ.inc.x']"
+  - "/links/type[@id='Φ.inc.x']/var"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-is-a-variable.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-is-a-variable.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What a void holds is decided by whoever fills it, and until then it is a
+# variable. The row says that and nothing more: the locator it is keyed by is
+# already the name every mention of the variable is written with.
+eo:
+  inc.eo: |
+    [x] > inc
+      x > @
+links:
+  - "/links/type[@id='Φ.inc.x']/var"
+  - "/links/type[@id='Φ.inc.x'][not(ref)]"


### PR DESCRIPTION
A chain of copies could be followed inside `links.xml` until it landed on a void, and there it fell off the table. `Φ.inc.φ` is a copy of `Φ.inc.x`, that row exists, and nothing was keyed by `Φ.inc.x` — so a reader who had been working entirely inside this document had to open `provides.xml` to learn whether the chain had arrived at a variable, at something nothing describes, or at nothing at all.

```xml
<type id="Φ.inc.x">
  <var/>
</type>
```

1,079 of them in `eo-runtime`, and not a corner case: the core objects *are* voids — `[as-bytes] > number` — which is why 8,070 objects, 18.7% of the world, are names rooted at one. Following a chain into that country is the common case, not the exception.

No `id` attribute, though `eo-inference-spec.md` §8.3 writes `<var id="…"/>`. The row is keyed by the locator, the locator is the name every mention of the variable is written with, and an attribute repeating its own row's key is noise. The spec line is the thing to change.

`Links` writes it, beside the datum and the termination: a void names no other object, so nothing looks for what it is a copy of, and `<o base="∅"/>` is visible in the text without anything being worked out first.

On `eo-runtime`: 1,079 rows, 39,120 to 40,199, and **every number on the ladder identical** — 8,070 names rooted at a void before and after, depth 65.7% both times. A void was already credited through `provides`; what changes is that the links table stops sending its reader elsewhere. Two runs of the goal produce the same file.

That leaves two silences, both of them objects that are known: a formation, whose type is itself, and the `λ` of an atom, which carries the forma it comes back with.
