### PR TITLE
Reject host names in win32.inet_addr instead of resolving them

### DIFF
--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -52,6 +52,14 @@
   02-02 > version
   32769 > wronly
 
+  os.is-windows.not.or ++> can-report-a-host-name-as-invalid
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "localhost"
+      win32.invalid
+
   os.is-windows.not.or ++> can-report-an-ipv6-address-as-invalid
     eq.
       code.
@@ -67,14 +75,6 @@
           "inet_addr"
           "127.0.0.1"
       16777343
-
-  os.is-windows.not.or ++> can-report-a-host-name-as-invalid
-    eq.
-      code.
-        win32 *1
-          "inet_addr"
-          "localhost"
-      win32.invalid
 
   --> stops-on-write-size-being-negative
     os.is-windows.not.if > @

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -68,6 +68,14 @@
           "127.0.0.1"
       16777343
 
+  os.is-windows.not.or ++> can-report-a-host-name-as-invalid
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "localhost"
+      win32.invalid
+
   --> stops-on-write-size-being-negative
     os.is-windows.not.if > @
       1.div 0

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -4,9 +4,9 @@
  */
 package org.eolang.win32;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.nio.ByteBuffer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -19,6 +19,13 @@ import org.eolang.Syscall;
  * @since 0.40.0
  */
 public final class InetAddrFuncCall implements Syscall {
+
+    /**
+     * Dotted-decimal IPv4 literal, e.g. "127.0.0.1".
+     */
+    private static final Pattern IPV4 = Pattern.compile(
+        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    );
 
     /**
      * Win32 object.
@@ -36,22 +43,35 @@ public final class InetAddrFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        byte[] address;
-        try {
-            address = InetAddress.getByName(new Dataized(params[0]).asString()).getAddress();
-        } catch (final UnknownHostException exception) {
-            address = new byte[0];
-        }
-        if (address.length == 4) {
-            result.put(
-                0,
-                new Data.ToPhi(Integer.reverseBytes(ByteBuffer.wrap(address).getInt(0)))
-            );
+        final String address = new Dataized(params[0]).asString();
+        final Matcher matcher = InetAddrFuncCall.IPV4.matcher(address);
+        if (matcher.matches() && InetAddrFuncCall.octetsValid(matcher)) {
+            final ByteBuffer buffer = ByteBuffer.allocate(4);
+            for (int octet = 1; octet <= 4; ++octet) {
+                buffer.put((byte) Integer.parseInt(matcher.group(octet)));
+            }
+            result.put(0, new Data.ToPhi(Integer.reverseBytes(buffer.getInt(0))));
         } else {
             Winsock.INSTANCE.WSASetLastError(Winsock.WSAEINVAL);
             result.put(0, new Data.ToPhi(-1));
         }
         result.put(1, new PhDefault());
         return result;
+    }
+
+    /**
+     * Checks that every matched octet fits into a byte.
+     * @param matcher Matcher already matched against {@link #IPV4}
+     * @return True if all four octets are in range 0-255
+     */
+    private static boolean octetsValid(final Matcher matcher) {
+        boolean valid = true;
+        for (int octet = 1; octet <= 4; ++octet) {
+            if (Integer.parseInt(matcher.group(octet)) > 255) {
+                valid = false;
+                break;
+            }
+        }
+        return valid;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -43,8 +43,7 @@ public final class InetAddrFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final String address = new Dataized(params[0]).asString();
-        final Matcher matcher = InetAddrFuncCall.IPV4.matcher(address);
+        final Matcher matcher = InetAddrFuncCall.IPV4.matcher(new Dataized(params[0]).asString());
         if (matcher.matches() && InetAddrFuncCall.octetsValid(matcher)) {
             final ByteBuffer buffer = ByteBuffer.allocate(4);
             for (int octet = 1; octet <= 4; ++octet) {

--- a/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
@@ -73,55 +73,6 @@ final class EOwin32EOφTest {
         );
     }
 
-    @Test
-    @DisabledOnOs({OS.LINUX, OS.MAC})
-    void acceptsDottedIpAddress() {
-        MatcherAssert.assertThat(
-            "The \"inet_addr\" function call should have parsed a dotted IPv4 literal",
-            this.inetAddr("1.2.3.4"),
-            Matchers.equalTo(67_305_985)
-        );
-    }
-
-    @Test
-    @DisabledOnOs({OS.LINUX, OS.MAC})
-    void rejectsHostName() {
-        MatcherAssert.assertThat(
-            "The \"inet_addr\" function call should have rejected a host name, not resolved it",
-            this.inetAddr("localhost"),
-            Matchers.equalTo(-1)
-        );
-    }
-
-    @Test
-    @DisabledOnOs({OS.LINUX, OS.MAC})
-    void rejectsIpvSixLiteral() {
-        MatcherAssert.assertThat(
-            "The \"inet_addr\" function call should have rejected an IPv6 literal",
-            this.inetAddr("::1"),
-            Matchers.equalTo(-1)
-        );
-    }
-
-    /**
-     * Calls "inet_addr" on the win32 object with the given address.
-     * @param address Address to resolve
-     * @return Resolved code
-     */
-    private int inetAddr(final String address) {
-        return new Dataized(
-            new PhApplication(
-                new PhApplication(
-                    Phi.Φ.take("win32").copy(),
-                    "name",
-                    new Data.ToPhi("inet_addr")
-                ),
-                "args",
-                new Data.ToPhi(new Phi[]{new Data.ToPhi(address)})
-            ).take("code")
-        ).asNumber().intValue();
-    }
-
     /**
      * Test case for {@link Winsock}.
      * @since 0.40

--- a/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
@@ -75,7 +75,7 @@ final class EOwin32EOφTest {
 
     @Test
     @DisabledOnOs({OS.LINUX, OS.MAC})
-    void acceptsDottedIpv4Literal() {
+    void acceptsDottedIpAddress() {
         MatcherAssert.assertThat(
             "The \"inet_addr\" function call should have parsed a dotted IPv4 literal",
             this.inetAddr("1.2.3.4"),
@@ -95,7 +95,7 @@ final class EOwin32EOφTest {
 
     @Test
     @DisabledOnOs({OS.LINUX, OS.MAC})
-    void rejectsIpv6Literal() {
+    void rejectsIpvSixLiteral() {
         MatcherAssert.assertThat(
             "The \"inet_addr\" function call should have rejected an IPv6 literal",
             this.inetAddr("::1"),

--- a/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
@@ -73,6 +73,55 @@ final class EOwin32EOφTest {
         );
     }
 
+    @Test
+    @DisabledOnOs({OS.LINUX, OS.MAC})
+    void acceptsDottedIpv4Literal() {
+        MatcherAssert.assertThat(
+            "The \"inet_addr\" function call should have parsed a dotted IPv4 literal",
+            this.inetAddr("1.2.3.4"),
+            Matchers.equalTo(67_305_985)
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.LINUX, OS.MAC})
+    void rejectsHostName() {
+        MatcherAssert.assertThat(
+            "The \"inet_addr\" function call should have rejected a host name, not resolved it",
+            this.inetAddr("localhost"),
+            Matchers.equalTo(-1)
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.LINUX, OS.MAC})
+    void rejectsIpv6Literal() {
+        MatcherAssert.assertThat(
+            "The \"inet_addr\" function call should have rejected an IPv6 literal",
+            this.inetAddr("::1"),
+            Matchers.equalTo(-1)
+        );
+    }
+
+    /**
+     * Calls "inet_addr" on the win32 object with the given address.
+     * @param address Address to resolve
+     * @return Resolved code
+     */
+    private int inetAddr(final String address) {
+        return new Dataized(
+            new PhApplication(
+                new PhApplication(
+                    Phi.Φ.take("win32").copy(),
+                    "name",
+                    new Data.ToPhi("inet_addr")
+                ),
+                "args",
+                new Data.ToPhi(new Phi[]{new Data.ToPhi(address)})
+            ).take("code")
+        ).asNumber().intValue();
+    }
+
     /**
      * Test case for {@link Winsock}.
      * @since 0.40


### PR DESCRIPTION
The Windows path for the \`inet_addr\` object called \`InetAddress.getByName()\`, which performs DNS resolution. A host name such as \`localhost\` resolved to a 4-byte address and was accepted, while the POSIX sibling (\`InetAddrSyscall\`, backed by the native \`inet_addr\`) rejects anything that isn't a numeric IPv4 literal.

This replaces the resolving call with a dotted-decimal IPv4 matcher: four 0-255 octets are packed the same way the old code did, and anything else (a host name, an IPv6 literal, garbage) takes the existing invalid-address path, setting \`WSAEINVAL\` and returning -1.

Added tests in \`EOwin32EOφTest\` covering a dotted IPv4 literal, a host name, and an IPv6 literal, so the two platform-specific implementations stay behaviorally consistent.

Closes #6893