### PR TITLE
#6584: refuse a loopback port instead of a Test-Net address

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -221,19 +221,15 @@ final class SyscallTest {
         }
 
         @RepeatedIfExceptionsTest(repeats = 3)
-        void refusesConnectionViaSyscall() throws UnknownHostException {
+        void refusesConnectionViaSyscall(@Ephemeral final int port) throws UnknownHostException {
             try {
                 this.ensure(this.startup() == 0);
                 final int socket = this.openSocket();
                 try {
                     this.ensure(socket > 0);
-                    final SockaddrIn addr = new SockaddrIn(
-                        (short) Winsock.AF_INET,
-                        SyscallTest.htons(8080),
-                        this.inetAddr("192.0.2.1")
-                    );
+                    final SockaddrIn addr = this.sockaddr(port);
                     MatcherAssert.assertThat(
-                        "Connection via windows syscall to Test-Net (192.0.2.1) must be refused",
+                        "Connection via windows syscall to a loopback port nobody listens on must be refused",
                         Winsock.INSTANCE.connect(socket, addr, addr.size()),
                         Matchers.equalTo(-1)
                     );


### PR DESCRIPTION
Closes #6584

The Windows `refusesConnectionViaSyscall` connected to `192.0.2.1:8080` and
expected `-1`. Whether TEST-NET traffic is refused is a property of the host's
routing, not of Winsock: with a TUN adapter or a transparent proxy in the way
the connect succeeds and the test fails on a machine whose syscall behaviour is
perfectly correct.

It now connects to an ephemeral loopback port that nothing listens on, the same
thing the POSIX sibling right below it does. The refusal is then produced by the
local stack and does not depend on routing, proxies or firewalls.

The port comes from the `@Ephemeral` resolver the class already uses for every
other socket test here, and the address from the existing `sockaddr` helper.
