### PR TITLE
Add tests for directory.walk glob edge cases

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -418,6 +418,15 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  ++> can-walk-an-empty-directory
+    eq. > @
+      length.
+        d.as-dir.walk "*.txt"
+      0
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
   ++> can-walk-past-a-symbolic-link-to-its-own-parent
     os.is-windows.or > @
       seq *
@@ -473,6 +482,25 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  ++> can-walk-with-a-double-star-immediately-before-a-suffix
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/deep.txt"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**.txt"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
   ++> can-walk-with-a-glob-brace-group
     seq * > @
       touched.
@@ -507,6 +535,22 @@
         length.
           d.as-dir.walk "[ab].txt"
         2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-a-glob-question-mark
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      touched.
+        as-file.
+          d.resolved "ab.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "?.txt"
+        d.resolved "a.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
@@ -558,6 +602,22 @@
         ",".joined
           d.as-dir.walk "[*].txt"
         d.resolved "*.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-with-an-escaped-character-inside-a-glob-class
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "&.txt"
+      touched.
+        as-file.
+          d.resolved "b.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "[&].txt"
+        d.resolved "&.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted


### PR DESCRIPTION
Coverage for directory.eo was under 30%. This adds five tests that exercise glob branches in `directory.walk` that had no test at all:

- walking an empty directory returns no matches
- the `?` single-character wildcard
- an escaped special character (`&`) inside a `[...]` character class
- `**` immediately followed by a suffix with no slash between them (e.g. `**.txt`)

Closes #6994