### PR TITLE
#7010: rename marksObjectWithAsAttribute to name the slot() method

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -279,13 +279,13 @@ final class EmitTest {
     }
 
     @Test
-    void marksObjectWithAsAttribute() {
+    void marksObjectWithSlotAttribute() {
         final Emit emit = new Emit();
         emit.object(null, "foo", 1, 0);
         emit.slot("label");
         emit.close();
         MatcherAssert.assertThat(
-            "as() must attach @as='label' for the inline-binding marker",
+            "slot() must attach @as='label' for the inline-binding marker",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPath("/object/o[@base='foo' and @as='label']")
         );


### PR DESCRIPTION
Fixes #7010.

`marksObjectWithAsAttribute` and its failure message both refer to an `as()` method that `Emit` does not have. The method under test is `slot()`, which happens to write the `@as` attribute. Every other test in the file names itself after the method it exercises (`marksObjectAsStar`/`star()`, `marksObjectAsConst`/`constant()`, `marksObjectAsSelf`/`self()`), so this one was an outlier.

Renamed the test to `marksObjectWithSlotAttribute` and reworded the message to reference `slot()`.
