### PR TITLE
Remove unwarranted @DisabledOnOs(OS.WINDOWS) from DrProgramTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -13,8 +13,6 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledOnOs;
-import org.junit.jupiter.api.condition.OS;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 
@@ -38,7 +36,6 @@ final class DrProgramTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void setsSchemaLocation() throws Exception {
         MatcherAssert.assertThat(
             "XSD location is set",
@@ -50,7 +47,6 @@ final class DrProgramTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void checksThatSchemaLocationPointToFile() throws Exception {
         MatcherAssert.assertThat(
             "URL of XSD is set to file",
@@ -61,7 +57,6 @@ final class DrProgramTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void checksThatSchemaLocationPointToExistingFile() throws Exception {
         MatcherAssert.assertThat(
             "XSD file exists",


### PR DESCRIPTION
Three tests in DrProgramTest.java were marked @DisabledOnOs(OS.WINDOWS), but none of them assert anything platform-specific. setsSchemaLocation checks for a namespace declaration in the serialized document. checksThatSchemaLocationPointToFile checks that the schema URL starts with file:///, which holds on Windows too, since DrProgram.schema() produces file:///C:/... there. checksThatSchemaLocationPointToExistingFile strips that same eight-character prefix and hands the rest to Paths.get, exactly like StrictXmirTest.refersToAbsoluteFileName already does unconditionally for the same attribute.

The annotations trace back to a hundred-file refactor (c471cc001c) whose message never mentions Windows, so there's no recorded reason for them. Removing all three restores coverage for DrProgram.java:97's replace("\\\\", "/") line, which was written for Windows and is otherwise never exercised there. The two now-unused imports (DisabledOnOs, OS) go with them.

Closes #6992
