### PR TITLE
#6707: the bottom term `T` takes arguments

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -168,7 +168,7 @@ The parser recognises the following lexical tokens:
 | `RHO` | `^` |
 | `ROOT` | `Q` |
 | `XI` | `$` |
-| `TERM` | `T` — the bottom term (§9.3), similar to `⊥` in 𝜑-calculus. A self-contained single-character token; carries no arguments and no chain. |
+| `TERM` | `T` — the bottom term (§9.3), similar to `⊥` in 𝜑-calculus. A value: it may carry arguments, horizontal (`T 42`) or vertical, which are the cause of the bottom, the way `T "why it failed"` is used across the runtime, and a `.method` chain (`T.foo` parses as `⊥.foo`), like any other head. |
 | `IDENTITY` | `I` — the identity object (§3.16), the one-character spelling of `x > [x]`. A value: it may carry arguments (`I 5`) and a `.method` chain, like any other head. |
 | `SELF` | `%` — self-reference (§3.15). Sugar for the auto-name of the enclosing anonymous (`>>`-named) formation; substituted at compile time. A value: it may carry arguments (`% 5`) and a `.method` chain, like any other head. |
 | `VOID` | `?` — the vertical-void marker (§3.4). A `? > name` body line declares a void attribute, equivalent to listing `name` in `[…]`. |

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -225,8 +225,9 @@ final class Value {
         ROOT,
 
         /**
-         * {@code T} — the bottom term of 𝜑-calculus (§9.3). A
-         * self-contained leaf carrying no arguments;
+         * {@code T} — the bottom term of 𝜑-calculus (§9.3). A value:
+         * it may carry arguments, which are the cause of the bottom,
+         * as in {@code T "why it failed"};
          * {@link Emissions} maps it to a bottom-based object.
          */
         TERM,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bottom-term-with-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bottom-term-with-arguments.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6707: `T` takes arguments - they are the cause of the bottom, the way
+# `T "why it failed"` is used across the runtime. Both the horizontal and the
+# vertical form are accepted, the arguments land under the `⊥` object, and a
+# `.method` chain on `T` is read as a dispatch on the bottom.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object//o[@base='⊥' and @name='result']/o[@base='Φ.number']
+  - /object//o[@base='⊥' and @name='failure']/o[@base='Φ.string']
+  - /object//o[@base='⊥.foo' and @name='dispatched']
+input: |
+  [] > main
+    T 42 > result
+    T > failure
+      "why it failed"
+      43
+    T.foo > dispatched


### PR DESCRIPTION
Closes #6707

Per @yegor256's comment on the issue, the spec was wrong, not the parser: `T`
should accept any arguments. §2.3 said the opposite ("carries no arguments and
no chain"), and the same claim sat in the `Value.Kind.TERM` javadoc.

Both now describe what the parser does and what the runtime relies on: `T` is a
value that may carry arguments, the cause of the bottom, as in
`T "why it failed"`. The "no chain" half was wrong too - `T.foo` parses today
into `⊥.foo`, it is not rejected - so it is stated as it is instead.

The new syntax pack pins all three forms: the horizontal `T 42`, the vertical
one with several arguments, and the dispatch. Without it nothing in the tests
covers a bottom with arguments, which is how the spec and the parser drifted
apart in the first place.
