### PR TITLE
#6871: close a compact tuple when a `.method` continuation takes its place

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -71,7 +71,7 @@ final class Eo implements Iterable<Directive> {
         final Globals globals = new Globals();
         final Emit emit = new Emit(this.source);
         final Stack stack = new Stack(
-            level -> Eo.checkOnClose(level, emit),
+            (level, naming) -> Eo.checkOnClose(level, emit, naming),
             parent -> Eo.beforeChild(parent, emit)
         );
         final java.util.List<Span> spans = new java.util.ArrayList<>(Eo.SPANS_CAPACITY);
@@ -893,19 +893,19 @@ final class Eo implements Iterable<Directive> {
      * <p>Checks: R-5.3.1 (naming requirement for plain children of
      * formations and top-level objects), the only-phi argument-naming
      * ban (§4.5), bare-reversed receiver presence, and the compact-tuple
-     * count. Atom-body and test-depth checks attach as their owning line
-     * shapes are implemented.</p>
+     * count.</p>
      *
      * @param level The level being closed
      * @param emit The directives sink
+     * @param naming Whether the naming requirement applies yet
      */
-    private static void checkOnClose(final Level level, final Emit emit) {
+    private static void checkOnClose(final Level level, final Emit emit, final boolean naming) {
         try {
             level.commitArg(null);
         } catch (final ParseError err) {
             emit.error(err.line(), err.pos(), err.getMessage());
         }
-        Eo.checkNaming(level, emit);
+        Eo.checkNaming(level, emit, naming);
         if (level.kind() == Kind.BARE_REVERSED && !level.taken()) {
             emit.error(
                 level.start(), level.indent(),
@@ -925,13 +925,13 @@ final class Eo implements Iterable<Directive> {
     /**
      * Report naming violations on the popped level: a plain child of a
      * formation or top-level object that lacks a name (R-5.3.1), and an
-     * only-phi argument that carries one — the formation binds only φ,
-     * so its φ's arguments may not be named (§4.5).
+     * only-phi argument that carries one, which §4.5 bans.
      * @param level The level being closed
      * @param emit The directives sink
+     * @param naming False while a level is only sealed - a chain is named on its last link
      */
-    private static void checkNaming(final Level level, final Emit emit) {
-        if (!level.named()
+    private static void checkNaming(final Level level, final Emit emit, final boolean naming) {
+        if (naming && !level.named()
             && (level.parent() == Kind.TOP_LEVEL
                 || level.parent() == Kind.BARE_FORMATION)) {
             emit.error(
@@ -939,7 +939,7 @@ final class Eo implements Iterable<Directive> {
                 "object inside formation must have a name"
             );
         }
-        if (level.argument() && level.named()) {
+        if (naming && level.argument() && level.named()) {
             emit.error(
                 level.start(), level.indent(),
                 level.onlyPhiNamingError()

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -449,6 +449,19 @@ final class Level {
     }
 
     /**
+     * Forget the compact-tuple state, after the closer has already
+     * accounted for it - the entry stays on the stack as the wrapper a
+     * same-indent {@code .method} continuation put around it, and the
+     * wrapper is no tuple of its own.
+     */
+    void sealed() {
+        this.star = false;
+        this.tupled = false;
+        this.children = 0;
+        this.count = 0;
+    }
+
+    /**
      * Mark the compact-tuple wrapper as opened — emission of the
      * {@code Φ.tuple} wrapper has fired and any further children land
      * inside it.

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -86,7 +86,7 @@ final class LnMethod implements Line {
                 stack.below().upgradeArgBinding();
             }
         }
-        emit.close();
+        stack.seal();
         emit.object(
             suffix.attribute(this.span.line(), this.span.indent()),
             ".".concat(method.raw()),

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -58,7 +58,7 @@ final class Stack {
      * transitions without semantic checks.
      */
     Stack() {
-        this(level -> { }, level -> { });
+        this((level, naming) -> { }, level -> { });
     }
 
     /**
@@ -230,7 +230,7 @@ final class Stack {
         while (!this.levels.isEmpty() && this.top().indent() > target) {
             final Level last = this.levels.remove(this.levels.size() - 1);
             stepped = true;
-            this.closer.onClose(last);
+            this.closer.onClose(last, true);
         }
         if (stepped && !this.levels.isEmpty() && this.top().openness() == Openness.OPEN) {
             this.top().close(Openness.VERTICAL_COMPLETED);
@@ -251,7 +251,7 @@ final class Stack {
             throw new IllegalStateException("cannot replace top of empty stack");
         }
         final Level old = this.levels.remove(this.levels.size() - 1);
-        this.closer.onClose(old);
+        this.closer.onClose(old, true);
         final int indent = old.indent();
         final Kind parent;
         final boolean patom;
@@ -280,13 +280,29 @@ final class Stack {
     }
 
     /**
+     * Run the closer on the top entry without popping it, so the entry
+     * can be re-purposed at the same indent (R-5.2.5): a same-indent
+     * {@code .method} continuation closes what stands above it and
+     * takes its place. Everything the closer does on a pop happens
+     * here too — the argument-binding check, the bare-reversed
+     * receiver check, the compact-tuple wrapper and count — and the
+     * entry is left with none of that state, since it is a plain
+     * dispatch from now on.
+     */
+    void seal() {
+        final Level level = this.top();
+        this.closer.onClose(level, false);
+        level.sealed();
+    }
+
+    /**
      * Pop every remaining entry and run the closer on each — used by EOF
      * (§8).
      */
     void close() {
         while (!this.levels.isEmpty()) {
             final Level last = this.levels.remove(this.levels.size() - 1);
-            this.closer.onClose(last);
+            this.closer.onClose(last, true);
         }
     }
 
@@ -307,10 +323,11 @@ final class Stack {
     interface Closer {
 
         /**
-         * Run close-time checks on a popped or replaced level.
+         * Run close-time checks on a popped, replaced or sealed level.
          * @param level The level being closed
+         * @param naming Whether the naming requirement applies to it
          */
-        void onClose(Level level);
+        void onClose(Level level, boolean naming);
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -101,7 +101,7 @@ final class LnMethodTest {
     @Test
     void emitsFlatSiblingForLink() {
         final Emit emit = new Emit();
-        final Stack stack = new Stack();
+        final Stack stack = new Stack((level, naming) -> emit.close());
         new LnApplication(new Span("foo", 1))
             .into(stack, new Globals(), emit);
         new LnMethod(new Span(".bar > x", 2))
@@ -153,7 +153,7 @@ final class LnMethodTest {
     @Test
     void emitsHargsAsChildrenOfLastLink() {
         final Emit emit = new Emit();
-        final Stack stack = new Stack();
+        final Stack stack = new Stack((level, naming) -> emit.close());
         new LnApplication(new Span("foo", 1))
             .into(stack, new Globals(), emit);
         new LnMethod(new Span(".bar 42 > x", 2))

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -109,7 +109,7 @@ final class StackTest {
     @Test
     void popsDeeperLevelsAndRunsCloser() {
         final List<Integer> closed = new ArrayList<>(0);
-        final Stack stack = new Stack(level -> closed.add(level.indent()));
+        final Stack stack = new Stack((level, naming) -> closed.add(level.indent()));
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
         stack.push(2, 2, Kind.HEAD, Openness.OPEN);
         stack.push(4, 3, Kind.HEAD, Openness.OPEN);
@@ -151,7 +151,7 @@ final class StackTest {
     @Test
     void replacesTopAndClosesOld() {
         final List<Integer> closed = new ArrayList<>(0);
-        final Stack stack = new Stack(level -> closed.add(level.start()));
+        final Stack stack = new Stack((level, naming) -> closed.add(level.start()));
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
         stack.push(2, 2, Kind.HEAD, Openness.OPEN);
         stack.replace(5, Kind.BARE_FORMATION, Openness.OPEN);
@@ -177,7 +177,7 @@ final class StackTest {
     @Test
     void runsCloserOnEveryRemainingEntryAtClose() {
         final List<Integer> closed = new ArrayList<>(0);
-        final Stack stack = new Stack(level -> closed.add(level.indent()));
+        final Stack stack = new Stack((level, naming) -> closed.add(level.indent()));
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
         stack.push(2, 2, Kind.HEAD, Openness.OPEN);
         stack.close();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-bare-reversed.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-bare-reversed.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6871: a reversed dispatch with nothing under it was not reported when a
+# same-indent `.method` continuation closed it, and the missing receiver was
+# emitted as an object with no base at all.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'reversed dispatch missing receiver')]
+input: |
+  [] > foo
+    size.
+    .m > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-compact-tuple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-compact-tuple.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6871: a same-indent `.method` continuation closed the line above it without
+# the emissions that closing a level normally carries, so the `Φ.tuple`
+# wrapper of a compact tuple was never built and the dispatch ended up under
+# the tuple head instead of around it.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='foo']/o[@base='.m' and @name='x']/o[@base='Φ.seq']/o[@as='α0' and @base='Φ.tuple']
+input: |
+  [] > foo
+    seq *
+      1
+    .m > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-empty-compact-tuple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-empty-compact-tuple.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6871: a compact tuple with nothing under it lost its argument entirely when
+# a same-indent `.method` continuation closed it - `seq` was left applied to
+# nothing at all.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='foo']/o[@base='.m' and @name='x']/o[@base='Φ.seq']/o[@as='α0' and @base='Φ.tuple.empty']
+input: |
+  [] > foo
+    seq *
+    .m > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-short-compact-tuple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-continuation-after-short-compact-tuple.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #6871: the compact-tuple count was not checked when a same-indent `.method`
+# continuation closed the tuple, so a tuple that promised three children and
+# got one passed without a word.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'compact tuple requires at least 3 children, got 1')]
+input: |
+  [] > foo
+    seq *3
+      1
+    .m > x


### PR DESCRIPTION
Closes #6871

A same-indent `.method` continuation closed the line above it with a bare
`emit.close()`, while every other place that closes a level goes through the
closer. So none of what the closer does happened: the `Φ.tuple` wrapper of a
compact tuple was never built - dropped altogether when the tuple had nothing
under it - the tuple's count was never checked, and a reversed dispatch with no
receiver was never reported. The dispatch also ended up under the head it was
supposed to wrap.

`Stack.seal()` runs the closer on the top entry without popping it, since the
entry stays and becomes the wrapper. The naming requirement is the one check
that cannot run there - a chain of continuations carries its name on the last
link - so the closer takes a flag for it, true everywhere a level is really
popped. After the closer, the entry drops its compact-tuple state: it is a
plain dispatch from then on and must not close a wrapper twice.

Four packs, one per symptom the issue lists: the nesting, the dropped empty
tuple, the count, and the missing receiver. Two unit tests in `LnMethodTest`
build their stack with a closer that closes, since the close is the closer's
job now.
