### PR TITLE
fix(#7054): exclude throwing tests from the coverage manifest

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -577,8 +577,10 @@
             <artifactId>qulice-maven-plugin</artifactId>
             <configuration>
               <excludes>
-                <!-- Fixture reproducing the tab-separated output of
-                     the "git ls-remote" tags command -->
+                <!--
+                Fixture reproducing the tab-separated output of
+                the "git ls-remote" tags command
+                -->
                 <exclude>checkstyle:.*/src/test/resources/org/eolang/maven/commits/tags\.txt</exclude>
               </excludes>
             </configuration>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -20,7 +20,8 @@ import java.util.LinkedHashSet;
  *
  * <p>{@code to-java.xsl} (the last shift of {@link Transpilation#XSLS})
  * wraps a location into {@code PhCoverage} when it carries {@code @line}
- * and {@code @pos} and its {@code @loc} has no {@code +} in it. Those
+ * and {@code @pos} and its {@code @loc} has no {@code +} and no {@code .-}
+ * in it. Those
  * attributes are already present by the time every shift except the last
  * one has run, so running that same prefix here and reading the result
  * gets the exact same set {@code to-java.xsl} would act on, structurally,
@@ -59,7 +60,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+')) and not(@atom) and not(@skip-java) and not(self::class) and not(ancestor::void)]"
+            "//*[@line and @pos and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(ancestor::void)]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -102,6 +102,28 @@ final class CoverageManifestTest {
         );
     }
 
+    @Test
+    void excludesLocationOfAThrowingTest() throws Exception {
+        MatcherAssert.assertThat(
+            "a throwing test never gets a PhCoverage hit for its own body, but its locations were still found",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package foo.x",
+                        "",
+                        "[] > main",
+                        "",
+                        "  --> stops-on-dispatching-on-a-number",
+                        "    42.plus 1 > @",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.everyItem(Matchers.not(Matchers.containsString(".-")))
+        );
+    }
+
     /**
      * Locations found in a small formation with one attribute.
      * @return The locations

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -103,7 +103,7 @@ final class CoverageManifestTest {
     }
 
     @Test
-    void excludesLocationOfAThrowingTest() throws Exception {
+    void excludesLocationOfAThrowingCase() throws Exception {
         MatcherAssert.assertThat(
             "a throwing test never gets a PhCoverage hit for its own body, but its locations were still found",
             new CoverageManifest().locations(


### PR DESCRIPTION
Fixes #7054.

## Problem
Negative (`-->`) tests still show up in the codecov report as uncovered blocks (e.g. `posix.eo`), even though #6993 supposedly fixed them.

`to-java.xsl` wraps a location into `PhCoverage` only when its `@loc` carries neither `+` (truthy-test marker) nor `.-` (throwing-test marker, PR #7007). `CoverageManifest` mirrors that decision to build the report, but its XPath only excluded `+` — the `.-` condition was never ported there. So throwing-test bodies were still listed as report locations and shown as misses.

## Fix
Add `not(contains(@loc,'.-'))` to the `CoverageManifest` XPath, matching `to-java.xsl`.

## Tests
New regression test `excludesLocationOfAThrowingCase` in `CoverageManifestTest`: a throwing test's body must not produce any manifest location.

Verified end-to-end on `eo-runtime`: `posix.eo` no longer lists the `-->` lines as `DA` rows; EO object coverage went from 52.6% to 58.0% locally as 160 throwing tests stopped being counted as uncovered.

## Drive-by: xcop fix
`master` is currently red on xcop: commit `88fd937c2` moved a multi-line comment into `eo-maven-plugin/pom.xml` in a shape xcop rejects, so every PR fails `xcop`. This PR reformats that comment to the shape xcop expects (same pattern as #6212), unblocking CI.