### PR TITLE
#6918: reject horizontal argument applied to the identity glyph

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -153,10 +153,11 @@ final class LnApplication implements Line {
     }
 
     /**
-     * Reject a paren-group head that cannot carry what follows it: bare
-     * redundant parentheses around a whole top-level expression, or a
-     * horizontal argument list applied to an inline-phi formation the
-     * group wraps.
+     * Reject a head that cannot carry what follows it: bare redundant
+     * parentheses around a whole top-level expression, or a horizontal
+     * argument list applied to a head that opens a formation body of its
+     * own — a paren-group wrapping an inline-phi expression, or the
+     * identity glyph {@code I}, itself sugar for one (#6848, #6918).
      * @param head The head value
      * @param chain Method-dispatch chain following the head (may be empty)
      * @param args Horizontal arguments following the head (may be empty)
@@ -173,12 +174,24 @@ final class LnApplication implements Line {
                 "redundant parentheses around a top-level expression — drop the outer `(` and `)`"
             );
         }
-        if (head.kind() == Value.Kind.GROUP && !args.isEmpty() && this.wrapsInlinePhi(head)) {
+        if (!args.isEmpty() && this.opensFormationBody(head)) {
             throw new ParseError(
                 this.span.line(), head.pos(),
                 "horizontal formation not allowed as argument"
             );
         }
+    }
+
+    /**
+     * Whether a head opens a formation body of its own, so any horizontal
+     * argument that follows it would land as an unnamed formation child
+     * instead of an argument (#6848, #6918).
+     * @param head The head value
+     * @return TRUE when the head opens a formation body
+     */
+    private boolean opensFormationBody(final Value head) {
+        return head.kind() == Value.Kind.IDENTITY
+            || head.kind() == Value.Kind.GROUP && this.wrapsInlinePhi(head);
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/identity-glyph-with-horizontal-arg.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/identity-glyph-with-horizontal-arg.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "horizontal formation not allowed as argument"
+input: |
+  [] > app
+    I 5 > y


### PR DESCRIPTION
Emissions.identity opens a base-less <o> for the I glyph and leaves it open, so horizontal arguments land on it exactly as they land on a parenthesised (x > [x]). Since the identity always expands to an inline-phi-style formation, any horizontal argument becomes an unnamed formation child.

This is #6848 under a new spelling. That issue rejected the same shape for a paren-group wrapping an inline-phi, gated on head.kind() == Value.Kind.GROUP. The I glyph carries Value.Kind.IDENTITY instead, which the guard did not name.

Extended LnApplication's guard to reject any horizontal argument applied to a head that opens a formation body of its own, whether that head is a paren-group wrapping an inline-phi or the identity glyph. Both now produce the same "horizontal formation not allowed as argument" error.

Verified the existing valid uses of I stay valid: I as a bare value, I named as a formation with a later pipe application (| 5), and I as a body/argument with no horizontal args, all still parse.

Closes #6918
