### PR TITLE
#6303: accept exponent notation in `string.as-number`

### DIFF
--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -17,20 +17,34 @@
 [cant-parse] > as-number
   if. > @
     not.
-      "/^[+-]?\\d+(?:\\.\\d+)?$/".regex.compiled.matches text
+      "/^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$/".regex.compiled.matches text
     cant-parse
       "Can't convert text %s to number".printf
         * text
     head. ("%f".scanf text).at.^
   ^ > text
 
+  1000.eq "1e3".as-number ++> can-convert-exponent-text
+
   3.14.eq "3.14".as-number ++> can-convert-float-text
+
+  -0.0025.eq "-2.5E-3".as-number ++> can-convert-negative-exponent-text
 
   -42.eq "-42".as-number ++> can-convert-negative-text
 
   5.eq "5".as-number ++> can-convert-text
 
   42.5.eq "42.5".as-number ++> can-convert-text-through-an-implicit-dispatch
+
+  eq. ++> can-recover-from-a-bare-exponent-marker
+    42
+    "1e".as-number
+      42 > [message]
+
+  eq. ++> can-recover-from-an-exponent-without-a-mantissa
+    42
+    "e3".as-number
+      42 > [message]
 
   eq. ++> can-recover-from-currency-prefixed-text
     42


### PR DESCRIPTION
Closes #6303

`scanf`'s `%f` reads exponent notation on master already, but `as-number`
validates the whole text first and its expression stopped at the fraction, so
`"1e3"` never reached the parser and took the `cant-parse` branch instead.

The expression accepts a trailing `[eE][+-]?\d+` now, which is the same shape
the `%f` token matches, so the guard and the parser agree on what a number
looks like.

Four tests: `"1e3"` and `"-2.5E-3"` convert, and `"1e"` and `"e3"` still fall
back, since an exponent needs digits on both sides of the marker.
