### PR TITLE
#7028: make win32 basename/dirname drive-aware

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -24,7 +24,7 @@
           or.
             pth.size.eq 0
             index.eq 0
-          ^.trimmed >> pth!
+          pth
           as-bytes.
             text.slice
               plus. >> index!
@@ -32,20 +32,23 @@
                 1
               text.length.minus
                 number index
+      ^.stripped ^.driveless >> pth!
       string pth > text
     [] > dirname
       string > @
-        if.
-          len.eq -1
-          "."
+        concat.
+          ^.drive
           if.
-            len.eq 0
-            ^.separator
-            as-bytes.
-              text.slice
-                0
-                text.last-index-of ^.separator >> len!
-      string ^.trimmed > text
+            len.eq -1
+            "."
+            if.
+              len.eq 0
+              ^.separator
+              as-bytes.
+                text.slice
+                  0
+                  text.last-index-of ^.separator >> len!
+      string (^.stripped ^.driveless) > text
     sys.drive uri > drive
     if. > driveless
       drive.size.eq 0
@@ -577,6 +580,26 @@
     dirname.
       path.posix "/foo//"
     "/"
+
+  eq. ++> can-return-the-basename-of-a-drive-relative-win32-path
+    basename.
+      path.win32 "C:foo"
+    "foo"
+
+  eq. ++> can-return-the-basename-of-a-win32-drive-root
+    basename.
+      path.win32 "C:\\"
+    ""
+
+  eq. ++> can-return-the-dirname-of-a-drive-relative-win32-path
+    dirname.
+      path.win32 "C:foo"
+    "C:"
+
+  eq. ++> can-return-the-dirname-of-a-win32-path-with-a-drive
+    dirname.
+      path.win32 "C:\\foo"
+    "C:\\"
 
   eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
     dirname.

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -24,7 +24,7 @@
           or.
             pth.size.eq 0
             index.eq 0
-          pth
+          ^.stripped ^.driveless >> pth!
           as-bytes.
             text.slice
               plus. >> index!
@@ -32,12 +32,10 @@
                 1
               text.length.minus
                 number index
-      ^.stripped ^.driveless >> pth!
       string pth > text
     [] > dirname
       string > @
-        concat.
-          ^.drive
+        ^.drive.concat
           if.
             len.eq -1
             "."
@@ -48,7 +46,8 @@
                 text.slice
                   0
                   text.last-index-of ^.separator >> len!
-      string (^.stripped ^.driveless) > text
+      string > text
+        ^.stripped ^.driveless
     sys.drive uri > drive
     if. > driveless
       drive.size.eq 0
@@ -512,10 +511,20 @@
       path.posix "foo//"
     "foo"
 
+  eq. ++> can-return-the-basename-of-a-drive-relative-win32-path
+    basename.
+      path.win32 "C:foo"
+    "foo"
+
   eq. ++> can-return-the-basename-of-a-root-relative-path-ending-with-a-separator
     basename.
       path.posix "/foo/"
     "foo"
+
+  eq. ++> can-return-the-basename-of-a-win32-drive-root
+    basename.
+      path.win32 "C:\\"
+    ""
 
   eq. ++> can-return-the-basename-of-an-absolute-path-with-repeated-trailing-separators
     basename.
@@ -556,6 +565,11 @@
           path.separator
     "var"
 
+  eq. ++> can-return-the-dirname-of-a-drive-relative-win32-path
+    dirname.
+      path.win32 "C:foo"
+    "C:"
+
   eq. ++> can-return-the-dirname-of-a-file-path
     dirname.
       path.joined
@@ -576,30 +590,15 @@
     path.joined
       * "var" "www"
 
-  eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
-    dirname.
-      path.posix "/foo//"
-    "/"
-
-  eq. ++> can-return-the-basename-of-a-drive-relative-win32-path
-    basename.
-      path.win32 "C:foo"
-    "foo"
-
-  eq. ++> can-return-the-basename-of-a-win32-drive-root
-    basename.
-      path.win32 "C:\\"
-    ""
-
-  eq. ++> can-return-the-dirname-of-a-drive-relative-win32-path
-    dirname.
-      path.win32 "C:foo"
-    "C:"
-
   eq. ++> can-return-the-dirname-of-a-win32-path-with-a-drive
     dirname.
       path.win32 "C:\\foo"
     "C:\\"
+
+  eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
+    dirname.
+      path.posix "/foo//"
+    "/"
 
   eq. ++> can-return-the-root-dirname-of-a-root-relative-win32-path
     dirname.


### PR DESCRIPTION
Fixes #7028.

`basename` and `dirname` computed everything from `trimmed` (the raw uri, drive included), never `driveless`, which `is-absolute` already builds for exactly this. On win32, a drive letter has no separator in front of it, so `last-index-of separator` found `-1` for a drive-relative path and `2` for a drive root, and the drive ended up either inside the basename or treated as a plain directory name.

Switched both to search inside `driveless` instead. `dirname` now prepends `drive` back to the result: a drive-relative path's dirname is the drive alone, a path under a drive keeps the drive in front of the separator, matching what `node:path.win32` gives and what the rest of the file is written against. POSIX is unaffected since `driveless` equals the full path there (`drive` is always empty).

Added four tests covering the table from the issue: drive-relative basename/dirname and drive-root basename/dirname.
