### PR TITLE
#6976: let the site javadoc report skip the missing-docs group

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -592,4 +592,25 @@
       </build>
     </profile>
   </profiles>
+  <reporting>
+    <plugins>
+      <plugin>
+        <!--
+        The "site" profile of the parent runs javadoc with "-Xdoclint:all"
+        and fails the build on any warning, and a mojo has to have a public
+        no-argument constructor for Maven to build it with. Javadoc warns
+        about every implicit one of those, which stopped the site build and
+        left the last two releases without a published site. The "missing"
+        group is what warns, and qulice checks the same thing on every
+        build anyway, class by class, method by method and field by field,
+        so nothing goes unwatched by dropping it here.
+        -->
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <doclint>all,-missing</doclint>
+        </configuration>
+      </plugin>
+    </plugins>
+  </reporting>
 </project>


### PR DESCRIPTION
Fixes the third item of #6976 - the one that keeps `eo-maven-plugin-site.yml`
red on every tag.

The parent's `site` profile runs javadoc with `-Xdoclint:all` and fails on any
warning, and `MjCoverageReport`, `MjInference` and `MjMerge` have no
constructor of their own, so javadoc warned about their implicit ones and the
site build stopped there. The `missing` group is what warns; qulice checks the
same thing on every build, class by class, method by method and field by field,
so the report skips that group now and still fails on anything javadoc calls
broken rather than absent.

I first added the three documented constructors, the way `MjClean` and the
other mojos have them, and the site built. Codacy rejected that: PMD reads an
empty constructor as `UnnecessaryConstructor`, and neither
`@SuppressWarnings("PMD.UnnecessaryConstructor")` nor `// NOPMD` helps, since
qulice's own PMD then reports the suppression as unnecessary - its ruleset does
not have that rule on. So the two analysers cannot both be satisfied by a
constructor, and this leaves the classes alone instead.

`mvn clean site -Psite -pl eo-maven-plugin`, the exact command the workflow
runs, reaches BUILD SUCCESS with this.

The other two items of the issue - a fresh clone cannot resolve the
inter-module SNAPSHOTs under the site lifecycle, and `-Psite` on the reactor
forks `eo-maven-plugin:format` into a build where `EO-Version` is unreadable -
are untouched here, so the issue stays open for them.
