### PR TITLE
Drop the ConstructorsCodeFree suppression in Data.ToPhi

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -52,10 +52,17 @@ public interface Data {
          * is dataized far away from the place that made it.</p>
          *
          * @param obj Data
-         * @checkstyle ConstructorsCodeFreeCheck (5 lines)
          */
         public ToPhi(final Object obj) {
-            this.object = Data.ToPhi.toPhi(obj);
+            this(Data.ToPhi.toPhi(obj));
+        }
+
+        /**
+         * Ctor.
+         * @param phi Already converted object
+         */
+        private ToPhi(final Phi phi) {
+            this.object = phi;
         }
 
         @Override


### PR DESCRIPTION
`Data.ToPhi` now has two constructors: the public one delegates with `this(Data.ToPhi.toPhi(obj))`, and a private primary one only assigns the field. That drops the `@checkstyle ConstructorsCodeFreeCheck` suppression the class was carrying.

The suppression was avoidable. `ConstructorsCodeFreeCheck` is right to complain about a method call on the right-hand side of a field assignment, but it exempts a constructor whose only statement is a delegating `this(...)` call and accepts calls in that delegate's arguments. The conversion still happens inside the constructor, so an unconvertible type is rejected where the object is made, which is what the docblock and #6369 ask for.

Nothing else changes for callers: the private constructor is not accessible outside `Data`, so every `new Data.ToPhi(...)` site elsewhere keeps binding to the `Object` overload.

Closes #7064
