### PR TITLE
Recognize a UNC prefix before the single-separator branch in path.win32.resolved

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -142,11 +142,14 @@
                 gt. (sys.drive valid).size 0
                 valid
                 if.
-                  eq.
-                    valid.slice 0 1
-                    separator
-                  drive.concat valid
-                  concat. (uri.concat separator) valid
+                  valid.starts-with (separator.concat separator)
+                  valid
+                  if.
+                    eq.
+                      valid.slice 0 1
+                      separator
+                    drive.concat valid
+                    concat. (uri.concat separator) valid
       string > valid!
         as-bytes.
           sys.sanitized other
@@ -409,6 +412,24 @@
       path.win32 "\\users\\local"
       "\\hello\\var"
     "\\hello\\var"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-a-drive-qualified-path
+    resolved.
+      path.win32 "C:\\work\\project"
+      "\\\\server\\share\\report.txt"
+    "\\\\server\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-a-relative-path
+    resolved.
+      path.win32 ".\\temp\\var"
+      "\\\\server\\share\\report.txt"
+    "\\\\server\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-another-unc-path
+    resolved.
+      path.win32 "\\\\server\\share\\project"
+      "\\\\other\\share\\report.txt"
+    "\\\\other\\share\\report.txt"
 
   eq. ++> can-resolve-a-win32-path-against-an-empty-one
     resolved.

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -142,7 +142,8 @@
                 gt. (sys.drive valid).size 0
                 valid
                 if.
-                  valid.starts-with (separator.concat separator)
+                  valid.starts-with
+                    separator.concat separator
                   valid
                   if.
                     eq.


### PR DESCRIPTION
path.win32.resolved treated any argument starting with a single backslash as drive-relative and prepended the base path's drive to it. That branch also matched UNC arguments (\\\\server\\share\\...), which start with two backslashes and are already absolute, turning a network path into a local drive path.

resolved now checks for a double-separator prefix before the single-separator branch and returns such an argument unchanged, since it needs no drive from the base.

Added driving tests covering a UNC argument resolved against a drive-qualified base, a relative base, and another UNC base.

Closes #6901