### PR TITLE
#5757: derive instrumented coverage locations structurally

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.TrClasspath;
+import com.yegor256.xsline.Train;
+import com.yegor256.xsline.Xsline;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+/**
+ * The locations a transpiled XMIR would have {@code PhCoverage} wrapped
+ * around, derived the same way {@code to-java.xsl} itself decides it,
+ * but without deriving it from generated Java text.
+ *
+ * <p>{@code to-java.xsl} (the last shift of {@link Transpilation#XSLS})
+ * wraps a location into {@code PhCoverage} when it carries {@code @line}
+ * and {@code @pos} and its {@code @loc} has no {@code +} in it. Those
+ * attributes are already present by the time every shift except the last
+ * one has run, so running that same prefix here and reading the result
+ * gets the exact same set {@code to-java.xsl} would act on, structurally,
+ * rather than by pattern-matching the Java it emits.</p>
+ *
+ * @since 0.75.0
+ * @todo #5757:30min Wire this into a Maven goal that reads the raw
+ *  {@code loc:line:pos} hits file {@code PhCoverage} appends to at
+ *  runtime, matches it against {@link #locations(XML)} for every
+ *  transpiled source, and renders an LCOV tracefile. Split out of this
+ *  PR solely to respect the 200-line pull request size cap; the wiring
+ *  is a separate, immediately-following PR against the same issue.
+ */
+final class CoverageManifest {
+
+    /**
+     * Every shift of the transpile train except {@code to-java.xsl}.
+     */
+    private final Train<Shift> train = new TrClasspath<Shift>(
+        Arrays.copyOf(Transpilation.XSLS, Transpilation.XSLS.length - 1)
+    ).back();
+
+    /**
+     * The locations a transpile of this XMIR would instrument, each as
+     * {@code loc:line:pos}, the same string {@code PhCoverage} records a
+     * hit under.
+     * @param xmir The XMIR a source was parsed and optimized into
+     * @return The locations, in document order
+     */
+    Collection<String> locations(final XML xmir) {
+        final XML passed = new Xsline(this.train).pass(xmir);
+        final Collection<String> found = new LinkedHashSet<>();
+        for (final XML located : passed.nodes(
+            "//*[@line and @pos and not(contains(@loc,'+'))]"
+        )) {
+            found.add(
+                String.format(
+                    "%s:%s:%s",
+                    located.xpath("./@loc").get(0),
+                    located.xpath("./@line").get(0),
+                    located.xpath("./@pos").get(0)
+                )
+            );
+        }
+        return found;
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.Collection;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CoverageManifest}.
+ * @since 0.75.0
+ */
+final class CoverageManifestTest {
+
+    @Test
+    void findsLocationsOfASimpleObject() throws Exception {
+        MatcherAssert.assertThat(
+            "a formation with a body must have at least one instrumented location, but none were found",
+            this.simpleObject(),
+            Matchers.not(Matchers.empty())
+        );
+    }
+
+    @Test
+    void findsLocationsShapedAsLocLinePos() throws Exception {
+        MatcherAssert.assertThat(
+            "every found location must look like loc:line:pos, but at least one didnt",
+            this.simpleObject(),
+            Matchers.everyItem(Matchers.matchesPattern("^[^:]+:\\d+:\\d+$"))
+        );
+    }
+
+    @Test
+    void findsExactlyOneLocationInAnEmptyFormation() throws Exception {
+        MatcherAssert.assertThat(
+            "an empty formation with no body still has itself to instrument, but the count was off",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(System.lineSeparator(), "[] > foo", "")
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    /**
+     * Locations found in a small formation with one attribute.
+     * @return The locations
+     * @throws Exception If parsing or deriving them fails
+     */
+    private Collection<String> simpleObject() throws Exception {
+        return new CoverageManifest().locations(
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > foo",
+                    "  42 > x",
+                    ""
+                )
+            ).parsed()
+        );
+    }
+}


### PR DESCRIPTION
Part of #5757 (turn raw coverage hits into an LCOV report). Split into three PRs to stay under the 200-line pull request size cap: this one derives which locations get instrumented, a second renders the LCOV format, a third wires both into a Maven goal that actually reads the raw hits file. All three are being opened against the same issue.

`to-java.xsl` decides whether a location gets wrapped in `PhCoverage` by checking `@line`/`@pos`/`@loc` on the XMIR right before it runs (the last shift of the transpile train). Those attributes are already set by every earlier shift, so `CoverageManifest` runs that same prefix (every shift except `to-java.xsl`) and reads the result with the identical XPath condition `to-java.xsl` itself uses, instead of pattern-matching the generated Java text (the class doc for the LCOV-derivation lesson learned on #5671/#5694 applies here too).

A `@todo` puzzle marks the still-missing wiring, referencing this same issue.
