### PR TITLE
#7041: fix missing imports in DrProgramTest that break the build

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -14,6 +14,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 


### PR DESCRIPTION
Fixes #7041.

`DrProgramTest.java:74` uses `@DisabledOnOs(OS.WINDOWS)`, added by the merge of PR #6996 (issue #6992), without importing `org.junit.jupiter.api.condition.DisabledOnOs` or `org.junit.jupiter.api.condition.OS`. This breaks `eo-parser` test compilation on master, and with it every downstream module. Added the two imports.
