### PR TITLE
Say what the world puts in a void

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What the program puts into every void, read back from the links.
+ *
+ * <p>Every application says what it fills, and says it in its own row, where
+ * {@link Bound} wrote it: a {@code bind} names the void and what went into it.
+ * So the fact is in the tables already and lies the wrong way round — to learn
+ * what one void is ever given, a reader walks the row of every object that
+ * ever filled anything, and eo-runtime has 22,818 of those bindings.</p>
+ *
+ * <p>What goes in is gathered as a type rather than as a locator, which is
+ * what makes the answer worth reading: {@code Φ.bytes} hands its answers to a
+ * void filled 7,355 times, and all but one of those fillings is a literal. As
+ * types there are two of them, a datum and a {@code Φ.bytes.as-bytes}; as
+ * locators there are 7,355.</p>
+ *
+ * @since 0.69.0
+ */
+final class Fillings {
+
+    /**
+     * The links table.
+     */
+    private final XML table;
+
+    /**
+     * Ctor.
+     * @param links The links table, as {@link Resolved} left it
+     */
+    Fillings(final XML links) {
+        this.table = links;
+    }
+
+    /**
+     * What is ever put into every void.
+     * @return The types put in, by the locator of the void, without the voids
+     *  nobody ever fills
+     */
+    Map<String, Collection<Type>> all() {
+        final Map<String, String> names = new Ends(new Pairs(this.table).all()).names();
+        final Forms forms = new Forms(this.table);
+        final Map<String, Map<String, Type>> found = new LinkedHashMap<>(0);
+        for (final XML bind : this.table.nodes("/links/type/ref/bind")) {
+            final List<String> given = bind.xpath("ref/@loc");
+            if (!given.isEmpty()) {
+                final String end = names.getOrDefault(given.get(0), given.get(0));
+                found.computeIfAbsent(
+                    bind.xpath("@void").get(0), key -> new LinkedHashMap<>(0)
+                ).putIfAbsent(forms.name(end), forms.type(end));
+            }
+        }
+        final Map<String, Collection<Type>> joined = new LinkedHashMap<>(found.size());
+        for (final Map.Entry<String, Map<String, Type>> hollow : found.entrySet()) {
+            joined.put(hollow.getKey(), hollow.getValue().values());
+        }
+        return joined;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Forms.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Forms.java
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * Which form of type the links table gives an object.
+ *
+ * <p>A row of that table holds one element and the element says what kind of
+ * answer it is: a datum, a termination, a variable, or an object this one is a
+ * copy of. Asked about an object, this gives back the same form, so that a
+ * type worked out over there can be written down again over here.</p>
+ *
+ * <p>It also gives the name that form goes by, and the two are not the same
+ * question. Every literal of a program has a locator of its own and all of
+ * them are one type, so a datum is kept by a name no locator can have —
+ * locators begin at the root of the program — and two fillings that arrive at
+ * a datum are one filling.</p>
+ *
+ * @since 0.69.0
+ */
+final class Forms {
+
+    /**
+     * The objects that are data.
+     */
+    private final Collection<String> ground;
+
+    /**
+     * The objects that terminate.
+     */
+    private final Collection<String> dead;
+
+    /**
+     * The objects that are voids.
+     */
+    private final Collection<String> free;
+
+    /**
+     * Ctor.
+     * @param links The links table, as {@link Resolved} left it
+     */
+    Forms(final XML links) {
+        this(
+            new HashSet<>(links.xpath("/links/type[data]/@id")),
+            new HashSet<>(links.xpath("/links/type[bottom]/@id")),
+            new HashSet<>(links.xpath("/links/type[var]/@id"))
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param data The objects that are data
+     * @param bottoms The objects that terminate
+     * @param voids The objects that are voids
+     */
+    Forms(
+        final Collection<String> data,
+        final Collection<String> bottoms,
+        final Collection<String> voids
+    ) {
+        this.ground = data;
+        this.dead = bottoms;
+        this.free = voids;
+    }
+
+    /**
+     * The name the form of this object goes by.
+     * @param object The locator of the object
+     * @return The name, which is the locator itself unless every object of
+     *  that form is one type
+     */
+    String name(final String object) {
+        final String found;
+        if (this.ground.contains(object)) {
+            found = "data";
+        } else if (this.dead.contains(object)) {
+            found = "bottom";
+        } else {
+            found = object;
+        }
+        return found;
+    }
+
+    /**
+     * The form of this object, to be written somewhere else.
+     * @param object The locator of the object
+     * @return The type
+     */
+    Type type(final String object) {
+        final Type found;
+        if (this.ground.contains(object)) {
+            found = new Data();
+        } else if (this.dead.contains(object)) {
+            found = new Bottom();
+        } else if (this.free.contains(object)) {
+            found = new Var(object);
+        } else {
+            found = new Ref(object);
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Union.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Union.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import org.xembly.Directives;
+
+/**
+ * A choice between several types.
+ *
+ * <p>One object is one type, and a place where several of them turn up is not
+ * one of them and not none: a void that two callers fill differently is a
+ * choice between what they filled it with. The members are written inside it,
+ * each in the form it goes by elsewhere, since a member of a choice is a type
+ * like any other and may be a choice in its turn.</p>
+ *
+ * @since 0.69.0
+ */
+final class Union implements Type {
+
+    /**
+     * The types this one is a choice between.
+     */
+    private final Collection<Type> members;
+
+    /**
+     * Ctor.
+     * @param types The types this one is a choice between
+     */
+    Union(final Collection<Type> types) {
+        this.members = types;
+    }
+
+    @Override
+    public Directives directives() {
+        final Directives dirs = new Directives().add("union");
+        for (final Type member : this.members) {
+            dirs.append(member.directives());
+        }
+        return dirs.up();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Var.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Var.java
@@ -7,24 +7,49 @@ package org.eolang.inference;
 import org.xembly.Directives;
 
 /**
- * An object whose type only a caller can say.
+ * A variable: an object whose type only a caller can decide.
  *
- * <p>A void is the one thing in a program that is deliberately left open, and
- * what it holds is decided by whoever fills it. So the row says that and
- * nothing more, and says it under the locator of the void, which is the name
- * every mention of that variable is written with: {@code Φ.inc.x.next} is the
- * {@code next} of whatever fills {@code x}, true of every caller and concrete
- * for none.</p>
+ * <p>A void is one. What it holds is put there by whoever copies the object
+ * that keeps it, so the text of the program says nothing about what it is —
+ * which is a fact, and a different one from the silence around an object
+ * nobody looked at.</p>
  *
- * <p>Nothing is carried here, not even the name, since the row is keyed by the
- * locator and the locator is the name.</p>
+ * <p>In the row of the void itself the variable needs no name: the row is
+ * keyed by the locator, and saying the same locator twice would only invite
+ * the two to disagree. Written anywhere else — inside a choice of what a void
+ * is ever filled with, say — it carries the locator, since there is nothing
+ * else there to say which variable it is.</p>
  *
  * @since 0.69.0
  */
 final class Var implements Type {
 
+    /**
+     * The locator of the void, empty when the place it is written says it.
+     */
+    private final String name;
+
+    /**
+     * Ctor.
+     */
+    Var() {
+        this("");
+    }
+
+    /**
+     * Ctor.
+     * @param id The locator of the void
+     */
+    Var(final String id) {
+        this.name = id;
+    }
+
     @Override
     public Directives directives() {
-        return new Directives().add("var").up();
+        final Directives dirs = new Directives().add("var");
+        if (!this.name.isEmpty()) {
+            dirs.attr("id", this.name);
+        }
+        return dirs.up();
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
@@ -1,0 +1,122 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * The rows about a void, with what the program is seen to put in it.
+ *
+ * <p>{@link Demanded} writes down what a void will have to offer. This writes
+ * the other half of what is known about one — what actually goes in, gathered
+ * by {@link Fillings} from every application that fills it, as the choice
+ * between the types they put there:</p>
+ *
+ * <pre> &lt;attr name="φ" type="Φ.bytes.φ" void="true"&gt;
+ *   &lt;witnessed&gt;
+ *     &lt;union&gt;
+ *       &lt;data/&gt;
+ *       &lt;ref loc="Φ.bytes.as-bytes"/&gt;
+ *     &lt;/union&gt;
+ *   &lt;/witnessed&gt;
+ * &lt;/attr&gt;</pre>
+ *
+ * <p>This is evidence of callers and never a contract. Nothing may work out
+ * the type of a void from it: the callers a program happens to have today do
+ * not oblige the one written tomorrow, and a void filled with a
+ * {@code number} everywhere is still a void. It is written because it is true
+ * and because whoever reads the tables wants it, which is the whole of the
+ * reason.</p>
+ *
+ * <p>A choice longer than the cap is written as {@code unknown} instead of its
+ * members. {@code Φ.tuple.head} is filled with 264 different types, and a
+ * choice of 264 tells a reader nothing except that nobody has thought about
+ * it; saying so outright is shorter and truer.</p>
+ *
+ * @since 0.69.0
+ */
+public final class Witnessed implements Clue {
+
+    /**
+     * The clues to follow first.
+     */
+    private final Clue origin;
+
+    /**
+     * How many members a choice may have before it says nothing.
+     */
+    private final int cap;
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the voids are looked into
+     */
+    public Witnessed(final Clue clues) {
+        this(clues, 8);
+    }
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the voids are looked into
+     * @param members How many members a choice may have before it says
+     *  nothing, measured at eight in the state document
+     */
+    Witnessed(final Clue clues, final int members) {
+        this.origin = clues;
+        this.cap = members;
+    }
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        this.origin.follow(xmirs, tables);
+        final Path table = tables.resolve("provides.xml");
+        final XML given = new XMLDocument(table);
+        final Map<String, Collection<Type>> filled = new Fillings(
+            new XMLDocument(tables.resolve("links.xml"))
+        ).all();
+        for (final XML hollow : given.nodes("//attr[@void='true']")) {
+            final Collection<Type> members = filled.getOrDefault(
+                hollow.xpath("@type").get(0), Collections.emptyList()
+            );
+            if (!members.isEmpty()) {
+                new Xembler(
+                    new Directives()
+                        .add("witnessed")
+                        .append(this.joined(members).directives())
+                        .up()
+                ).applyQuietly(hollow.inner());
+            }
+        }
+        Files.write(table, given.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * The types put into one void, as one type.
+     * @param members The types put into it, at least one
+     * @return The type: the one that was put in, the choice between the ones
+     *  that were, or nothing known when there are too many of them
+     */
+    private Type joined(final Collection<Type> members) {
+        final Type found;
+        if (members.size() > this.cap) {
+            found = new Unknown();
+        } else if (members.size() == 1) {
+            found = members.iterator().next();
+        } else {
+            found = new Union(members);
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/WitnessedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/WitnessedTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Witnessed}.
+ * @since 0.69.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class WitnessedTest {
+
+    @Test
+    void putsWhatWentIntoAVoidOnTheVoid(@Mktmp final Path temp) throws IOException {
+        WitnessedTest.program(temp, "Φ.oak");
+        new Witnessed(new Demanded(new Resolved(new Clues()))).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "the void must say what was put into it, but it didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
+                "/provides/type[@id='Φ.inc']/attr[@name='x']/witnessed/ref[@loc='Φ.oak']"
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void saysNothingWhenTooManyThingsWentIn(@Mktmp final Path temp) throws IOException {
+        WitnessedTest.program(temp, "Φ.oak", "Φ.elm");
+        new Witnessed(new Demanded(new Resolved(new Clues())), 1).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "a choice too long to read must say so, but it was written out",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml"))
+                .nodes("//witnessed/unknown"),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void keepsTheChoiceBetweenWhatWentIn(@Mktmp final Path temp) throws IOException {
+        WitnessedTest.program(temp, "Φ.oak", "Φ.elm");
+        new Witnessed(new Demanded(new Resolved(new Clues()))).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "two callers filling one void must make a choice of two, but they didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml"))
+                .nodes("//witnessed/union/ref"),
+            Matchers.hasSize(2)
+        );
+    }
+
+    /**
+     * A program that keeps one void and fills it once per caller.
+     * @param temp The directory to write it into
+     * @param fillers What every caller puts into the void
+     * @throws IOException If the file cannot be written
+     */
+    private static void program(final Path temp, final String... fillers) throws IOException {
+        final StringBuilder text = new StringBuilder(
+            String.join(
+                "",
+                "<object><o loc='Φ.inc' name='inc'>",
+                "<o base='∅' loc='Φ.inc.x' name='x'/></o>",
+                "<o loc='Φ.oak' name='oak'/><o loc='Φ.elm' name='elm'/>"
+            )
+        );
+        for (int caller = 0; caller < fillers.length; caller += 1) {
+            text.append(
+                String.format(
+                    "<o base='Φ.inc' loc='Φ.app%1$d' name='app%1$d'><o as='α0' base='%2$s' loc='Φ.app%1$d.α0'/></o>",
+                    caller, fillers[caller]
+                )
+            );
+        }
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("wood.xmir"),
+            text.append("</object>").toString()
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -22,6 +22,7 @@ import org.eolang.inference.Demanded;
 import org.eolang.inference.Depth;
 import org.eolang.inference.Ladder;
 import org.eolang.inference.Resolved;
+import org.eolang.inference.Witnessed;
 import org.eolang.parser.TrFull;
 
 /**
@@ -90,7 +91,8 @@ final class Inferring implements Step {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
             final int ready = this.ready();
-            new Demanded(new Resolved(new Clues())).follow(this.prepared, this.tables);
+            new Witnessed(new Demanded(new Resolved(new Clues())))
+                .follow(this.prepared, this.tables);
             Logger.info(
                 this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
                 ready, this.tables

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/two-callers-of-a-void-make-a-choice.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/two-callers-of-a-void-make-a-choice.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# One caller puts an `oak` in and another an `elm`, so what the void is seen
+# to hold is neither of them alone and not nothing: it is the choice between
+# the two, written the way a choice is written everywhere else.
+eo:
+  first.eo: |
+    [] > first
+      inc oak > @
+  second.eo: |
+    [] > second
+      inc elm > @
+  inc.eo: |
+    [x] > inc
+      x > @
+  oak.eo: |
+    [] > oak
+  elm.eo: |
+    [] > elm
+provides:
+  - "//attr[@void='true']/witnessed/union/ref[@loc='Φ.oak']"
+  - "//attr[@void='true']/witnessed/union/ref[@loc='Φ.elm']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/two-literals-are-one-filling.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/two-literals-are-one-filling.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Two literals are two objects and one type. What goes into a void is gathered
+# as a type, so filling `inc` with `42` and then with `7` is one thing seen
+# twice and the choice never grows. The bytes of both go into the void of
+# `bytes` itself, and those are one thing too, however many literals there are.
+eo:
+  app.eo: |
+    [] > app
+      inc 42 > first
+      inc 7 > second
+  inc.eo: |
+    [x] > inc
+      x > @
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  bytes.eo: |
+    [b] > bytes
+      b > @
+provides:
+  - "//type[@id='Φ.inc']/attr[@void='true']/witnessed/ref[@loc='Φ.number']"
+  - "//type[@id='Φ.bytes']/attr[@void='true']/witnessed/data"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-remembers-what-was-put-in-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-remembers-what-was-put-in-it.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void holds whatever a caller puts in it, and the callers are known: this
+# one puts an `oak` in. That is not a promise about the next caller, only what
+# this program is seen to do, and the void's row is where it is seen from.
+eo:
+  app.eo: |
+    [] > app
+      inc oak > @
+  inc.eo: |
+    [x] > inc
+      x > @
+  oak.eo: |
+    [] > oak
+provides:
+  - "//type[@id='Φ.inc']/attr[@void='true']/witnessed/ref[@loc='Φ.oak']"


### PR DESCRIPTION
Since #6915 a void's row says what its value will have to offer. This is
the other half: what the program is actually seen to put in it.

Every filling was already written down — since #6787 an application
records what it fills as a `bind` in its own row — but scattered across
the rows of the objects doing the filling, 22,818 of them in
`eo-runtime`. `Fillings` turns them round onto the void, and gathers
what went in as a **type** rather than as a locator, which is what makes
the answer worth reading: the void of `bytes` is filled 7,355 times and
comes out as

```xml
<attr name="φ" type="Φ.bytes.φ" void="true">
  <witnessed>
    <union>
      <data/>
      <ref loc="Φ.bytes.as-bytes"/>
    </union>
  </witnessed>
</attr>
```

`Forms` answers which form the links table gave an object — a datum, a
termination, a variable, or the object it is a copy of — and is where
the collapsing happens: every literal of a program has a locator of its
own and all of them are one type. `Union` writes a choice, in the
element the grammar has had a place for since §8.3 and nothing wrote
yet. `Witnessed` is a new decorator around the clues, beside `Demanded`,
so the two halves of a void's row are written by two objects.

A choice longer than eight members becomes `<unknown/>` instead of its
members, per §5.5 of the state document: `Φ.tuple.head` is filled with
264 different types, and a list that long tells a reader nothing except
that nobody has thought about it.

This is evidence of callers and never a contract — nothing may infer a
void's type from it, and nothing in the resolver reads it. The callers a
program happens to have today do not oblige the one written tomorrow.

Measured on a clean build, 171 files, 44,142 objects: 526 of the 1,001
voids come out with a join — 201 of a single member, 301 of two to
eight, 24 too many to say. `links.xml` and `needs.xml` are
byte-identical, every existing `provides` cell and every demand
unchanged, two runs byte-identical, and the goal takes the same time it
did. No number on the ladder moves, and none should.
