### PR TITLE
#7024: CentralMaven should use Maven's own resolver session

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -63,7 +63,7 @@ public final class MjCompile extends MjSafe {
                         new Resolving(
                             tojos,
                             this.targetDir.toPath().resolve(MjResolve.DIR),
-                            new CentralMaven(this.system),
+                            new CentralMaven(this.system, this.session, this.repositories),
                             this.discoverSelf,
                             this.skipZeroVersions,
                             this.resolveJna,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -55,7 +55,7 @@ public final class MjResolve extends MjSafe {
     @Override
     public void exec() throws IOException {
         if (this.central == null) {
-            this.central = new CentralMaven(this.system);
+            this.central = new CentralMaven(this.system, this.session, this.repositories);
         }
         try (TjsForeign tojos = this.tojos()) {
             new Resolving(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -8,6 +8,7 @@ import com.jcabi.log.Logger;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Set;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoFailureException;
@@ -20,6 +21,8 @@ import org.cactoos.Scalar;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
 import org.eclipse.aether.RepositorySystem;
+import org.eclipse.aether.RepositorySystemSession;
+import org.eclipse.aether.repository.RemoteRepository;
 import org.slf4j.impl.StaticLoggerBinder;
 
 /**
@@ -45,6 +48,24 @@ abstract class MjSafe extends AbstractMojo {
      */
     @Component
     protected RepositorySystem system;
+
+    /**
+     * Maven Resolver repository session, carrying the local repository,
+     * mirrors, proxies and credentials from {@code settings.xml}.
+     * Do NOT move this field to a subclass: same reason as {@link #system}.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @Parameter(defaultValue = "${repositorySystemSession}", readonly = true, required = true)
+    protected RepositorySystemSession session;
+
+    /**
+     * Remote repositories configured for the current project, including
+     * any mirror substitutions Maven already applied.
+     * Do NOT move this field to a subclass: same reason as {@link #system}.
+     * @checkstyle VisibilityModifierCheck (5 lines)
+     */
+    @Parameter(defaultValue = "${project.remoteProjectRepositories}", readonly = true)
+    protected List<RemoteRepository> repositories;
 
     /**
      * Directory where classes are stored in target.


### PR DESCRIPTION
Fixes #7024.

`MjResolve` and `MjCompile` both built `CentralMaven` from the one-argument constructor, which falls back to a synthetic standalone session: hard-coded `~/.m2/repository` as the local repo and `repo1.maven.org` as the only remote. Maven's own `RepositorySystemSession` and the project's configured remote repositories (mirrors, proxies, `<localRepository>`, private repos) were never used, even though `CentralMaven` already has a Maven-plugin constructor for exactly this.

Injected `RepositorySystemSession` and `List<RemoteRepository>` into `MjSafe` (`${repositorySystemSession}` and `${project.remoteProjectRepositories}`), and switched both mojos to the three-argument `CentralMaven` constructor, so `eo:resolve` and `eo:compile` resolve artifacts through the same session and repositories as the rest of the Maven build.
