### PR TITLE
#7023: fix eo.foreign default name/format mismatch

### DIFF
--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjRegisterIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjRegisterIT.java
@@ -184,7 +184,7 @@ final class MjRegisterIT {
             new TjSynchronized(
                 new TjCached(
                     new TjDefault(
-                        new MnCsv(temp.resolve("target/eo-foreign.json"))
+                        new MnCsv(temp.resolve("target/eo-foreign.csv"))
                     )
                 )
             )

--- a/eo-integration-tests/src/test/resources/snippets/simple.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/simple.yaml
@@ -6,7 +6,7 @@ out:
   - ".*Hello, Jeff.*"
   - ".*eoc/classes.*"
   - ".*eoc/eo/4-resolve.*"
-  - ".*eoc/eo-foreign.json.*"
+  - ".*eoc/eo-foreign.csv.*"
 file: simple.eo
 args: ["simple", "Jeff"]
 target: "eoc"

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
@@ -80,6 +80,13 @@ final class Catalogs {
      * @param file The file
      * @param fmt The format
      * @return The Tojos
+     * @todo #7023:30min This caches on the absolute path alone, so if two
+     *  callers ask for the same path with a different format, the second
+     *  format is silently dropped and the first caller's mono keeps
+     *  serving both. Key the cache on path and format together, or throw
+     *  when a path is requested again with a format that disagrees with
+     *  the one it was first built with. See
+     *  https://github.com/objectionary/eo/issues/7023.
      */
     Tojos make(final Path file, final String fmt) {
         return this.all.computeIfAbsent(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -65,7 +65,7 @@ abstract class MjSafe extends AbstractMojo {
     @Parameter(
         property = "eo.foreign",
         required = true,
-        defaultValue = "${project.build.directory}/eo-foreign.json"
+        defaultValue = "${project.build.directory}/eo-foreign.csv"
     )
     protected File foreign;
 


### PR DESCRIPTION
`eo.foreign` defaulted to `eo-foreign.json` while `eo.foreignFormat` defaulted to `csv`, so a default build wrote CSV content into a file named `.json`. The sibling pair right below it (`eo.placed`/`eo.placedFormat`) is consistent: both say `json`.

Changed the default to `eo-foreign.csv`, matching what `eo-runtime/pom.xml` already overrides it to, and what the rest of the repo assumes. Updated `MjRegisterIT.java`, which read the same mismatched filename with a CSV parser, to read `eo-foreign.csv` instead.

Left the second part of #7023 (`Catalogs.make` silently dropping a second format for a path it already cached) as a `@todo` puzzle in `Catalogs.java` — it's a separate, riskier change (cache keying), and the specific repro this PR fixes (foreign's own default fighting itself) no longer applies once the default agrees with the format. See the added `@todo` for the remaining part.
