### PR TITLE
#6640: let a memory block be taken only through a releasing scope

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -14,10 +14,6 @@ import java.util.function.IntFunction;
 /**
  * Dynamic memory.
  * @since 0.19
- * @todo #6507:30min Move the negative-argument, size and resize tests in HeapsTest and
- *  both free probes in EOmallocEOofTest onto the scoped malloc, then make malloc with two
- *  arguments and free private, so that a block can only be taken through a scope that
- *  releases it, and drop failsOnClearingEmptyBlock, which nobody can reach any more.
  */
 final class Heaps {
 
@@ -43,29 +39,6 @@ final class Heaps {
     private Heaps() {
         this.blocks = new ConcurrentHashMap<>(0);
         this.lock = new ReentrantLock();
-    }
-
-    /**
-     * Allocate a block in memory.
-     * @param phi Object
-     * @param size How many bytes
-     * @return The identifier of pointer to the block in memory
-     */
-    int malloc(final Phi phi, final int size) {
-        final int identifier = phi.hashCode();
-        this.lock.lock();
-        try {
-            if (this.blocks.containsKey(identifier)) {
-                throw new ExFailure(
-                    "Can't allocate block in memory with identifier '%d' because it's already allocated",
-                    identifier
-                );
-            }
-            this.blocks.put(identifier, new byte[size]);
-        } finally {
-            this.lock.unlock();
-        }
-        return identifier;
     }
 
     /**
@@ -239,10 +212,33 @@ final class Heaps {
     }
 
     /**
+     * Allocate a block in memory.
+     * @param phi Object
+     * @param size How many bytes
+     * @return The identifier of pointer to the block in memory
+     */
+    private int malloc(final Phi phi, final int size) {
+        final int identifier = phi.hashCode();
+        this.lock.lock();
+        try {
+            if (this.blocks.containsKey(identifier)) {
+                throw new ExFailure(
+                    "Can't allocate block in memory with identifier '%d' because it's already allocated",
+                    identifier
+                );
+            }
+            this.blocks.put(identifier, new byte[size]);
+        } finally {
+            this.lock.unlock();
+        }
+        return identifier;
+    }
+
+    /**
      * Free it.
      * @param identifier Identifier of pointer
      */
-    void free(final int identifier) {
+    private void free(final int identifier) {
         this.lock.lock();
         try {
             if (!this.blocks.containsKey(identifier)) {

--- a/eo-runtime/src/test/java/org/eolang/EOmallocEOofTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocEOofTest.java
@@ -27,8 +27,8 @@ final class EOmallocEOofTest {
         ).take();
         Assertions.assertThrows(
             ExAbstract.class,
-            () -> Heaps.INSTANCE.free((int) dummy.id),
-            "Heaps should throw an exception on attempt to free already freed memory, but it didn't"
+            () -> Heaps.INSTANCE.size((int) dummy.id),
+            "Heaps should throw an exception on attempt to reach already freed memory, but it didn't"
         );
     }
 
@@ -47,8 +47,8 @@ final class EOmallocEOofTest {
         );
         Assertions.assertThrows(
             ExAbstract.class,
-            () -> Heaps.INSTANCE.free((int) dummy.id),
-            "Heaps should throw an exception on attempting to free already freed memory after failure, but it didn't"
+            () -> Heaps.INSTANCE.size((int) dummy.id),
+            "Heaps should throw an exception on attempting to reach already freed memory after failure, but it didn't"
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -107,19 +107,22 @@ final class HeapsTest {
 
     @Test
     void keepsBlockIntactAfterWriteWithNegativeOffset() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 3);
-        Heaps.INSTANCE.write(idx, 0, new byte[] {7, 8, 9});
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.write(idx, -2, new byte[] {1, 2}),
-            "Heaps must reject a negative write offset before touching the block, but it didn't"
-        );
         MatcherAssert.assertThat(
             "Heaps must leave the block untouched after a rejected negative-offset write, but it didn't",
-            Heaps.INSTANCE.read(idx, 0, 3),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 3,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {7, 8, 9});
+                    Assertions.assertThrows(
+                        ExFailure.class,
+                        () -> Heaps.INSTANCE.write(idx, -2, new byte[] {1, 2}),
+                        "Heaps must reject a negative write offset before touching the block, but it didn't"
+                    );
+                    return Heaps.INSTANCE.read(idx, 0, 3);
+                }
+            ),
             Matchers.equalTo(new byte[] {7, 8, 9})
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
@@ -156,18 +159,21 @@ final class HeapsTest {
 
     @Test
     void failsCleanlyOnNegativeReadArguments() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 10);
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.read(idx, -5, 3),
-            "Heaps must reject a negative offset with a clean ExFailure, not a raw JVM exception"
+        Heaps.INSTANCE.malloc(
+            new HeapsTest.PhFake(), 10,
+            idx -> {
+                Assertions.assertThrows(
+                    ExFailure.class,
+                    () -> Heaps.INSTANCE.read(idx, -5, 3),
+                    "Heaps must reject a negative offset with a clean ExFailure, not a raw JVM exception"
+                );
+                return Assertions.assertThrows(
+                    ExFailure.class,
+                    () -> Heaps.INSTANCE.read(idx, 2, -3),
+                    "Heaps must reject a negative length with a clean ExFailure, not a raw JVM exception"
+                );
+            }
         );
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.read(idx, 2, -3),
-            "Heaps must reject a negative length with a clean ExFailure, not a raw JVM exception"
-        );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
@@ -255,15 +261,6 @@ final class HeapsTest {
     }
 
     @Test
-    void failsOnClearingEmptyBlock() {
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.free(new HeapsTest.PhFake().hashCode()),
-            "Heaps should throw an exception on attempting to free a non-existent block, but it didn't"
-        );
-    }
-
-    @Test
     void throwsOnGettingSizeOfEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,
@@ -274,24 +271,26 @@ final class HeapsTest {
 
     @Test
     void returnsValidSize() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
         MatcherAssert.assertThat(
             "Heaps should return valid size of allocated block, but it didn't",
-            Heaps.INSTANCE.size(idx),
+            Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5, Heaps.INSTANCE::size),
             Matchers.equalTo(5)
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
     void throwsOnChangingSizeToNegative() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.resize(idx, -1),
+            () -> Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.resize(idx, -1);
+                    return idx;
+                }
+            ),
             "Heaps should throw an exception on trying to changing size to negative, but it didn't"
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
@@ -305,41 +304,50 @@ final class HeapsTest {
 
     @Test
     void increasesSizeSuccessfully() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
-        Heaps.INSTANCE.resize(idx, 7);
         MatcherAssert.assertThat(
             "Heaps should successfully increase size of allocated block, but it didn't",
-            Heaps.INSTANCE.read(idx, 0, 7),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
+                    Heaps.INSTANCE.resize(idx, 7);
+                    return Heaps.INSTANCE.read(idx, 0, 7);
+                }
+            ),
             Matchers.equalTo(new byte[] {1, 2, 3, 4, 5, 0, 0})
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
     void decreasesSizeSuccessfully() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Heaps.INSTANCE.write(idx, 0, new byte[]{1, 2, 3, 4, 5});
-        Heaps.INSTANCE.resize(idx, 3);
         MatcherAssert.assertThat(
             "Heaps should successfully decrease size of allocated block, but it didn't",
-            Heaps.INSTANCE.read(idx, 0, 3),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
+                    Heaps.INSTANCE.resize(idx, 3);
+                    return Heaps.INSTANCE.read(idx, 0, 3);
+                }
+            ),
             Matchers.equalTo(new byte[] {1, 2, 3})
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     @Test
     void returnsValidSizeAfterDecreasing() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5);
-        Heaps.INSTANCE.write(idx, 0, new byte[]{1, 2, 3, 4, 5});
-        Heaps.INSTANCE.resize(idx, 3);
         MatcherAssert.assertThat(
             "Heaps should return valid size after decreasing, but it didn't",
-            Heaps.INSTANCE.size(idx),
+            Heaps.INSTANCE.malloc(
+                new HeapsTest.PhFake(), 5,
+                idx -> {
+                    Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
+                    Heaps.INSTANCE.resize(idx, 3);
+                    return Heaps.INSTANCE.size(idx);
+                }
+            ),
             Matchers.equalTo(3)
         );
-        Heaps.INSTANCE.free(idx);
     }
 
     /**


### PR DESCRIPTION
Closes #6640

The puzzle `6507-93ee2a46` asked for a block to be reachable only through a
scope that releases it.

`malloc(phi, size)` and `free(identifier)` are private now, so `malloc.of` and
the scoped `malloc(phi, size, scope)` are the only ways in, and no caller can
leak a block by forgetting the `free`. The two of them moved down to the
private part of the class, which is what `MethodsOrderCheck` wants.

The seven tests that took a raw block - the negative write and read probes, the
size one and the four resize ones - run inside the scope now and return what
they assert from it. `failsOnClearingEmptyBlock` is gone: it called `free` on an
unallocated block, which nothing outside the class can do any more. In
`EOmallocEOofTest` the two probes that proved the block was released by trying
to free it twice now ask for its size instead, which fails the same way and for
the same reason.
