### PR TITLE
setsSchemaLocation checks the schema location attribute, not the namespace

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -38,14 +38,12 @@ final class DrProgramTest {
     }
 
     @Test
-    @DisabledOnOs(OS.WINDOWS)
     void setsSchemaLocation() throws Exception {
         MatcherAssert.assertThat(
             "XSD location is set",
-            new XMLDocument(new Xembler(new DrProgram()).xml()).toString(),
-            Matchers.containsString(
-                "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
-            )
+            new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner())
+                .element("object").attribute("xsi:noNamespaceSchemaLocation").text().get(),
+            Matchers.not(Matchers.emptyString())
         );
     }
 


### PR DESCRIPTION
Closes #6991

`setsSchemaLocation` in `DrProgramTest` was serializing the document with `toString()` and asserting the result contained the literal `xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"`. That checks that a namespace was declared and which prefix and quote character the serializer picked, not the schema location the test is named after.

The fix reads `xsi:noNamespaceSchemaLocation` through `Xnav`, the same way the two neighbouring tests already do, and asserts the attribute is set. The `@DisabledOnOs(OS.WINDOWS)` annotation is dropped since reading an attribute value does not depend on the operating system.
