### PR TITLE
Keep the UNC share root as a floor for .. in path.win32.normalized

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -114,9 +114,7 @@
                         accum.length.gt 0
                         not. (accum.head.eq "..")
                       if.
-                        and.
-                          unc
-                          accum.length.lte 2
+                        unc.and (accum.length.lte 2)
                         accum
                         accum.tail
                       is-absolute.not.if (accum.with segment) accum
@@ -303,6 +301,21 @@
       path.win32 "\\\\server\\share\\folder"
     "\\\\server\\share\\folder"
 
+  eq. ++> can-normalize-a-unc-win32-path-with-a-current-and-a-parent-segment-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\.\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-alone-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\.."
+    "\\\\server\\share"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-and-a-trailing-separator
+    normalized.
+      path.win32 "\\\\server\\share\\..\\"
+    "\\\\server\\share\\"
+
   eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-at-the-share-root
     normalized.
       path.win32 "\\\\server\\share\\..\\folder"
@@ -313,30 +326,15 @@
       path.win32 "\\\\server\\share\\a\\..\\folder"
     "\\\\server\\share\\folder"
 
-  eq. ++> can-normalize-a-unc-win32-path-with-repeated-parent-segments-at-the-share-root
-    normalized.
-      path.win32 "\\\\server\\share\\..\\..\\folder"
-    "\\\\server\\share\\folder"
-
-  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-and-a-trailing-separator
-    normalized.
-      path.win32 "\\\\server\\share\\..\\"
-    "\\\\server\\share\\"
-
   eq. ++> can-normalize-a-unc-win32-path-with-parent-segments-past-two-child-directories
     normalized.
       path.win32 "\\\\server\\share\\a\\b\\..\\..\\..\\folder"
     "\\\\server\\share\\folder"
 
-  eq. ++> can-normalize-a-unc-win32-path-with-a-current-and-a-parent-segment-at-the-share-root
+  eq. ++> can-normalize-a-unc-win32-path-with-repeated-parent-segments-at-the-share-root
     normalized.
-      path.win32 "\\\\server\\share\\.\\..\\folder"
+      path.win32 "\\\\server\\share\\..\\..\\folder"
     "\\\\server\\share\\folder"
-
-  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-alone-at-the-share-root
-    normalized.
-      path.win32 "\\\\server\\share\\.."
-    "\\\\server\\share"
 
   eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -113,7 +113,12 @@
                       and.
                         accum.length.gt 0
                         not. (accum.head.eq "..")
-                      accum.tail
+                      if.
+                        and.
+                          unc
+                          accum.length.lte 2
+                        accum
+                        accum.tail
                       is-absolute.not.if (accum.with segment) accum
                     if.
                       or.
@@ -297,6 +302,41 @@
     normalized.
       path.win32 "\\\\server\\share\\folder"
     "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-below-a-child-directory
+    normalized.
+      path.win32 "\\\\server\\share\\a\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-repeated-parent-segments-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\..\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-and-a-trailing-separator
+    normalized.
+      path.win32 "\\\\server\\share\\..\\"
+    "\\\\server\\share\\"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-parent-segments-past-two-child-directories
+    normalized.
+      path.win32 "\\\\server\\share\\a\\b\\..\\..\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-current-and-a-parent-segment-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\.\\..\\folder"
+    "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-unc-win32-path-with-a-parent-segment-alone-at-the-share-root
+    normalized.
+      path.win32 "\\\\server\\share\\.."
+    "\\\\server\\share"
 
   eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.


### PR DESCRIPTION
path.win32.normalized let a `..` segment pop the `server`/`share` components of a UNC path, escaping above the share root. `\\server\share\..\folder` normalized to `\\server\folder`, which is not a valid path within the original share.

The fix keeps the first two components after a UNC prefix (`server` and `share`) as a floor that `..` cannot pop past, the same way an ordinary absolute root already discards leading `..` instead of climbing above `/`.

Added regression tests for a parent segment at the share root, below a child directory, repeated parent segments, a trailing separator, parent segments past two child directories, a combined `.`/`..` segment, and a lone `..` at the share root.

Closes #6896