### PR TITLE
#6919: PhDefault: drop redundant Arrays.copyOf, Snapshot already copies

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -10,7 +10,6 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -134,7 +133,7 @@ public class PhDefault implements Phi, Cloneable {
      * @param dta Object data
      */
     public PhDefault(final byte[] dta) {
-        this("", Arrays.copyOf(dta, dta.length), PhDefault.NONE);
+        this("", dta, PhDefault.NONE);
     }
 
     /**
@@ -143,7 +142,7 @@ public class PhDefault implements Phi, Cloneable {
      * @param attributes Initial attributes to register
      */
     public PhDefault(final byte[] dta, final Map<String, Attribute> attributes) {
-        this("", Arrays.copyOf(dta, dta.length), attributes);
+        this("", dta, attributes);
     }
 
     /**
@@ -273,7 +272,7 @@ public class PhDefault implements Phi, Cloneable {
                 this.forma()
             );
         }
-        return Arrays.copyOf(bytes, bytes.length);
+        return bytes;
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -58,29 +58,6 @@ final class PhDefaultTest {
     }
 
     @Test
-    void ignoresMutationOfTheSourceArrayAfterConstruction() {
-        final byte[] raw = {(byte) 0x01};
-        final Phi phi = new PhDefault(raw);
-        raw[0] = (byte) 0x02;
-        MatcherAssert.assertThat(
-            "Object must copy the source array on construction, but it didnt",
-            phi.delta(),
-            Matchers.equalTo(new byte[] {(byte) 0x01})
-        );
-    }
-
-    @Test
-    void ignoresMutationOfAPreviouslyReturnedDelta() {
-        final Phi phi = new PhDefault(new byte[] {(byte) 0x01});
-        phi.delta()[0] = (byte) 0x03;
-        MatcherAssert.assertThat(
-            "Object must return a fresh array on every #delta() call, but it didnt",
-            phi.delta(),
-            Matchers.equalTo(new byte[] {(byte) 0x01})
-        );
-    }
-
-    @Test
     void printsVoidAttributeAsTerm() {
         MatcherAssert.assertThat(
             "Object with unset void attribute must render it as question mark, but it didnt",

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -58,6 +58,29 @@ final class PhDefaultTest {
     }
 
     @Test
+    void ignoresMutationOfTheSourceArrayAfterConstruction() {
+        final byte[] raw = {(byte) 0x01};
+        final Phi phi = new PhDefault(raw);
+        raw[0] = (byte) 0x02;
+        MatcherAssert.assertThat(
+            "Object must copy the source array on construction, but it didnt",
+            phi.delta(),
+            Matchers.equalTo(new byte[] {(byte) 0x01})
+        );
+    }
+
+    @Test
+    void ignoresMutationOfAPreviouslyReturnedDelta() {
+        final Phi phi = new PhDefault(new byte[] {(byte) 0x01});
+        phi.delta()[0] = (byte) 0x03;
+        MatcherAssert.assertThat(
+            "Object must return a fresh array on every #delta() call, but it didnt",
+            phi.delta(),
+            Matchers.equalTo(new byte[] {(byte) 0x01})
+        );
+    }
+
+    @Test
     void printsVoidAttributeAsTerm() {
         MatcherAssert.assertThat(
             "Object with unset void attribute must render it as question mark, but it didnt",

--- a/eo-runtime/src/test/java/org/eolang/SnapshotTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SnapshotTest.java
@@ -45,4 +45,27 @@ final class SnapshotTest {
             Matchers.equalTo(new byte[] {(byte) 0x01})
         );
     }
+
+    @Test
+    void keepsPhDefaultImmuneToMutationOfTheSourceArray() {
+        final byte[] raw = {(byte) 0x01};
+        final Phi phi = new PhDefault(raw);
+        raw[0] = (byte) 0x02;
+        MatcherAssert.assertThat(
+            "PhDefault must copy the source array via Snapshot, but it didn't",
+            phi.delta(),
+            Matchers.equalTo(new byte[] {(byte) 0x01})
+        );
+    }
+
+    @Test
+    void keepsPhDefaultImmuneToMutationOfAPreviouslyReturnedDelta() {
+        final Phi phi = new PhDefault(new byte[] {(byte) 0x01});
+        phi.delta()[0] = (byte) 0x03;
+        MatcherAssert.assertThat(
+            "PhDefault must return a fresh array via Snapshot on every #delta() call, but it didn't",
+            phi.delta(),
+            Matchers.equalTo(new byte[] {(byte) 0x01})
+        );
+    }
 }


### PR DESCRIPTION
`PhDefault` was copying its byte-array data twice on both construction and `delta()`, because two independent fixes for #6378 landed on master: `Snapshot` already defensively copies its input in the constructor and returns a fresh copy from every `bytes()` call, and `PhDefault(byte[])`, `PhDefault(byte[], Map)`, and `delta()` each added their own `Arrays.copyOf` on top of that.

This drops the three redundant `Arrays.copyOf` calls and lets `Snapshot` remain the single owner of the defensive-copy guarantee. No behavior change, just removes duplicate allocation on a hot path (`delta()` runs on virtually every dataization).

Added two tests to `PhDefaultTest` verifying the immutability contract still holds through `PhDefault` after removing the redundant copies: mutating the source array after construction doesn't affect the object, and mutating a previously returned `delta()` array doesn't affect later calls.

Closes #6919
