### PR TITLE
#7011: remove parsesSimpleCodeWithDebugMode, its logger is gone

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -19,7 +19,6 @@ import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.commons.text.StringEscapeUtils;
-import org.apache.log4j.Level;
 import org.cactoos.io.InputOf;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.iterable.Mapped;
@@ -82,23 +81,6 @@ final class EoSyntaxTest {
             () -> new EoSyntax(new InputOf(""), (UnaryOperator<XML>) null).parsed(),
             "EoSyntax must reject a null transform, but it didn't"
         );
-    }
-
-    @Test
-    void parsesSimpleCodeWithDebugMode() {
-        final org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(EoSyntax.class);
-        final Level previous = logger.getLevel();
-        logger.setLevel(Level.DEBUG);
-        try {
-            Assertions.assertDoesNotThrow(
-                new EoSyntax(
-                    "[] > x-н, 1".concat(System.lineSeparator())
-                )::parsed,
-                "EO syntax should not fail in debug mode when program has errors"
-            );
-        } finally {
-            logger.setLevel(previous);
-        }
     }
 
     @Test


### PR DESCRIPTION
Fixes #7011.

`parsesSimpleCodeWithDebugMode` raises the log4j level of `Logger.getLogger(EoSyntax.class)` to DEBUG to cover a debug branch that commit 2e4fb89a58 added. Commit 769675b1af replaced the ANTLR-based parser with the spec-driven converter and removed that log message along with it. `EoSyntax`, `Eo`, `Listing` and `DrProgram` now have no logger at all, so the level toggle reaches nothing.

What's left is a duplicate of `printsProperListingEvenWhenSyntaxIsBroken`, parsing the same source `[] > x-н, 1`, plus global logger state mutation on every run.

Removed the test and the now-unused `org.apache.log4j.Level` import. The parsing behavior stays covered by `printsProperListingEvenWhenSyntaxIsBroken`.
