### PR TITLE
#6912: keep the fragile dispatch marker on every shortened base

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -349,79 +349,89 @@
     reference at all) must not suppress the "$." marker here.
     -->
     <xsl:variable name="local-handle" select="//o[@local=$hop-name][ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
-    <xsl:choose>
-      <!-- NOT OPTIMIZED TUPLE -->
-      <xsl:when test="@star">
-        <xsl:text>*</xsl:text>
-      </xsl:when>
-      <xsl:when test="@base=$eo:bottom">
-        <xsl:text>T</xsl:text>
-      </xsl:when>
-      <xsl:when test="starts-with(@base, concat($eo:program, '.')) and (exists(ancestor::o/o[@name = eo:root-name(current()/@base)]) or /object/metas/meta[head = 'alias']/part[1] = eo:root-name(current()/@base))">
-        <!--
-        The plain top-level name would be shadowed by an in-scope
-        attribute, or reinterpreted through a "+alias" declaring that
-        same short name for a different object (#6211), so keep the
-        explicit Q. root to disambiguate.
-        -->
-        <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
-      </xsl:when>
-      <xsl:when test="$package != '' and starts-with(@base, $self-prefix) and $self-first = /object/o[1]/@name and empty(ancestor::o/o[@name = $self-first])">
-        <!--
-        The base names this program's own top-level object through its
-        fully-qualified "Φ.<package>.<name>…" form. The source wrote it
-        bare and every other same-package reference prints bare, so drop
-        the redundant "Φ.<package>." prefix and render the bare name. If
-        an in-scope attribute shadows that name, this branch is skipped:
-        either the package segment is shadowed too (kept "Q."-rooted by
-        the branch above) or the qualified "<package>.<name>" survives
-        through the otherwise branch, both of which resolve correctly.
-        -->
-        <xsl:value-of select="eo:translate-path($self-rest)"/>
-      </xsl:when>
-      <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and (exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name]) or ancestor::o[not(@base)][$rho-count]/@local = $hop-name)">
-        <!--
-        The run of leading "^." parent hops is redundant: the name is
-        absent from each of the N nearer enclosing formations but
-        present in the (N+1)-th, so plain scope resolution re-derives
-        exactly the very same ρ-chain of length N. Drop the whole run.
-        The second alternative catches a recursive self-reference to a
-        file-local handle hosted as a moniker (#5848): the formation reached
-        after the run carries that very handle name in its "@local", so the
-        hops resolve back to the formation itself and the bare handle name
-        re-derives the same ρ-chain. Without it a recursive `&gt;&gt; name`
-        handle folded into a reversed-dispatch receiver would print its
-        self-reference as `^.name` instead of the readable `name`.
-        -->
-        <xsl:value-of select="eo:translate-path($hop-rest)"/>
-      </xsl:when>
-      <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty($local-handle)">
-        <!--
-        An explicit "$.name" (zero ρ hops) whose immediate enclosing
-        formation has no "name" of its own, and which is not a
-        ">> name" handle owned by a formation this reference actually
-        nests inside either ("local-handle" mirrors resolve-local-names.xsl's
-        lexically-scoped "eo:captor", #5875 — a same-named handle declared
-        by some unrelated formation elsewhere in the file, one this
-        reference is not nested inside, must not count), denotes a
-        genuinely different reference than a bare "name" would (which
-        would instead resolve via an implicit ρ hop into an outer scope,
-        per the branch above) — #6237. Render it with its "$." marker so
-        reparsing keeps the same meaning. When the immediate formation
-        DOES own "name", or "name" is such an in-scope file-local handle,
-        bare and "$.name" resolve identically, so the otherwise branch
-        below safely prints it bare, matching a plain same-scope
-        reference. A node that itself carries "@local" is a moniker's own
-        bound value, already relocated in place of its reference site by
-        merge-monikers.xsl, so its ancestor context here no longer
-        reflects its original scope — skip it too, matching bare.
-        -->
-        <xsl:value-of select="concat('$.', eo:translate-path($hop-rest))"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="eo:fragile-marked(eo:surface(@base), exists(@fragile))"/>
-      </xsl:otherwise>
-    </xsl:choose>
+    <!--
+    The surface the arms below build, before its fragile marker is put
+    back. A dispatch stays fragile whatever shortening its base happens
+    to qualify for, so the marker goes back on the last dot of whatever
+    surface the choose produced (#6912); dotless heads ("*", "T", "$",
+    "Q") have no dispatch to mark and pass through untouched.
+    -->
+    <xsl:variable name="surface" as="xs:string">
+      <xsl:choose>
+        <!-- NOT OPTIMIZED TUPLE -->
+        <xsl:when test="@star">
+          <xsl:text>*</xsl:text>
+        </xsl:when>
+        <xsl:when test="@base=$eo:bottom">
+          <xsl:text>T</xsl:text>
+        </xsl:when>
+        <xsl:when test="starts-with(@base, concat($eo:program, '.')) and (exists(ancestor::o/o[@name = eo:root-name(current()/@base)]) or /object/metas/meta[head = 'alias']/part[1] = eo:root-name(current()/@base))">
+          <!--
+          The plain top-level name would be shadowed by an in-scope
+          attribute, or reinterpreted through a "+alias" declaring that
+          same short name for a different object (#6211), so keep the
+          explicit Q. root to disambiguate.
+          -->
+          <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
+        </xsl:when>
+        <xsl:when test="$package != '' and starts-with(@base, $self-prefix) and $self-first = /object/o[1]/@name and empty(ancestor::o/o[@name = $self-first])">
+          <!--
+          The base names this program's own top-level object through its
+          fully-qualified "Φ.<package>.<name>…" form. The source wrote it
+          bare and every other same-package reference prints bare, so drop
+          the redundant "Φ.<package>." prefix and render the bare name. If
+          an in-scope attribute shadows that name, this branch is skipped:
+          either the package segment is shadowed too (kept "Q."-rooted by
+          the branch above) or the qualified "<package>.<name>" survives
+          through the otherwise branch, both of which resolve correctly.
+          -->
+          <xsl:value-of select="eo:translate-path($self-rest)"/>
+        </xsl:when>
+        <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and (exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name]) or ancestor::o[not(@base)][$rho-count]/@local = $hop-name)">
+          <!--
+          The run of leading "^." parent hops is redundant: the name is
+          absent from each of the N nearer enclosing formations but
+          present in the (N+1)-th, so plain scope resolution re-derives
+          exactly the very same ρ-chain of length N. Drop the whole run.
+          The second alternative catches a recursive self-reference to a
+          file-local handle hosted as a moniker (#5848): the formation reached
+          after the run carries that very handle name in its "@local", so the
+          hops resolve back to the formation itself and the bare handle name
+          re-derives the same ρ-chain. Without it a recursive `&gt;&gt; name`
+          handle folded into a reversed-dispatch receiver would print its
+          self-reference as `^.name` instead of the readable `name`.
+          -->
+          <xsl:value-of select="eo:translate-path($hop-rest)"/>
+        </xsl:when>
+        <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty($local-handle)">
+          <!--
+          An explicit "$.name" (zero ρ hops) whose immediate enclosing
+          formation has no "name" of its own, and which is not a
+          ">> name" handle owned by a formation this reference actually
+          nests inside either ("local-handle" mirrors resolve-local-names.xsl's
+          lexically-scoped "eo:captor", #5875 — a same-named handle declared
+          by some unrelated formation elsewhere in the file, one this
+          reference is not nested inside, must not count), denotes a
+          genuinely different reference than a bare "name" would (which
+          would instead resolve via an implicit ρ hop into an outer scope,
+          per the branch above) — #6237. Render it with its "$." marker so
+          reparsing keeps the same meaning. When the immediate formation
+          DOES own "name", or "name" is such an in-scope file-local handle,
+          bare and "$.name" resolve identically, so the otherwise branch
+          below safely prints it bare, matching a plain same-scope
+          reference. A node that itself carries "@local" is a moniker's own
+          bound value, already relocated in place of its reference site by
+          merge-monikers.xsl, so its ancestor context here no longer
+          reflects its original scope — skip it too, matching bare.
+          -->
+          <xsl:value-of select="concat('$.', eo:translate-path($hop-rest))"/>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="eo:surface(@base)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:value-of select="eo:fragile-marked($surface, exists(@fragile))"/>
   </xsl:template>
   <!-- ABSTRACT OR ATOM -->
   <xsl:template match="o[eo:abstract(.) and not(eo:has-data(.))]" mode="head">

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-kept-on-shortened-base.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-kept-on-shortened-base.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6912: the `?.` marker was put back only by the branch that prints a base as
+# it stands, so a fragile dispatch on any of the shortening branches printed as
+# a hard one. The kept `Q.` root, the dropped `Φ.<package>.` prefix, the dropped
+# run of redundant `^.` hops and the kept `$.` marker all keep their marker here.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package sandbox
+  +alias com.example.string
+  +alias string.sprintf
+
+  [] > app
+    42 > a
+    string > s
+    sprintf?.fmt > b
+    Q.sandbox.app?.a > c
+    [] > inner
+      $.a?.bar > @
+    [x] > outer
+      [] > deep
+        ^.x?.y > @
+
+printed: |
+  +package sandbox
+  +alias com.example.string
+
+  [] > app
+    42 > a
+    Q.string.sprintf?.fmt > b
+    app?.a > c
+    $.a?.bar > [] > inner
+    [x] > outer
+      x?.y > [] > deep
+    com.example.string > s


### PR DESCRIPTION
Closes #6912

`eo:fragile-marked` was called from the `otherwise` arm only, so the four arms
that shorten the base first (the `Q.` root kept for disambiguation, the dropped
`Φ.<package>.` prefix, the dropped run of redundant `^.` hops and the `$.name`
marker) printed a fragile dispatch as a hard one.

The call is lifted out: the whole `xsl:choose` now builds a `$surface` variable
and the marker goes back on the last dot of whatever surface it produced.
Dotless heads (`*`, `T`, `$`, `Q`) have no dispatch to mark and pass through,
which the function already handled.

Most of the diff is the two-space re-indent of the `choose` that moving it into
the variable requires; the change itself is the new variable, one call site and
the `otherwise` arm losing its own call.

The new print pack covers all four shapes in one program. It lives in the
directory that both `XmirTest#printsToEo` and `MjPrintTest#printsXmirToEo` read,
so it runs under the parser-only printer and the full mojo pipeline. On master
all four lose their marker, with the change all four keep it.
