### PR TITLE
Merge the bytes package

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -314,6 +314,7 @@
               gets a receiver, and with '^' but no merge it has no rho to read.
               -->
               <mergedPackages>
+                <mergedPackage>bytes</mergedPackage>
                 <mergedPackage>chunk</mergedPackage>
                 <mergedPackage>directory</mergedPackage>
                 <mergedPackage>file</mergedPackage>

--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -9,7 +9,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > array
+[] > array
+  ^ > b
   size. >> len!
     b >> data!
   if. > [tup index] >> slice-byte

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -7,8 +7,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-bool
-  b.eq 01- > @
+[] > as-bool
+  ^.eq 01- > @
 
   not. ++> can-convert-bytes-to-a-bool
     01-.as-bool.eq 00-.as-bool

--- a/eo-runtime/src/main/eo/bytes/as-bytes.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bytes.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-bytes
-  b > @
+[] > as-bytes
+  ^ > @
 
   20-1F-EE.as-bytes.eq 20-1F-EE ++> can-return-itself

--- a/eo-runtime/src/main/eo/bytes/as-hex.eo
+++ b/eo-runtime/src/main/eo/bytes/as-hex.eo
@@ -8,7 +8,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-hex
+[] > as-hex
+  ^ > b
   if. > [h] >> hex-digit
     h.lt 10
     as-char.

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i16
+[cant-convert] > as-i16
   if. > @
     b.size.eq 2
     i16 b
     cant-convert
       "Can't convert non 2 length bytes to i16, bytes are %x".printf
         * b
+  ^ > b
 
   00-33.as-i16.as-bytes.eq 00-33 ++> can-convert-bytes-to-i16-and-back
 

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i32
+[cant-convert] > as-i32
   if. > @
     b.size.eq 4
     i32 b
     cant-convert
       "Can't convert non 4 length bytes to i32, bytes are %x".printf
         * b
+  ^ > b
 
   00-00-00-33.as-i32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-i32-and-back
 

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i64
+[cant-convert] > as-i64
   if. > @
     b.size.eq 8
     i64 b
     cant-convert
       "Can't convert non 8 length bytes to i64, bytes are %x".printf
         * b
+  ^ > b
 
   00-00-00-00-00-00-00-2A.as-i64.eq 42.as-i64 ++> can-convert-bytes-to-i64
 

--- a/eo-runtime/src/main/eo/bytes/as-i8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i8.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-i8
+[cant-convert] > as-i8
   if. > @
     b.size.eq 1
     i8 b
     cant-convert
       "Can't convert non 1 length bytes to i8, bytes are %x".printf
         * b
+  ^ > b
 
   2A-.as-i8.as-bytes.eq 2A- ++> can-convert-bytes-to-i8-and-back
 

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -28,7 +28,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b] > as-input
+[] > as-input
+  ^ > b
   [size] > read
     @. > @
       read.

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-number
+[cant-convert] > as-number
   if. > @
     b.size.eq 8
     if.
@@ -26,6 +26,7 @@
     cant-convert
       "Can't convert non 8 length bytes to a number, bytes are %x".printf
         * b
+  ^ > b
 
   eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-a-number
     "recovered"

--- a/eo-runtime/src/main/eo/bytes/as-u16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u16.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u16
+[cant-convert] > as-u16
   if. > @
     b.size.eq 2
     u16 b
     cant-convert
       "Can't convert non 2 length bytes to u16, bytes are %x".printf
         * b
+  ^ > b
 
   00-33.as-u16.as-bytes.eq 00-33 ++> can-convert-bytes-to-u16-and-back
 

--- a/eo-runtime/src/main/eo/bytes/as-u32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u32.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u32
+[cant-convert] > as-u32
   if. > @
     b.size.eq 4
     u32 b
     cant-convert
       "Can't convert non 4 length bytes to u32, bytes are %x".printf
         * b
+  ^ > b
 
   00-00-00-33.as-u32.as-bytes.eq 00-00-00-33 ++> can-convert-bytes-to-u32-and-back
 

--- a/eo-runtime/src/main/eo/bytes/as-u64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u64.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u64
+[cant-convert] > as-u64
   if. > @
     b.size.eq 8
     u64 b
     cant-convert
       "Can't convert non 8 length bytes to u64, bytes are %x".printf
         * b
+  ^ > b
 
   eq. ++> can-convert-bytes-to-u64-and-back
     00-00-00-00-00-00-00-33.as-u64.as-bytes

--- a/eo-runtime/src/main/eo/bytes/as-u8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u8.eo
@@ -9,13 +9,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b cant-convert] > as-u8
+[cant-convert] > as-u8
   if. > @
     b.size.eq 1
     u8 b
     cant-convert
       "Can't convert non 1 length bytes to u8, bytes are %x".printf
         * b
+  ^ > b
 
   2A-.as-u8.as-bytes.eq 2A- ++> can-convert-bytes-to-u8-and-back
 

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -11,8 +11,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[input] > hash
-  input.as-bytes >> b!
+[] > hash
+  ^.as-bytes >> b!
   [acc index] >> rec-hash-code
     if. > @
       index.eq b.size!
@@ -30,87 +30,63 @@
     0
 
   and. ++> can-hash-a-bool-into-a-number
-    eq.
-      size.
-        as-bytes.
-          hash true
-      8
-    eq.
-      size.
-        as-bytes.
-          hash false
-      8
+    true.hash.as-bytes.size.eq 8
+    false.hash.as-bytes.size.eq 8
 
   ++> can-hash-an-integer-into-an-integer
     1.eq > @
       div.
         number
-          hash 42 >> inthash!
+          42.hash >> inthash!
         number inthash
 
   ++> can-hash-equal-numbers-alike
-    eq. > @
-      hash num
-      hash num
+    num.hash.eq num.hash > @
     123456789012345680 > num
 
-  eq. ++> can-hash-equal-integers-alike
-    hash 42
-    hash 42
+  42.hash.eq 42.hash ++> can-hash-equal-integers-alike
 
   not. ++> can-hash-different-integers-apart
-    eq.
-      hash 42
-      hash 24
+    42.hash.eq 24.hash
 
   not. ++> can-hash-integers-of-different-signs-apart
-    eq.
-      hash 42
-      hash -42
+    42.hash.eq -42.hash
 
   ++> can-hash-a-string-into-an-integer
     1.eq > @
       div.
         number
-          hash "hello" >> strhash!
+          "hello".hash >> strhash!
         number strhash
 
-  eq. ++> can-hash-equal-strings-alike
-    hash "Hello"
-    hash "Hello"
+  "Hello".hash.eq "Hello".hash ++> can-hash-equal-strings-alike
 
   not. ++> can-hash-strings-of-the-same-length-apart
-    eq.
-      hash "one"
-      hash "two"
+    "one".hash.eq "two".hash
 
   not. ++> can-hash-different-strings-apart
-    eq.
-      hash "hello"
-      hash "bye!!!"
+    "hello".hash.eq "bye!!!".hash
 
   ++> can-hash-an-abstract-object-into-an-integer
     1.eq > @
       div.
         number
-          hash >> objhash!
+          hash. >> objhash!
             obj 42
         number objhash
     I > obj
 
   ++> can-hash-equal-abstract-objects-alike
-    eq. > @
-      hash value
-      hash value
+    value.hash.eq value.hash > @
     I > obj
     obj 42 > value
 
   ++> can-hash-different-abstract-objects-apart
     not. > @
       eq.
-        hash
+        hash.
           obj 42
-        hash
+        hash.
           obj "42"
     I > obj
 
@@ -118,27 +94,20 @@
     1.eq > @
       div.
         number
-          hash 42.42 >> flthash!
+          42.42.hash >> flthash!
         number flthash
 
   ++> can-hash-equal-floats-alike
-    eq. > @
-      hash emergency
-      hash emergency
+    emergency.hash.eq emergency.hash > @
     0.911 > emergency
 
   ++> can-hash-equal-big-values-alike
-    eq. > @
-      hash
+    bigval.hash.eq > @
+      hash.
         4.242e43 >> bigval!
-      hash bigval
 
   not. ++> can-hash-different-floats-apart
-    eq.
-      hash 3.14
-      hash 2.72
+    3.14.hash.eq 2.72.hash
 
   not. ++> can-hash-floats-of-different-signs-apart
-    eq.
-      hash 3.22
-      hash -3.22
+    3.22.hash.eq -3.22.hash

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -8,8 +8,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b x] > left
-  b.right x.neg > @
+[x] > left
+  ^.right x.neg > @
 
   eq. ++> can-shift-left-an-even-negative
     FF-FF-FF-FF-FF-FF-FF-EE.left 2

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -8,10 +8,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[b x] > xor
+[x] > xor
   or. > @
     b.and x.not
     b.not.and x
+  ^ > b
 
   eq. ++> can-xor-negative-bytes-with-leading-zeroes
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -9,7 +9,6 @@
 # hash code is derived from those bytes rather than from the key itself,
 # so that keys with side effects are never evaluated more than once.
 
-+alias bytes.hash
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
 +version 0.0.0
@@ -32,7 +31,7 @@
                 ^.kbts > kbts
                 tup.head.key > key
                 tup.head.value > value
-          bytes.hash >> hash!
+          hash. >> hash!
             tup.head.key.as-bytes >> kbts!
           prev.filtered > others
             not. > [ent] >>
@@ -64,7 +63,7 @@
           @. > prev
             rec-key-search tup.tail
         | entries
-      bytes.hash >> hash!
+      hash. >> hash!
         key.as-bytes >> kbts!
       [] > not-found
         false > exists
@@ -91,7 +90,7 @@
             ^.kbts > kbts
             ^.key > key
             ^.value > value
-      bytes.hash >> hash!
+      hash. >> hash!
         key.as-bytes >> kbts!
     [key] > without
       map.ctor > @
@@ -100,7 +99,7 @@
             and.
               hash.eq entry.hash
               kbts.eq entry.kbts
-      bytes.hash >> hash!
+      hash. >> hash!
         key.as-bytes >> kbts!
   [key value] > entry
 


### PR DESCRIPTION
Continues #6657 with `bytes`, the second-to-last package: its 17 members read
their receiver through `^` and `bytes` joins `<mergedPackages>`.

This one was held back in `9e63abca22` because merging it exhausted a 7.6GB
heap in the fifth README snippet — #6781. That is gone. With the same snippet,
the same sandbox and the default heap, the merged build now finishes in 60s,
so the work is simply the revert of the hold-back plus the call sites master
grew in the meantime. #6851 is the likely reason: it made a copy cost what it
reads rather than what it holds, and `bytes` is allocated on every arithmetic
operation, so it gained the most from that.

Two kinds of call site had to move. `map.eo` reached the hash through the
package four times and carried an `+alias bytes.hash` for it:

```
      hash. >> hash!
        key.as-bytes >> kbts!
```

And the 28 tests in `bytes/hash.eo` applied the member standalone
(`hash 42`), the shape #6682 converted everywhere else and left here because
`bytes/hash` was still waiting on #6655. They now dispatch: `42.hash`.

The detector over `target/eo/1-parse` comes back clean — across all eleven
merged packages nothing under `Φ.<package>.<member>` survives except
`number.integral`, `input.dead`, `output.dead` and the void-less `tuple.empty`.
Locally 687 tests pass across `EObytesTest`, `EOmapTest`, `EOnumberTest`,
`EOstringTest` and `PhDefaultTest`, run with `-Deo.deadline=30` so that a slow
one fails instead of being skipped.

`string` is the last package left, and then #6658 and #6659.
