### PR TITLE
Cover an object that takes its members inside a package

### DIFF
--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/object-inside-a-package-takes-its-members.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/object-inside-a-package-takes-its-members.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An object takes the members of the package it names without being merged
+# anywhere itself. `obj` lives in `hello`, which names no object, so nothing
+# above it moves and `obj` keeps the place it had. `abc` arrives all the same,
+# because a name is cut at its last dot and the merge asks only whether an
+# object carries the prefix right above the member.
+eo:
+  hello/obj.eo: |
+    +package hello
+
+    [x] > obj
+      x > @
+  hello/obj/abc.eo: |
+    +package hello.obj
+
+    [y] > abc
+      y > @
+xmir:
+  hello/obj.eo:
+    - "/object/o[@name='obj']/o[@name='abc']"
+absent:
+  - hello.eo


### PR DESCRIPTION
Closes #7058.

The merge packs all build their program around `number.eo` with a `number/`
directory beside it, so one layout goes untested — the ordinary one for a
program that declares a package of its own, where an object sits inside a
package no object is named after:

```yaml
eo:
  hello/obj.eo: |
    +package hello

    [x] > obj
      x > @
  hello/obj/abc.eo: |
    +package hello.obj

    [y] > abc
      y > @
xmir:
  hello/obj.eo:
    - "/object/o[@name='obj']/o[@name='abc']"
absent:
  - hello.eo
```

`abc` arrives in `obj` because `Merging.deepest` cuts a name at its last dot
and asks only whether an object carries the prefix right above the member.
`hello` carries none, so nothing is invented to hold `obj`.

`deeper-package-stays-out.yaml` does already exercise a receiver below the top
level, since `plus` lands in `i64` and `i64` is `number.i64` — but there the
receiver is itself merged upward, which is what the `deeper` ordering exists
for. Here nothing above the receiver moves at all. Removing the
`filter(all::containsKey)` from the discovery makes this pack fail, so it is
not merely restating what its neighbours already assert.
