### PR TITLE
#6888: strip every trailing separator in path.basename and path.dirname

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -151,19 +151,22 @@
         as-bytes.
           sys.sanitized other
     sys.separator > separator
-    string > [] > trimmed
+    if. > [tail] > stripped
+      or.
+        tail.size.eq 0
+        tail.eq separator
+      tail
       if.
-        or.
-          uri.size.eq 0
-          uri.eq separator
-        uri
-        if.
-          uri.ends-with separator
-          as-bytes.
-            uri.slice
-              0
-              uri.length.minus separator.length
-          uri
+        tail.ends-with separator
+        stripped
+          string
+            as-bytes.
+              tail.slice
+                0
+                tail.length.minus separator.length
+        tail
+    string > [] > trimmed
+      stripped uri
     and. > unc
       driveless.size.gt 1
       driveless.starts-with
@@ -443,9 +446,19 @@
           path.separator
     "html"
 
+  eq. ++> can-return-the-basename-ignoring-repeated-trailing-separators
+    basename.
+      path.posix "foo//"
+    "foo"
+
   eq. ++> can-return-the-basename-of-a-root-relative-path-ending-with-a-separator
     basename.
       path.posix "/foo/"
+    "foo"
+
+  eq. ++> can-return-the-basename-of-an-absolute-path-with-repeated-trailing-separators
+    basename.
+      path.posix "/foo//"
     "foo"
 
   eq. ++> can-return-the-current-dirname-of-a-hidden-relative-posix-file
@@ -461,6 +474,11 @@
   eq. ++> can-return-the-current-dirname-of-a-relative-posix-file-ending-with-a-separator
     dirname.
       path.posix "foo/"
+    "."
+
+  eq. ++> can-return-the-dirname-ignoring-repeated-trailing-separators
+    dirname.
+      path.posix "foo//"
     "."
 
   eq. ++> can-return-the-dirname-of-a-directory-path
@@ -491,6 +509,11 @@
           "html"
     path.joined
       * "var" "www"
+
+  eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
+    dirname.
+      path.posix "/foo//"
+    "/"
 
   eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
     dirname.


### PR DESCRIPTION
Fixes #6888

`impl.trimmed` removed exactly one trailing separator, so a path ending in two or more of them still reached the branch #6820 was meant to retire. `path.posix "foo//"` became `"foo/"`, and from there `basename` returned `""` and `dirname` returned `"foo"`.

`trimmed` now delegates to a small recursive `stripped`, which drops the whole trailing run and stops at the root, so the number of trailing separators no longer changes the answer:

| path | basename | dirname |
| --- | --- | --- |
| `foo` | `foo` | `.` |
| `foo/` | `foo` | `.` |
| `foo//` | `foo` | `.` |
| `/foo//` | `foo` | `/` |
| `/` | `` | `/` |

Verified against the runtime before and after: on master `foo//` gave basename `""` and dirname `"foo"`, and `/foo//` gave `""` and `"/foo"`, while the single-separator and root cases were already right and stay right.

Four regression tests, two per object. They are properly discriminating: against master's `trimmed` all four fail, and with this change all four pass. One local note for whoever reruns them: on my machine most of `EOpathTest` aborts on the one-second dataization deadline, so I ran it with `-Deo.deadline=60`; the five `can_resolve_*` errors it reports are identical on a clean master checkout and are unrelated to this change.
