### PR TITLE
Separate EOF from an empty decoded line in stdin.all-lines

### DIFF
--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -23,25 +23,28 @@
 [] > stdin
   all-lines > @
   [] > all-lines
-    [line buffer first] >> rec-read
+    [scan buffer is-first] >> rec-read
       if. > @
-        line.length.eq 0
+        scan.eof
         string buffer
         rec-read
-          next-line
-          first.if
-            buffer.concat line
+          line-or-eof
+          is-first.if
+            buffer.concat scan.line
             concat.
               buffer.concat eol!
-              line
+              scan.line
           false
     | > @
-      next-line
-      --
+      line-or-eof
+      ""
       true
   [] > next-line
-    if. > @
-      first.as-bytes.size.eq 0
+    line-or-eof.line > @
+  [] > line-or-eof
+    first.as-bytes.size.eq 0 > eof
+    if. > line
+      eof
       ""
       [input buffer] >> rec-read
         if. > @

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -24,8 +24,7 @@
   all-lines > @
   [] > all-lines
     [scan buffer is-first] >> rec-read
-      if. > @
-        scan.eof
+      scan.eof.if > @
         string buffer
         rec-read
           line-or-eof
@@ -39,12 +38,11 @@
       line-or-eof
       ""
       true
-  [] > next-line
-    line-or-eof.line > @
   [] > line-or-eof
     first.as-bytes.size.eq 0 > eof
-    if. > line
-      eof
+    @. > first
+      console.read 1
+    eof.if > line
       ""
       [input buffer] >> rec-read
         if. > @
@@ -63,5 +61,4 @@
         @. > next
           input.read 1
       | first --
-    @. > first
-      console.read 1
+  line-or-eof.line > [] > next-line


### PR DESCRIPTION
stdin.next-line returned "" both for a blank line and for end of input, since \`stdin.eo\` only decoded the line and never kept track of whether a byte was actually available.

stdin.all-lines used that "" as its sole stop condition (\`line.length.eq 0\`), so reading stopped at the very first blank line instead of continuing to the real end of input.

This introduces \`line-or-eof\`, a helper that reads a line once and exposes both \`.line\` (the decoded text, unchanged behavior) and \`.eof\` (whether the underlying read produced no byte at all). \`next-line\` keeps its existing public contract by delegating to \`.line\`. \`all-lines\` now stops on \`.eof\` instead of on the decoded line's length, so blank lines in the input are preserved and later lines after them are still read.

Fixes #6898