### PR TITLE
#5757: turn raw coverage hits into an LCOV report

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -30,6 +30,6 @@ jobs:
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./eo-parser/target/site/jacoco/jacoco.xml,./eo-runtime/target/site/jacoco/jacoco.xml,./eo-maven-plugin/target/site/jacoco/jacoco.xml
+          files: ./eo-parser/target/site/jacoco/jacoco.xml,./eo-runtime/target/site/jacoco/jacoco.xml,./eo-maven-plugin/target/site/jacoco/jacoco.xml,./eo-runtime/target/coverage.info
           fail_ci_if_error: true
         if: github.ref == 'refs/heads/master'

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -27,12 +27,6 @@ import java.util.LinkedHashSet;
  * rather than by pattern-matching the Java it emits.</p>
  *
  * @since 0.75.0
- * @todo #5757:30min Wire this into a Maven goal that reads the raw
- *  {@code loc:line:pos} hits file {@code PhCoverage} appends to at
- *  runtime, matches it against {@link #locations(XML)} for every
- *  transpiled source, and renders an LCOV tracefile. Split out of this
- *  PR solely to respect the 200-line pull request size cap; the wiring
- *  is a separate, immediately-following PR against the same issue.
  */
 final class CoverageManifest {
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XML;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.TrClasspath;
+import com.yegor256.xsline.Train;
+import com.yegor256.xsline.Xsline;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+/**
+ * The locations a transpiled XMIR would have {@code PhCoverage} wrapped
+ * around, derived the same way {@code to-java.xsl} itself decides it,
+ * but without deriving it from generated Java text.
+ *
+ * <p>{@code to-java.xsl} (the last shift of {@link Transpilation#XSLS})
+ * wraps a location into {@code PhCoverage} when it carries {@code @line}
+ * and {@code @pos} and its {@code @loc} has no {@code +} in it. Those
+ * attributes are already present by the time every shift except the last
+ * one has run, so running that same prefix here and reading the result
+ * gets the exact same set {@code to-java.xsl} would act on, structurally,
+ * rather than by pattern-matching the Java it emits.</p>
+ *
+ * @since 0.75.0
+ * @todo #5757:30min Wire this into a Maven goal that reads the raw
+ *  {@code loc:line:pos} hits file {@code PhCoverage} appends to at
+ *  runtime, matches it against {@link #locations(XML)} for every
+ *  transpiled source, and renders an LCOV tracefile. Split out of this
+ *  PR solely to respect the 200-line pull request size cap; the wiring
+ *  is a separate, immediately-following PR against the same issue.
+ */
+final class CoverageManifest {
+
+    /**
+     * Every shift of the transpile train except {@code to-java.xsl}.
+     */
+    private final Train<Shift> train = new TrClasspath<Shift>(
+        Arrays.copyOf(Transpilation.XSLS, Transpilation.XSLS.length - 1)
+    ).back();
+
+    /**
+     * The locations a transpile of this XMIR would instrument, each as
+     * {@code loc:line:pos}, the same string {@code PhCoverage} records a
+     * hit under.
+     * @param xmir The XMIR a source was parsed and optimized into
+     * @return The locations, in document order
+     */
+    Collection<String> locations(final XML xmir) {
+        final XML passed = new Xsline(this.train).pass(xmir);
+        final Collection<String> found = new LinkedHashSet<>();
+        for (final XML located : passed.nodes(
+            "//*[@line and @pos and not(contains(@loc,'+'))]"
+        )) {
+            found.add(
+                String.format(
+                    "%s:%s:%s",
+                    located.xpath("./@loc").get(0),
+                    located.xpath("./@line").get(0),
+                    located.xpath("./@pos").get(0)
+                )
+            );
+        }
+        return found;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/LcovReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/LcovReport.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+/**
+ * A coverage report rendered in the LCOV tracefile format, one
+ * {@code SF}/{@code DA}/{@code LH}/{@code LF} block per source file.
+ *
+ * <p>LCOV is chosen because Codecov and Coveralls both consume it
+ * directly. Format reference:
+ * https://github.com/linux-test-project/lcov/blob/master/man/geninfo.1</p>
+ *
+ * @since 0.75.0
+ */
+final class LcovReport {
+
+    /**
+     * Per source file, per line number, how many times it was hit.
+     */
+    private final Map<String, Map<Integer, Integer>> files;
+
+    /**
+     * Ctor.
+     * @param hits Per source file, per line number, how many times it was hit
+     */
+    LcovReport(final Map<String, Map<Integer, Integer>> hits) {
+        this.files = hits;
+    }
+
+    /**
+     * Render the whole tracefile.
+     * @return The LCOV text
+     */
+    String text() {
+        final StringBuilder out = new StringBuilder(32);
+        final SortedMap<String, Map<Integer, Integer>> byfile = new TreeMap<>(this.files);
+        for (final Map.Entry<String, Map<Integer, Integer>> file : byfile.entrySet()) {
+            final SortedMap<Integer, Integer> byline = new TreeMap<>(file.getValue());
+            final List<String> block = new ArrayList<>(byline.size() + 4);
+            block.add(String.format("SF:%s", file.getKey()));
+            int hit = 0;
+            for (final Map.Entry<Integer, Integer> line : byline.entrySet()) {
+                block.add(String.format("DA:%d,%d", line.getKey(), line.getValue()));
+                if (line.getValue() > 0) {
+                    hit += 1;
+                }
+            }
+            block.add(String.format("LH:%d", hit));
+            block.add(String.format("LF:%d", byline.size()));
+            block.add("end_of_record");
+            out.append(String.join(String.valueOf('\n'), block)).append('\n');
+        }
+        return out.toString();
+    }
+
+    /**
+     * The percentage of lines with at least one hit, across every file.
+     * @return A number from 0 to 100
+     */
+    double covered() {
+        int hit = 0;
+        int total = 0;
+        for (final Map<Integer, Integer> lines : this.files.values()) {
+            for (final int count : lines.values()) {
+                total += 1;
+                if (count > 0) {
+                    hit += 1;
+                }
+            }
+        }
+        final double percentage;
+        if (total == 0) {
+            percentage = 100.0;
+        } else {
+            percentage = 100.0 * hit / total;
+        }
+        return percentage;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -56,13 +56,6 @@ public final class MjCoverageReport extends MjSafe {
     )
     private File lcovFile;
 
-    /**
-     * Ctor.
-     */
-    public MjCoverageReport() {
-        // nothing
-    }
-
     @Override
     public void exec() throws IOException {
         if (this.coverageFile == null || !this.coverageFile.exists()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Turns the raw {@code loc:line:pos} coverage hits {@code PhCoverage}
+ * appended at runtime into an LCOV tracefile.
+ *
+ * <p>Bound to the {@code verify} phase, after the tests that actually
+ * populate the raw hits file have run (unlike {@code transpile}, which
+ * only decides whether locations get wrapped in {@code PhCoverage} in
+ * the first place, long before any test executes). Silently does
+ * nothing when {@code eo.coverageFile} is not set or the file does not
+ * exist yet, the same "no-op when disabled" contract {@code PhCoverage}
+ * itself follows.</p>
+ *
+ * @since 0.75.0
+ */
+@Mojo(
+    name = "coverage-report",
+    defaultPhase = LifecyclePhase.VERIFY,
+    threadSafe = true
+)
+public final class MjCoverageReport extends MjSafe {
+
+    /**
+     * The raw {@code loc:line:pos} hits file {@code PhCoverage} appended to.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "eo.coverageFile")
+    private File coverageFile;
+
+    /**
+     * Where to write the LCOV tracefile.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(
+        property = "eo.lcovFile",
+        defaultValue = "${project.build.directory}/coverage.info"
+    )
+    private File lcovFile;
+
+    /**
+     * Ctor.
+     */
+    public MjCoverageReport() {
+        // nothing
+    }
+
+    @Override
+    public void exec() throws IOException {
+        if (this.coverageFile == null || !this.coverageFile.exists()) {
+            Logger.info(
+                this,
+                "No coverage hits file at %[file]s, skipping the LCOV report",
+                this.coverageFile
+            );
+        } else {
+            this.report();
+        }
+    }
+
+    /**
+     * Build the manifest of every instrumented location, match it against
+     * the raw hits, and save the LCOV tracefile.
+     * @throws IOException If reading the hits file or writing the report fails
+     */
+    private void report() throws IOException {
+        final Map<String, Map<Integer, Integer>> perfile = new LinkedHashMap<>(0);
+        final Map<String, Integer> lineof = new HashMap<>(0);
+        final Map<String, String> fileof = new HashMap<>(0);
+        final CoverageManifest manifest = new CoverageManifest();
+        for (final TjForeign tojo : this.scopedTojos().standalone()) {
+            final String source = tojo.source().toString();
+            final XML xmir = new XMLDocument(tojo.xmir());
+            for (final String location : manifest.locations(xmir)) {
+                final int last = location.lastIndexOf(':');
+                final int line = Integer.parseInt(
+                    location.substring(location.lastIndexOf(':', last - 1) + 1, last)
+                );
+                perfile.computeIfAbsent(source, key -> new LinkedHashMap<>(0))
+                    .putIfAbsent(line, 0);
+                lineof.put(location, line);
+                fileof.put(location, source);
+            }
+        }
+        final List<String> hits = Files.readAllLines(this.coverageFile.toPath());
+        for (final String hit : hits) {
+            final String source = fileof.get(hit);
+            if (source != null) {
+                perfile.get(source).merge(lineof.get(hit), 1, Integer::sum);
+            }
+        }
+        final LcovReport report = new LcovReport(perfile);
+        new Saved(report.text(), this.lcovFile.toPath()).value();
+        Logger.info(
+            this, "EO object coverage: %.1f%%, LCOV report saved to %[file]s",
+            report.covered(), this.lcovFile
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -83,18 +83,12 @@ public final class MjTranspile extends MjSafe {
      * compiled program; when that property is absent, every hit is a
      * silent no-op. In {@code eo-runtime} the {@code coverage-file}
      * profile turns this on and forwards that property to surefire in
-     * one step (see its {@code pom.xml}).
-     * @todo #5466:60min Turn raw coverage hits into an LCOV report.
-     *  Right now the runtime only produces a raw, append-only
-     *  {@code loc:line:pos} file: the {@code PhCoverage} decorator
-     *  writes every touched location into it, but nothing consumes that
-     *  file yet. Add a reporter step that merges those raw hits against
-     *  the full set of instrumented locations, which the transpiler
-     *  already knows because it emits every wrapper, and produces an
-     *  LCOV ({@code .info}) tracefile plus the covered percentage. LCOV
-     *  is chosen because Codecov and Coveralls consume it directly.
+     * one step (see its {@code pom.xml}). The {@code coverage-report}
+     * Maven goal ({@link MjCoverageReport}) turns the raw hits into an
+     * LCOV tracefile, bound to the {@code verify} phase since the hits
+     * only exist after tests actually run.
      * @todo #5466:30min Enforce a minimum EO object coverage in eo-runtime.
-     *  Once the LCOV report from the puzzle above exists, set
+     *  Now that the LCOV report exists ({@link MjCoverageReport}), set
      *  {@code coverageTracking} on the {@code transpile} execution in
      *  {@code eo-runtime/pom.xml} and fail the build when the covered
      *  percentage of dataized {@code .eo} objects drops below a

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.Collection;
+import org.eolang.parser.EoSyntax;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CoverageManifest}.
+ * @since 0.75.0
+ */
+final class CoverageManifestTest {
+
+    @Test
+    void findsLocationsOfASimpleObject() throws Exception {
+        MatcherAssert.assertThat(
+            "a formation with a body must have at least one instrumented location, but none were found",
+            this.simpleObject(),
+            Matchers.not(Matchers.empty())
+        );
+    }
+
+    @Test
+    void findsLocationsShapedAsLocLinePos() throws Exception {
+        MatcherAssert.assertThat(
+            "every found location must look like loc:line:pos, but at least one didnt",
+            this.simpleObject(),
+            Matchers.everyItem(Matchers.matchesPattern("^[^:]+:\\d+:\\d+$"))
+        );
+    }
+
+    @Test
+    void findsExactlyOneLocationInAnEmptyFormation() throws Exception {
+        MatcherAssert.assertThat(
+            "an empty formation with no body still has itself to instrument, but the count was off",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(System.lineSeparator(), "[] > foo", "")
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    /**
+     * Locations found in a small formation with one attribute.
+     * @return The locations
+     * @throws Exception If parsing or deriving them fails
+     */
+    private Collection<String> simpleObject() throws Exception {
+        return new CoverageManifest().locations(
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > foo",
+                    "  42 > x",
+                    ""
+                )
+            ).parsed()
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LcovReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LcovReportTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link LcovReport}.
+ * @since 0.75.0
+ */
+final class LcovReportTest {
+
+    @Test
+    void rendersOneFileWithAMixOfHitAndMissedLines() {
+        final Map<Integer, Integer> lines = new LinkedHashMap<>(2);
+        lines.put(5, 2);
+        lines.put(9, 0);
+        final Map<String, Map<Integer, Integer>> files = new LinkedHashMap<>(1);
+        files.put("foo.eo", lines);
+        final StringBuilder expected = new StringBuilder(32);
+        for (final String line : new String[] {
+            "SF:foo.eo", "DA:5,2", "DA:9,0", "LH:1", "LF:2", "end_of_record",
+        }) {
+            expected.append(line).append('\n');
+        }
+        MatcherAssert.assertThat(
+            "the rendered text must carry SF/DA/LH/LF for the one file, but it didnt",
+            new LcovReport(files).text(),
+            Matchers.equalTo(expected.toString())
+        );
+    }
+
+    @Test
+    void computesTheCoveredPercentageAcrossFiles() {
+        final Map<Integer, Integer> first = new LinkedHashMap<>(2);
+        first.put(1, 1);
+        first.put(2, 0);
+        final Map<Integer, Integer> second = new LinkedHashMap<>(2);
+        second.put(1, 3);
+        second.put(2, 0);
+        final Map<String, Map<Integer, Integer>> files = new LinkedHashMap<>(2);
+        files.put("a.eo", first);
+        files.put("b.eo", second);
+        MatcherAssert.assertThat(
+            "two hit lines out of four total must be 50 percent, but it wasnt",
+            new LcovReport(files).covered(),
+            Matchers.closeTo(50.0, 0.001)
+        );
+    }
+
+    @Test
+    void reportsFullCoverageWhenThereIsNothingToInstrument() {
+        MatcherAssert.assertThat(
+            "an empty report has nothing uncovered, so it must read as fully covered, but it didnt",
+            new LcovReport(new LinkedHashMap<>(0)).covered(),
+            Matchers.closeTo(100.0, 0.001)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link MjCoverageReport}.
+ * @since 0.75.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class MjCoverageReportTest {
+
+    @Test
+    void doesNothingWhenNoCoverageFileIsSet(@Mktmp final Path temp) throws IOException {
+        new FakeMaven(temp).withProgram(
+            String.join(System.lineSeparator(), "[] > x", "  42 > y")
+        ).execute(MjParse.class).execute(MjCoverageReport.class);
+        MatcherAssert.assertThat(
+            "no LCOV report must be written when eo.coverageFile is unset, but one was",
+            Files.exists(temp.resolve("target/coverage.info")),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void marksAHitLocationAsCoveredInTheLcovReport(@Mktmp final Path temp) throws Exception {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(System.lineSeparator(), "[] > x", "  42 > y")
+        ).execute(MjParse.class);
+        final String location = new CoverageManifest().locations(
+            new XMLDocument(maven.programTojo().xmir())
+        ).iterator().next();
+        final Path hits = temp.resolve("coverage.txt");
+        Files.writeString(hits, String.format("%s%n", location));
+        final Path lcov = temp.resolve("coverage.info");
+        maven.with("coverageFile", hits.toFile())
+            .with("lcovFile", lcov.toFile())
+            .execute(MjCoverageReport.class);
+        MatcherAssert.assertThat(
+            "the LCOV report must record at least one hit line, but LH:0 everywhere",
+            Files.readString(lcov),
+            Matchers.not(Matchers.containsString("LH:0"))
+        );
+    }
+}

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -29,6 +29,19 @@
     runs to its end instead of being skipped.
     -->
     <eo.deadline>1</eo.deadline>
+    <!--
+    Whether to wrap located objects into PhCoverage at transpile time, so
+    tests record EO-level coverage hits. Off by default; codecov.yml flips
+    it to true for the coverage CI job (see #5757).
+    -->
+    <eo.coverageTracking>false</eo.coverageTracking>
+    <!--
+    Where PhCoverage.hit() appends coverage records at runtime, and where
+    the coverage-report goal reads them back from afterwards. Shared as a
+    project property so both the surefire JVM (system property) and the
+    eo-maven-plugin goal (Maven parameter) agree on one path (see #5673).
+    -->
+    <eo.coverageFile>${project.build.directory}/coverage.txt</eo.coverageFile>
   </properties>
   <dependencies>
     <dependency>
@@ -225,7 +238,7 @@
             located objects into PhCoverage at transpile time, so both ends
             agree on one file (see #5673).
             -->
-            <eo.coverageFile>${project.build.directory}/coverage.txt</eo.coverageFile>
+            <eo.coverageFile>${eo.coverageFile}</eo.coverageFile>
             <java.util.logging.config.file>
               ${project.basedir}/src/test/resources/jul.properties
             </java.util.logging.config.file>
@@ -269,7 +282,7 @@
           <!-- Tests assert on precise .eo locations in panics (off by default). -->
           <trackLocations>true</trackLocations>
           <!-- Wrap located objects into PhCoverage so tests record EO coverage. -->
-          <coverageTracking>false</coverageTracking>
+          <coverageTracking>${eo.coverageTracking}</coverageTracking>
         </configuration>
         <executions>
           <execution>
@@ -330,6 +343,13 @@
                 <glob>org/eolang/package-info.class</glob>
               </keepBinaries>
             </configuration>
+          </execution>
+          <execution>
+            <id>coverage-report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>coverage-report</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Turns the raw `loc:line:pos` coverage hits `PhCoverage` appends at runtime into an LCOV tracefile.

Three pieces:

- `CoverageManifest`: derives which locations `to-java.xsl` would wrap in `PhCoverage`, structurally. `to-java.xsl` (the last shift of the transpile train) decides this from `@line`/`@pos`/`@loc` on the XMIR, attributes already set by every earlier shift, so `CoverageManifest` runs that same prefix and reads the result with the identical XPath condition, instead of pattern-matching the generated Java text.
- `LcovReport`: pure formatter, turns a per-file per-line hit-count map into the LCOV `SF`/`DA`/`LH`/`LF` text.
- `MjCoverageReport`: new Maven goal (`coverage-report`), bound to the `verify` phase since the raw hits only exist after tests actually run (unlike `transpile`, which only decides whether locations get wrapped, long before any test executes). Reads `eo.coverageFile`, matches it against every transpiled source's manifest, writes the LCOV file. No-ops when `eo.coverageFile` is unset, the same contract `PhCoverage` itself follows.

Removed the now-resolved `@todo` puzzle from `MjTranspile.java`; the second one (enforcing a minimum coverage threshold, a separate concern) stays.

Closes #5757
