### PR TITLE
test: cover dataized.eo edge cases

### DIFF
--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -70,3 +70,46 @@
         true
         m.put
           m.as-number.plus 1
+
+  eq. ++> can-dataize-a-plain-number
+    as-number.
+      dataized 42
+    42
+
+  eq. ++> can-dataize-a-nested-attribute
+    as-number.
+      dataized
+        [] > foo
+          [] > @
+            inner.five > @
+          [] > inner
+            5 > five
+    5
+
+  eq. ++> can-dataize-a-number-to-the-same-bytes-as-as-bytes
+    as-bytes.
+      dataized 42
+    42.as-bytes
+
+  eq. ++> can-dataize-the-same-target-consistently
+    as-bytes.
+      dataized 7
+    as-bytes.
+      dataized 7
+
+  as-bool. ++> can-dataize-true-as-bool
+    dataized true
+
+  not. ++> can-dataize-false-as-bool
+    as-bool.
+      dataized false
+
+  eq. ++> can-dataize-a-string
+    as-bytes.
+      dataized "hello"
+    "hello".as-bytes
+
+  eq. ++> can-dataize-a-target-that-is-already-bytes
+    as-bytes.
+      dataized 42.as-bytes
+    42.as-bytes

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -71,45 +71,44 @@
         m.put
           m.as-number.plus 1
 
+  ++> can-dataize-a-nested-attribute
+    eq. > @
+      as-number.
+        dataized foo
+      5
+    [] > foo
+      inner.five > [] > @
+      [] > inner
+        5 > five
+
+  ++> can-dataize-a-number-to-the-same-bytes-as-as-bytes
+    eq. > @
+      42 >>!
+      42.as-bytes
+
   eq. ++> can-dataize-a-plain-number
     as-number.
       dataized 42
     42
 
-  eq. ++> can-dataize-a-nested-attribute
-    as-number.
-      dataized
-        [] > foo
-          [] > @
-            inner.five > @
-          [] > inner
-            5 > five
-    5
+  ++> can-dataize-a-string
+    eq. > @
+      "hello" >>!
+      "hello".as-bytes
 
-  eq. ++> can-dataize-a-number-to-the-same-bytes-as-as-bytes
-    as-bytes.
-      dataized 42
-    42.as-bytes
-
-  eq. ++> can-dataize-the-same-target-consistently
-    as-bytes.
-      dataized 7
-    as-bytes.
-      dataized 7
-
-  as-bool. ++> can-dataize-true-as-bool
-    dataized true
+  ++> can-dataize-a-target-that-is-already-bytes
+    eq. > @
+      42.as-bytes >>!
+      42.as-bytes
 
   not. ++> can-dataize-false-as-bool
     as-bool.
       dataized false
 
-  eq. ++> can-dataize-a-string
-    as-bytes.
-      dataized "hello"
-    "hello".as-bytes
+  ++> can-dataize-the-same-target-consistently
+    eq. > @
+      7 >>!
+      7 >>!
 
-  eq. ++> can-dataize-a-target-that-is-already-bytes
-    as-bytes.
-      dataized 42.as-bytes
-    42.as-bytes
+  as-bool. ++> can-dataize-true-as-bool
+    dataized true

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -77,7 +77,7 @@
         dataized foo
       5
     [] > foo
-      inner.five > [] > @
+      inner.five > @
       [] > inner
         5 > five
 


### PR DESCRIPTION
Adds 6 inline eo tests to dataized.eo for cases Codecov flagged as uncovered: dataizing a plain number, a nested attribute (the object from the class docblock), a string, a target that is already bytes, and both boolean outcomes.

The existing two tests only exercise dataized's interaction with malloc-based caching; these add straightforward coverage of the dataization itself, checking results against as-bytes/as-number of the same values rather than hardcoded byte sequences.