### PR TITLE
fix(#7056): report coverage per source file, not per merged package

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -6,7 +6,6 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
-import com.jcabi.xml.XMLDocument;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -17,6 +16,7 @@ import java.util.Map;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
+import org.eolang.parser.EoSyntax;
 
 /**
  * Turns the raw {@code loc:line:pos} coverage hits {@code PhCoverage}
@@ -29,6 +29,15 @@ import org.apache.maven.plugins.annotations.Parameter;
  * nothing when {@code eo.coverageFile} is not set or the file does not
  * exist yet, the same "no-op when disabled" contract {@code PhCoverage}
  * itself follows.</p>
+ *
+ * <p>Every {@code .eo} file is re-parsed from its own source instead of
+ * reading the {@code xmir} stored in its tojo, because that xmir is the
+ * {@code MjMerge} one for a package root and mixes the members it spliced
+ * in, whose lines refer to their own files. Reporting those members'
+ * locations against the package root puts lines of unrelated files where
+ * the package's meta directives are, so each file is covered under its
+ * own name (they all carry {@code @loc} with the {@code Φ} prefix of the
+ * object they name, so the runtime hits still line up).</p>
  *
  * @since 0.75.0
  */
@@ -95,9 +104,9 @@ public final class MjCoverageReport extends MjSafe {
         final Map<String, String> fileof = new HashMap<>(0);
         final CoverageManifest manifest = new CoverageManifest();
         try (TjsForeign tojos = this.tojos()) {
-            for (final TjForeign tojo : tojos.standalone()) {
+            for (final TjForeign tojo : tojos.withXmir()) {
                 final String source = tojo.source().toString();
-                final XML xmir = new XMLDocument(tojo.xmir());
+                final XML xmir = new EoSyntax(Files.readString(tojo.source())).parsed();
                 for (final String location : manifest.locations(xmir)) {
                     final int last = location.lastIndexOf(':');
                     final int line = Integer.parseInt(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -72,4 +72,61 @@ final class MjCoverageReportTest {
             "coverage-report must fail the build when coverage is below the minimum, but it didnt"
         );
     }
+
+    @Test
+    void doesNotAttributeMergedMembersToThePackageFile(@Mktmp final Path temp) throws Exception {
+        final FakeMaven maven = new FakeMaven(temp)
+            .withProgram(
+                String.join(
+                    System.lineSeparator(),
+                    "+architect me@example.com",
+                    "+version 0.0.0",
+                    "",
+                    "[n] > foo",
+                    "  42 > x",
+                    "  n > @"
+                ),
+                "foo",
+                "foo.eo"
+            )
+            .withProgram(
+                String.join(
+                    System.lineSeparator(),
+                    "+package foo",
+                    "",
+                    "[] > bar",
+                    "  42 > @"
+                ),
+                "foo.bar",
+                "foo/bar.eo"
+            )
+            .execute(MjParse.class)
+            .execute(new FakeMaven.Merge());
+        final Path hits = temp.resolve("coverage.txt");
+        Files.writeString(hits, "");
+        final Path lcov = temp.resolve("coverage.info");
+        maven.with("coverageFile", hits.toFile())
+            .with("lcovFile", lcov.toFile())
+            .execute(MjCoverageReport.class);
+        final String text = Files.readString(lcov);
+        final int first = text.indexOf("SF:");
+        final int second = text.indexOf("SF:", first + 3);
+        MatcherAssert.assertThat(
+            "a package member merged into its package must have a coverage block of its own, but only one file was reported",
+            second,
+            Matchers.greaterThan(0)
+        );
+        final String foo = text.substring(first, second);
+        MatcherAssert.assertThat(
+            "the meta directives of the package file must not appear as DA lines in its coverage block, but they did",
+            foo,
+            Matchers.not(Matchers.matchesPattern("(?s).*DA:([123]),0.*"))
+        );
+        final String bar = text.substring(second);
+        MatcherAssert.assertThat(
+            "the member must be covered under its own file, but its block was not reported",
+            bar,
+            Matchers.containsString("foo/bar.eo")
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -75,58 +75,44 @@ final class MjCoverageReportTest {
 
     @Test
     void doesNotAttributeMergedMembersToThePackageFile(@Mktmp final Path temp) throws Exception {
-        final FakeMaven maven = new FakeMaven(temp)
-            .withProgram(
-                String.join(
-                    System.lineSeparator(),
-                    "+architect me@example.com",
-                    "+version 0.0.0",
-                    "",
-                    "[n] > foo",
-                    "  42 > x",
-                    "  n > @"
-                ),
-                "foo",
-                "foo.eo"
-            )
-            .withProgram(
-                String.join(
-                    System.lineSeparator(),
-                    "+package foo",
-                    "",
-                    "[] > bar",
-                    "  42 > @"
-                ),
-                "foo.bar",
-                "foo/bar.eo"
-            )
-            .execute(MjParse.class)
-            .execute(new FakeMaven.Merge());
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "+architect me@example.com",
+                "+version 0.0.0",
+                "",
+                "[n] > foo",
+                "  42 > x",
+                "  n > @"
+            ),
+            "foo",
+            "foo.eo"
+        ).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "+package foo",
+                "",
+                "[] > bar",
+                "  42 > @"
+            ),
+            "foo.bar",
+            "foo/bar.eo"
+        ).execute(MjParse.class).execute(new FakeMaven.Merge());
         final Path hits = temp.resolve("coverage.txt");
         Files.writeString(hits, "");
         final Path lcov = temp.resolve("coverage.info");
         maven.with("coverageFile", hits.toFile())
             .with("lcovFile", lcov.toFile())
             .execute(MjCoverageReport.class);
-        final String text = Files.readString(lcov);
-        final int first = text.indexOf("SF:");
-        final int second = text.indexOf("SF:", first + 3);
         MatcherAssert.assertThat(
-            "a package member merged into its package must have a coverage block of its own, but only one file was reported",
-            second,
-            Matchers.greaterThan(0)
-        );
-        final String foo = text.substring(first, second);
-        MatcherAssert.assertThat(
-            "the meta directives of the package file must not appear as DA lines in its coverage block, but they did",
-            foo,
-            Matchers.not(Matchers.matchesPattern("(?s).*DA:([123]),0.*"))
-        );
-        final String bar = text.substring(second);
-        MatcherAssert.assertThat(
-            "the member must be covered under its own file, but its block was not reported",
-            bar,
-            Matchers.containsString("foo/bar.eo")
+            "the meta directives of the package file must not be reported as DA misses, while its merged member must get a coverage block of its own",
+            Files.readString(lcov),
+            Matchers.allOf(
+                Matchers.matchesPattern(
+                    "(?s).*SF:[^\\n]*foo\\.eo\\r?\\n(?:(?!DA:[123],0).)*end_of_record.*"
+                ),
+                Matchers.containsString("bar.eo")
+            )
         );
     }
 }


### PR DESCRIPTION
Fixes #7056.

## Problem
`MjCoverageReport` read `tojo.xmir()` of every "standalone" tojo. For a package root, that XMIR is the **merged** one (see `Merging`), which contains all spliced package members whose `@line`/`@pos` refer to **their own** files. The report attributed those member lines to the package file, so they landed exactly on the package's meta lines (`+architect`, `+version`, etc.). Since metas have no `@pos` they can't be covered, and codecov showed them as uncovered. Package members themselves were excluded from the report entirely (`standalone()`), so their coverage was lost.

## Fix
- Iterate all `tojos.withXmir()` instead of `tojos.standalone()`, so package members are no longer dropped.
- Re-parse each source file with `EoSyntax(...).parsed()` instead of reading the stored (merged) XMIR, so every location is attributed to the file it actually belongs to.
- Metas have no `@pos`, so `CoverageManifest` never lists them — they no longer appear as misses.

The re-parsing is equivalent to the stored per-file XMIR: locations match for all 171 sources in `eo-runtime`.

## Tests
New regression test in `MjCoverageReportTest.doesNotAttributeMergedMembersToThePackageFile`: a package with metas + a member; asserts the package block has no `DA` misses on the meta lines and the member gets its own coverage block.

Verified locally that `eo-runtime` coverage (`-Deo.coverageTracking=true`) keeps the member files covered under their own paths (e.g. `chunk/to-output.eo` 100%) and the package meta lines are no longer DA misses.