### PR TITLE
#7022: fix eo.xslMeasuresFile default extension, StMeasured writes CSV

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -151,7 +151,7 @@ abstract class MjSafe extends AbstractMojo {
     @Parameter(
         property = "eo.xslMeasuresFile",
         required = true,
-        defaultValue = "${project.build.directory}/eo/xsl-measures.json"
+        defaultValue = "${project.build.directory}/eo/xsl-measures.csv"
     )
     protected File xslMeasures;
 


### PR DESCRIPTION
Fixes #7022.

`eo.xslMeasuresFile` defaulted to `xsl-measures.json`, but `StMeasured.apply` only ever writes CSV lines (`uid,duration`) to that path. The default was changed from `.csv` to `.json` in commit b6fc209b7e without touching the writer, so a build leaves a `.json` file no JSON parser accepts.

The rest of the repo already assumes CSV: README's example, `FakeMaven.java`, `TranspilingTest.java` and `TranspilationTest.java` all reference `xsl-measures.csv`. Changed the default back to `.csv` to match what's actually written and what everything else expects.
