### PR TITLE
Close the file descriptor when file.open's scope fails

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -222,18 +222,18 @@
   eq. ++> can-close-a-descriptor-when-the-scope-fails
     drain 300
     true
-  if. > [n] > drain
-    n.lte 0
-    true
-    seq *
-      recovered
-        tmp.open
-          "r"
-          T "boom" > [f]
-        true
-      drain
-        n.minus 1
-  mktemp.tmpfile > tmp
+    if. > [n] > drain
+      n.lte 0
+      true
+      seq *
+        recovered
+          tmp.open
+            "r"
+            T "boom" > [f]
+          true
+        drain
+          n.minus 1
+    mktemp.tmpfile > tmp
 
   eq. ++> can-keep-the-size-of-a-file-opened-for-appending
     size.

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -110,13 +110,25 @@
           cant-open
             "Couldn't open file '%s': %s".printf
               * path opened.output
-          seq *
-            scope
-              stream descriptor
-            code.
-              syscall.close
-                * descriptor
-            true
+          if.
+            recovered
+              seq *
+                scope
+                  stream descriptor
+                true
+              false
+            seq *
+              code.
+                syscall.close
+                  * descriptor
+              true
+            seq *
+              code.
+                syscall.close
+                  * descriptor
+              cant-open
+                "The scope given to '%s'.open() failed; the descriptor was closed before propagating the failure".printf
+                  * path
         appending.if syscall.append 0 > append
         existing.not.if syscall.creat 0 > creat
         opened.code > descriptor
@@ -206,6 +218,22 @@
         "a"
         f.write "!" > [f]
     13
+
+  eq. ++> can-close-a-descriptor-when-the-scope-fails
+    drain 300
+    true
+  if. > [n] > drain
+    n.lte 0
+    true
+    seq *
+      recovered
+        tmp.open
+          "r"
+          T "boom" > [f]
+        true
+      drain
+        n.minus 1
+  mktemp.tmpfile > tmp
 
   eq. ++> can-keep-the-size-of-a-file-opened-for-appending
     size.

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -219,9 +219,12 @@
         f.write "!" > [f]
     13
 
-  eq. ++> can-close-a-descriptor-when-the-scope-fails
-    drain 300
-    true
+  ++> can-close-a-descriptor-when-the-scope-fails
+    eq. > @
+      drain 300
+      true
+      drain
+      tmp
     if. > [n] > drain
       n.lte 0
       true


### PR DESCRIPTION
file.open only closed its native descriptor after dataizing the caller's scope. When that scope terminates, the surrounding seq stops and the close call is never reached, so a repeatedly failing open leaks descriptors until the process runs out.

This wraps the scope dataization in recovered so the descriptor is always closed, then rethrows through the existing cant-open hook so callers still see the failure.

Closes #6894.

Adds can-close-a-descriptor-when-the-scope-fails, which repeats a failing open 300 times and checks the process survives, as a regression against the leak.