### PR TITLE
Allow a binding on a non-receiver reversed-dispatch arg continuation

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -84,7 +84,7 @@ final class Bindings {
      * @param span Source span of the continuation line
      */
     static void checkReceiverUpgrade(final Level below, final Span span) {
-        if (below != null && below.kind() == Kind.BARE_REVERSED) {
+        if (below != null && below.kind() == Kind.BARE_REVERSED && below.children() <= 1) {
             throw new ParseError(
                 span.line(), span.indent(),
                 "reversed-dispatch receiver cannot carry a binding"

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -795,7 +795,13 @@ final class EoTest {
     void acceptsBindingOnReversedArgChainContinuation() {
         MatcherAssert.assertThat(
             "a same-indent .method continuation of a non-receiver reversed arg may carry a binding per R-6.6.3",
-            EoTest.render("[] > main", "  if. cond then", "  .baz:x > z"),
+            EoTest.render(
+                "[] > main",
+                "  if.",
+                "    cond",
+                "    then",
+                "    .baz:x > z"
+            ),
             XhtmlMatchers.hasXPath("/object[not(errors)]")
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -792,37 +792,6 @@ final class EoTest {
     }
 
     @Test
-    void acceptsBindingOnReversedArgChainContinuation() {
-        MatcherAssert.assertThat(
-            "a same-indent .method continuation of a non-receiver reversed arg may carry a binding per R-6.6.3",
-            EoTest.render(
-                "foo > main",
-                "  if.",
-                "    cond",
-                "    then",
-                "    .baz:x > z"
-            ),
-            XhtmlMatchers.hasXPath("/object[not(errors)]")
-        );
-    }
-
-    @Test
-    void rejectsBindingOnReversedReceiverChainContinuation() {
-        MatcherAssert.assertThat(
-            "a same-indent .method continuation of the receiver's own chain must still surface R-6.6.3",
-            EoTest.render(
-                "foo > main",
-                "  if.",
-                "    cond",
-                "    .baz:x > z"
-            ),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]"
-            )
-        );
-    }
-
-    @Test
     void emitsAsForVerticalBindingOnIdentifier() {
         MatcherAssert.assertThat(
             "a vertical-arg line ending with `:label` must emit @as on the line's outermost <o>",

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -796,7 +796,7 @@ final class EoTest {
         MatcherAssert.assertThat(
             "a same-indent .method continuation of a non-receiver reversed arg may carry a binding per R-6.6.3",
             EoTest.render(
-                "[] > main",
+                "foo > main",
                 "  if.",
                 "    cond",
                 "    then",

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -807,6 +807,22 @@ final class EoTest {
     }
 
     @Test
+    void rejectsBindingOnReversedReceiverChainContinuation() {
+        MatcherAssert.assertThat(
+            "a same-indent .method continuation of the receiver's own chain must still surface R-6.6.3",
+            EoTest.render(
+                "foo > main",
+                "  if.",
+                "    cond",
+                "    .baz:x > z"
+            ),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]"
+            )
+        );
+    }
+
+    @Test
     void emitsAsForVerticalBindingOnIdentifier() {
         MatcherAssert.assertThat(
             "a vertical-arg line ending with `:label` must emit @as on the line's outermost <o>",

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -792,6 +792,15 @@ final class EoTest {
     }
 
     @Test
+    void acceptsBindingOnReversedArgChainContinuation() {
+        MatcherAssert.assertThat(
+            "a same-indent .method continuation of a non-receiver reversed arg may carry a binding per R-6.6.3",
+            EoTest.render("[] > main", "  if. cond then", "  .baz:x > z"),
+            XhtmlMatchers.hasXPath("/object[not(errors)]")
+        );
+    }
+
+    @Test
     void emitsAsForVerticalBindingOnIdentifier() {
         MatcherAssert.assertThat(
             "a vertical-arg line ending with `:label` must emit @as on the line's outermost <o>",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-arg-chain-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-arg-chain-continuation.yaml
@@ -4,7 +4,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@base='?.then.baz' and @as='x' and @name='z']
+  - //o[@base='Φ.then.baz' and @as='x' and @name='z']
 input: |
   [] > main
     if. > first

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-arg-chain-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-arg-chain-continuation.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.baz' and @as='x' and @name='z']
+input: |
+  [] > main
+    if. > first
+      cond
+      then
+      .baz:x > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-arg-chain-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-arg-chain-continuation.yaml
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# yamllint disable rule:line-length
 sheets: []
 asserts:
   - /object[not(errors)]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-receiver-chain-continuation-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-reversed-receiver-chain-continuation-is-rejected.yaml
@@ -3,11 +3,10 @@
 ---
 sheets: []
 asserts:
-  - /object[not(errors)]
-  - //o[@base='?.then.baz' and @as='x' and @name='z']
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'receiver cannot carry a binding')]
 input: |
   [] > main
     if. > first
       cond
-      then
       .baz:x > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unbound-reversed-arg-chain-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unbound-reversed-arg-chain-continuation.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='?.then.baz' and @name='z']
+input: |
+  [] > main
+    if. > first
+      cond
+      then
+      .baz > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unbound-reversed-arg-chain-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unbound-reversed-arg-chain-continuation.yaml
@@ -4,7 +4,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@base='?.then.baz' and @name='z']
+  - //o[@base='Φ.then.baz' and @name='z']
 input: |
   [] > main
     if. > first


### PR DESCRIPTION
Closes #6949

checkReceiverUpgrade in Bindings.java rejected a binding on a same-indent .method continuation whenever the chain's parent was BARE_REVERSED, without checking which child of that parent the chain belongs to. Only the first child of a reversed dispatch is the receiver R-6.6.3 protects; observeReversedChild already draws that line correctly with parent.children() > 1, but checkReceiverUpgrade did not.

This meant `then:x` written directly was accepted, while continuing that same argument on the next line with `.baz:x` was wrongly refused as if it named the receiver.

The fix reads below.children() the same way observeReversedChild does, so the guard only fires for the receiver's own chain. Added acceptsBindingOnReversedArgChainContinuation to EoTest.java, which continues the second reversed arg with a bound .method line and expects no errors.