### PR TITLE
#6892: reject an empty delimiter in string.nsplit

### DIFF
--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -1,7 +1,8 @@
 # Returns a `tuple` of `strings`: `text` is split by `delimiter` with a maximum of `limit` parts.
 # The last element contains the remainder of the string after splitting.
-# If `limit` is not a finite integer of at least 1 (fractional, nan, infinite,
-# zero or negative), the `cant-split` fallback is returned, or the bottom object when unbound.
+# If `delimiter` is empty, or `limit` is not a finite integer of at least 1
+# (fractional, nan, infinite, zero or negative), the `cant-split` fallback is
+# returned, or the bottom object when unbound, the same way `split` behaves.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,11 +14,18 @@
 [delimiter limit cant-split] > nsplit
   if. > @
     or.
-      1.gt limit
-      limit.is-integer.not
+      eq.
+        delimiter.size >> size!
+        0
+      or.
+        1.gt limit
+        limit.is-integer.not
     cant-split
-      "Invalid limit %d for nsplit, must be at least 1".printf
-        * limit
+      if.
+        size.eq 0
+        "The delimiter must not be empty"
+        "Invalid limit %d for nsplit, must be at least 1".printf
+          * limit
     if.
       text.size.eq 0
       *
@@ -72,7 +80,6 @@
           0
           0
   text.as-bytes >> bts!
-  delimiter.size >> size!
   ^ > text
 
   eq. ++> can-recover-from-a-fractional-limit
@@ -80,6 +87,13 @@
     "a-b-c".nsplit
       "-"
       1.5
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-empty-delimiter-when-nsplitting
+    "recovered"
+    "abc".nsplit
+      ""
+      3
       "recovered" > [message]
 
   eq. ++> can-recover-from-an-infinite-limit-when-splitting


### PR DESCRIPTION
Fixes #6892

`nsplit` had no front-door check for an empty delimiter, so `"abc".nsplit "" 3` walked the text one byte at a time and appended the whole thing, returning `* "abc"` as if it were a successful one-part split. Its unlimited counterpart `split` rejects the same delimiter through `cant-split`, so the two halves of the API disagreed.

`nsplit` now invokes `cant-split` for an empty delimiter, with the same message `split` uses, keeping the existing limit check and its message intact. I extended the existing condition rather than nesting a second `if.`, so the body below stays where it is.

The regression test mirrors `split.eo`'s own `can-recover-from-an-empty-delimiter`. One honest note about it: with the fix it runs and passes in 0.18s, and against the unfixed code it does not pass, but it fails by hitting the one-second dataization limit rather than by a plain assertion failure, because comparing the returned tuple with a string is what goes slow there. So it is reported as aborted rather than red. The five-fold margin means it is not flaky on the fixed code.

Verified separately against the runtime before writing the fix: `"abc".nsplit "" N` returned `* "abc"` for N of 1, 2, 3 and 4, while `"abc".split ""` raised an `ExFailure`.
