### PR TITLE
fix(#7016): move chainable decision from Emissions onto Value

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -9,7 +9,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Set;
 
 /**
  * Shared {@link Value}-to-XMIR rendering helpers.
@@ -40,21 +39,6 @@ final class Emissions {
      * The void the identity object {@code I} binds and decorates.
      */
     private static final String IDENTITY = "x";
-
-    /**
-     * Kinds of head value that a {@code .method} chain may follow.
-     */
-    private static final Set<Value.Kind> CHAINABLE = Set.of(
-        Value.Kind.IDENTIFIER,
-        Value.Kind.ROOT,
-        Value.Kind.SELF,
-        Value.Kind.GROUP,
-        Value.Kind.INTEGER,
-        Value.Kind.FLOAT,
-        Value.Kind.STRING,
-        Value.Kind.BYTES,
-        Value.Kind.HEX
-    );
 
     /**
      * No instances.
@@ -216,15 +200,6 @@ final class Emissions {
             tag = raw;
         }
         return tag;
-    }
-
-    /**
-     * Whether a head value can carry a {@code .method} chain.
-     * @param head The head value
-     * @return True if chain may follow
-     */
-    static boolean chainable(final Value head) {
-        return Emissions.CHAINABLE.contains(head.kind());
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -696,7 +696,7 @@ final class Tokens {
     private Value readArg() {
         final Value bare = this.readValue();
         final List<MethodChain> tail;
-        if (Emissions.chainable(bare)) {
+        if (bare.chainable()) {
             tail = this.readChain();
         } else {
             tail = Collections.emptyList();

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -29,7 +29,7 @@ final class Value {
      */
     private static final Set<Kind> CHAINABLE = Set.of(
         Kind.IDENTIFIER, Kind.ROOT, Kind.SELF, Kind.GROUP,
-        Kind.INTEGER, Kind.FLOAT, Kind.STRING, Kind.BYTES
+        Kind.INTEGER, Kind.FLOAT, Kind.STRING, Kind.BYTES, Kind.HEX
     );
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -6,6 +6,7 @@ package org.eolang.parser;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 /**
  * One parsed value in an EO expression — identifier, INT, STAR, etc.
@@ -16,14 +17,20 @@ import java.util.List;
  * Φ.bytes} wrapper, STAR to {@code Φ.tuple} with {@code @star=''}, and
  * so on as more shapes land.</p>
  *
- * <p>Used both as the line's head and as horizontal argument slots; the
- * {@link Head} role is just a {@link Value} promoted to head position
- * for readability. *
+ * <p>Used both as the line's head and as horizontal argument slots.</p>
  *
  * @since 0.1
  */
 @SuppressWarnings("PMD.DataClass")
 final class Value {
+
+    /**
+     * Kinds of value that may carry a {@code .method} chain behind them.
+     */
+    private static final Set<Kind> CHAINABLE = Set.of(
+        Kind.IDENTIFIER, Kind.ROOT, Kind.SELF, Kind.GROUP,
+        Kind.INTEGER, Kind.FLOAT, Kind.STRING, Kind.BYTES
+    );
 
     /**
      * Empty chain shared by all bare values.
@@ -197,6 +204,18 @@ final class Value {
         return this.constant;
     }
 
+    /**
+     * Whether this value may carry a {@code .method} chain behind it.
+     * @return True if a chain may follow
+     */
+    boolean chainable() {
+        return Value.CHAINABLE.contains(this.kind);
+    }
+
+    // @todo #7016:30min Move the remaining kind()/raw()-driven decisions out
+    //  of Emissions, LnMethod, LnPipe, LnCompactTuple, LnApplication and
+    //  LnOnlyPhi onto Value, then drop the @SuppressWarnings("PMD.DataClass")
+    //  above along with the accessors it no longer needs.
     /**
      * The kinds of value recognised by the parser. Further kinds
      * (HEX, BYTES, paren groups) attach as the corresponding line

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -162,7 +162,7 @@ final class ValueTest {
     void marksIdentifierChainable() {
         MatcherAssert.assertThat(
             "an IDENTIFIER value must allow a .method chain behind it",
-            new Value(Value.Kind.IDENTIFIER, "foo", 0, 3).chainable(),
+            new Value(Value.Kind.IDENTIFIER, "foo", 0).chainable(),
             Matchers.equalTo(true)
         );
     }
@@ -171,7 +171,7 @@ final class ValueTest {
     void marksHexChainable() {
         MatcherAssert.assertThat(
             "a HEX value must allow a .method chain behind it",
-            new Value(Value.Kind.HEX, "0xF00D", 0, 6).chainable(),
+            new Value(Value.Kind.HEX, "0xF00D", 0).chainable(),
             Matchers.equalTo(true)
         );
     }
@@ -180,7 +180,7 @@ final class ValueTest {
     void marksStarNotChainable() {
         MatcherAssert.assertThat(
             "a STAR tuple marker must not allow a .method chain behind it",
-            new Value(Value.Kind.STAR, "*", 0, 1).chainable(),
+            new Value(Value.Kind.STAR, "*", 0).chainable(),
             Matchers.equalTo(false)
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -177,6 +177,15 @@ final class ValueTest {
     }
 
     @Test
+    void marksHexChainable() {
+        MatcherAssert.assertThat(
+            "a HEX value must allow a .method chain behind it",
+            new Value(Value.Kind.HEX, "0xF00D", 0, 6).chainable(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
     void marksStarNotChainable() {
         MatcherAssert.assertThat(
             "a STAR tuple marker must not allow a .method chain behind it",

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -168,7 +168,7 @@ final class ValueTest {
     }
 
     @Test
-    void identifierIsChainable() {
+    void marksIdentifierChainable() {
         MatcherAssert.assertThat(
             "an IDENTIFIER value must allow a .method chain behind it",
             new Value(Value.Kind.IDENTIFIER, "foo", 0, 3).chainable(),
@@ -177,7 +177,7 @@ final class ValueTest {
     }
 
     @Test
-    void starIsNotChainable() {
+    void marksStarNotChainable() {
         MatcherAssert.assertThat(
             "a STAR tuple marker must not allow a .method chain behind it",
             new Value(Value.Kind.STAR, "*", 0, 1).chainable(),

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -166,4 +166,22 @@ final class ValueTest {
             Matchers.equalTo(Value.Kind.IDENTITY)
         );
     }
+
+    @Test
+    void identifierIsChainable() {
+        MatcherAssert.assertThat(
+            "an IDENTIFIER value must allow a .method chain behind it",
+            new Value(Value.Kind.IDENTIFIER, "foo", 0, 3).chainable(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void starIsNotChainable() {
+        MatcherAssert.assertThat(
+            "a STAR tuple marker must not allow a .method chain behind it",
+            new Value(Value.Kind.STAR, "*", 0, 1).chainable(),
+            Matchers.equalTo(false)
+        );
+    }
 }


### PR DESCRIPTION
Closes #7016

Emissions kept a private CHAINABLE kind set and a static `chainable(Value)` helper that only read `Value.kind()` to decide whether a head value may carry a `.method` chain. That decision lived next to Value instead of on it. Value now answers `chainable()` itself, and `Tokens.readArg()` calls it directly instead of going through Emissions.

The issue also names the full fix: every kind()/raw()-driven decision that Emissions, LnMethod, LnPipe, LnCompactTuple, LnApplication, LnOnlyPhi and Bindings currently make from a Value should move onto Value itself, which would let the `@SuppressWarnings("PMD.DataClass")` come off. That's well beyond a single pull request, so this one moves the smallest self-contained piece — chainable() — and leaves the rest as a puzzle inside Value.java for a follow-up.

Along the way, Value's docblock loses a dangling `{@link Head}` reference (no `Head` type exists in this package) and a stray trailing asterisk left over from an earlier edit.
