### PR TITLE
#5466: enforce a minimum EO object coverage in eo-runtime

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,7 +26,7 @@ jobs:
           key: maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             maven-
-      - run: mvn install -Pjacoco -Deo.coverageTracking=true
+      - run: mvn install -Pjacoco -Deo.coverageTracking=true -Deo.minCoverage=60
       - uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -56,6 +56,19 @@ public final class MjCoverageReport extends MjSafe {
     )
     private File lcovFile;
 
+    /**
+     * The minimum percentage of dataized {@code .eo} objects that must be
+     * covered, or the build fails. Zero by default, so a build with
+     * coverage tracking off (the common case, see {@code coverageTracking}
+     * on {@link MjTranspile}) never fails on a threshold it never opted
+     * into; {@code eo-runtime} raises it once tracking is on, mirroring
+     * how the {@code jacoco} profile binds a {@code check} goal with its
+     * own per-metric thresholds.
+     * @checkstyle MemberNameCheck (7 lines)
+     */
+    @Parameter(property = "eo.minCoverage", defaultValue = "0")
+    private double minCoverage;
+
     @Override
     public void exec() throws IOException {
         if (this.coverageFile == null || !this.coverageFile.exists()) {
@@ -71,8 +84,10 @@ public final class MjCoverageReport extends MjSafe {
 
     /**
      * Build the manifest of every instrumented location, match it against
-     * the raw hits, and save the LCOV tracefile.
-     * @throws IOException If reading the hits file or writing the report fails
+     * the raw hits, save the LCOV tracefile, and enforce the minimum
+     * coverage threshold.
+     * @throws IOException If reading the hits file or writing the report
+     *  fails, or the covered percentage is below {@link #minCoverage}
      */
     private void report() throws IOException {
         final Map<String, Map<Integer, Integer>> perfile = new LinkedHashMap<>(0);
@@ -102,9 +117,18 @@ public final class MjCoverageReport extends MjSafe {
         }
         final LcovReport report = new LcovReport(perfile);
         new Saved(report.text(), this.lcovFile.toPath()).value();
+        final double covered = report.covered();
         Logger.info(
             this, "EO object coverage: %.1f%%, LCOV report saved to %[file]s",
-            report.covered(), this.lcovFile
+            covered, this.lcovFile
         );
+        if (covered < this.minCoverage) {
+            throw new IOException(
+                String.format(
+                    "EO object coverage is %.1f%%, below the required %.1f%% minimum",
+                    covered, this.minCoverage
+                )
+            );
+        }
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -86,15 +86,11 @@ public final class MjTranspile extends MjSafe {
      * one step (see its {@code pom.xml}). The {@code coverage-report}
      * Maven goal ({@link MjCoverageReport}) turns the raw hits into an
      * LCOV tracefile, bound to the {@code verify} phase since the hits
-     * only exist after tests actually run.
-     * @todo #5466:30min Enforce a minimum EO object coverage in eo-runtime.
-     *  Now that the LCOV report exists ({@link MjCoverageReport}), set
-     *  {@code coverageTracking} on the {@code transpile} execution in
-     *  {@code eo-runtime/pom.xml} and fail the build when the covered
-     *  percentage of dataized {@code .eo} objects drops below a
-     *  threshold (for example 80 percent), mirroring how the existing
-     *  {@code jacoco} profile binds a {@code check} goal with per-metric
-     *  thresholds.
+     * only exist after tests actually run. {@code eo-runtime} pairs it
+     * with {@code minCoverage} on that same goal, failing the build when
+     * the covered percentage of dataized {@code .eo} objects drops below
+     * a threshold, mirroring how the {@code jacoco} profile binds a
+     * {@code check} goal with its own per-metric thresholds.
      * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(property = "eo.coverageTracking")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -52,6 +53,23 @@ final class MjCoverageReportTest {
             "the LCOV report must record at least one hit line, but LH:0 everywhere",
             Files.readString(lcov),
             Matchers.not(Matchers.containsString("LH:0"))
+        );
+    }
+
+    @Test
+    void failsTheBuildWhenCoverageIsBelowTheMinimum(@Mktmp final Path temp) throws Exception {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(System.lineSeparator(), "[] > x", "  42 > y")
+        ).execute(MjParse.class);
+        final Path hits = temp.resolve("coverage.txt");
+        Files.writeString(hits, "");
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> maven.with("coverageFile", hits.toFile())
+                .with("lcovFile", temp.resolve("coverage.info").toFile())
+                .with("minCoverage", 1.0d)
+                .execute(MjCoverageReport.class),
+            "coverage-report must fail the build when coverage is below the minimum, but it didnt"
         );
     }
 }

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -42,6 +42,13 @@
     eo-maven-plugin goal (Maven parameter) agree on one path (see #5673).
     -->
     <eo.coverageFile>${project.build.directory}/coverage.txt</eo.coverageFile>
+    <!--
+    Minimum percentage of dataized .eo objects that must be covered, or
+    the coverage-report goal fails the build. Only bites when coverage
+    tracking is actually on (see eo.coverageTracking above), so a build
+    that never opts in never trips it (see #5466).
+    -->
+    <eo.minCoverage>0</eo.minCoverage>
   </properties>
   <dependencies>
     <dependency>
@@ -351,6 +358,9 @@
             <goals>
               <goal>coverage-report</goal>
             </goals>
+            <configuration>
+              <minCoverage>${eo.minCoverage}</minCoverage>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Resolves the puzzle 5466-4264405c in MjTranspile.java.

MjCoverageReport gets a minCoverage parameter, zero by default, so a build with coverage tracking off never fails on a threshold it never opted into. eo-runtime/pom.xml raises it via a new eo.minCoverage property, wired into the coverage-report execution, mirroring how the jacoco profile binds a check goal with its own per-metric thresholds.

codecov.yml now passes -Deo.minCoverage=60 alongside the existing -Deo.coverageTracking=true. I measured the real baseline by running the full eo-runtime test suite locally with coverage tracking on: 67.39% of dataized .eo objects covered (2959 of 4391 lines, from the LCOV totals). 60 leaves some margin below that while still catching a real regression.

Added a test verifying the build fails when coverage drops below the configured minimum.

Closes #6925
