### PR TITLE
#6903: retry directory.tmpfile creation only on a genuine name collision

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -26,12 +26,26 @@
     [index] >> attempted
       if. > @
         descriptor.eq -1
-        attempted
-          index.plus 1
+        if.
+          errno.eq
+            os.is-windows.if win32.eexist posix.eexist
+          attempted
+            index.plus 1
+          T
+            "Can't create a unique file in %s, OS error %d".printf
+              * dir errno
         seq *
           closed descriptor
           path
       opened path > descriptor!
+      code. > errno
+        os.is-windows.if
+          win32
+            "_errno"
+            *
+          posix
+            "errno"
+            *
       candidate index > path!
     | 0 > @
     [index] > candidate
@@ -452,6 +466,14 @@
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
+
+  --> stops-on-a-permanent-open-failure
+    parent.retried > @
+      parent.path
+      42
+      9
+      0.5
+    mktemp.tmpfile.deleted.as-path.as-dir > parent
 
   tmpfile. --> stops-on-a-tmpfile-in-an-absent-directory
     @.

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -19,6 +19,7 @@
   os.is-macos.if > creat
     512
     64
+  17 > eexist
   os.is-macos.if > exclusive
     2048
     128

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -20,6 +20,7 @@
   [] > @ /Q.win32.return
   8 > append
   256 > creat
+  17 > eexist
   1024 > exclusive
   -1 > failure
   2 > inet

--- a/eo-runtime/src/main/java/org/eolang/win32/ErrnoFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ErrnoFuncCall.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
+import org.eolang.Syscall;
+
+/**
+ * The msvcrt {@code _errno} function call: the raw CRT error code left by the
+ * last failed {@code msvcrt} file function, read the same way {@link Errno}
+ * reads it to build a failure message.
+ * @since 0.75.0
+ */
+public final class ErrnoFuncCall implements Syscall {
+
+    /**
+     * Win32 object.
+     */
+    private final Phi win;
+
+    /**
+     * Ctor.
+     * @param win Win32 object
+     */
+    public ErrnoFuncCall(final Phi win) {
+        this.win = win;
+    }
+
+    @Override
+    public Phi make(final Phi... params) {
+        final Phi result = this.win.take("return").copy();
+        result.put(0, new Data.ToPhi(Msvcrt.INSTANCE._errno().getInt(0)));
+        result.put(1, new PhDefault());
+        return result;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/win32/NamedFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/NamedFuncCall.java
@@ -7,7 +7,6 @@ package org.eolang.win32;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -28,6 +27,7 @@ public final class NamedFuncCall implements Syscall {
 
     static {
         NamedFuncCall.ALL.put("_getpid", GetpidFuncCall::new);
+        NamedFuncCall.ALL.put("_errno", ErrnoFuncCall::new);
         NamedFuncCall.ALL.put("_open", OpenFuncCall::new);
         NamedFuncCall.ALL.put("_access", AccessFuncCall::new);
         NamedFuncCall.ALL.put("_stat64", Stat64FuncCall::new);
@@ -42,18 +42,6 @@ public final class NamedFuncCall implements Syscall {
         NamedFuncCall.ALL.put("_close", CloseFuncCall::new);
         NamedFuncCall.ALL.put("getenv", GetenvFuncCall::new);
         NamedFuncCall.ALL.put("_ftime64_s", FtimeFuncCall::new);
-        NamedFuncCall.ALL.put("WSAStartup", WSAStartupFuncCall::new);
-        NamedFuncCall.ALL.put("WSACleanup", WSACleanupFuncCall::new);
-        NamedFuncCall.ALL.put("WSAGetLastError", WSAGetLastErrorFuncCall::new);
-        NamedFuncCall.ALL.put("socket", SocketFuncCall::new);
-        NamedFuncCall.ALL.put("connect", ConnectFuncCall::new);
-        NamedFuncCall.ALL.put("accept", AcceptFuncCall::new);
-        NamedFuncCall.ALL.put("bind", BindFuncCall::new);
-        NamedFuncCall.ALL.put("listen", ListenFuncCall::new);
-        NamedFuncCall.ALL.put("send", SendFuncCall::new);
-        NamedFuncCall.ALL.put("recv", RecvFuncCall::new);
-        NamedFuncCall.ALL.put("closesocket", ClosesocketFuncCall::new);
-        NamedFuncCall.ALL.put("inet_addr", InetAddrFuncCall::new);
     }
 
     /**
@@ -78,12 +66,12 @@ public final class NamedFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
-        if (!NamedFuncCall.ALL.containsKey(this.name)) {
-            throw new ExFailure(
-                "Can't make win32 function call '%s' because it's either not supported yet or does not exist",
-                this.name
-            );
+        final Syscall call;
+        if (NamedFuncCall.ALL.containsKey(this.name)) {
+            call = NamedFuncCall.ALL.get(this.name).apply(this.rho);
+        } else {
+            call = new NamedSocketFuncCall(this.name, this.rho);
         }
-        return NamedFuncCall.ALL.get(this.name).apply(this.rho).make(params);
+        return call.make(params);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/win32/NamedSocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/NamedSocketFuncCall.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.eolang.Syscall;
+
+/**
+ * A Winsock function call known by its name, split out of {@link NamedFuncCall}
+ * to keep that class's fan-out down: sockets stay on Winsock (ws2_32), unlike
+ * every other Win32 call this package makes, which goes through the C runtime.
+ * @since 0.75.0
+ */
+final class NamedSocketFuncCall implements Syscall {
+
+    /**
+     * All function calls, by their Winsock names.
+     */
+    private static final Map<String, Function<Phi, Syscall>> ALL = new HashMap<>();
+
+    static {
+        NamedSocketFuncCall.ALL.put("WSAStartup", WSAStartupFuncCall::new);
+        NamedSocketFuncCall.ALL.put("WSACleanup", WSACleanupFuncCall::new);
+        NamedSocketFuncCall.ALL.put("WSAGetLastError", WSAGetLastErrorFuncCall::new);
+        NamedSocketFuncCall.ALL.put("socket", SocketFuncCall::new);
+        NamedSocketFuncCall.ALL.put("connect", ConnectFuncCall::new);
+        NamedSocketFuncCall.ALL.put("accept", AcceptFuncCall::new);
+        NamedSocketFuncCall.ALL.put("bind", BindFuncCall::new);
+        NamedSocketFuncCall.ALL.put("listen", ListenFuncCall::new);
+        NamedSocketFuncCall.ALL.put("send", SendFuncCall::new);
+        NamedSocketFuncCall.ALL.put("recv", RecvFuncCall::new);
+        NamedSocketFuncCall.ALL.put("closesocket", ClosesocketFuncCall::new);
+        NamedSocketFuncCall.ALL.put("inet_addr", InetAddrFuncCall::new);
+    }
+
+    /**
+     * The Winsock name of the function.
+     */
+    private final String name;
+
+    /**
+     * The object the function call belongs to.
+     */
+    private final Phi rho;
+
+    /**
+     * Ctor.
+     * @param call The Winsock name of the function
+     * @param obj The object the function call belongs to
+     */
+    NamedSocketFuncCall(final String call, final Phi obj) {
+        this.name = call;
+        this.rho = obj;
+    }
+
+    @Override
+    public Phi make(final Phi... params) {
+        if (!NamedSocketFuncCall.ALL.containsKey(this.name)) {
+            throw new ExFailure(
+                "Can't make win32 function call '%s' because it's either not supported yet or does not exist",
+                this.name
+            );
+        }
+        return NamedSocketFuncCall.ALL.get(this.name).apply(this.rho).make(params);
+    }
+}


### PR DESCRIPTION
directory.retried retried forever after any failed exclusive file creation, not only after a name collision. opened uses O_CREAT | O_EXCL but discarded the failure reason, so a permanent error like an unwritable directory looked identical to an EEXIST collision and kept generating new names indefinitely.

attempted now reads the OS error code right after a failed open (posix.errno on POSIX, the msvcrt CRT errno via a new win32 _errno call on Windows) and only retries when it matches EEXIST. Any other error terminates immediately with a message naming the directory and the error code.

Adding _errno to NamedFuncCall's dispatch table pushed its Checkstyle ClassFanOutComplexity over the limit, so I split the Winsock-only calls (already documented in the file's own header as a separate concern from the msvcrt-backed file/process calls) into their own NamedSocketFuncCall class. Same dispatch behavior, just relocated.

Added a regression test: retried against a path that was never a real directory now stops with an error instead of hanging.

Closes #6903
