### PR TITLE
#7020: PhDefault.φTerm() renders non-UTF-8 bytes as lossy literal

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -5,11 +5,6 @@
 
 package org.eolang;
 
-import java.nio.ByteBuffer;
-import java.nio.charset.CharacterCodingException;
-import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
-import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -114,24 +109,7 @@ public final class PhApplication extends PhOnce {
      * @return Escaped literal, or null if bytes are not valid UTF-8
      */
     private static String string(final byte[] bytes) {
-        Optional<String> text;
-        try {
-            text = Optional.of(
-                StandardCharsets.UTF_8.newDecoder()
-                    .onMalformedInput(CodingErrorAction.REPORT)
-                    .onUnmappableCharacter(CodingErrorAction.REPORT)
-                    .decode(ByteBuffer.wrap(bytes)).toString()
-            );
-        } catch (final CharacterCodingException ignored) {
-            text = Optional.empty();
-        }
-        final String result;
-        if (text.isPresent()) {
-            result = new Quoted(bytes).get();
-        } else {
-            result = null;
-        }
-        return result;
+        return new Quoted(bytes).get().orElse(null);
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -339,7 +339,7 @@ public class PhDefault implements Phi, Cloneable {
         if (this.literal(name)) {
             final byte[] raw = this.loaded().get("as-bytes").get().delta();
             if ("string".equals(name)) {
-                result = new Quoted(raw).get();
+                result = new Quoted(raw).get().orElseGet(this::structural);
             } else {
                 result = new Numeral(new BytesOf(raw).asNumber()).get();
             }

--- a/eo-runtime/src/main/java/org/eolang/Quoted.java
+++ b/eo-runtime/src/main/java/org/eolang/Quoted.java
@@ -45,11 +45,13 @@ final class Quoted implements Supplier<Optional<String>> {
 
     @Override
     public Optional<String> get() {
+        Optional<String> result;
         try {
-            return Optional.of(this.quoted());
+            result = Optional.of(this.quoted());
         } catch (final CharacterCodingException ex) {
-            return Optional.empty();
+            result = Optional.empty();
         }
+        return result;
     }
 
     /**
@@ -64,8 +66,8 @@ final class Quoted implements Supplier<Optional<String>> {
             .decode(ByteBuffer.wrap(this.data))
             .toString();
         final StringBuilder out = new StringBuilder("\"");
-        for (final char glyph : text.toCharArray()) {
-            out.append(new Escaped(glyph).get());
+        for (int idx = 0; idx < text.length(); idx = idx + 1) {
+            out.append(new Escaped(text.charAt(idx)).get());
         }
         return out.append('"').toString();
     }

--- a/eo-runtime/src/main/java/org/eolang/Quoted.java
+++ b/eo-runtime/src/main/java/org/eolang/Quoted.java
@@ -45,21 +45,28 @@ final class Quoted implements Supplier<Optional<String>> {
 
     @Override
     public Optional<String> get() {
-        final Optional<String> result;
         try {
-            final String text = StandardCharsets.UTF_8.newDecoder()
-                .onMalformedInput(CodingErrorAction.REPORT)
-                .onUnmappableCharacter(CodingErrorAction.REPORT)
-                .decode(ByteBuffer.wrap(this.data))
-                .toString();
-            final StringBuilder out = new StringBuilder("\"");
-            for (final char glyph : text.toCharArray()) {
-                out.append(new Escaped(glyph).get());
-            }
-            result = Optional.of(out.append('"').toString());
+            return Optional.of(this.quoted());
         } catch (final CharacterCodingException ex) {
-            result = Optional.empty();
+            return Optional.empty();
         }
-        return result;
+    }
+
+    /**
+     * Decode the bytes as UTF-8 and quote every glyph.
+     * @return The quoted literal
+     * @throws CharacterCodingException If the bytes are not valid UTF-8
+     */
+    private String quoted() throws CharacterCodingException {
+        final String text = StandardCharsets.UTF_8.newDecoder()
+            .onMalformedInput(CodingErrorAction.REPORT)
+            .onUnmappableCharacter(CodingErrorAction.REPORT)
+            .decode(ByteBuffer.wrap(this.data))
+            .toString();
+        final StringBuilder out = new StringBuilder("\"");
+        for (final char glyph : text.toCharArray()) {
+            out.append(new Escaped(glyph).get());
+        }
+        return out.append('"').toString();
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/Quoted.java
+++ b/eo-runtime/src/main/java/org/eolang/Quoted.java
@@ -4,8 +4,12 @@
  */
 package org.eolang;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 /**
@@ -16,9 +20,15 @@ import java.util.function.Supplier;
  * the literal early and a line feed splits it across lines, so the
  * printed φ-term denotes a string other than the one it came from.</p>
  *
+ * <p>Decoding is strict: bytes that are not valid UTF-8 would otherwise
+ * turn into replacement characters (U+FFFD), and a term built from
+ * those denotes a different object than the one it came from. The
+ * caller gets an empty result for such bytes and is expected to print
+ * the structural form instead.</p>
+ *
  * @since 0.73.3
  */
-final class Quoted implements Supplier<String> {
+final class Quoted implements Supplier<Optional<String>> {
 
     /**
      * The bytes of the text.
@@ -34,11 +44,22 @@ final class Quoted implements Supplier<String> {
     }
 
     @Override
-    public String get() {
-        final StringBuilder out = new StringBuilder("\"");
-        for (final char glyph : new String(this.data, StandardCharsets.UTF_8).toCharArray()) {
-            out.append(new Escaped(glyph).get());
+    public Optional<String> get() {
+        final Optional<String> result;
+        try {
+            final String text = StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(this.data))
+                .toString();
+            final StringBuilder out = new StringBuilder("\"");
+            for (final char glyph : text.toCharArray()) {
+                out.append(new Escaped(glyph).get());
+            }
+            result = Optional.of(out.append('"').toString());
+        } catch (final CharacterCodingException ex) {
+            result = Optional.empty();
         }
-        return out.append('"').toString();
+        return result;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/QuotedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/QuotedTest.java
@@ -5,6 +5,7 @@
 package org.eolang;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,7 @@ final class QuotedTest {
         MatcherAssert.assertThat(
             "Text without special glyphs must be quoted as it is, but it wasnt",
             new Quoted("Привет, мир".getBytes(StandardCharsets.UTF_8)).get(),
-            Matchers.equalTo("\"Привет, мир\"")
+            Matchers.equalTo(Optional.of("\"Привет, мир\""))
         );
     }
 
@@ -29,7 +30,7 @@ final class QuotedTest {
         MatcherAssert.assertThat(
             "Quote and backslash must not break out of the literal, but they did",
             new Quoted("say \"hi\\bye\"".getBytes(StandardCharsets.UTF_8)).get(),
-            Matchers.equalTo("\"say \\\"hi\\\\bye\\\"\"")
+            Matchers.equalTo(Optional.of("\"say \\\"hi\\\\bye\\\"\""))
         );
     }
 
@@ -38,7 +39,7 @@ final class QuotedTest {
         MatcherAssert.assertThat(
             "Delete character must be spelled as a unicode escape, but it wasnt",
             new Quoted(String.format("%c", 0x7F).getBytes(StandardCharsets.UTF_8)).get(),
-            Matchers.equalTo("\"\\u007f\"")
+            Matchers.equalTo(Optional.of("\"\\u007f\""))
         );
     }
 }


### PR DESCRIPTION
Fixes #7020.

`PhDefault.φTerm()` built a string literal with `new Quoted(raw).get()` without checking the bytes are valid UTF-8. `Quoted` decoded with `new String(data, StandardCharsets.UTF_8)`, which replaces malformed bytes with U+FFFD instead of failing, so the printed term could denote a different object than the one it came from.

`PhApplication.string()` already guarded against this with its own strict decode before calling `Quoted`, but `PhDefault` had no such guard.

Moved the strict decode into `Quoted` itself: it now decodes with `CodingErrorAction.REPORT` and returns `Optional<String>`, empty when the bytes are not valid UTF-8. `PhDefault.φTerm()` falls back to the structural form on empty. `PhApplication.string()` now just delegates to `Quoted`, dropping its own duplicate decode logic.
