### PR TITLE
Document why Listing drops the XML 1.1 restricted characters

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -16,18 +16,19 @@ import org.xembly.Directives;
  *
  * <p>The text is set as is, without any manual escaping: the XML writer
  * escapes it exactly once, so the text value of {@code /object/listing}
- * equals the source. Only the characters that XML forbids in text nodes
- * are dropped, since they can't be represented there at all.</p>
+ * equals the source. The characters of the XML 1.1 restricted set are
+ * dropped first, because {@link Directives#set(Object)} refuses them and
+ * throws, whatever version the writer emits later.</p>
  *
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
 
     /**
-     * Characters that are not allowed inside an XML text node.
+     * Characters that Xembly refuses to put inside an XML text node.
      */
     private static final Pattern FORBIDDEN = Pattern.compile(
-        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\uFFFE\\uFFFF]"
+        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
     );
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -27,7 +27,7 @@ final class Listing implements Iterable<Directive> {
      * Characters that are not allowed inside an XML text node.
      */
     private static final Pattern FORBIDDEN = Pattern.compile(
-        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
+        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\uFFFE\\uFFFF]"
     );
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -112,10 +112,6 @@ final class ListingTest {
         );
     }
 
-    /**
-     * Sources to embed into {@code <listing>}.
-     * @return Stream of sources
-     */
     private static Stream<Arguments> sources() {
         return Stream.of(
             "[] > foo",

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -37,51 +37,17 @@ final class ListingTest {
     @Test
     void dropsCharactersForbiddenInXml() {
         MatcherAssert.assertThat(
-            "characters that XML 1.0 text nodes can't hold must be dropped",
+            "characters that XML text nodes can't hold must be dropped",
             ListingTest.listing(
                 String.format(
-                    "[] > x%c%c%c",
+                    "[] > x%c%c%c%c",
                     (char) 0x01,
                     (char) 0x07,
-                    (char) 0x1F
+                    (char) 0x1F,
+                    (char) 0x7F
                 )
             ),
             Matchers.equalTo("[] > x")
-        );
-    }
-
-    @Test
-    void keepsCharactersLegalInXml10() {
-        MatcherAssert.assertThat(
-            "characters legal in an XML 1.0 text node must survive in the listing",
-            ListingTest.listing(
-                String.format(
-                    "[] > x%c%c",
-                    (char) 0x7F,
-                    (char) 0x9F
-                )
-            ),
-            Matchers.equalTo(
-                String.format(
-                    "[] > x%c%c",
-                    (char) 0x7F,
-                    (char) 0x9F
-                )
-            )
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {0x09, 0x0A, 0x0D})
-    void keepsControlCharactersLegalInXml(final int codepoint) {
-        final String source = new String(Character.toChars(codepoint));
-        MatcherAssert.assertThat(
-            String.format(
-                "Character '%s' (%s code) must survive between the forbidden C0 ranges",
-                source, codepoint
-            ),
-            ListingTest.listing(source),
-            Matchers.equalTo(source)
         );
     }
 
@@ -113,7 +79,12 @@ final class ListingTest {
             0x0E,
             0x1F,
             0xFFFE,
-            0xFFFF
+            0xFFFF,
+            0x7F,
+            0x80,
+            0x84,
+            0x86,
+            0x9F
         }
     )
     void removesForbiddenCharacters(final int codepoint) {
@@ -127,6 +98,24 @@ final class ListingTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0x09, 0x0A, 0x0D, 0x20, 0x85, 0xA0, 0xFFFD})
+    void keepsCharactersOutsideRestrictedRanges(final int codepoint) {
+        final String source = String.format("x%cy", codepoint);
+        MatcherAssert.assertThat(
+            String.format(
+                "Character with code %s falls between the restricted ranges and is not dropped",
+                codepoint
+            ),
+            ListingTest.listing(source),
+            Matchers.equalTo(source)
+        );
+    }
+
+    /**
+     * Sources to embed into {@code <listing>}.
+     * @return Stream of sources
+     */
     private static Stream<Arguments> sources() {
         return Stream.of(
             "[] > foo",

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -71,6 +71,20 @@ final class ListingTest {
         );
     }
 
+    @ParameterizedTest
+    @ValueSource(ints = {0x09, 0x0A, 0x0D})
+    void keepsControlCharactersLegalInXml(final int codepoint) {
+        final String source = new String(Character.toChars(codepoint));
+        MatcherAssert.assertThat(
+            String.format(
+                "Character '%s' (%s code) must survive between the forbidden C0 ranges",
+                source, codepoint
+            ),
+            ListingTest.listing(source),
+            Matchers.equalTo(source)
+        );
+    }
+
     @Test
     void doesNotThrowExceptionOnEmptySource() {
         Assertions.assertDoesNotThrow(

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -37,17 +37,37 @@ final class ListingTest {
     @Test
     void dropsCharactersForbiddenInXml() {
         MatcherAssert.assertThat(
-            "characters that XML text nodes can't hold must be dropped",
+            "characters that XML 1.0 text nodes can't hold must be dropped",
             ListingTest.listing(
                 String.format(
-                    "[] > x%c%c%c%c",
+                    "[] > x%c%c%c",
                     (char) 0x01,
                     (char) 0x07,
-                    (char) 0x1F,
-                    (char) 0x7F
+                    (char) 0x1F
                 )
             ),
             Matchers.equalTo("[] > x")
+        );
+    }
+
+    @Test
+    void keepsCharactersLegalInXml10() {
+        MatcherAssert.assertThat(
+            "characters legal in an XML 1.0 text node must survive in the listing",
+            ListingTest.listing(
+                String.format(
+                    "[] > x%c%c",
+                    (char) 0x7F,
+                    (char) 0x9F
+                )
+            ),
+            Matchers.equalTo(
+                String.format(
+                    "[] > x%c%c",
+                    (char) 0x7F,
+                    (char) 0x9F
+                )
+            )
         );
     }
 
@@ -79,12 +99,7 @@ final class ListingTest {
             0x0E,
             0x1F,
             0xFFFE,
-            0xFFFF,
-            0x7F,
-            0x80,
-            0x84,
-            0x86,
-            0x9F
+            0xFFFF
         }
     )
     void removesForbiddenCharacters(final int codepoint) {


### PR DESCRIPTION
This started as an attempt to narrow `FORBIDDEN` to the XML 1.0 forbidden set, on the theory that `#x7F-#x9F` are ordinary characters in an XML 1.0 text node and so nothing should force them out of `<listing>`. That theory is wrong, and CI proved it: the new test died with `IllegalArgumentException: Failed to understand XML content, SET(...)`.

The source text never reaches `XMLDocument`. It goes through `Directives.set` first, and Xembly validates every character in `Arg.ifValid` against the XML 1.1 *restricted* set before any document version is chosen:

```java
Arg.range(chr, 0x00, 0x08);  Arg.range(chr, 0x0B, 0x0C);  Arg.range(chr, 0x0E, 0x1F);
Arg.range(chr, 0x7F, 0x84);  Arg.range(chr, 0x86, 0x9F);
```

Probed directly against `xembly-0.32.2`:

```
0x7F REJECTED: Character #7F is in the restricted XML range #7F-#84
0x85 accepted
0x9F REJECTED: Character #9F is in the restricted XML range #86-#9F
```

So `FORBIDDEN` was never a mistaken XML-version choice. It mirrors Xembly's restricted set exactly, gap at `0x85` included. Narrowing it does not make DEL and C1 bytes survive, it turns a silent deletion into a hard throw on any source that carries one, which is strictly worse than what master does today. `Xembler.escape` is the library's suggested way out, but it replaces a `0x7F` byte with a six-character backslash-u escape written out as literal text, so that is not verbatim either.

There is no fix that gets the characters through while `Listing` builds its element with `Directives.set`. What is left is the part that really was wrong: the docblock said only the characters XML forbids in text nodes are dropped, which names the wrong reason and is what made the behaviour look like a bug. It now names Xembly and points at `Directives#set`.

The regex is unchanged from master. The added test pins the other half of the contract, which nothing covered before: the characters sitting in the gaps between the restricted ranges, `0x09`, `0x0A`, `0x0D`, `0x20`, `0x85`, `0xA0` and `0xFFFD`, survive the round trip verbatim. `0x85` is the interesting one, since it is the single legal character inside the `0x7F-0x9F` band.

Closes #7013
