### PR TITLE
#6904: don't delete a sibling version's dependency when conflicts are ignored

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DepCoordinate.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DepCoordinate.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.apache.maven.model.Dependency;
+
+/**
+ * A dependency's coordinate, without its version: {@code groupId:artifactId:classifier}.
+ * @since 0.61.0
+ */
+final class DepCoordinate {
+
+    /**
+     * The dependency.
+     */
+    private final Dependency dependency;
+
+    /**
+     * Ctor.
+     * @param dep The dependency
+     */
+    DepCoordinate(final Dependency dep) {
+        this.dependency = dep;
+    }
+
+    /**
+     * The coordinate string.
+     * @return The coordinate, without the version
+     */
+    String value() {
+        return String.join(
+            ":",
+            this.dependency.getGroupId(),
+            this.dependency.getArtifactId(),
+            this.classifier()
+        );
+    }
+
+    /**
+     * The dependency's classifier, normalized to {@code "-"} when absent.
+     * @return The classifier
+     */
+    String classifier() {
+        final String classifier;
+        if (this.dependency.getClassifier() == null
+            || this.dependency.getClassifier().isEmpty()) {
+            classifier = "-";
+        } else {
+            classifier = this.dependency.getClassifier();
+        }
+        return classifier;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ResolvedVersions.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ResolvedVersions.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.maven.model.Dependency;
+
+/**
+ * Every version legitimately resolved in a run, grouped by coordinate, so
+ * {@link Resolving#cleanPlace} can tell a stale version (absent from the
+ * whole set) from a sibling version resolved alongside it in the same run.
+ * @since 0.61.0
+ */
+final class ResolvedVersions {
+
+    /**
+     * Dependencies resolved in this run.
+     */
+    private final Collection<Dep> deps;
+
+    /**
+     * Ctor.
+     * @param resolved Dependencies resolved in this run
+     */
+    ResolvedVersions(final Collection<Dep> resolved) {
+        this.deps = resolved;
+    }
+
+    /**
+     * Every version, by coordinate.
+     * @return Versions, by coordinate
+     */
+    Map<String, Set<String>> byCoordinate() {
+        final Map<String, Set<String>> result = new HashMap<>(0);
+        for (final Dep dep : this.deps) {
+            final Dependency dependency = dep.get();
+            result.computeIfAbsent(
+                new DepCoordinate(dependency).value(),
+                key -> new HashSet<>(0)
+            ).add(dependency.getVersion());
+        }
+        return result;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -11,6 +11,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -113,9 +117,10 @@ final class Resolving implements Step {
         if (deps.isEmpty()) {
             unpacked = 0;
         } else {
+            final Map<String, Set<String>> versions = this.versionsByCoordinate(deps);
             unpacked = new Threaded<>(
                 deps,
-                dep -> this.resolved(dep, this.target)
+                dep -> this.resolved(dep, this.target, versions)
             ).total();
         }
         if (unpacked == 0) {
@@ -134,23 +139,22 @@ final class Resolving implements Step {
      * Resolve a single dependency.
      * @param dep Dependency
      * @param dest Destination directory
+     * @param versions Every version legitimately resolved in this run, by coordinate
      * @return Count resolved
      * @throws IOException If fails
      */
-    private int resolved(final Dep dep, final Path dest) throws IOException {
-        final String classifier;
+    private int resolved(
+        final Dep dep, final Path dest, final Map<String, Set<String>> versions
+    ) throws IOException {
         final Dependency dependency = dep.get();
-        if (dependency.getClassifier() == null || dependency.getClassifier().isEmpty()) {
-            classifier = "-";
-        } else {
-            classifier = dependency.getClassifier();
-        }
+        final String classifier = this.classifier(dependency);
         final Path place = this.cleanPlace(
             dest
                 .resolve(dependency.getGroupId())
                 .resolve(dependency.getArtifactId())
                 .resolve(classifier),
-            dependency.getVersion()
+            dependency.getVersion(),
+            versions.get(this.coordinate(dependency, classifier))
         );
         final int total;
         if (Files.exists(place)) {
@@ -200,18 +204,27 @@ final class Resolving implements Step {
     }
 
     /**
-     * Returns directory where files should be unpacked, removing outdated versions.
+     * Returns directory where files should be unpacked, removing stale versions:
+     * ones no longer requested by any dependency of this coordinate in the
+     * current run, not merely ones other than the version being resolved right
+     * now. With {@code eo.ignoreVersionConflicts} on, two versions of the same
+     * coordinate can both be legitimately part of the resolution set, and
+     * neither may delete the other's just-unpacked files (#6904).
      * @param dir Directory
      * @param version Version
+     * @param keep Every version of this coordinate legitimately resolved in
+     *  this run
      * @return Full path
      * @throws IOException If fails
      */
-    private Path cleanPlace(final Path dir, final String version) throws IOException {
+    private Path cleanPlace(
+        final Path dir, final String version, final Set<String> keep
+    ) throws IOException {
         final File[] subs = dir.toFile().listFiles();
         if (subs != null) {
             for (final File sub : subs) {
                 final String base = sub.getName();
-                if (base.equals(version)) {
+                if (keep.contains(base)) {
                     continue;
                 }
                 final Path bad = dir.resolve(base);
@@ -223,12 +236,62 @@ final class Resolving implements Step {
                 }
                 Logger.info(
                     this,
-                    "Directory %[file]s deleted because it contained wrong version files (not %s)",
-                    bad, version
+                    "Directory %[file]s deleted because it contained a stale version (not %s)",
+                    bad, keep
                 );
             }
         }
         return dir.resolve(version);
+    }
+
+    /**
+     * Group every resolved dependency's version by its coordinate, so
+     * {@link #cleanPlace} can tell a stale version (absent from the whole
+     * set) from a sibling version legitimately resolved alongside it in
+     * the same run.
+     * @param deps Dependencies resolved in this run
+     * @return Every version, by coordinate
+     * @checkstyle NonStaticMethodCheck (2 lines)
+     */
+    private Map<String, Set<String>> versionsByCoordinate(final Collection<Dep> deps) {
+        final Map<String, Set<String>> result = new HashMap<>(0);
+        for (final Dep dep : deps) {
+            final Dependency dependency = dep.get();
+            result.computeIfAbsent(
+                this.coordinate(dependency, this.classifier(dependency)),
+                key -> new HashSet<>(0)
+            ).add(dependency.getVersion());
+        }
+        return result;
+    }
+
+    /**
+     * A dependency's coordinate, without its version.
+     * @param dependency Dependency
+     * @param classifier Its classifier, already normalized
+     * @return The coordinate
+     * @checkstyle NonStaticMethodCheck (2 lines)
+     */
+    private String coordinate(final Dependency dependency, final String classifier) {
+        return String.join(
+            ":", dependency.getGroupId(), dependency.getArtifactId(), classifier
+        );
+    }
+
+    /**
+     * A dependency's classifier, normalized to "-" when absent.
+     * @param dependency Dependency
+     * @return The classifier
+     * @checkstyle NonStaticMethodCheck (2 lines)
+     */
+    private String classifier(final Dependency dependency) {
+        final String classifier;
+        if (dependency.getClassifier() == null || dependency.getClassifier().isEmpty()) {
+            classifier = "-";
+        } else {
+            classifier = dependency.getClassifier();
+        }
+        return classifier;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -251,7 +251,6 @@ final class Resolving implements Step {
      * the same run.
      * @param deps Dependencies resolved in this run
      * @return Every version, by coordinate
-     * @checkstyle NonStaticMethodCheck (2 lines)
      */
     private Map<String, Set<String>> versionsByCoordinate(final Collection<Dep> deps) {
         final Map<String, Set<String>> result = new HashMap<>(0);
@@ -270,7 +269,6 @@ final class Resolving implements Step {
      * @param dependency Dependency
      * @param classifier Its classifier, already normalized
      * @return The coordinate
-     * @checkstyle NonStaticMethodCheck (2 lines)
      */
     private String coordinate(final Dependency dependency, final String classifier) {
         return String.join(
@@ -282,7 +280,6 @@ final class Resolving implements Step {
      * A dependency's classifier, normalized to "-" when absent.
      * @param dependency Dependency
      * @return The classifier
-     * @checkstyle NonStaticMethodCheck (2 lines)
      */
     private String classifier(final Dependency dependency) {
         final String classifier;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -147,14 +147,14 @@ final class Resolving implements Step {
         final Dep dep, final Path dest, final Map<String, Set<String>> versions
     ) throws IOException {
         final Dependency dependency = dep.get();
-        final String classifier = this.classifier(dependency);
+        final DepCoordinate coords = new DepCoordinate(dependency);
         final Path place = this.cleanPlace(
             dest
                 .resolve(dependency.getGroupId())
                 .resolve(dependency.getArtifactId())
-                .resolve(classifier),
+                .resolve(coords.classifier()),
             dependency.getVersion(),
-            versions.get(this.coordinate(dependency, classifier))
+            versions.get(coords.value())
         );
         final int total;
         if (Files.exists(place)) {
@@ -257,38 +257,11 @@ final class Resolving implements Step {
         for (final Dep dep : deps) {
             final Dependency dependency = dep.get();
             result.computeIfAbsent(
-                this.coordinate(dependency, this.classifier(dependency)),
+                new DepCoordinate(dependency).value(),
                 key -> new HashSet<>(0)
             ).add(dependency.getVersion());
         }
         return result;
-    }
-
-    /**
-     * A dependency's coordinate, without its version.
-     * @param dependency Dependency
-     * @param classifier Its classifier, already normalized
-     * @return The coordinate
-     */
-    private String coordinate(final Dependency dependency, final String classifier) {
-        return String.join(
-            ":", dependency.getGroupId(), dependency.getArtifactId(), classifier
-        );
-    }
-
-    /**
-     * A dependency's classifier, normalized to "-" when absent.
-     * @param dependency Dependency
-     * @return The classifier
-     */
-    private String classifier(final Dependency dependency) {
-        final String classifier;
-        if (dependency.getClassifier() == null || dependency.getClassifier().isEmpty()) {
-            classifier = "-";
-        } else {
-            classifier = dependency.getClassifier();
-        }
-        return classifier;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -11,8 +11,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
@@ -117,7 +115,7 @@ final class Resolving implements Step {
         if (deps.isEmpty()) {
             unpacked = 0;
         } else {
-            final Map<String, Set<String>> versions = this.versionsByCoordinate(deps);
+            final Map<String, Set<String>> versions = new ResolvedVersions(deps).byCoordinate();
             unpacked = new Threaded<>(
                 deps,
                 dep -> this.resolved(dep, this.target, versions)
@@ -242,26 +240,6 @@ final class Resolving implements Step {
             }
         }
         return dir.resolve(version);
-    }
-
-    /**
-     * Group every resolved dependency's version by its coordinate, so
-     * {@link #cleanPlace} can tell a stale version (absent from the whole
-     * set) from a sibling version legitimately resolved alongside it in
-     * the same run.
-     * @param deps Dependencies resolved in this run
-     * @return Every version, by coordinate
-     */
-    private Map<String, Set<String>> versionsByCoordinate(final Collection<Dep> deps) {
-        final Map<String, Set<String>> result = new HashMap<>(0);
-        for (final Dep dep : deps) {
-            final Dependency dependency = dep.get();
-            result.computeIfAbsent(
-                new DepCoordinate(dependency).value(),
-                key -> new HashSet<>(0)
-            ).add(dependency.getVersion());
-        }
-        return result;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -314,4 +314,36 @@ final class MjResolveTest {
             new ContainsFiles("**/eo-runtime-*.class")
         );
     }
+
+    @Test
+    void keepsBothSiblingVersionsWithConflictsIgnored(@Mktmp final Path temp)
+        throws IOException {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "+package foo.x",
+                "+rt jvm org.eolang:eo-runtime:0.22.0",
+                String.format("+version 0.25.0%n"),
+                "[] > main /bytes"
+            )
+        ).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "+package foo.x",
+                "+rt jvm org.eolang:eo-runtime:0.22.1",
+                String.format("+version 0.25.0%n"),
+                "[] > main-1 /bytes"
+            )
+        );
+        maven.with("ignoreConflicts", true)
+            .execute(new FakeMaven.Resolve());
+        MatcherAssert.assertThat(
+            "Both sibling versions must survive resolving, but one was deleted",
+            maven.targetPath(),
+            Matchers.allOf(
+                new ContainsFiles("**/eo-runtime-0.22.0.class"),
+                new ContainsFiles("**/eo-runtime-0.22.1.class")
+            )
+        );
+    }
 }


### PR DESCRIPTION
Resolving.resolved() calls cleanPlace(dir, version) for every dependency it resolves. cleanPlace deleted every existing subdirectory of dir whose name wasn't the version currently being resolved. That is correct for the normal case (a version bump between builds, where only one version should exist on disk), but when eo.ignoreVersionConflicts intentionally lets two versions of the same coordinate coexist in one build, resolving version A deleted version B's just-unpacked files, and resolving version B (which can run in parallel via Threaded) deleted version A's.

cleanPlace now takes the full set of versions legitimately resolved for that coordinate in the current run, computed once in exec() from the same deps() collection Threaded iterates over, and only deletes a subdirectory whose name is outside that set. A genuinely stale version (no longer requested by anything in the current build) still gets deleted; a sibling version that is part of the current resolution set does not.

Added a test resolving two eo-runtime versions from two programs with eo.ignoreVersionConflicts on, asserting both survive on disk.

Closes #6904
