### PR TITLE
Fix contradictory columns in two BindingsTest fixtures

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
@@ -59,7 +59,7 @@ final class BindingsTest {
             () -> Bindings.checkAllOrNothing(
                 Arrays.asList(
                     new Value(Value.Kind.IDENTIFIER, "a", 4, 5, "x"),
-                    new Value(Value.Kind.IDENTIFIER, "b", 6, 7, "y")
+                    new Value(Value.Kind.IDENTIFIER, "b", 8, 9, "y")
                 ),
                 new Span("foo a:x b:y", 1)
             ),
@@ -69,16 +69,20 @@ final class BindingsTest {
 
     @Test
     void rejectsMixedBoundAndUnbound() {
-        Assertions.assertThrows(
-            ParseError.class,
-            () -> Bindings.checkAllOrNothing(
-                Arrays.asList(
-                    new Value(Value.Kind.IDENTIFIER, "a", 4, 5, "x"),
-                    new Value(Value.Kind.IDENTIFIER, "b", 6, 7)
+        MatcherAssert.assertThat(
+            "the divergent arg's column must be reported",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> Bindings.checkAllOrNothing(
+                    Arrays.asList(
+                        new Value(Value.Kind.IDENTIFIER, "a", 4, 5, "x"),
+                        new Value(Value.Kind.IDENTIFIER, "b", 8, 9)
+                    ),
+                    new Span("foo a:x b", 1)
                 ),
-                new Span("foo a:x b", 1)
-            ),
-            "a bound arg followed by an unbound one must be rejected per R-6.6.2"
+                "a bound arg followed by an unbound one must be rejected per R-6.6.2"
+            ).pos(),
+            Matchers.equalTo(8)
         );
     }
 


### PR DESCRIPTION
Two fixtures in BindingsTest.java build Value objects whose columns contradict the source line they are paired with.

In acceptsAllBoundArgs the span is `foo a:x b:y`, which puts `b` at column 8, but the value was constructed at column 6. rejectsMixedBoundAndUnbound repeated the same mismatch with the span `foo a:x b`.

Bindings.checkAllOrNothing reads nothing from the span but the line number, so the wrong column passed silently. This shifts both `b` values to column 8, matching their spans, and turns rejectsMixedBoundAndUnbound into a position assertion so a future regression here fails loudly instead of passing by accident.

Closes #6951