### PR TITLE
#6897: reject fractional and non-finite read sizes

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -7,7 +7,7 @@ package org.eolang.posix;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
-import org.eolang.ExFailure;
+import org.eolang.Expect;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,13 +32,9 @@ public final class ReadSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
-        final int size = new Dataized(params[1]).asNumber().intValue();
-        if (size < 0) {
-            throw new ExFailure(
-                "Can't read a negative number of bytes '%d'",
-                size
-            );
-        }
+        final int size = new Expect.Natural(
+            new Expect<>("the 'size' argument of read", () -> params[1])
+        ).it();
         final Phi result = this.posix.take("return").copy();
         final byte[] buf = new byte[size];
         final int count = CStdLib.INSTANCE.read(

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
-import org.eolang.ExFailure;
+import org.eolang.Expect;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,13 +32,9 @@ public final class ReadFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
-        final int size = new Dataized(params[1]).asNumber().intValue();
-        if (size < 0) {
-            throw new ExFailure(
-                "Can't read a negative number of bytes '%d'",
-                size
-            );
-        }
+        final int size = new Expect.Natural(
+            new Expect<>("the 'size' argument of read", () -> params[1])
+        ).it();
         final byte[] buf = new byte[size];
         final int count = Msvcrt.INSTANCE._read(
             new Dataized(params[0]).asNumber().intValue(), buf, size

--- a/eo-runtime/src/test/java/org/eolang/ReadSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ReadSyscallTest.java
@@ -19,6 +19,54 @@ final class ReadSyscallTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    void rejectsFractionalSizeOnPosixRead() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(-1), new Data.ToPhi(1.5)
+            ),
+            "A fractional posix read size must fail with ExFailure, not read a truncated count"
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsFractionalSizeOnWindowsRead() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(-1), new Data.ToPhi(1.5)
+            ),
+            "A fractional win32 read size must fail with ExFailure, not read a truncated count"
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsInfiniteSizeOnPosixRead() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(-1), new Data.ToPhi(Double.POSITIVE_INFINITY)
+            ),
+            "An infinite posix read size must fail with ExFailure, not allocate the largest int"
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsInfiniteSizeOnWindowsRead() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadFuncCall(Phi.Φ.take("win32").copy()).make(
+                new Data.ToPhi(-1), new Data.ToPhi(Double.POSITIVE_INFINITY)
+            ),
+            "An infinite win32 read size must fail with ExFailure, not allocate the largest int"
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
     void rejectsNegativeSizeOnPosixRead() {
         Assertions.assertThrows(
             ExFailure.class,


### PR DESCRIPTION
Fixes #6897
Fixes #6890

Both issues land on the same two lines. `console.read` and the stream returned by `file.open` pass their byte count straight to `ReadSyscall.make()` / `ReadFuncCall.make()`, which took it through `new Dataized(params[1]).asNumber().intValue()`. So `0.5` became a zero-byte read, `2.9` became a two-byte one, and a positive infinity became `Integer.MAX_VALUE` and went into `new byte[size]`. Only the negative case was guarded.

Both bridges now take the count through `Expect.Natural`, the same checked conversion `chunk.read`, `bytes.slice` and `chunk.resized` already use, so a fractional, `nan`, infinite, out-of-int-range or negative size fails with an `ExFailure` before anything is allocated or any native call happens. The negative case keeps failing as before, with the canonical message.

Four regression tests in `ReadSyscallTest`, which already covered the negative case for both platforms. Verified against the unfixed code: the fractional one reports "Expected org.eolang.ExFailure to be thrown, but nothing was thrown", and the infinite one dies on the `Integer.MAX_VALUE` allocation. They use an invalid descriptor so nothing can block on real input. Locally 6/6 (3 Windows, 3 POSIX skipped on this machine) and qulice on `eo-runtime` is clean.
