### PR TITLE
Exclude throwing tests from coverage instrumentation

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -697,7 +697,7 @@
       <xsl:value-of select="eo:literal(eo:escape-plus(@original-name))"/>
       <xsl:text>");</xsl:text>
     </xsl:if>
-    <xsl:if test="$coverage='true' and @line and @pos and not(contains(@loc, '+'))">
+    <xsl:if test="$coverage='true' and @line and @pos and not(contains(@loc, '+')) and not(contains(@loc, '.-'))">
       <xsl:value-of select="eo:eol($indent)"/>
       <xsl:value-of select="$name"/>
       <xsl:text> = new PhCoverage(</xsl:text>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -127,7 +127,7 @@ final class MjTranspileTest {
     }
 
     @Test
-    void excludesThrowingTestsFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
+    void excludesThrowingCasesFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
         throws Exception {
         MatcherAssert.assertThat(
             "the generated Java must not wrap a throwing test's body into PhCoverage when coverageTracking is on",
@@ -144,7 +144,7 @@ final class MjTranspileTest {
     }
 
     @Test
-    void excludesTruthyTestsFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
+    void excludesTruthyCasesFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
         throws Exception {
         MatcherAssert.assertThat(
             "the generated Java must not wrap a truthy test's body into PhCoverage when coverageTracking is on",
@@ -622,7 +622,8 @@ final class MjTranspileTest {
             "+package foo.x",
             "",
             "[] > main",
-            "  --> throwing-test",
+            "",
+            "  --> stops-on-dispatching-on-a-number",
             "    42.plus 1 > @"
         );
     }
@@ -639,7 +640,8 @@ final class MjTranspileTest {
             "+package foo.x",
             "",
             "[] > main",
-            "  ++> truthy-test",
+            "",
+            "  ++> can-dispatch-on-a-number",
             "    42.plus 1 > @"
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -127,6 +127,40 @@ final class MjTranspileTest {
     }
 
     @Test
+    void excludesThrowingTestsFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
+        throws Exception {
+        MatcherAssert.assertThat(
+            "the generated Java must not wrap a throwing test's body into PhCoverage when coverageTracking is on",
+            new TextOf(
+                new FakeMaven(temp)
+                    .withProgram(MjTranspileTest.throwing())
+                    .with("coverageTracking", true)
+                    .execute(new FakeMaven.Transpile())
+                    .result()
+                    .get(MjTranspileTest.compiled())
+            ).asString(),
+            Matchers.not(Matchers.containsString("new PhCoverage("))
+        );
+    }
+
+    @Test
+    void excludesTruthyTestsFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
+        throws Exception {
+        MatcherAssert.assertThat(
+            "the generated Java must not wrap a truthy test's body into PhCoverage when coverageTracking is on",
+            new TextOf(
+                new FakeMaven(temp)
+                    .withProgram(MjTranspileTest.truthy())
+                    .with("coverageTracking", true)
+                    .execute(new FakeMaven.Transpile())
+                    .result()
+                    .get(MjTranspileTest.compiled())
+            ).asString(),
+            Matchers.not(Matchers.containsString("new PhCoverage("))
+        );
+    }
+
+    @Test
     void keepsGeneratedJavaFreeOfPhCoverageByDefault(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "the generated Java must not mention PhCoverage when coverageTracking is off",
@@ -573,6 +607,40 @@ final class MjTranspileTest {
             "",
             "[] > main",
             "  42.plus 1 > @"
+        );
+    }
+
+    /**
+     * An EO program whose only attribute is a throwing test dispatching on
+     * a number.
+     * @return Source code of the program
+     */
+    private static String throwing() {
+        return String.join(
+            System.lineSeparator(),
+            "+architect yegor256@gmail.com",
+            "+package foo.x",
+            "",
+            "[] > main",
+            "  --> throwing-test",
+            "    42.plus 1 > @"
+        );
+    }
+
+    /**
+     * An EO program whose only attribute is a truthy test dispatching on
+     * a number.
+     * @return Source code of the program
+     */
+    private static String truthy() {
+        return String.join(
+            System.lineSeparator(),
+            "+architect yegor256@gmail.com",
+            "+package foo.x",
+            "",
+            "[] > main",
+            "  ++> truthy-test",
+            "    42.plus 1 > @"
         );
     }
 


### PR DESCRIPTION
Closes #6993

The coverage report includes negative (throwing, `-->`) tests as covered code, even though positive (truthy, `++>`) tests are already excluded.

The truthy-test exclusion in `to-java.xsl` works by checking whether an object's `@loc` locator contains a `+`, since a truthy test attribute's XMIR name carries a leading `+` marker (`+name`) that ends up in the locator. The throwing-test counterpart uses a leading `-` marker (`-name`) the same way, but the coverage condition never checked for it, so any dispatch inside a throwing test still got wrapped in `PhCoverage`.

The fix adds a second check that skips instrumentation when a locator segment starts with `-` right after a dot (`.-`), which only happens for a throwing-test marker segment — a bare `-` can't appear there otherwise, since kebab-case dashes only occur mid-segment.

Added two transpile tests: one confirming a throwing test's body stays free of `PhCoverage`, and one doing the same for a truthy test (there wasn't a dedicated regression test for that exclusion before either).