### PR TITLE
Read what a void says it holds

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Held.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Held.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What every void says it will hold.
+ *
+ * <p>A void holds whatever a caller puts in it, and the source is sometimes
+ * able to say what that will be: a formation only Java ever copies has no
+ * caller to read the answer off, so it writes the answer down instead, as the
+ * annotation of {@code ? > code /Q.number}. {@link Provides} keeps it, and
+ * this reads it back by the locator of the void.</p>
+ *
+ * <p>An annotation may end in a question mark, which says the value is that
+ * type or a termination. It is dropped here, since the two answer to the same
+ * names: a termination answers to every name there is.</p>
+ *
+ * @since 0.69.0
+ */
+final class Held {
+
+    /**
+     * The provides table.
+     */
+    private final XML table;
+
+    /**
+     * Ctor.
+     * @param provides The provides table, as {@link Provides} wrote it
+     */
+    Held(final XML provides) {
+        this.table = provides;
+    }
+
+    /**
+     * What every void that says so will hold.
+     * @return The types, by the locator of the void, without the voids that
+     *  say nothing
+     */
+    Map<String, String> all() {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final XML attr : this.table.nodes("//attr[@void='true' and @holds]")) {
+            final String holds = attr.xpath("@holds").get(0);
+            found.put(
+                attr.xpath("@type").get(0),
+                holds.replace("?", "")
+            );
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -30,7 +30,10 @@ import java.util.Map;
  * <p>The walk stops at a type it has already passed, so an object that
  * delegates in a circle is walked once and answers nothing. A void answers
  * nothing either: the table has no row for one, since what a void holds is
- * decided by whoever fills it.</p>
+ * decided by whoever fills it — unless the source has said what will go in,
+ * which a formation only Java ever copies has to do (#6189). Such a void is
+ * walked through like a delegation, and the answer is the same for every
+ * caller, which is what an annotation claims.</p>
  *
  * @since 0.68.0
  */
@@ -52,6 +55,11 @@ final class Provided {
     private final Collection<String> hollows;
 
     /**
+     * What every void that says so will hold, from {@link Held}.
+     */
+    private final Map<String, String> held;
+
+    /**
      * Ctor.
      * @param provides The provides table, as {@link Provides} wrote it
      * @param aliases The name every type goes by, from {@link Same}
@@ -62,7 +70,10 @@ final class Provided {
         final Map<String, String> aliases,
         final Collection<String> voids
     ) {
-        this(new Ungrouped(provides, aliases).rows(), aliases, voids);
+        this(
+            new Ungrouped(provides, aliases).rows(), aliases, voids,
+            new Held(provides).all()
+        );
     }
 
     /**
@@ -70,15 +81,18 @@ final class Provided {
      * @param rows The rows of the provides table, by the name of their owner
      * @param aliases The name every type goes by, from {@link Same}
      * @param voids The locator of every void, from {@link Hollows}
+     * @param holds What every void that says so will hold, from {@link Held}
      */
     Provided(
         final Map<String, Collection<Map<String, String>>> rows,
         final Map<String, String> aliases,
-        final Collection<String> voids
+        final Collection<String> voids,
+        final Map<String, String> holds
     ) {
         this.table = rows;
         this.names = aliases;
         this.hollows = voids;
+        this.held = holds;
     }
 
     /**
@@ -146,7 +160,7 @@ final class Provided {
     private String kept(final String type, final String name, final Collection<String> walked) {
         String found = this.bound(type, name);
         final String member = String.join(".", type, name);
-        if (found.isEmpty() && (this.table.containsKey(member) || this.hollow(type))) {
+        if (found.isEmpty() && (this.table.containsKey(member) || this.blank(type))) {
             found = member;
         }
         final String behind = this.behind(type);
@@ -173,7 +187,20 @@ final class Provided {
         if (next.isEmpty()) {
             next = this.cell(type, "returns");
         }
+        if (next.isEmpty()) {
+            next = this.held.getOrDefault(type, "");
+        }
         return this.names.getOrDefault(next, next);
+    }
+
+    /**
+     * Whether this type is a void nothing says anything about.
+     * @param type The name the type goes by
+     * @return True when only a caller can say what it is, and the source has
+     *  not said it either
+     */
+    private boolean blank(final String type) {
+        return this.hollow(type) && !this.held.containsKey(type);
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * What every object certainly has.
@@ -60,6 +61,14 @@ import java.util.Collection;
  * skipped: {@code [] > recovered /A} comes back with whatever the caller put
  * in, and that is a variable, which nothing here understands yet.</p>
  *
+ * <p>What a void says it will hold is written down for the same reason, and
+ * skipped for the same one. {@code ? > code /Q.number} is how a formation that
+ * only Java ever copies says what goes into its voids, since it has no caller
+ * in the program to say it for it, and {@code /A} names no object and is
+ * passed over. {@link Provided} walks through such a void the way it walks
+ * behind a delegation, so a name asked of it is answered once and for all
+ * rather than left to a caller.</p>
+ *
  * <p>Not every attribute is written inside the formation it belongs to.
  * {@code ρ}, the object something sits in, is written nowhere and every
  * object has one, which {@link Parents} reads off the locator. And
@@ -94,6 +103,10 @@ final class Provides implements Clue {
                         .set("type", attr.xpath("@loc").get(0));
                     if (attr.xpath("@base").contains("∅")) {
                         row.set("void", "true");
+                        final List<String> held = attr.xpath("@type[starts-with(., 'Φ.')]");
+                        if (!held.isEmpty()) {
+                            row.set("holds", held.get(0));
+                        }
                     }
                 }
             }

--- a/eo-inference/src/test/java/org/eolang/inference/HeldTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/HeldTest.java
@@ -1,0 +1,35 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Held}.
+ * @since 0.69.0
+ */
+final class HeldTest {
+
+    @Test
+    void dropsTheMarkOfATerminationFromWhatAVoidHolds() {
+        MatcherAssert.assertThat(
+            "a value that may terminate must be read as the type it otherwise is, but it wasnt",
+            new Held(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.reader'>",
+                        "<attr name='code' type='Φ.reader.code' void='true' holds='Φ.number?'/>",
+                        "</type></provides>"
+                    )
+                )
+            ).all(),
+            Matchers.hasEntry("Φ.reader.code", "Φ.number")
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-says-nothing-stays-a-variable.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-says-nothing-stays-a-variable.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Where the source says nothing, nothing is claimed: a name taken from a
+# void that carries no annotation is still the name of whatever a caller
+# puts there, and two voids of one object are read apart.
+eo:
+  app.eo: |
+    [] > app
+      reader.raw.eq > @
+  reader.eo: |
+    [] > reader /Q.bytes
+      ? > code /Q.number
+      ? > raw
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+      [x] > eq
+        x > @
+provides:
+  - "//attr[@name='raw' and @void='true' and not(@holds)]"
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.reader.raw.eq']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-says-what-it-holds-is-that.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-says-what-it-holds-is-that.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void filled from Java has no caller in the program to read the answer
+# off, so the source says what will go in. A name asked of such a void is
+# then a name of the type it says it holds — the same answer for every
+# caller, which is what an annotation claims.
+eo:
+  app.eo: |
+    [] > app
+      reader.code.eq > @
+  reader.eo: |
+    [] > reader /Q.bytes
+      ? > code /Q.number
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+      [x] > eq
+        x > @
+provides:
+  - "//attr[@name='code' and @void='true' and @holds='Φ.number']"
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.number.eq']"


### PR DESCRIPTION
Second half of #6189, and the half that reads. The annotations
themselves come in a third pull request, once the parser change in
#6960 allows them outside an atom.

The parser already writes a void's annotation into the XMIR —
`<o base="∅" loc="Φ.number.plus.x" name="x" type="Φ.number"/>` — and the
tables dropped it. `Provides` now keeps it, next to `void="true"`:

```java
if (attr.xpath("@base").contains("∅")) {
    row.set("void", "true");
    final List<String> held = attr.xpath("@type[starts-with(., 'Φ.')]");
    if (!held.isEmpty()) {
        row.set("holds", held.get(0));
    }
}
```

An annotation that names no object — `/A`, `/A?` — is skipped exactly as
an atom's return forma is, since a variable is not a type this module
understands yet. New `Held` reads the cell back by the locator of the
void, dropping the question mark of `/Q.number?`, since a termination
answers to every name there is. `Provided` walks through an annotated
void the way it walks behind a `φ`, so `Φ.number.plus.x.eq` resolves to
`Φ.number.eq` rather than staying a name rooted at a variable, and such
a void is no longer treated as blank.

The gain today is nil and that is deliberate. Sixteen voids in
`eo-runtime` carry an annotation, fourteen `Φ.number` and two
`Φ.bytes`, and all of them are parameters of atoms, which have no EO
body to dispatch in — so `links.xml` and `needs.xml` come out
byte-identical and the ladder stays at 44,015 objects, 98.9% described,
depth 67.2%. The whole of the gain arrives with the annotations
themselves: `Φ.posix.return.code` roots 62 answers today and
`Φ.win32.return.code` 52, and every one of them is a name rooted at a
void that an annotation would make concrete.

Two packs describe the behaviour, both through an atom, since master's
parser still refuses an annotation on a formation void.
