### PR TITLE
#7025: fix Bytes.shift javadoc, direction stated backwards

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Bytes.java
+++ b/eo-runtime/src/main/java/org/eolang/Bytes.java
@@ -45,7 +45,7 @@ public interface Bytes {
 
     /**
      * Big-endian unsigned shift.
-     * Shifts left if value is positive, or right otherwise.
+     * Shifts right if the value is positive, or left otherwise.
      * Does not perform sign extension.
      * @param bits Bits to shift, negative to shift left
      * @return Bytes


### PR DESCRIPTION
Fixes #7025.

`Bytes.shift`'s javadoc contradicted itself: the prose said "shifts left if value is positive", the `@param` said "negative to shift left". The implementation (`BytesRaw.shift`) and the `right` EO object both follow the `@param`, so the prose sentence was the wrong one. Fixed it to match.
