### PR TITLE
#7027: file.deleted fails to remove dangling symlinks

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -10,21 +10,20 @@
   path > @
   @. > as-path
     Q.path path
-  [] > exists
-    or. > @
-      eq.
-        code.
-          os.is-windows.if
-            win32 *1
-              "_access"
-              path
-              0
-            posix *1
-              "access"
-              path
-              0
-        0
-      is-symlink false
+  or. > [] > exists
+    eq.
+      code.
+        os.is-windows.if
+          win32 *1
+            "_access"
+            path
+            0
+          posix *1
+            "access"
+            path
+            0
+      0
+    is-symlink false
   [cant-check] > is-directory
     if. > @
       info.code.eq 0

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -10,18 +10,21 @@
   path > @
   @. > as-path
     Q.path path
-  eq. > [] > exists
-    code.
-      os.is-windows.if
-        win32 *1
-          "_access"
-          path
-          0
-        posix *1
-          "access"
-          path
-          0
-    0
+  [] > exists
+    or. > @
+      eq.
+        code.
+          os.is-windows.if
+            win32 *1
+              "_access"
+              path
+              0
+            posix *1
+              "access"
+              path
+              0
+        0
+      is-symlink false
   [cant-check] > is-directory
     if. > @
       info.code.eq 0

--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -47,6 +47,20 @@
     mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
     d.resolved "ссылка" > link
 
+  ++> can-delete-a-dangling-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            link
+        d.as-file.deleted
+        link.as-file.deleted
+        link.as-file.exists.not
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "broken-link" > link
+
   ++> can-return-itself-after-deleting
     temp.deleted.path.eq temp.path > @
     mktemp.tmpfile > temp

--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -31,6 +31,20 @@
           f.is-directory.if "rmdir" "unlink"
         f.path
 
+  ++> can-delete-a-dangling-symlink
+    os.is-windows.or > @
+      seq *
+        code.
+          posix *1
+            "symlink"
+            d
+            link
+        d.as-file.deleted
+        link.as-file.deleted
+        link.as-file.exists.not
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "broken-link" > link
+
   mktemp.tmpfile.deleted.deleted.exists.not ++> can-delete-a-file-twice
 
   ++> can-delete-a-symlink-to-a-directory
@@ -46,20 +60,6 @@
         d.as-file.exists
     mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
     d.resolved "ссылка" > link
-
-  ++> can-delete-a-dangling-symlink
-    os.is-windows.or > @
-      seq *
-        code.
-          posix *1
-            "symlink"
-            d
-            link
-        d.as-file.deleted
-        link.as-file.deleted
-        link.as-file.exists.not
-    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
-    d.resolved "broken-link" > link
 
   ++> can-return-itself-after-deleting
     temp.deleted.path.eq temp.path > @


### PR DESCRIPTION
Fixes #7027.

`file.exists` was `access(path, 0) == 0`. POSIX `access` resolves symlinks, so a dangling link (target gone) makes `exists` say `false`. `file.deleted` gates removal on `exists`, so it handed the file back as if it had deleted it, and the dangling link stayed on disk. `directory.deleted` then fails removing a directory that still has that entry in it.

Made `exists` also true when `is-symlink` is true, the same lstat-based check `is-symlink` already does, so a link is treated as existing regardless of whether its target does.

Added `can-delete-a-dangling-symlink` next to the existing `can-delete-a-symlink-to-a-directory` test: creates a symlink to a directory, deletes the target first (leaving the link dangling), then confirms `deleted` still removes the link.
