### PR TITLE
feat(#6905): write unanswerable dispatches down as unknown in links

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -81,6 +81,9 @@ public final class Resolved implements Clue {
             pairs, new Bound(args, names, new Provided(given, names, voids)).all()
         ).all();
         rows.putAll(written.others());
+        for (final XML dispatch : dispatches) {
+            rows.putIfAbsent(dispatch.xpath("@loc").get(0), new Unknown());
+        }
         Files.write(
             links,
             new Types(rows).asXml().toString().getBytes(StandardCharsets.UTF_8)

--- a/eo-inference/src/main/java/org/eolang/inference/Unknown.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Unknown.java
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * A dispatch that nothing could answer.
+ *
+ * <p>A dispatch is only known to be unanswerable once the passes have
+ * stopped adding pairs: the passes keep going while they add, so a row
+ * written before they settled would call something unanswerable that a
+ * later pass answers. An unknown is a fact like any other — the silence
+ * around an object that was never looked at says something else than the
+ * silence around one that was looked at and gave nothing.</p>
+ *
+ * @since 0.69.0
+ */
+final class Unknown implements Type {
+
+    @Override
+    public Directives directives() {
+        return new Directives().add("unknown").up();
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/answered-dispatch-keeps-its-ref.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/answered-dispatch-keeps-its-ref.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A dispatch that was answered keeps its ref row and gains no unknown: the
+# unknown is written only where nothing could be worked out.
+eo:
+  app.eo: |
+    [] > app
+      x > @
+      [] > x
+        [] > next
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.app.x']"
+  - "/links[not(type[@id='Φ.app.φ']/unknown)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-that-comes-back-with-a-variable-stays-quiet.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/atom-that-comes-back-with-a-variable-stays-quiet.yaml
@@ -3,7 +3,8 @@
 ---
 # `A` names no object. It stands for whatever the caller puts in, and which
 # object that is cannot be read off the text of `keep` alone. So nothing is
-# written down and `keep.plus` waits for the day variables are understood.
+# written down about what `keep` returns, and `keep.plus` is written as a
+# dispatch nothing could answer.
 eo:
   app.eo: |
     [] > app
@@ -14,4 +15,4 @@ eo:
 provides:
   - "/provides/type[@id='Φ.keep'][not(@returns)]"
 links:
-  - "/links[not(type[@id='Φ.app.φ'])]"
+  - "/links/type[@id='Φ.app.φ']/unknown"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/delegation-that-comes-back-is-walked-once.yaml
@@ -3,7 +3,7 @@
 ---
 # `one` hands its answers to `two` and `two` hands them back, so looking for a
 # name behind the delegation walks in a circle. It is walked once and answers
-# nothing, which leaves the dispatch unnamed rather than the pass unfinished.
+# nothing, which leaves the dispatch unknown rather than the pass unfinished.
 eo:
   app.eo: |
     [] > app
@@ -15,4 +15,4 @@ eo:
     [] > two
       one > @
 links:
-  - "/links[not(type[@id='Φ.app.φ'])]"
+  - "/links/type[@id='Φ.app.φ']/unknown"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/unanswerable-dispatch-is-written-down.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/unanswerable-dispatch-is-written-down.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A dispatch whose receiver nothing describes is written down as unknown once
+# the passes have settled, so a reader can tell "not looked at" from "looked
+# at, nothing known".
+eo:
+  app.eo: |
+    [] > app
+      arg.if > @
+      arg > @
+links:
+  - "/links/type[@id='Φ.app.φ']/unknown"


### PR DESCRIPTION
Fixes #6905.

## Problem

`needs.xml` records every dispatch, but `links.xml` says nothing about a dispatch that could not be answered — `Links` writes rows only for objects whose base names another object, and `Dispatched` only when it can work the dispatch out. A dispatch whose receiver nothing describes (`.if` 49 times, `.eq` 49, `.not` 28 in the runtime) falls between the two and leaves no trace. That silence is ambiguous between "not looked at" and "looked at, nothing known", and only the second is a fact (`eo-inference-spec.md` §8.3).

## Solution

Once the passes have stopped adding pairs, `Resolved` writes an `<unknown/>` row for every dispatch it could not answer:

```xml
<type id="Φ.app.φ">
  <unknown/>
</type>
```

A dispatch that *was* answered keeps its `ref` row and is never overwritten, and rows saying an object is a copy of something are left alone — the new type is only ever added where nothing was written.

## Changes

- `eo-inference/src/main/java/org/eolang/inference/Unknown.java` — new `Type` that writes `<unknown/>`.
- `eo-inference/src/main/java/org/eolang/inference/Resolved.java` — after the links are settled, `putIfAbsent` an `Unknown` row for every dispatch with no answer.
- Two new inference packs; two existing packs (`atom-that-comes-back-with-a-variable-stays-quiet`, `delegation-that-comes-back-is-walked-once`) updated — they previously asserted the *absence* of a row for an unanswerable dispatch, which is exactly the behaviour this issue changes.

## Tests

- `InferringTest` — 48 packs pass (46 existing + 2 new).
- `eo-inference` — 23 tests pass.
- `qulice` — clean.

@yegor256 please take a look.
