### PR TITLE
Exclude a file's root object from the coverage manifest

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -24,13 +24,16 @@ import java.util.LinkedHashSet;
  * attributes are already present by the time every shift except the last
  * one has run, so running that same prefix here and reading the result
  * gets the exact same set {@code to-java.xsl} would act on, structurally,
- * rather than by pattern-matching the Java it emits. Two shapes never get a
- * hit and are left out here: {@code classes.xsl} marks a whole atomic class
- * {@code @skip-java}, and {@code to-java.xsl} then writes no {@code <java>}
- * for it at all; and the lambda marker of any atom (the {@code o[@name='λ']}
- * carrying {@code @atom}, whether the atom is a whole class or a single
- * attribute) is never the argument {@code to-java.xsl} runs through
- * {@code located} mode, only its parent is.</p>
+ * rather than by pattern-matching the Java it emits. Three shapes never get
+ * a hit and are left out here: {@code classes.xsl} marks a whole atomic
+ * class {@code @skip-java}, and {@code to-java.xsl} then writes no
+ * {@code <java>} for it at all; the lambda marker of any atom (the
+ * {@code o[@name='λ']} carrying {@code @atom}, whether the atom is a whole
+ * class or a single attribute) is never the argument {@code to-java.xsl}
+ * runs through {@code located} mode, only its parent is; and a file's own
+ * root object, since {@code classes.xsl} turns it into a {@code <class>}
+ * whose constructor is called once from Java itself, never through the
+ * {@code located} mode any of its attributes go through (#6995).</p>
  *
  * @since 0.75.0
  */
@@ -54,7 +57,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+')) and not(@atom) and not(@skip-java)]"
+            "//*[@line and @pos and not(contains(@loc,'+')) and not(@atom) and not(@skip-java) and not(self::class)]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -30,10 +30,12 @@ import java.util.LinkedHashSet;
  * {@code <java>} for it at all; the lambda marker of any atom (the
  * {@code o[@name='λ']} carrying {@code @atom}, whether the atom is a whole
  * class or a single attribute) is never the argument {@code to-java.xsl}
- * runs through {@code located} mode, only its parent is; and a file's own
- * root object, since {@code classes.xsl} turns it into a {@code <class>}
- * whose constructor is called once from Java itself, never through the
- * {@code located} mode any of its attributes go through (#6995).</p>
+ * runs through {@code located} mode, only its parent is; and a free
+ * attribute {@code attrs.xsl} wraps into a {@code <void>}, since
+ * {@code to-java.xsl} compiles it to a bare {@code AtVoid} and never runs
+ * it through {@code located} mode either — the formal attributes a file's
+ * root object declares are free this same way, which is why its own
+ * declaration line never gets a hit (#6995).</p>
  *
  * @since 0.75.0
  */
@@ -57,7 +59,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+')) and not(@atom) and not(@skip-java) and not(self::class)]"
+            "//*[@line and @pos and not(contains(@loc,'+')) and not(@atom) and not(@skip-java) and not(self::class) and not(ancestor::void)]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -35,15 +35,33 @@ final class CoverageManifestTest {
     }
 
     @Test
-    void findsExactlyOneLocationInAnEmptyFormation() throws Exception {
+    void findsNoLocationsInAnEmptyFormation() throws Exception {
         MatcherAssert.assertThat(
-            "an empty formation with no body still has itself to instrument, but the count was off",
+            "an empty formation has no body and is never dispatched itself, so it must have no locations",
             new CoverageManifest().locations(
                 new EoSyntax(
                     String.join(System.lineSeparator(), "[] > foo", "")
                 ).parsed()
             ),
-            Matchers.iterableWithSize(1)
+            Matchers.iterableWithSize(0)
+        );
+    }
+
+    @Test
+    void excludesLocationOfAFilesRootObject() throws Exception {
+        MatcherAssert.assertThat(
+            "a file's root object is constructed once from Java and never dispatched through PhCoverage, but its own location was still found",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "[x] > foo",
+                        "  x > @",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.everyItem(Matchers.not(Matchers.matchesPattern("^[^:]+:1:\\d+$")))
         );
     }
 
@@ -61,7 +79,7 @@ final class CoverageManifestTest {
                     )
                 ).parsed()
             ),
-            Matchers.iterableWithSize(2)
+            Matchers.iterableWithSize(1)
         );
     }
 


### PR DESCRIPTION
CoverageManifest.locations() picked up the top-level formation's own
line as an instrumentable location, but to-java.xsl never wraps that
line in PhCoverage: classes.xsl turns a file's root object into a
<class>, and its constructor is called once from generated Java, never
through the "located" mode any of its attributes go through. That line
therefore always shows as uncovered in the LCOV report, no matter how
many times the object is used.

`bool.eo`'s `[if] > bool` is exactly this shape: the free-attribute
formation itself never dispatches, only the attributes underneath it
do, so the report flags a line that structurally can never be hit.

The fix excludes the root `<class>` element from the XPath the
manifest walks. Locations found through a bound root object's inner
`o` (same loc:line:pos key) are unaffected, since that key is still
reached via the normal "located" mode call on the attribute itself.

Updated CoverageManifestTest to match: an empty formation now reports
zero locations instead of one, and a formation's own declaring line is
asserted absent from what gets found.

Closes #6995