### PR TITLE
#6885: dataize the host chain of a `uri` once, through const bytes

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -25,28 +25,12 @@
 
 [text] > uri
   text > @
-  if. > authority
-    starts-with. >> has-authority
-      has-query.if >> hier-part
-        before-fragment.slice 0 question-idx
-        before-fragment
-      "//"
-    if.
-      not. >> has-authority-path
-        eq.
-          after-slashes.index-of "/" >> authority-path-idx
-          -1
-      slice.
-        has-authority.if >> after-slashes
-          hier-part.slice
-            2
-            hier-part.length.minus
-              number 2
-          ""
-        0
-        authority-path-idx
-      after-slashes
-    ""
+  string > authority
+    has-authority.if >> authority-bytes!
+      has-authority-path.if
+        after-slashes.slice 0 authority-path-idx
+        after-slashes
+      ""
   if. > fragment
     not. >> has-fragment
       hash-idx.eq -1
@@ -85,21 +69,39 @@
           host-port.index-of ":"
         -1
     slice.
-      has-userinfo.if >> host-port
-        authority.slice
-          plus.
-            authority.index-of "@" >> userinfo-at-idx
-            1
-          authority.length.minus
-            number
-              userinfo-at-idx.plus 1
-        authority
+      string >> host-port
+        has-userinfo.if >> host-port-bytes!
+          authority.slice
+            plus.
+              authority.index-of "@" >> userinfo-at-idx
+              1
+            authority.length.minus
+              number
+                userinfo-at-idx.plus 1
+          authority
       0
       port-colon-idx
     host-port
-  has-authority.if > path
-    has-authority-path.if
-      after-slashes.slice
+  if. > path
+    starts-with. >> has-authority
+      string >> hier-part
+        has-query.if >> hier-bytes!
+          before-fragment.slice 0 question-idx
+          before-fragment
+      "//"
+    if.
+      not. >> has-authority-path
+        eq.
+          after-slashes.index-of "/" >> authority-path-idx
+          -1
+      slice.
+        string >> after-slashes
+          has-authority.if >> after-slashes-bytes!
+            hier-part.slice
+              2
+              hier-part.length.minus
+                number 2
+            ""
         authority-path-idx
         after-slashes.length.minus
           number authority-path-idx


### PR DESCRIPTION
Closes #6885

`host-port`, `authority`, `hier-part` and `after-slashes` were recomputed on
every read, and the reads are nested, so one `.host` walked the chain many
times over.

Marking them with `!` alone does not work: the marker compiles to
`dataized(...).as-bytes` (R-9.4), so a const local is bytes and every string
method on it disappears. Each of the four, forced on its own, breaks
`EOuriTest` with `the attribute "length" is not found in []` and friends.

So each one keeps a const in bytes and a string around it, the shape `path.eo`
already uses (`string pth > text`): `string >> hier-part` over
`has-query.if >> hier-bytes!`, and the same for the other three. The bytes are
computed once per top-level call, the string wrapper around them is what the
rest of the file reads, and `authority` stays a string for whoever asks a `uri`
for it.

All 44 `EOuriTest` tests pass. On a straight `.host` benchmark
(`https://user:pw@example.com:8080/a/b/c?q=1#frag`, ten calls) this is about
seven percent slower than master - 75 s against 70 s - so the repeated reads
were not what the time went to. The chain is dataized once per call now, which
is what the issue asks for; the time itself is somewhere else and worth its own
measurement.
