### PR TITLE
Drop MethodChain's dead end attribute

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/MethodChain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/MethodChain.java
@@ -27,11 +27,6 @@ final class MethodChain {
     private final int dot;
 
     /**
-     * Index past this link in the source body.
-     */
-    private final int end;
-
-    /**
      * Whether this link is a fragile dispatch ({@code ?.} instead of
      * {@code .}) — R-3.5 / §9.4.
      */
@@ -41,13 +36,11 @@ final class MethodChain {
      * Ctor.
      * @param ident Method name
      * @param dot Column of the dot
-     * @param after Index past this link
      * @param weak Whether the link is a fragile {@code ?.} dispatch
      */
-    MethodChain(final String ident, final int dot, final int after, final boolean weak) {
+    MethodChain(final String ident, final int dot, final boolean weak) {
         this.name = ident;
         this.dot = dot;
-        this.end = after;
         this.fragile = weak;
     }
 
@@ -73,13 +66,5 @@ final class MethodChain {
      */
     int dot() {
         return this.dot;
-    }
-
-    /**
-     * Index past this link.
-     * @return End index
-     */
-    int end() {
-        return this.end;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/MethodChain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/MethodChain.java
@@ -13,7 +13,6 @@ package org.eolang.parser;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.DataClass")
 final class MethodChain {
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -416,7 +416,7 @@ final class Tokens {
             }
             this.consumeDispatch();
             final Value name = this.readMethodName();
-            chain.add(new MethodChain(name.raw(), dot, name.end(), fragile));
+            chain.add(new MethodChain(name.raw(), dot, fragile));
         }
         return chain;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/ChainEmissionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ChainEmissionTest.java
@@ -49,7 +49,7 @@ final class ChainEmissionTest {
             emit,
             new Span("foo.bar > wrap", 1),
             new Value(Value.Kind.IDENTIFIER, "foo", 0, 3),
-            Collections.singletonList(new MethodChain("bar", 3, 7, false)),
+            Collections.singletonList(new MethodChain("bar", 3, false)),
             new Suffix("> wrap", new Span("foo.bar > wrap", 1), 8)
         ).run();
         emit.close();
@@ -96,8 +96,8 @@ final class ChainEmissionTest {
             new Span("foo.bar.baz > q", 1),
             new Value(Value.Kind.IDENTIFIER, "foo", 0, 3),
             Arrays.asList(
-                new MethodChain("bar", 3, 7, false),
-                new MethodChain("baz", 7, 11, false)
+                new MethodChain("bar", 3, false),
+                new MethodChain("baz", 7, false)
             ),
             new Suffix("> q", new Span("foo.bar.baz > q", 1), 12)
         ).run();

--- a/eo-parser/src/test/java/org/eolang/parser/MethodChainTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MethodChainTest.java
@@ -18,7 +18,7 @@ final class MethodChainTest {
     void retainsMethodName() {
         MatcherAssert.assertThat(
             "name() must round-trip the method identifier without the leading dot",
-            new MethodChain("bar", 3, 7, false).name(),
+            new MethodChain("bar", 3, false).name(),
             Matchers.equalTo("bar")
         );
     }
@@ -27,17 +27,8 @@ final class MethodChainTest {
     void retainsDotColumnForPosAttribute() {
         MatcherAssert.assertThat(
             "dot() must round-trip the column where the leading dot sits per R-9.1.3",
-            new MethodChain("bar", 3, 7, false).dot(),
+            new MethodChain("bar", 3, false).dot(),
             Matchers.equalTo(3)
-        );
-    }
-
-    @Test
-    void retainsEndIndex() {
-        MatcherAssert.assertThat(
-            "end() must round-trip the cursor-advance position past the link",
-            new MethodChain("bar", 3, 7, false).end(),
-            Matchers.equalTo(7)
         );
     }
 
@@ -45,7 +36,7 @@ final class MethodChainTest {
     void retainsFragileFlag() {
         MatcherAssert.assertThat(
             "fragile() must round-trip the `?.` dispatch marker",
-            new MethodChain("read", 3, 9, true).fragile(),
+            new MethodChain("read", 3, true).fragile(),
             Matchers.equalTo(true)
         );
     }


### PR DESCRIPTION
The `end` attribute on `MethodChain` was written by `Tokens.readChain()` but never read: the emitter only consumes `name()`, `dot()` and `fragile()`, taking its `@pos` from the dot column per R-9.1.3. The only caller of `end()` was a test of the accessor itself.

This drops the attribute, the `end()` accessor, and the `retainsEndIndex` test, and trims the constructor to the three values the emitter actually uses. `Value.end()` is untouched, since it still has a genuine reader elsewhere in `Tokens`.

Closes #6954