### PR TITLE
#7012: fix not(@name='xi🌵') filter that never excludes anything

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -249,7 +249,7 @@ final class EoSyntaxTest {
             ).parsed(),
             XhtmlMatchers.hasXPaths(
                 "/object[count(o)=1]",
-                "/object/o[@name='base' and count(o[not(@name='xi🌵')])=2]",
+                "/object/o[@name='base' and count(o[not(starts-with(@name, 'a🌵'))])=2]",
                 "/object/o[@name='base']/o[@name='x']",
                 "/object/o[@name='base']/o[@name='f']"
             )

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/application-in-tests.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - /object/o[@name='foo'][count(o[not(@name='xi🌵')])=3]
+  - /object/o[@name='foo'][count(o[not(starts-with(@name, 'a🌵'))])=3]
   - /object/o[@name='foo']/o[@base='Φ.true' and @name='+test-works']
   - /object/o[@name='foo']/o[@base='Φ.false' and @name='+always-fails']
   - /object/o[@name='foo']/o[@base='.eq' and @name='+compares-something']

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/atoms-with-inner-tests.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - /object/o[count(o[not(@name='xi🌵')])=4]
+  - /object/o[count(o[not(starts-with(@name, 'a🌵'))])=4]
   - /object/o[@name='foo']/o[@name='λ']
 input: |-
   [] > foo /bytes

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/empty-vs-free.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/empty-vs-free.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@name='foo' and count(o[not(@name='xi🌵')])=2]
+  - //o[@name='foo' and count(o[not(starts-with(@name, 'a🌵'))])=2]
   - //o[@name='x']
   - //o[@name='y' and not(@base)]
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-idempotency.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-idempotency.yaml
@@ -5,9 +5,9 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[not(@base) and @name='foo' and o[not(@name='xi🌵')][1][@base='∅' and @name='f']]
-  - //o[not(@base) and @name='bar' and o[not(@name='xi🌵')][1][@base='∅' and @name='a']]
-  - //o[not(@base) and @name='xyz' and o[not(@name='xi🌵')][1][@base='∅' and @name='w']]
+  - //o[not(@base) and @name='foo' and o[not(starts-with(@name, 'a🌵'))][1][@base='∅' and @name='f']]
+  - //o[not(@base) and @name='bar' and o[not(starts-with(@name, 'a🌵'))][1][@base='∅' and @name='a']]
+  - //o[not(@base) and @name='xyz' and o[not(starts-with(@name, 'a🌵'))][1][@base='∅' and @name='w']]
 input: |
   [f] > foo
     [a] > bar

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/full-syntax.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/full-syntax.yaml
@@ -15,7 +15,7 @@ asserts:
   - //o[@as='α0']
   - //o[@base='ξ.five.plus']
   - /object[not(.//o[@name=''])]
-  - //o[o[@name='λ'] and @name='atom' and count(o[not(@name='xi🌵')])=3 and o[@name='a']]
+  - //o[o[@name='λ'] and @name='atom' and count(o[not(starts-with(@name, 'a🌵'))])=3 and o[@name='a']]
 input: |
   +alias org.example.foo
   +alias Test Test

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/numbers.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/numbers.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object/o[count(o[not(@name='xi🌵')])=7]
+  - /object/o[count(o[not(starts-with(@name, 'a🌵'))])=7]
 input: |
   [] > main
     3.1415 > x1

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/scopes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/scopes.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - //o[not(@base) and count(o[not(@name='xi🌵')])=1 and @name='aliases']
+  - //o[not(@base) and count(o[not(starts-with(@name, 'a🌵'))])=1 and @name='aliases']
 input: |
   [] > aliases
     a (b (c d)) > scopes


### PR DESCRIPTION
Fixes #7012.

Several parser tests try to count only the object's own children, excluding auto-named ones, with a predicate like `count(o[not(@name='xi🌵')])=2`. `AutoName.asString()` actually formats auto names as `a🌵%d-%d`, not `xi🌵`, so the filter matches nothing and every one of these assertions is really a plain `count(o)=N` over all children including auto-named ones.

Replaced `not(@name='xi🌵')` with `not(starts-with(@name, 'a🌵'))` in `EoSyntaxTest.java` and the 7 affected yaml packs (`numbers.yaml`, `empty-vs-free.yaml`, `scopes.yaml`, `formation-idempotency.yaml`, `atoms-with-inner-tests.yaml`, `application-in-tests.yaml`, `full-syntax.yaml`), matching the idiom `resolve-self.xsl` already uses to find the same nodes.

Verified locally: with the auto-name prefix temporarily changed to collide with the old literal `xi🌵`, the old filter let 9 assertions silently pass wrong values; with the fix in place, the same change makes those 9 tests fail as expected.
