### PR TITLE
#6912: add regression tests for the remaining fragile-marker arms

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -349,79 +349,88 @@
     reference at all) must not suppress the "$." marker here.
     -->
     <xsl:variable name="local-handle" select="//o[@local=$hop-name][ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
-    <xsl:choose>
-      <!-- NOT OPTIMIZED TUPLE -->
-      <xsl:when test="@star">
-        <xsl:text>*</xsl:text>
-      </xsl:when>
-      <xsl:when test="@base=$eo:bottom">
-        <xsl:text>T</xsl:text>
-      </xsl:when>
-      <xsl:when test="starts-with(@base, concat($eo:program, '.')) and (exists(ancestor::o/o[@name = eo:root-name(current()/@base)]) or /object/metas/meta[head = 'alias']/part[1] = eo:root-name(current()/@base))">
-        <!--
-        The plain top-level name would be shadowed by an in-scope
-        attribute, or reinterpreted through a "+alias" declaring that
-        same short name for a different object (#6211), so keep the
-        explicit Q. root to disambiguate.
-        -->
-        <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
-      </xsl:when>
-      <xsl:when test="$package != '' and starts-with(@base, $self-prefix) and $self-first = /object/o[1]/@name and empty(ancestor::o/o[@name = $self-first])">
-        <!--
-        The base names this program's own top-level object through its
-        fully-qualified "Φ.<package>.<name>…" form. The source wrote it
-        bare and every other same-package reference prints bare, so drop
-        the redundant "Φ.<package>." prefix and render the bare name. If
-        an in-scope attribute shadows that name, this branch is skipped:
-        either the package segment is shadowed too (kept "Q."-rooted by
-        the branch above) or the qualified "<package>.<name>" survives
-        through the otherwise branch, both of which resolve correctly.
-        -->
-        <xsl:value-of select="eo:translate-path($self-rest)"/>
-      </xsl:when>
-      <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and (exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name]) or ancestor::o[not(@base)][$rho-count]/@local = $hop-name)">
-        <!--
-        The run of leading "^." parent hops is redundant: the name is
-        absent from each of the N nearer enclosing formations but
-        present in the (N+1)-th, so plain scope resolution re-derives
-        exactly the very same ρ-chain of length N. Drop the whole run.
-        The second alternative catches a recursive self-reference to a
-        file-local handle hosted as a moniker (#5848): the formation reached
-        after the run carries that very handle name in its "@local", so the
-        hops resolve back to the formation itself and the bare handle name
-        re-derives the same ρ-chain. Without it a recursive `&gt;&gt; name`
-        handle folded into a reversed-dispatch receiver would print its
-        self-reference as `^.name` instead of the readable `name`.
-        -->
-        <xsl:value-of select="eo:translate-path($hop-rest)"/>
-      </xsl:when>
-      <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty($local-handle)">
-        <!--
-        An explicit "$.name" (zero ρ hops) whose immediate enclosing
-        formation has no "name" of its own, and which is not a
-        ">> name" handle owned by a formation this reference actually
-        nests inside either ("local-handle" mirrors resolve-local-names.xsl's
-        lexically-scoped "eo:captor", #5875 — a same-named handle declared
-        by some unrelated formation elsewhere in the file, one this
-        reference is not nested inside, must not count), denotes a
-        genuinely different reference than a bare "name" would (which
-        would instead resolve via an implicit ρ hop into an outer scope,
-        per the branch above) — #6237. Render it with its "$." marker so
-        reparsing keeps the same meaning. When the immediate formation
-        DOES own "name", or "name" is such an in-scope file-local handle,
-        bare and "$.name" resolve identically, so the otherwise branch
-        below safely prints it bare, matching a plain same-scope
-        reference. A node that itself carries "@local" is a moniker's own
-        bound value, already relocated in place of its reference site by
-        merge-monikers.xsl, so its ancestor context here no longer
-        reflects its original scope — skip it too, matching bare.
-        -->
-        <xsl:value-of select="concat('$.', eo:translate-path($hop-rest))"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="eo:fragile-marked(eo:surface(@base), exists(@fragile))"/>
-      </xsl:otherwise>
-    </xsl:choose>
+    <!--
+    Whichever arm below decides the head, none of them look at "@fragile"
+    themselves — the whole choice is wrapped in "eo:fragile-marked" after
+    it, so a fragile dispatch keeps its "?." marker no matter which arm's
+    shortening it takes (#6912, the remainder of #6560).
+    -->
+    <xsl:variable name="head" as="xs:string">
+      <xsl:choose>
+        <!-- NOT OPTIMIZED TUPLE -->
+        <xsl:when test="@star">
+          <xsl:text>*</xsl:text>
+        </xsl:when>
+        <xsl:when test="@base=$eo:bottom">
+          <xsl:text>T</xsl:text>
+        </xsl:when>
+        <xsl:when test="starts-with(@base, concat($eo:program, '.')) and (exists(ancestor::o/o[@name = eo:root-name(current()/@base)]) or /object/metas/meta[head = 'alias']/part[1] = eo:root-name(current()/@base))">
+          <!--
+          The plain top-level name would be shadowed by an in-scope
+          attribute, or reinterpreted through a "+alias" declaring that
+          same short name for a different object (#6211), so keep the
+          explicit Q. root to disambiguate.
+          -->
+          <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
+        </xsl:when>
+        <xsl:when test="$package != '' and starts-with(@base, $self-prefix) and $self-first = /object/o[1]/@name and empty(ancestor::o/o[@name = $self-first])">
+          <!--
+          The base names this program's own top-level object through its
+          fully-qualified "Φ.<package>.<name>…" form. The source wrote it
+          bare and every other same-package reference prints bare, so drop
+          the redundant "Φ.<package>." prefix and render the bare name. If
+          an in-scope attribute shadows that name, this branch is skipped:
+          either the package segment is shadowed too (kept "Q."-rooted by
+          the branch above) or the qualified "<package>.<name>" survives
+          through the otherwise branch, both of which resolve correctly.
+          -->
+          <xsl:value-of select="eo:translate-path($self-rest)"/>
+        </xsl:when>
+        <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and (exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name]) or ancestor::o[not(@base)][$rho-count]/@local = $hop-name)">
+          <!--
+          The run of leading "^." parent hops is redundant: the name is
+          absent from each of the N nearer enclosing formations but
+          present in the (N+1)-th, so plain scope resolution re-derives
+          exactly the very same ρ-chain of length N. Drop the whole run.
+          The second alternative catches a recursive self-reference to a
+          file-local handle hosted as a moniker (#5848): the formation reached
+          after the run carries that very handle name in its "@local", so the
+          hops resolve back to the formation itself and the bare handle name
+          re-derives the same ρ-chain. Without it a recursive `&gt;&gt; name`
+          handle folded into a reversed-dispatch receiver would print its
+          self-reference as `^.name` instead of the readable `name`.
+          -->
+          <xsl:value-of select="eo:translate-path($hop-rest)"/>
+        </xsl:when>
+        <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty($local-handle)">
+          <!--
+          An explicit "$.name" (zero ρ hops) whose immediate enclosing
+          formation has no "name" of its own, and which is not a
+          ">> name" handle owned by a formation this reference actually
+          nests inside either ("local-handle" mirrors resolve-local-names.xsl's
+          lexically-scoped "eo:captor", #5875 — a same-named handle declared
+          by some unrelated formation elsewhere in the file, one this
+          reference is not nested inside, must not count), denotes a
+          genuinely different reference than a bare "name" would (which
+          would instead resolve via an implicit ρ hop into an outer scope,
+          per the branch above) — #6237. Render it with its "$." marker so
+          reparsing keeps the same meaning. When the immediate formation
+          DOES own "name", or "name" is such an in-scope file-local handle,
+          bare and "$.name" resolve identically, so the otherwise branch
+          below safely prints it bare, matching a plain same-scope
+          reference. A node that itself carries "@local" is a moniker's own
+          bound value, already relocated in place of its reference site by
+          merge-monikers.xsl, so its ancestor context here no longer
+          reflects its original scope — skip it too, matching bare.
+          -->
+          <xsl:value-of select="concat('$.', eo:translate-path($hop-rest))"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="eo:surface(@base)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:value-of select="eo:fragile-marked($head, exists(@fragile))"/>
   </xsl:template>
   <!-- ABSTRACT OR ATOM -->
   <xsl:template match="o[eo:abstract(.) and not(eo:has-data(.))]" mode="head">

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-dollar-marker.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-dollar-marker.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6912: the explicit "$.name" arm of to-eo-tree.xsl's head choice (kept
+# when the immediate formation has no attribute of its own by that name,
+# #6237) never looked at "@fragile", so a fragile dispatch through it
+# lost its "?." marker.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    42 > foo
+    [] > inner
+      $.foo?.bar > @
+
+printed: |
+  [] > app
+    42 > foo
+    $.foo?.bar > [] > inner

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-package-shortening.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-package-shortening.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6912: the same-package shortening arm of to-eo-tree.xsl's head choice
+# (drops the "Φ.<package>." prefix a same-file self-reference gets homed
+# into) never looked at "@fragile", so a fragile dispatch through it lost
+# its "?." marker.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package pkg
+
+  [] > app
+    5 > bar
+    [] > nested
+      app?.bar > @
+
+printed: |
+  +package pkg
+
+  [] > app
+    5 > bar
+    app?.bar > [] > nested

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-q-root.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-q-root.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6912: the "Q." disambiguation arm of to-eo-tree.xsl's head choice (kept
+# for a Φ-rooted base whose plain name is shadowed by an in-scope
+# attribute) never looked at "@fragile", so a fragile dispatch through it
+# lost its "?." marker. "nested" shadows "app" with its own attribute, so
+# "Q.app?.foo" keeps its explicit "Q." root; the marker must survive too.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    5 > foo
+    [] > nested
+      9 > app
+      Q.app?.foo > @
+
+printed: |
+  [] > app
+    5 > foo
+    [] > nested
+      Q.app?.foo > @
+      9 > app

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-redundant-hop-drop.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-survives-redundant-hop-drop.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6912: the redundant-ρ-hop arm of to-eo-tree.xsl's head choice (drops a
+# leading run of "^." hops that plain scope resolution would re-derive on
+# its own) never looked at "@fragile", so a fragile dispatch through it
+# lost its "?." marker. "bar" has no "x" of its own, so the "^." hop to
+# the enclosing "foo"'s "x" is redundant and dropped; the marker must
+# survive the drop.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package org.eolang
+
+  [x] > foo
+    [] > bar
+      ^.x?.y > @
+
+printed: |
+  +package org.eolang
+
+  [x] > foo
+    x?.y > [] > bar


### PR DESCRIPTION
Follow-up to #6933, split solely to respect the 200-line PR-size cap.

Adds regression tests for the other three head-shortening arms that #6933 fixes but didn't have room to test: same-package shortening, redundant-ρ-hop drop, and the explicit $.name marker. No code change, test-only.

References #6912, already closed by #6933.
