### PR TITLE
fix(#6964): exclude atom locations from lcov coverage manifest

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -24,12 +24,13 @@ import java.util.LinkedHashSet;
  * attributes are already present by the time every shift except the last
  * one has run, so running that same prefix here and reading the result
  * gets the exact same set {@code to-java.xsl} would act on, structurally,
- * rather than by pattern-matching the Java it emits. An atom never gets a
- * hit: {@code classes.xsl} marks a whole atomic class {@code @skip-java}
- * and {@code to-java.xsl} then writes no {@code <java>} for it, while
- * {@code attrs.xsl} wraps an atomic attribute into an {@code atom} element
- * whose own line {@code to-java.xsl} never runs through {@code located}
- * mode. Both are left out here.</p>
+ * rather than by pattern-matching the Java it emits. Two shapes never get a
+ * hit and are left out here: {@code classes.xsl} marks a whole atomic class
+ * {@code @skip-java}, and {@code to-java.xsl} then writes no {@code <java>}
+ * for it at all; and the lambda marker of any atom (the {@code o[@name='λ']}
+ * carrying {@code @atom}, whether the atom is a whole class or a single
+ * attribute) is never the argument {@code to-java.xsl} runs through
+ * {@code located} mode, only its parent is.</p>
  *
  * @since 0.75.0
  */
@@ -53,7 +54,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+')) and not(self::atom) and not(@skip-java)]"
+            "//*[@line and @pos and not(contains(@loc,'+')) and not(@atom) and not(@skip-java)]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -24,7 +24,12 @@ import java.util.LinkedHashSet;
  * attributes are already present by the time every shift except the last
  * one has run, so running that same prefix here and reading the result
  * gets the exact same set {@code to-java.xsl} would act on, structurally,
- * rather than by pattern-matching the Java it emits.</p>
+ * rather than by pattern-matching the Java it emits. An atom never gets a
+ * hit: {@code classes.xsl} marks a whole atomic class {@code @skip-java}
+ * and {@code to-java.xsl} then writes no {@code <java>} for it, while
+ * {@code attrs.xsl} wraps an atomic attribute into an {@code atom} element
+ * whose own line {@code to-java.xsl} never runs through {@code located}
+ * mode. Both are left out here.</p>
  *
  * @since 0.75.0
  */
@@ -48,7 +53,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+'))]"
+            "//*[@line and @pos and not(contains(@loc,'+')) and not(self::atom) and not(@skip-java)]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -47,6 +47,42 @@ final class CoverageManifestTest {
         );
     }
 
+    @Test
+    void excludesLocationOfAnAtomAttribute() throws Exception {
+        MatcherAssert.assertThat(
+            "an atom attribute never gets a PhCoverage hit, but its location was still found",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "[] > foo",
+                        "  [] > bar /Q.bytes",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    @Test
+    void excludesLocationOfAWholeAtomClass() throws Exception {
+        MatcherAssert.assertThat(
+            "a class that is itself an atom never gets a PhCoverage hit for its own line, but the location was still found",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "[] > foo /Q.bytes",
+                        "  true.eq true ++> works",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.everyItem(Matchers.not(Matchers.matchesPattern("^[^:]+:1:\\d+$")))
+        );
+    }
+
     /**
      * Locations found in a small formation with one attribute.
      * @return The locations

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -48,9 +48,9 @@ final class CoverageManifestTest {
     }
 
     @Test
-    void excludesLocationOfAnAtomAttribute() throws Exception {
+    void excludesLocationOfAnAtomsLambdaMarker() throws Exception {
         MatcherAssert.assertThat(
-            "an atom attribute never gets a PhCoverage hit, but its location was still found",
+            "the lambda marker of an atom attribute never gets a PhCoverage hit, but its location was still found",
             new CoverageManifest().locations(
                 new EoSyntax(
                     String.join(
@@ -61,7 +61,7 @@ final class CoverageManifestTest {
                     )
                 ).parsed()
             ),
-            Matchers.iterableWithSize(1)
+            Matchers.iterableWithSize(2)
         );
     }
 
@@ -74,6 +74,7 @@ final class CoverageManifestTest {
                     String.join(
                         System.lineSeparator(),
                         "[] > foo /Q.bytes",
+                        "",
                         "  true.eq true ++> works",
                         ""
                     )


### PR DESCRIPTION
CoverageManifest.locations() was picking up phantom locations for atoms. A whole class that is itself an atom gets marked @skip-java by classes.xsl, and to-java.xsl then writes no <java> block for it at all. An atomic attribute gets wrapped by attrs.xsl into an <atom> element whose own line to-java.xsl never runs through its "located" mode (only the atom's argument child does). Neither ever ends up with a PhCoverage hit, so both were showing up in the LCOV report as always-uncovered lines that could never be covered, dataized.eo being the example from the issue.

The XPath in CoverageManifest now excludes self::atom and @skip-java nodes, matching exactly what to-java.xsl itself does structurally.

Added excludesLocationOfAnAtomAttribute and excludesLocationOfAWholeAtomClass to CoverageManifestTest to cover both cases.

Closes #6964