### PR TITLE
#6959: give a ring of copies one name

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Ends.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ends.java
@@ -16,8 +16,9 @@ import java.util.Map;
  * at a time: {@code a} is a copy of {@code b}, {@code b} of {@code c}. Asking
  * the table about {@code a} has to arrive at {@code c}, so each pair is
  * followed as far as it goes and the end is written down against every name on
- * the way. A chain that comes back on itself is walked once and stops where it
- * started, since an object that is a copy of itself is nothing new.</p>
+ * the way. A chain that comes back on itself is a ring of copies of one and
+ * the same thing, so every name on that ring answers with the same one - the
+ * first of them in alphabetical order - no matter which of them is asked.</p>
  *
  * @since 0.68.0
  */
@@ -44,12 +45,35 @@ final class Ends {
         final Map<String, String> ends = new HashMap<>(this.copies.size());
         for (final Map.Entry<String, String> link : this.copies.entrySet()) {
             final Collection<String> walked = new HashSet<>(0);
+            walked.add(link.getKey());
             String end = link.getValue();
             while (this.copies.containsKey(end) && walked.add(end)) {
                 end = this.copies.get(end);
             }
+            if (this.copies.containsKey(end)) {
+                end = this.anchor(end);
+            }
             ends.put(link.getKey(), end);
         }
         return ends;
+    }
+
+    /**
+     * The name a ring of copies goes by - the first of its names in
+     * alphabetical order, which is the same one wherever the ring is
+     * entered.
+     * @param node A name on the ring, the one the walk came back to
+     * @return The name the whole ring answers with
+     */
+    private String anchor(final String node) {
+        String chosen = node;
+        String next = this.copies.get(node);
+        while (!next.equals(node)) {
+            if (next.compareTo(chosen) < 0) {
+                chosen = next;
+            }
+            next = this.copies.get(next);
+        }
+        return chosen;
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/EndsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/EndsTest.java
@@ -1,0 +1,86 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Ends}.
+ * @since 0.68.0
+ */
+final class EndsTest {
+
+    @Test
+    void walksAChainToItsEnd() {
+        MatcherAssert.assertThat(
+            "every name on a chain must arrive at the one the chain ends with, but it didnt",
+            new Ends(this.pairs("a", "b", "b", "c")).names(),
+            Matchers.allOf(
+                Matchers.hasEntry("a", "c"),
+                Matchers.hasEntry("b", "c")
+            )
+        );
+    }
+
+    @Test
+    void givesOneNameToBothSidesOfATwoNameRing() {
+        MatcherAssert.assertThat(
+            "two names that are copies of each other are one type and must answer with one name, but they didnt",
+            new Ends(this.pairs("a", "b", "b", "a")).names(),
+            Matchers.allOf(
+                Matchers.hasEntry("a", "a"),
+                Matchers.hasEntry("b", "a")
+            )
+        );
+    }
+
+    @Test
+    void givesOneNameToAWholeRing() {
+        MatcherAssert.assertThat(
+            "a ring of three copies must answer with the same name wherever it is entered, but it didnt",
+            new Ends(this.pairs("b", "c", "c", "a", "a", "b")).names(),
+            Matchers.allOf(
+                Matchers.hasEntry("a", "a"),
+                Matchers.hasEntry("b", "a"),
+                Matchers.hasEntry("c", "a")
+            )
+        );
+    }
+
+    @Test
+    void leadsAChainIntoTheNameOfTheRingItReaches() {
+        MatcherAssert.assertThat(
+            "a chain that runs into a ring must answer with the name of that ring, but it didnt",
+            new Ends(this.pairs("d", "b", "b", "c", "c", "b")).names(),
+            Matchers.hasEntry("d", "b")
+        );
+    }
+
+    @Test
+    void keepsANameThatIsACopyOfItself() {
+        MatcherAssert.assertThat(
+            "a name that is a copy of itself is nothing new and must answer with itself, but it didnt",
+            new Ends(this.pairs("a", "a")).names(),
+            Matchers.hasEntry("a", "a")
+        );
+    }
+
+    /**
+     * The pairs, read as a flat list of key and value.
+     * @param flat The names, a key followed by the name it is a copy of
+     * @return The pairs
+     */
+    private Map<String, String> pairs(final String... flat) {
+        final Map<String, String> pairs = new LinkedHashMap<>(flat.length / 2);
+        for (int idx = 0; idx < flat.length; idx = idx + 2) {
+            pairs.put(flat[idx], flat[idx + 1]);
+        }
+        return pairs;
+    }
+}


### PR DESCRIPTION
Closes #6959

The walk stepped one hop past the point where it saw a name for the second
time, so the answer depended on which name it started from: `{a=b, b=a}` came
back as `{a=b, b=a}`, two names for one type instead of one.

The starting name goes into the walked set now, so the walk stops on the name
it came back to, and that name is on the ring by construction. From there the
ring is read round once and its alphabetically first name is the answer, which
is the same wherever the ring is entered - `a` and `b` above both answer `a`,
and a chain that runs into a ring answers with the ring's name too.

A chain that ends somewhere is untouched: it stops where it always did, on the
name that is nobody's copy.
