### PR TITLE
Say what must fill a void

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Asked.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Asked.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Every name the program asks, gathered on the object that answers it.
+ *
+ * <p>{@link Needs} writes a row per dispatch, against the site that did the
+ * asking, since that is what it sees. The same fact is worth having the other
+ * way round — everything ever asked of one object, in one place — and nobody
+ * can turn the table around until the links say what each of those asks
+ * arrived at.</p>
+ *
+ * <p>Which object a name is asked of is not the receiver, and the difference
+ * is the whole point. {@code book.size} asks a {@code book}, and a
+ * {@code book} that binds no {@code size} hands the question to the void it
+ * keeps, so it is that void the name is really asked of. The links have
+ * already worked this out — the dispatch turns out to be
+ * {@code Φ.book.pages.size} — and the object that answers is that name
+ * without its last step, which is why an answer that does not end in the name
+ * asked is left alone: nothing there says whose it is.</p>
+ *
+ * @since 0.69.0
+ */
+final class Asked {
+
+    /**
+     * The needs table.
+     */
+    private final XML wanted;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param needs The needs table, as {@link Needs} wrote it
+     * @param aliases The name every type goes by, from {@link Ends}
+     */
+    Asked(final XML needs, final Map<String, String> aliases) {
+        this.wanted = needs;
+        this.names = aliases;
+    }
+
+    /**
+     * What is asked of every object of the program.
+     * @return The names asked, by the object they are asked of, each against
+     *  the object that answers it
+     */
+    Map<String, Map<String, String>> all() {
+        final Map<String, Map<String, String>> found = new LinkedHashMap<>(0);
+        for (final XML attr : this.wanted.nodes("/needs/type/attr")) {
+            final String name = attr.xpath("@name").get(0);
+            final String step = ".".concat(name);
+            final String answer = this.names.getOrDefault(attr.xpath("@type").get(0), "");
+            if (answer.endsWith(step)) {
+                found.computeIfAbsent(
+                    answer.substring(0, answer.length() - step.length()),
+                    key -> new LinkedHashMap<>(0)
+                ).put(name, answer);
+            }
+        }
+        return Collections.unmodifiableMap(found);
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.xembly.Xembler;
+
+/**
+ * The rows about a void, with what the program asks of it.
+ *
+ * <p>{@link Provides} writes a void down as an attribute nobody has filled and
+ * has nothing more to say, since what a void holds is decided elsewhere. What
+ * it will have to <em>offer</em> is not decided elsewhere at all — it is
+ * written all over the program, one name at a time, and {@link Needs} has every
+ * one of those names against the site that asked. Turning that round and
+ * putting it where it belongs is all this does.</p>
+ *
+ * <p>It waits until the links are settled, since a site asks a receiver and
+ * only the links say where the asking arrived: a {@code book} that binds no
+ * {@code size} hands the question to the void it keeps, and it is that void
+ * which will have to answer. And it writes into the table the voids are
+ * already in, because a demand is a fact about a void, and a second table
+ * saying things about voids would only invite the two to disagree.</p>
+ *
+ * @since 0.69.0
+ */
+public final class Demanded implements Clue {
+
+    /**
+     * The clues to follow first.
+     */
+    private final Clue origin;
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the voids are asked of
+     */
+    public Demanded(final Clue clues) {
+        this.origin = clues;
+    }
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        this.origin.follow(xmirs, tables);
+        final Path table = tables.resolve("provides.xml");
+        final XML given = new XMLDocument(table);
+        final Map<String, Map<String, String>> asked = new Asked(
+            new XMLDocument(tables.resolve("needs.xml")),
+            new Ends(new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()).names()
+        ).all();
+        for (final XML hollow : given.nodes("//attr[@void='true']")) {
+            final Demands demands = new Demands(asked, hollow.xpath("@type").get(0));
+            if (demands.any()) {
+                new Xembler(demands.directives()).applyQuietly(hollow.inner());
+            }
+        }
+        Files.write(table, given.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Demands.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demands.java
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Map;
+import org.xembly.Directives;
+
+/**
+ * What whatever fills a void will have to offer.
+ *
+ * <p>A void holds nothing until a caller puts something in it, so nothing can
+ * be said about what it <em>is</em>. Plenty can be said about what it must
+ * have, though, and the program says it: every name taken from the void is a
+ * name its value will have to answer to. {@code number} keeps one void and
+ * hands everything to it, and the program asks that void for {@code and},
+ * {@code as-bytes}, {@code eq} and {@code size} — which is to say that only a
+ * {@code bytes} will do, without a word of it ever being written down.</p>
+ *
+ * <p>A name taken from the answer is a demand in its turn, of the object one
+ * step deeper: {@code x.next.foo} says that {@code x} must have a {@code next}
+ * and that the {@code next} must have a {@code foo}. Every one of those objects
+ * is a name rooted at the void, so all of them are gathered here, each demand
+ * saying which one it is made of.</p>
+ *
+ * <p>They are written side by side rather than one inside the other, which
+ * would have read better, because the chain is not always there to nest them
+ * along: {@code while} hands its answers through several objects to the
+ * {@code if} of the {@code as-bool} of what fills {@code Φ.bool.if}, and
+ * nobody ever asked for that {@code as-bool} — the delegation went through it.
+ * Nesting drops every demand whose chain was walked that way rather than
+ * asked for, 77 of the 2,303 in eo-runtime, and a fact that cannot be written
+ * where it belongs is still a fact.</p>
+ *
+ * @since 0.69.0
+ */
+final class Demands {
+
+    /**
+     * What is asked of every object, from {@link Asked}.
+     */
+    private final Map<String, Map<String, String>> asked;
+
+    /**
+     * The void these demands are made of.
+     */
+    private final String hollow;
+
+    /**
+     * Ctor.
+     * @param all What is asked of every object, from {@link Asked}
+     * @param object The void these demands are made of
+     */
+    Demands(final Map<String, Map<String, String>> all, final String object) {
+        this.asked = all;
+        this.hollow = object;
+    }
+
+    /**
+     * These demands, to be put inside the row of the void.
+     * @return The directives, empty when nothing is ever asked of it
+     */
+    Directives directives() {
+        final Directives dirs = new Directives();
+        for (final Map.Entry<String, Map<String, String>> bearer : this.asked.entrySet()) {
+            if (this.below(bearer.getKey())) {
+                for (final Map.Entry<String, String> demand : bearer.getValue().entrySet()) {
+                    dirs.add("demand")
+                        .attr("of", bearer.getKey())
+                        .attr("name", demand.getKey())
+                        .attr("type", demand.getValue())
+                        .up();
+                }
+            }
+        }
+        return dirs;
+    }
+
+    /**
+     * Whether anything is ever asked of this void, or of a name rooted at it.
+     * @return True when at least one name is
+     */
+    boolean any() {
+        boolean found = false;
+        for (final String bearer : this.asked.keySet()) {
+            if (this.below(bearer)) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Whether this object is the void itself, or a name rooted at it.
+     * @param object The name of the object
+     * @return True when what it is depends on what fills this void
+     */
+    private boolean below(final String object) {
+        return object.equals(this.hollow) || object.startsWith(this.hollow.concat("."));
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/DemandedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandedTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Demanded}.
+ * @since 0.69.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class DemandedTest {
+
+    @Test
+    void putsWhatIsAskedOfAVoidOnTheVoid(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("inc.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.inc' name='inc'>",
+                "<o base='∅' loc='Φ.inc.x' name='x'/>",
+                "<o base='.next' loc='Φ.inc.φ' name='φ'>",
+                "<o base='ξ.x' loc='Φ.inc.φ.ρ'/></o></o></object>"
+            )
+        );
+        new Demanded(new Resolved(new Clues())).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "the void must remember the name taken from it, but it didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
+                "/provides/type[@id='Φ.inc']/attr[@name='x']/demand[@name='next']"
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void leavesAVoidNobodyAsksOfAlone(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("pipe.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.pipe' name='pipe'>",
+                "<o base='∅' loc='Φ.pipe.x' name='x'/>",
+                "<o base='ξ.x' loc='Φ.pipe.φ' name='φ'/></o></object>"
+            )
+        );
+        new Demanded(new Resolved(new Clues())).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "a void nobody asks anything of must stay empty, but it didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml"))
+                .nodes("//demand"),
+            Matchers.empty()
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link Demands}.
+ * @since 0.69.0
+ */
+final class DemandsTest {
+
+    @Test
+    void gathersWhatIsAskedOfAnAnswerOntoTheVoidItCameFrom() {
+        final Map<String, Map<String, String>> asked = new LinkedHashMap<>(0);
+        asked.put("Φ.inc.x", Collections.singletonMap("next", "Φ.inc.x.next"));
+        asked.put("Φ.inc.x.next", Collections.singletonMap("foo", "Φ.inc.x.next.foo"));
+        MatcherAssert.assertThat(
+            "the name asked of the answer must stand beside the one that named it, but it didnt",
+            new XMLDocument(
+                new Xembler(
+                    new Directives().add("attr").append(new Demands(asked, "Φ.inc.x").directives())
+                ).xmlQuietly()
+            ).nodes("/attr/demand[@of='Φ.inc.x.next' and @name='foo']"),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void leavesAloneWhatIsAskedOfAnotherVoid() {
+        MatcherAssert.assertThat(
+            "a name asked of another void must stay there, but it came here",
+            new Demands(
+                Collections.singletonMap(
+                    "Φ.dec.y", Collections.singletonMap("prev", "Φ.dec.y.prev")
+                ),
+                "Φ.inc.x"
+            ).any(),
+            Matchers.is(false)
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -18,6 +18,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eolang.inference.Clues;
+import org.eolang.inference.Demanded;
 import org.eolang.inference.Depth;
 import org.eolang.inference.Ladder;
 import org.eolang.inference.Resolved;
@@ -89,7 +90,7 @@ final class Inferring implements Step {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
             final int ready = this.ready();
-            new Resolved(new Clues()).follow(this.prepared, this.tables);
+            new Demanded(new Resolved(new Clues())).follow(this.prepared, this.tables);
             Logger.info(
                 this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
                 ready, this.tables

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/demand-of-an-answer-sits-under-the-void.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/demand-of-an-answer-sits-under-the-void.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name taken from an answer is a demand in its turn. `x.next.foo` says two
+# things — that `x` must have a `next`, and that the `next` must have a `foo` —
+# and the second is about the answer rather than about the void, so it says
+# whose it is. Both stand under the void, since both are its business.
+eo:
+  inc.eo: |
+    [x] > inc
+      x.next.foo > @
+provides:
+  - "//attr[@void='true']/demand[@of='Φ.inc.x' and @name='next']"
+  - "//attr[@void='true']/demand[@of='Φ.inc.x.next' and @name='foo']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-hears-what-another-file-asks.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-hears-what-another-file-asks.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void is asked of far from where it is declared. `book` binds no `size` and
+# hands every name it does not bind to the void it keeps, so a `size` asked of
+# a `book` in another file is a `size` asked of `pages` — which is how the core
+# of eo-runtime is written, and where most of what we know about voids is said.
+eo:
+  app.eo: |
+    [] > app
+      book.size > @
+  book.eo: |
+    [pages] > book
+      pages > @
+provides:
+  - "/provides/type[@id='Φ.book']/attr[@void='true']/demand[@name='size']"
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.book.pages.size']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-remembers-what-is-asked-of-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-remembers-what-is-asked-of-it.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Nothing can be said about what a void holds, since a caller decides that.
+# What its value will have to offer is another matter, and the program says
+# that out loud: `next` is taken from `x`, so whatever fills `x` must have a
+# `next`, and what comes back of it goes by a name of its own.
+eo:
+  inc.eo: |
+    [x] > inc
+      x.next > @
+provides:
+  - "/provides/type[@id='Φ.inc']/attr[@void='true']/demand[@name='next']"
+  - "//demand[@name='next' and @type='Φ.inc.x.next']"


### PR DESCRIPTION
A void was a row with nothing in it. `provides.xml` said that `number`
keeps one, that it is called `as-bytes` and that nobody has filled it,
and there it stopped, because what a void holds is a caller's business.
What its value has to *offer* is nobody's business but the program's,
though, and the program is loud about it: five different names are
taken from that void across `eo-runtime`, and every one of them was
written down in `needs.xml` against the site that did the asking, where
finding them again meant resolving every dispatch of the program a
second time.

`Asked` turns that table round, onto the object each ask arrives at
rather than the one it was made of — a difference that is the whole
point, since a `book` binding no `size` hands the question to the void
it keeps, and it is the void that will have to answer:

```java
final String answer = this.names.getOrDefault(attr.xpath("@type").get(0), "");
if (answer.endsWith(step)) {
    found.computeIfAbsent(
        answer.substring(0, answer.length() - step.length()),
        key -> new LinkedHashMap<>(0)
    ).put(name, answer);
}
```

`Demands` picks out the ones that belong to a void — the void itself and
every name rooted at it, since `x.next.foo` says something about the
`next` too — and `Demanded`, a new decorator around the clues, writes
them into the row the void is already in. It runs after `Resolved`,
because only settled links say where an ask arrived.

They stand side by side, each saying which object it is made of, rather
than one inside the other. Nesting reads better and was what I wrote
first, and it drops 77 of the 2,303: `while` hands its answers through
to the `if` of the `as-bool` of whatever fills `Φ.bool.if`, and nobody
ever asked for that `as-bool` — the delegation walked through it, so
there is no ask to nest the deeper one under.

Measured on a clean build of 171 files, 44,182 objects: 2,303 demands
over 558 of the 1,018 voids, naming 1,676 objects. `Φ.number.as-bytes`
wants `and`, `as-bytes`, `as-number`, `eq` and `size` — which is to say
a `Φ.bytes`, and nothing anywhere had said so before. `needs.xml` comes
out byte-identical, `links.xml` unchanged, every cell of every existing
`provides` row the same, two runs byte-identical, and the goal takes the
same minute it did.

No number on the ladder moves, and none should: this records what a
program asks, not what an object turns out to be. It is the half of the
spec's §6.4 that was never built, and the rungs that hold a name rooted
at a void — 15,428 objects — are where the next of it goes.
