### PR TITLE
seal the top comment block from its first line, not its last

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Comments.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Comments.java
@@ -56,7 +56,7 @@ final class Comments {
             );
         }
         if (!pending.isEmpty()) {
-            emit.comment(pending, pending.get(pending.size() - 1).line());
+            emit.comment(pending, pending.get(0).line());
             globals.clearComments();
         }
         globals.seal();

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -146,12 +146,12 @@ final class Emit {
      *
      * <p>The body is the comment text with the leading {@code #} stripped
      * from each line. If the comment block spans multiple lines, they
-     * are joined by {@code \n}. The reported line number is the line of
-     * the <em>last</em> comment line in the block. Wraps absolute
-     * navigation in {@code push}/{@code pop}.</p>
+     * are joined by {@code \n}. The reported line number is the caller's
+     * choice of target line. Wraps absolute navigation in
+     * {@code push}/{@code pop}.</p>
      *
      * @param spans Comment line spans, in source order
-     * @param target Line of the last comment span in the block
+     * @param target Line to report for the flushed comment
      */
     void comment(final List<Span> spans, final int target) {
         if (spans.isEmpty()) {

--- a/eo-parser/src/test/java/org/eolang/parser/CommentsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/CommentsTest.java
@@ -33,6 +33,21 @@ final class CommentsTest {
     }
 
     @Test
+    void reportsFirstLineOfMultiLineBlock() {
+        final Globals globals = new Globals();
+        globals.addComment(new Span("# first", 1));
+        globals.addComment(new Span("# second", 2));
+        globals.blank();
+        final Emit emit = new Emit();
+        Comments.seal(globals, emit, new Span("+package foo", 4));
+        MatcherAssert.assertThat(
+            "a multi-line top comment block must report the line of its first span, not its last",
+            CommentsTest.render(emit),
+            XhtmlMatchers.hasXPath("/object/comments/comment[@line='1']")
+        );
+    }
+
+    @Test
     void clearsBufferAfterFlush() {
         final Globals globals = new Globals();
         globals.addComment(new Span("# x", 1));

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multi-line-top-comment-reports-first-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multi-line-top-comment-reports-first-line.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/comments/comment[@line='1' and starts-with(text(), 'First.')]
+input: |
+  # First.
+  # Second.
+
+  [] > hello


### PR DESCRIPTION
Comments.seal picked pending.get(pending.size() - 1).line() as the target line for the flushed comment, which is the line of the last span in the block. Every existing CommentsTest case buffered a single span, so size() - 1 was always 0 and nothing told the two indices apart.

This switches the target to pending.get(0).line(), the line the block actually starts on, and adds a test that buffers a two-line block and asserts the flushed comment's @line attribute points at the first span.

Closes #6988