### PR TITLE
#7008: EmitTest.recordsTargetLineOnCommentAttribute asserts a dead contract

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -66,7 +66,7 @@ final class EmitTest {
         final Emit emit = new Emit();
         emit.comment(Collections.singletonList(new Span("# hello", 7)), 8);
         MatcherAssert.assertThat(
-            "a single-line comment must produce <comments><comment line='8'>hello</comment>, where the line is that of the attached named object",
+            "a single-line comment must produce <comments><comment line='8'>hello</comment>, where the line is the target given by the caller",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPaths(
                 "/object/comments/comment[@line='8']",
@@ -106,7 +106,7 @@ final class EmitTest {
             6
         );
         MatcherAssert.assertThat(
-            "a comment's @line attribute must point at the line of the named object it attaches to",
+            "a comment's @line attribute must record the target line given by the caller, which is the line of the last comment span in the block",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPath("/object/comments/comment[@line='6']")
         );


### PR DESCRIPTION
Fixes #7008.

`EmitTest.recordsTargetLineOnCommentAttribute` and `emitsCommentWithSingleLine` both described the `@line` attribute as pointing at "the line of the named object it attaches to". That description is stale since commit 5617c921eb (#6401), which changed the contract to the last comment span's own line and updated `Emit.comment`'s javadoc accordingly. Both callers (`Comments.java`, `Eo.java`) now pass the last span's line as `target`.

Reworded both failure messages to describe the real contract: the `@line` value is the target line given by the caller, which is the last comment span's line.
