### PR TITLE
#7009: EmitTest failure messages promise checks the XPath now makes

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -44,7 +44,8 @@ final class EmitTest {
             EmitTest.render(emit),
             XhtmlMatchers.hasXPaths(
                 "/object/metas/meta[@line='2']/head[text()='foo']",
-                "/object/metas/meta[not(part)]"
+                "/object/metas/meta[not(part)]",
+                "/object/metas/meta[tail[not(text()) or text()='']]"
             )
         );
     }
@@ -89,7 +90,7 @@ final class EmitTest {
             "a multi-line comment must join the bodies with a newline",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPath(
-                "/object/comments/comment[contains(text(),'first') and contains(text(),'second')]"
+                "/object/comments/comment[contains(text(), concat('first', codepoints-to-string(10), 'second'))]"
             )
         );
     }


### PR DESCRIPTION
Fixes #7009.

Two `EmitTest` tests promise a check in their failure message that the XPath assertion never makes:

- `emitsCommentJoiningMultipleLines` says the comment bodies are joined "with a newline", but only checked `contains(text(),'first')` and `contains(text(),'second')`, which passes even if `Emit.comment` joined with a space or nothing.
- `emitsMetaWithoutParts` says a parameterless meta produces "an empty <tail>", but only checked the head text and the absence of `<part>`, never the tail's own content.

Added a real XPath assertion for each: `contains(text(), concat('first', codepoints-to-string(10), 'second'))` for the newline join, and `tail[not(text()) or text()='']` for the empty tail. Verified locally that both new assertions fail when the underlying behavior regresses (space-joined body, or a dropped `<tail>` element).
