### PR TITLE
#6314: keep the meta-header blank line readable by the test-attribute check

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -58,17 +58,19 @@ final class Blanks {
      * that sits deeper than a direct child of the top-level object,
      * illegal per R-6.3.3.
      * @param span The offending line's span (used for error position)
-     * @param globals The global parser state
+     * @param blanks How many blank lines precede the line - read by the
+     *  caller before {@link #enterAfterMeta(Span, Globals, Emit)} had a
+     *  chance to consume them
      * @param emit The directives sink
      */
-    static void checkTest(final Span span, final Globals globals, final Emit emit) {
+    static void checkTest(final Span span, final int blanks, final Emit emit) {
         if (span.indent() != 2) {
             emit.error(
                 span.line(), span.indent(),
                 "test attribute legal only as direct child of top-level object"
             );
         }
-        if (globals.pendingBlanks() == 0) {
+        if (blanks == 0) {
             emit.error(
                 span.line(), span.indent(),
                 "missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute"
@@ -83,8 +85,11 @@ final class Blanks {
      * @param span The first post-meta line's span
      * @param globals The global parser state
      * @param emit The directives sink
+     * @return How many blank lines preceded the line, counted before
+     *  this method consumed them
      */
-    static void enterAfterMeta(final Span span, final Globals globals, final Emit emit) {
+    static int enterAfterMeta(final Span span, final Globals globals, final Emit emit) {
+        final int blanks = globals.pendingBlanks();
         if (globals.inMetaHeader()) {
             if (globals.pendingBlanks() == 0) {
                 emit.error(
@@ -96,5 +101,6 @@ final class Blanks {
             }
             globals.closeMetaHeader();
         }
+        return blanks;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -68,7 +68,7 @@ final class LnApplication implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, globals.pendingBlanks(), emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -86,7 +86,7 @@ final class LnCompactTuple implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, globals.pendingBlanks(), emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -46,7 +46,7 @@ final class LnFormation implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.enterAfterMeta(this.span, globals, emit);
+        final int blanks = Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
         final List<String> params;
         final String binding;
@@ -75,7 +75,7 @@ final class LnFormation implements Line {
         }
         this.checkAtomVoids(suffix, params);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, blanks, emit);
         }
         Comments.seal(globals, emit, this.span);
         this.transition(stack, suffix);

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -75,7 +75,7 @@ final class LnMethod implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, globals.pendingBlanks(), emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -75,7 +75,7 @@ final class LnOnlyPhi implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.enterAfterMeta(this.span, globals, emit);
+        final int blanks = Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
         final int phi = Eo.topLevelGreaterBracketIndex(body);
         final String lhs;
@@ -121,7 +121,7 @@ final class LnOnlyPhi implements Line {
             );
         }
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, blanks, emit);
         }
         Comments.seal(globals, emit, this.span);
         final Tokens tokens = this.slot(

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -81,7 +81,7 @@ final class LnReversed implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, globals.pendingBlanks(), emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -55,7 +55,7 @@ final class LnTextBlock implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, globals, emit);
+            Blanks.checkTest(this.span, globals.pendingBlanks(), emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/first-object-test-attribute.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/first-object-test-attribute.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6314: the blank line that follows the meta header was consumed by the
+# R-6.5.5 check before the R-6.5.3 one could read it, so the very first object
+# of a file was told a blank line was missing while it was right there. The
+# line below is still rejected, for sitting outside a top-level object, but
+# that is the only thing wrong with it.
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'direct child of top-level object')]
+input: |
+  +package foo
+
+  [] +> works
+    true > @


### PR DESCRIPTION
Closes #6314

One blank line was answering two questions, and the first answer erased it.
`enterAfterMeta` cleared the pending-blank counter to satisfy R-6.5.5, and
`checkTest` then read that same counter for R-6.5.3 and found nothing, so the
first object of a file was told its blank line was missing while it was right
there above it.

`enterAfterMeta` returns the count it saw before consuming it, and `checkTest`
takes that number instead of re-reading the counter. `LnFormation` and
`LnOnlyPhi`, the two that call both, pass what they got; the five that only
check a test attribute pass the counter as they read it, which is what they
were doing indirectly before.

The new syntax pack pins the error list for the reported input: the line is
still rejected for sitting outside a top-level object, and that is now the only
complaint about it. On master the same input collects the R-6.5.3 one as well.
