### PR TITLE
rename tstartsen back to token and drop the dead Tstartsens link

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -198,7 +198,7 @@ final class Eo implements Iterable<Directive> {
      * Merge a BYTES continuation starting at index {@code start} —
      * concatenates the trailing-dash chunk with subsequent BYTES-only
      * lines at &gt;= the same indent until a chunk without trailing
-     * dash terminates the tstartsen (R-3.13).
+     * dash terminates the token (R-3.13).
      * @param spans Materialised list of source spans
      * @param start Index of the continuation start
      * @param stack Indent stack
@@ -281,9 +281,8 @@ final class Eo implements Iterable<Directive> {
      * Whether a character is a valid BYTES hex digit. Per the grammar
      * (matching ANTLR's {@code BYTE : [0-9A-F][0-9A-F]}), BYTES accept
      * only uppercase hex — lowercase letters belong to {@code NAME}
-     * tstartsens. Compare with the case-insensitive
-     * {@link Tstartsens#hexDigit(char)} used for the {@code 0x...} HEX
-     * literal (R-9.8.3).
+     * tokens. Compare with the case-insensitive {@code hexDigit}
+     * used for the {@code 0x...} HEX literal (R-9.8.3).
      * @param glyph The character
      * @return True if 0-9 or A-F
      */
@@ -342,12 +341,12 @@ final class Eo implements Iterable<Directive> {
     ) {
         if (Eo.closesTextBlock(span, globals)) {
             stack.popDeeperThan(span.indent());
-            final int tstartsen = emit.savepoint();
+            final int token = emit.savepoint();
             final java.util.List<Level> frame = stack.snapshot();
             try {
                 new LnTextBlock(span).into(stack, globals, emit);
             } catch (final ParseError err) {
-                emit.rollback(tstartsen);
+                emit.rollback(token);
                 stack.restore(frame);
                 emit.error(err.line(), err.pos(), err.getMessage());
                 globals.closeTextBlock();
@@ -408,13 +407,13 @@ final class Eo implements Iterable<Directive> {
         if (!span.blank() && span.head() != '#') {
             stack.popDeeperThan(span.indent());
         }
-        final int tstartsen = emit.savepoint();
+        final int token = emit.savepoint();
         final java.util.List<Level> frame = stack.snapshot();
         boolean failed = false;
         try {
             Eo.classify(span).into(stack, globals, emit);
         } catch (final ParseError err) {
-            emit.rollback(tstartsen);
+            emit.rollback(token);
             stack.restore(frame);
             emit.error(err.line(), err.pos(), err.getMessage(), true);
             failed = true;
@@ -846,7 +845,7 @@ final class Eo implements Iterable<Directive> {
      * Whether a root-headed line (e.g., {@code ^.} or {@code @.}) is
      * a reversed-dispatch — the root character is immediately
      * followed by {@code .} and then a space or end-of-body. The
-     * head's source tstartsen maps to its XMIR symbol per R-9.3 inside
+     * head's source token maps to its XMIR symbol per R-9.3 inside
      * {@link LnReversed}.
      * @param span The span
      * @return True if the line shape is reversed dispatch with a


### PR DESCRIPTION
Eo.java carried a partial substitution of `oke` by `startse` in seven spots, left over from the ANTLR replacement in 769675b1af: the local variable `token` became `tstartsen` in two places, and the word survived mangled in four doc comments, including a `{@link Tstartsens#hexDigit(char)}` that resolves to nothing since the class is `Tokens` and `hexDigit` is private there anyway.

This renames the locals back to `token`, fixes the prose, and drops the broken link in favor of naming the method in plain text, since `Tokens#hexDigit` is private and wouldn't resolve either.

Closes #6989