### PR TITLE
#6895: reject fractional and non-finite recv sizes

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -7,7 +7,7 @@ package org.eolang.posix;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
-import org.eolang.ExFailure;
+import org.eolang.Expect;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -33,13 +33,9 @@ public final class RecvSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        final int size = new Dataized(params[1]).asNumber().intValue();
-        if (size < 0) {
-            throw new ExFailure(
-                "Can't receive a negative number of bytes '%d'",
-                size
-            );
-        }
+        final int size = new Expect.Natural(
+            new Expect<>("the 'size' argument of recv", () -> params[1])
+        ).it();
         final byte[] buf = new byte[size];
         final int received = CStdLib.INSTANCE.recv(
             new Dataized(params[0]).asNumber().intValue(),

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
-import org.eolang.ExFailure;
+import org.eolang.Expect;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -34,13 +34,9 @@ public final class RecvFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int size = new Dataized(params[1]).asNumber().intValue();
-        if (size < 0) {
-            throw new ExFailure(
-                "Can't receive a negative number of bytes '%d'",
-                size
-            );
-        }
+        final int size = new Expect.Natural(
+            new Expect<>("the 'size' argument of recv", () -> params[1])
+        ).it();
         final byte[] buf = new byte[size];
         final int received = Winsock.INSTANCE.recv(
             new Dataized(params[0]).asNumber().intValue(),

--- a/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
@@ -49,6 +49,30 @@ final class RecvSyscallTest {
         );
     }
 
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsFractionalSizeOnPosixRecv() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(1.5), new Data.ToPhi(0)
+            ),
+            "A fractional posix recv size must fail with ExFailure, not receive a truncated count"
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsInfiniteSizeOnPosixRecv() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(Double.POSITIVE_INFINITY), new Data.ToPhi(0)
+            ),
+            "An infinite posix recv size must fail with ExFailure, not allocate the largest int"
+        );
+    }
+
     /**
      * The recv outcome as a {@code [code, output-length]} pair.
      * @param result The dataizable recv result

--- a/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
@@ -49,6 +49,30 @@ final class RecvFuncCallTest {
         );
     }
 
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsFractionalSizeOnWindowsRecv() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(1.5), new Data.ToPhi(0)
+            ),
+            "A fractional win32 recv size must fail with ExFailure, not receive a truncated count"
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsInfiniteSizeOnWindowsRecv() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(Double.POSITIVE_INFINITY), new Data.ToPhi(0)
+            ),
+            "An infinite win32 recv size must fail with ExFailure, not allocate the largest int"
+        );
+    }
+
     /**
      * The recv outcome as a {@code [code, output-length]} pair.
      * @param result The dataizable recv result


### PR DESCRIPTION
Fixes #6895

`recv` took its byte count through `new Dataized(params[1]).asNumber().intValue()`, so anything that was not already a whole number was quietly turned into a different request: `1.5` became a one-byte read, and a positive infinity became `Integer.MAX_VALUE` and went straight into `new byte[size]`. The `size < 0` guard added in #6833 only covered the negative case.

Both bridges now take the count through `Expect.Natural`, the same checked conversion `chunk.read`, `bytes.slice` and `chunk.resized` already use, so a fractional, `nan`, infinite, out-of-int-range or negative size fails with an `ExFailure` before anything is allocated. The negative case keeps failing as it did, just with the canonical message.

Two regression tests per platform, both verified against the unfixed code: `rejectsFractionalSizeOn*Recv` reports "Expected org.eolang.ExFailure to be thrown, but nothing was thrown", and `rejectsInfiniteSizeOn*Recv` dies on an `OutOfMemoryError` from the `Integer.MAX_VALUE` allocation. Both pass with the fix. Locally `RecvFuncCallTest` is 4/4 on Windows, `RecvSyscallTest` runs the same four on POSIX, and qulice on `eo-runtime` is clean.
