### PR TITLE
Build schema location URLs from Path.toUri() to avoid duplicate slash

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/DrProgram.java
+++ b/eo-parser/src/main/java/org/eolang/parser/DrProgram.java
@@ -92,10 +92,7 @@ final class DrProgram implements Iterable<Directive> {
             }
             final Path path = Paths.get(opt).toAbsolutePath();
             if (path.toFile().exists()) {
-                schema = String.format(
-                    "file:///%s",
-                    path.toString().replace("\\", "/")
-                );
+                schema = path.toUri().toString();
                 break;
             }
         }

--- a/eo-parser/src/main/java/org/eolang/parser/StrictXmir.java
+++ b/eo-parser/src/main/java/org/eolang/parser/StrictXmir.java
@@ -167,15 +167,12 @@ public final class StrictXmir implements XML {
             final String before = location.get();
             final String after;
             if (before.startsWith("http")) {
-                after = String.format(
-                    "file:///%s",
-                    StrictXmir.fetch(
-                        before,
-                        tmp.resolve(
-                            before.substring(before.lastIndexOf('/') + 1)
-                        )
-                    ).getAbsoluteFile().toString().replace("\\", "/")
-                );
+                after = StrictXmir.fetch(
+                    before,
+                    tmp.resolve(
+                        before.substring(before.lastIndexOf('/') + 1)
+                    )
+                ).getAbsoluteFile().toPath().toUri().toString();
             } else {
                 after = before;
             }

--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -8,6 +8,7 @@ import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.StrictXML;
 import com.jcabi.xml.XMLDocument;
+import java.net.URI;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -66,11 +67,23 @@ final class DrProgramTest {
         MatcherAssert.assertThat(
             "XSD file exists",
             Paths.get(
-                new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner())
-                    .element("object").attribute("xsi:noNamespaceSchemaLocation").text().get()
-                    .substring("file:///".length())
+                new URI(
+                    new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner())
+                        .element("object").attribute("xsi:noNamespaceSchemaLocation").text().get()
+                )
             ).toFile().exists(),
             Matchers.is(true)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void doesNotDuplicateSlashesInSchemaLocation() throws Exception {
+        MatcherAssert.assertThat(
+            "URL of XSD has no redundant slash after the scheme",
+            new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner()).element("object")
+                .attribute("xsi:noNamespaceSchemaLocation").text().get(),
+            Matchers.not(Matchers.startsWith("file:////"))
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StrictXmirTest.java
@@ -13,6 +13,7 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.Together;
 import com.yegor256.WeAreOnline;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -86,16 +87,17 @@ final class StrictXmirTest {
     @Test
     @ExtendWith(MktmpResolver.class)
     @ExtendWith(WeAreOnline.class)
-    void refersToAbsoluteFileName(@Mktmp final Path tmp) {
+    void refersToAbsoluteFileName(@Mktmp final Path tmp) throws Exception {
         MatcherAssert.assertThat(
             "XSD location must be absolute",
             Paths.get(
-                new Xnav(
-                    new StrictXmir(
-                        StrictXmirTest.xmir("https://www.eolang.org/XMIR.xsd"), tmp
-                    ).inner()
-                ).element("object").attribute("xsi:noNamespaceSchemaLocation").text().get()
-                    .substring("file:///".length())
+                new URI(
+                    new Xnav(
+                        new StrictXmir(
+                            StrictXmirTest.xmir("https://www.eolang.org/XMIR.xsd"), tmp
+                        ).inner()
+                    ).element("object").attribute("xsi:noNamespaceSchemaLocation").text().get()
+                )
             ).isAbsolute(),
             Matchers.is(true)
         );


### PR DESCRIPTION
DrProgram.schema() and StrictXmir.reset() both built the xsi:noNamespaceSchemaLocation URL with String.format("file:///%s", path). On Unix an absolute path already starts with a slash, so the format string's three slashes plus the path's leading slash produce four slashes, giving a malformed file:////... URL in every generated XMIR.

Both sites now build the URL from path.toUri().toString() instead, which yields the correct three-slash file:///... form on Unix and keeps file:///C:/... on Windows without any manual backslash replacement.

DrProgramTest and StrictXmirTest both had assertions that only passed because of the bug: they stripped exactly "file:///".length() characters off the location to recover the filesystem path. That coupling is gone now; those tests parse the location with java.net.URI instead of counting characters. Also added a test asserting the location never starts with four slashes.

Closes #6990