### PR TITLE
#6886: widen `Winsock` socket descriptors to pointer width

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
@@ -39,7 +39,7 @@ public final class AcceptFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.accept(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Dataized(params[0]).asNumber().longValue(),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),

--- a/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
@@ -38,7 +38,7 @@ public final class BindFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.bind(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Dataized(params[0]).asNumber().longValue(),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),

--- a/eo-runtime/src/main/java/org/eolang/win32/ClosesocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ClosesocketFuncCall.java
@@ -36,7 +36,7 @@ public final class ClosesocketFuncCall implements Syscall {
         result.put(
             0,
             new Data.ToPhi(
-                Winsock.INSTANCE.closesocket(new Dataized(params[0]).asNumber().intValue())
+                Winsock.INSTANCE.closesocket(new Dataized(params[0]).asNumber().longValue())
             )
         );
         result.put(1, new PhDefault());

--- a/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
@@ -38,7 +38,7 @@ public final class ConnectFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.connect(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Dataized(params[0]).asNumber().longValue(),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),

--- a/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
@@ -37,7 +37,7 @@ public final class ListenFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.listen(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Dataized(params[0]).asNumber().longValue(),
                     new Dataized(params[1]).asNumber().intValue()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -39,7 +39,7 @@ public final class RecvFuncCall implements Syscall {
         ).it();
         final byte[] buf = new byte[size];
         final int received = Winsock.INSTANCE.recv(
-            new Dataized(params[0]).asNumber().intValue(),
+            new Dataized(params[0]).asNumber().longValue(),
             buf,
             size,
             new Dataized(params[2]).asNumber().intValue()

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -46,7 +46,7 @@ public final class SendFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.send(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Dataized(params[0]).asNumber().longValue(),
                     buf,
                     size,
                     new Dataized(params[3]).asNumber().intValue()

--- a/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
@@ -57,7 +57,7 @@ public interface Winsock extends StdCallLibrary {
     /**
      * Invalid socket descriptor.
      */
-    int INVALID_SOCKET = -1;
+    long INVALID_SOCKET = -1L;
 
     /**
      * Status returned on errors with socket.
@@ -85,14 +85,14 @@ public interface Winsock extends StdCallLibrary {
      * @param protocol Socket protocol
      * @return Socket descriptor
      */
-    int socket(int domain, int type, int protocol);
+    long socket(int domain, int type, int protocol);
 
     /**
      * Closes a socket.
      * @param socket Socket descriptor
      * @return Zero on success, otherwise, a value of SOCKET_ERROR is returned
      */
-    int closesocket(int socket);
+    int closesocket(long socket);
 
     /**
      * Connects to the server at the specified IP address and port.
@@ -101,7 +101,7 @@ public interface Winsock extends StdCallLibrary {
      * @param addrlen The size of the address structure
      * @return Zero on success, otherwise, a value of SOCKET_ERROR is returned
      */
-    int connect(int sockfd, SockaddrIn addr, int addrlen);
+    int connect(long sockfd, SockaddrIn addr, int addrlen);
 
     /**
      * Assigns the address specified by {@code addr} to the socket referred to
@@ -111,7 +111,7 @@ public interface Winsock extends StdCallLibrary {
      * @param addrlen The size of the address structure
      * @return Zero on success, -1 on error
      */
-    int bind(int sockfd, SockaddrIn addr, int addrlen);
+    int bind(long sockfd, SockaddrIn addr, int addrlen);
 
     /**
      * Listen for incoming connections on socket.
@@ -120,7 +120,7 @@ public interface Winsock extends StdCallLibrary {
      *  waiting to be accepted
      * @return Zero on success, -1 on error
      */
-    int listen(int sockfd, int backlog);
+    int listen(long sockfd, int backlog);
 
     /**
      * Accept connection on socket.
@@ -130,7 +130,7 @@ public interface Winsock extends StdCallLibrary {
      * @return On success, file descriptor for the accepted socket (a nonnegative integer)
      *  is returned. On error, -1 is returned
      */
-    int accept(int sockfd, SockaddrIn addr, IntByReference addrlen);
+    long accept(long sockfd, SockaddrIn addr, IntByReference addrlen);
 
     /**
      * Send a message to a socket.
@@ -141,7 +141,7 @@ public interface Winsock extends StdCallLibrary {
      * @return The number of sent bytes on success, -1 on error
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    int send(int sockfd, byte[] buf, int len, int flags);
+    int send(long sockfd, byte[] buf, int len, int flags);
 
     /**
      * Receive a message from a socket.
@@ -152,7 +152,7 @@ public interface Winsock extends StdCallLibrary {
      * @return The number of received bytes on success, -1 on error
      * @checkstyle ParameterNumberCheck (5 lines)
      */
-    int recv(int sockfd, byte[] buf, int len, int flags);
+    int recv(long sockfd, byte[] buf, int len, int flags);
 
     /**
      * Retrieve the last error from winsock.

--- a/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
@@ -106,7 +106,7 @@ final class EOwin32EOφTest {
         @Test
         void opensTcpSocket() {
             this.startupsWSA();
-            final int socket = this.createsSocket();
+            final long socket = this.createsSocket();
             MatcherAssert.assertThat(
                 "Winsock library should successfully create a TCP socket, but it didn't",
                 socket,
@@ -131,7 +131,7 @@ final class EOwin32EOφTest {
          * Creates socket.
          * @return Closes socket
          */
-        private int createsSocket() {
+        private long createsSocket() {
             return Winsock.INSTANCE.socket(
                 Winsock.AF_INET,
                 Winsock.SOCK_STREAM,
@@ -144,7 +144,7 @@ final class EOwin32EOφTest {
          * @param socket Socket descriptor
          * @return Status code
          */
-        private int closesSocket(final int socket) {
+        private int closesSocket(final long socket) {
             return Winsock.INSTANCE.closesocket(socket);
         }
 

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -199,7 +199,7 @@ final class SyscallTest {
             final SyscallTest.RandomServer server = new SyscallTest.RandomServer(port).started();
             try {
                 this.ensure(this.startup() == 0);
-                final int socket = this.openSocket();
+                final long socket = this.openSocket();
                 try {
                     this.ensure(socket > 0);
                     final SockaddrIn addr = this.sockaddr(server.port());
@@ -224,7 +224,7 @@ final class SyscallTest {
         void refusesConnectionViaSyscall(@Ephemeral final int port) throws UnknownHostException {
             try {
                 this.ensure(this.startup() == 0);
-                final int socket = this.openSocket();
+                final long socket = this.openSocket();
                 try {
                     this.ensure(socket > 0);
                     final SockaddrIn addr = this.sockaddr(port);
@@ -246,7 +246,7 @@ final class SyscallTest {
             throws UnknownHostException {
             try {
                 this.ensure(this.startup() == 0);
-                final int socket = this.openSocket();
+                final long socket = this.openSocket();
                 try {
                     this.ensure(socket > 0);
                     MatcherAssert.assertThat(
@@ -270,7 +270,7 @@ final class SyscallTest {
             throws UnknownHostException {
             try {
                 this.ensure(this.startup() == 0);
-                final int socket = this.openSocket();
+                final long socket = this.openSocket();
                 try {
                     this.ensure(socket > 0);
                     this.ensure(this.bindSocket(socket, port) == 0);
@@ -302,7 +302,7 @@ final class SyscallTest {
                 );
                 server.start();
                 Thread.sleep(2000);
-                final int client = this.openSocket();
+                final long client = this.openSocket();
                 try {
                     this.ensure(client >= 0);
                     final SockaddrIn sockaddr = this.sockaddr(port);
@@ -343,7 +343,7 @@ final class SyscallTest {
                 );
                 server.start();
                 Thread.sleep(2000);
-                final int client = this.openSocket();
+                final long client = this.openSocket();
                 try {
                     this.ensure(client >= 0);
                     final SockaddrIn sockaddr = this.sockaddr(port);
@@ -372,8 +372,8 @@ final class SyscallTest {
          * Open socket.
          * @return Socket descriptor
          */
-        private int openSocket() {
-            final int socket = Winsock.INSTANCE.socket(
+        private long openSocket() {
+            final long socket = Winsock.INSTANCE.socket(
                 Winsock.AF_INET,
                 Winsock.SOCK_STREAM,
                 Winsock.IPPROTO_TCP
@@ -387,7 +387,7 @@ final class SyscallTest {
          * @param socket Socket descriptor
          * @return Zero on success, -1 on error
          */
-        private int closeSocket(final int socket) {
+        private int closeSocket(final long socket) {
             final int closed = Winsock.INSTANCE.closesocket(socket);
             if (closed == 0) {
                 Logger.debug(this, "Closed socket: %d", socket);
@@ -440,7 +440,7 @@ final class SyscallTest {
          * @param port Port
          * @return Zero on success, -1 on error
          */
-        private int bindSocket(final int socket, final int port) throws UnknownHostException {
+        private int bindSocket(final long socket, final int port) throws UnknownHostException {
             return Winsock.INSTANCE.bind(
                 socket,
                 this.sockaddr(port),
@@ -475,17 +475,17 @@ final class SyscallTest {
         private void acceptViaWinsock(
             final int port, final AtomicInteger accept, final AtomicInteger error
         ) {
-            final int socket = this.openSocket();
+            final long socket = this.openSocket();
             try {
                 this.ensure(socket > 0);
                 this.ensure(this.bindSocket(socket, port) == 0);
                 this.ensure(Winsock.INSTANCE.listen(socket, 5) == 0);
                 final SockaddrIn addr = new SockaddrIn();
-                final int accepted = Winsock.INSTANCE.accept(
+                final long accepted = Winsock.INSTANCE.accept(
                     socket, addr, new IntByReference(addr.size())
                 );
                 Logger.debug(this, "Accepted socket: %d", accepted);
-                accept.set(accepted);
+                accept.set((int) accepted);
                 if (accepted < 0) {
                     error.set(this.getError());
                 }
@@ -503,8 +503,8 @@ final class SyscallTest {
             final int port, final AtomicInteger received,
             final AtomicReference<byte[]> bytes
         ) {
-            final int socket = this.openSocket();
-            int accepted = 0;
+            final long socket = this.openSocket();
+            long accepted = 0L;
             try {
                 this.ensure(socket > 0);
                 this.ensure(this.bindSocket(socket, port) == 0);


### PR DESCRIPTION
Closes #6886

`SOCKET` is `UINT_PTR`, so on 64-bit Windows it is eight bytes wide, while the
bindings declared it as `int`. The values happen to fit today, but the declared
signature is what JNA marshals by, and it did not match the one the library
exports.

Every socket descriptor in `Winsock` is `long` now - what `socket` and `accept`
return, and what `closesocket`, `connect`, `bind`, `listen`, `send` and `recv`
take - and `INVALID_SOCKET` is a `long` too, so a returned descriptor is still
compared against it directly. The eight `FuncCall` classes read the descriptor
with `longValue()` instead of `intValue()`; nothing else about them changes,
since an EO number carries the value either way.

Same shape as the `_ftime64_s` widening: the declared width follows the real
type instead of the value that happens to fit.
