### PR TITLE
Fix Bindings docblock to name LnPipe instead of LnCompactTuple

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -16,8 +16,8 @@ import java.util.List;
  *
  * <p>This class collects the small rule set as static helpers shared
  * by every line shape that reads an argument group — {@link
- * LnApplication}, {@link LnMethod}, {@link LnReversed}, and the
- * compact-tuple flavours.</p>
+ * LnApplication}, {@link LnMethod}, {@link LnReversed}, and {@link
+ * LnPipe}.</p>
  *
  * @since 0.1
  */


### PR DESCRIPTION
The class docblock of \`Bindings\` listed \`LnCompactTuple\` among the line shapes that call its helpers, but \`LnCompactTuple.java\` contains no reference to \`Bindings\` at all. Meanwhile \`LnPipe\` calls \`checkAllOrNothing\` and was left out of the list entirely.

This fixes the docblock to name the four call sites that actually exist: \`LnApplication\`, \`LnMethod\`, \`LnReversed\`, and \`LnPipe\`.

Closes #6952