### PR TITLE
#7021: RetryOnFailure in ObjectsIndex.asText is ineffective

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
@@ -13,7 +13,6 @@ import org.cactoos.Text;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.scalar.Sticky;
-import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.cactoos.text.Split;
 import org.cactoos.text.TextOf;
@@ -138,11 +137,10 @@ final class ObjectsIndex {
      * Download from the URL and return the content.
      * @param url The URL with tags
      * @return The body of the web page
+     * @throws Exception If the download fails
      */
     @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
-    private static Text asText(final URL url) {
-        return new TextOf(
-            new Unchecked<>(() -> new TextOf(url).asString())
-        );
+    private static Text asText(final URL url) throws Exception {
+        return new TextOf(new TextOf(url).asString());
     }
 }


### PR DESCRIPTION
Fixes #7021.

`ObjectsIndex.asText(URL)` carried `@RetryOnFailure` but only assembled a lazy `TextOf(Unchecked(...))` and returned. The actual GET ran later, outside the annotated method, while the returned `Text` was evaluated, so the retry aspect never saw the exception.

`CommitHashesText.asText()` already does this correctly: it calls `.asString()` inside the annotated method. Made `ObjectsIndex.asText` do the same, calling `new TextOf(url).asString()` inside the method and wrapping the resolved string, so a transient failure is retried where it happens instead of costing the whole index download.
