### PR TITLE
#7041 and #7047: fix two build-breaking bugs on master

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -94,18 +94,20 @@ public final class MjCoverageReport extends MjSafe {
         final Map<String, Integer> lineof = new HashMap<>(0);
         final Map<String, String> fileof = new HashMap<>(0);
         final CoverageManifest manifest = new CoverageManifest();
-        for (final TjForeign tojo : this.scopedTojos().standalone()) {
-            final String source = tojo.source().toString();
-            final XML xmir = new XMLDocument(tojo.xmir());
-            for (final String location : manifest.locations(xmir)) {
-                final int last = location.lastIndexOf(':');
-                final int line = Integer.parseInt(
-                    location.substring(location.lastIndexOf(':', last - 1) + 1, last)
-                );
-                perfile.computeIfAbsent(source, key -> new LinkedHashMap<>(0))
-                    .putIfAbsent(line, 0);
-                lineof.put(location, line);
-                fileof.put(location, source);
+        try (TjsForeign tojos = this.tojos()) {
+            for (final TjForeign tojo : tojos.standalone()) {
+                final String source = tojo.source().toString();
+                final XML xmir = new XMLDocument(tojo.xmir());
+                for (final String location : manifest.locations(xmir)) {
+                    final int last = location.lastIndexOf(':');
+                    final int line = Integer.parseInt(
+                        location.substring(location.lastIndexOf(':', last - 1) + 1, last)
+                    );
+                    perfile.computeIfAbsent(source, key -> new LinkedHashMap<>(0))
+                        .putIfAbsent(line, 0);
+                    lineof.put(location, line);
+                    fileof.put(location, source);
+                }
             }
         }
         final List<String> hits = Files.readAllLines(this.coverageFile.toPath());

--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -14,6 +14,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 


### PR DESCRIPTION
Fixes #7047 
Fixes #7041

Master currently has two independent compile-breaking bugs at the same time, both introduced by recent merges:

1. `MjCoverageReport.java` calls `this.scopedTojos()`, which was removed by commit 59962b998b (PR #6880) and never updated at this one call site. Switched to `this.tojos()`, closed via try-with-resources, matching the other mojos touched by that same commit.
2. `DrProgramTest.java` uses `@DisabledOnOs(OS.WINDOWS)` (added by PR #6996) without importing `DisabledOnOs`/`OS`. Added the two imports.

Combined into one PR because each bug alone masks the other: a PR fixing only one of them still fails `mvn`/`qulice`/`integration` CI on the other, unrelated bug. I had these split across #7046 and #7048 separately; closing #7046 and keeping both fixes here so CI actually goes green.
