### PR TITLE
fix(#6888): trim repeated trailing path separators

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -438,10 +438,25 @@
       "/www/html"
     "/www/html"
 
+  eq. ++> can-return-a-basename-ignoring-repeated-posix-separators
+    basename.
+      path.posix "foo//"
+    "foo"
+
+  eq. ++> can-return-a-basename-ignoring-repeated-win32-separators
+    basename.
+      path.win32 "foo\\\\"
+    "foo"
+
   eq. ++> can-return-a-basename-with-a-backslash-on-posix
     basename.
       path.posix "/var/www/html/foo\\bar"
     "foo\\bar"
+
+  eq. ++> can-return-an-absolute-basename-ignoring-repeated-posix-separators
+    basename.
+      path.posix "/foo//"
+    "foo"
 
   eq. ++> can-return-the-basename-ignoring-a-trailing-separator
     basename.
@@ -458,20 +473,15 @@
       path.posix "/foo/"
     "foo"
 
-  eq. ++> can-return-a-basename-ignoring-repeated-posix-separators
-    basename.
+  eq. ++> can-return-the-current-dirname-ignoring-repeated-posix-separators
+    dirname.
       path.posix "foo//"
-    "foo"
+    "."
 
-  eq. ++> can-return-an-absolute-basename-ignoring-repeated-posix-separators
-    basename.
-      path.posix "/foo//"
-    "foo"
-
-  eq. ++> can-return-a-basename-ignoring-repeated-win32-separators
-    basename.
+  eq. ++> can-return-the-current-dirname-ignoring-repeated-win32-separators
+    dirname.
       path.win32 "foo\\\\"
-    "foo"
+    "."
 
   eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
     dirname.
@@ -486,16 +496,6 @@
   eq. ++> can-return-the-current-dirname-of-a-relative-posix-file-ending-with-a-separator
     dirname.
       path.posix "foo/"
-    "."
-
-  eq. ++> can-return-the-current-dirname-ignoring-repeated-posix-separators
-    dirname.
-      path.posix "foo//"
-    "."
-
-  eq. ++> can-return-the-current-dirname-ignoring-repeated-win32-separators
-    dirname.
-      path.win32 "foo\\\\"
     "."
 
   eq. ++> can-return-the-dirname-of-a-directory-path
@@ -527,6 +527,11 @@
     path.joined
       * "var" "www"
 
+  eq. ++> can-return-the-root-dirname-ignoring-repeated-posix-separators
+    dirname.
+      path.posix "/foo//"
+    "/"
+
   eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
     dirname.
       path.win32 "\\foo"
@@ -540,11 +545,6 @@
   eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path-ending-with-a-separator
     dirname.
       path.posix "/foo/"
-    "/"
-
-  eq. ++> can-return-the-root-dirname-ignoring-repeated-posix-separators
-    dirname.
-      path.posix "/foo//"
     "/"
 
   eq. ++> can-return-the-same-string-without-a-separator

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -162,7 +162,17 @@
           as-bytes.
             uri.slice
               0
-              uri.length.minus separator.length
+              [index] >> first-non-separator
+                if. > @
+                  index.eq 0
+                  1
+                  if.
+                    eq.
+                      uri.slice index 1
+                      separator
+                    first-non-separator (index.plus -1).as-number
+                    index.plus 1
+              | ((number uri.length).plus -1)
           uri
     and. > unc
       driveless.size.gt 1
@@ -448,6 +458,21 @@
       path.posix "/foo/"
     "foo"
 
+  eq. ++> can-return-a-basename-ignoring-repeated-posix-separators
+    basename.
+      path.posix "foo//"
+    "foo"
+
+  eq. ++> can-return-an-absolute-basename-ignoring-repeated-posix-separators
+    basename.
+      path.posix "/foo//"
+    "foo"
+
+  eq. ++> can-return-a-basename-ignoring-repeated-win32-separators
+    basename.
+      path.win32 "foo\\\\"
+    "foo"
+
   eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
     dirname.
       path.posix ".gitignore"
@@ -461,6 +486,16 @@
   eq. ++> can-return-the-current-dirname-of-a-relative-posix-file-ending-with-a-separator
     dirname.
       path.posix "foo/"
+    "."
+
+  eq. ++> can-return-the-current-dirname-ignoring-repeated-posix-separators
+    dirname.
+      path.posix "foo//"
+    "."
+
+  eq. ++> can-return-the-current-dirname-ignoring-repeated-win32-separators
+    dirname.
+      path.win32 "foo\\\\"
     "."
 
   eq. ++> can-return-the-dirname-of-a-directory-path
@@ -505,6 +540,11 @@
   eq. ++> can-return-the-root-dirname-of-a-single-component-posix-path-ending-with-a-separator
     dirname.
       path.posix "/foo/"
+    "/"
+
+  eq. ++> can-return-the-root-dirname-ignoring-repeated-posix-separators
+    dirname.
+      path.posix "/foo//"
     "/"
 
   eq. ++> can-return-the-same-string-without-a-separator

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -151,19 +151,19 @@
         as-bytes.
           sys.sanitized other
     sys.separator > separator
-    string > [] > trimmed
-      if.
-        or.
-          uri.size.eq 0
-          uri.eq separator
-        uri
+    [] > trimmed
+      string > @
         if.
-          uri.ends-with separator
-          as-bytes.
-            uri.slice
-              0
-              [index] >> first-non-separator
-                if. > @
+          or.
+            uri.size.eq 0
+            uri.eq separator
+          uri
+          if.
+            uri.ends-with separator
+            as-bytes.
+              uri.slice
+                0
+                if. > [index] >> first-non-separator
                   index.eq 0
                   1
                   if.
@@ -172,8 +172,8 @@
                       separator
                     first-non-separator (index.plus -1).as-number
                     index.plus 1
-              | ((number uri.length).plus -1)
-          uri
+                | ((number uri.length).plus -1)
+            uri
     and. > unc
       driveless.size.gt 1
       driveless.starts-with


### PR DESCRIPTION
@yegor256

Closes #6888

## Summary

- Trim the complete trailing separator run before calculating `basename` or `dirname`.
- Preserve one separator when the input is the root path.
- Cover repeated POSIX and Win32 separators, including absolute POSIX paths.

## Root cause

The shared `trimmed` helper removed exactly one trailing separator. Inputs ending in two or more separators therefore still reached `basename` and `dirname` with a separator at the end.

## Validation

- `git diff --check` — passed.
- Server-side diff — one file, 41 additions and 1 deletion.
- Targeted Maven test execution was attempted, but the sandboxed Java process could not finish resolving the cold Maven dependency graph because outbound DNS/network access is restricted. The PR should remain a draft until repository CI completes.