### PR TITLE
fix(#7060): drop MemberNameCheck suppressions by using short attribute names

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -577,8 +577,10 @@
             <artifactId>qulice-maven-plugin</artifactId>
             <configuration>
               <excludes>
-                <!-- Fixture reproducing the tab-separated output of
-                     the "git ls-remote" tags command -->
+                <!--
+                Fixture reproducing the tab-separated output of
+                the "git ls-remote" tags command
+                -->
                 <exclude>checkstyle:.*/src/test/resources/org/eolang/maven/commits/tags\.txt</exclude>
               </excludes>
             </configuration>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -82,21 +82,18 @@ final class Linting implements Step {
 
     /**
      * Target directory.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Path targetDir;
+    private final Path target;
 
     /**
      * Cache base directory.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Path cacheDir;
+    private final Path cache;
 
     /**
      * Whether caching is enabled.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final boolean cacheEnabled;
+    private final boolean enabled;
 
     /**
      * Plugin version.
@@ -105,40 +102,33 @@ final class Linting implements Step {
 
     /**
      * Source lints to skip.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Collection<String> skipSourceLints;
+    private final Collection<String> sourcelints;
 
     /**
      * Program (WPA) lints to skip.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final Collection<String> skipProgramLints;
+    private final Collection<String> programlints;
 
     /**
      * Whether to skip experimental lints.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    @SuppressWarnings("PMD.LongVariable")
-    private final boolean skipExperimentalLints;
+    private final boolean experimental;
 
     /**
      * Whether to fail on warnings.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final boolean failOnWarning;
+    private final boolean warning;
 
     /**
      * Whether to lint all sources as a package (WPA).
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final boolean lintAsPackage;
+    private final boolean pkg;
 
     /**
      * Whether to skip linting entirely.
-     * @checkstyle MemberNameCheck (5 lines)
      */
-    private final boolean skipLinting;
+    private final boolean skip;
 
     /**
      * Cache guard, see {@link ConcurrentCache} for why it is one per instance.
@@ -177,22 +167,22 @@ final class Linting implements Step {
     ) {
         this.tojos = srcs;
         this.compile = compiled;
-        this.targetDir = target;
-        this.cacheDir = cache;
-        this.cacheEnabled = enabled;
+        this.target = target;
+        this.cache = cache;
+        this.enabled = enabled;
         this.version = ver;
-        this.skipSourceLints = sourcelints;
-        this.skipProgramLints = programlints;
-        this.skipExperimentalLints = experimental;
-        this.failOnWarning = warning;
-        this.lintAsPackage = pkg;
-        this.skipLinting = skip;
+        this.sourcelints = sourcelints;
+        this.programlints = programlints;
+        this.experimental = experimental;
+        this.warning = warning;
+        this.pkg = pkg;
+        this.skip = skip;
         this.guard = new ConcurrentCache();
     }
 
     @Override
     public void exec() throws IOException {
-        if (this.skipLinting) {
+        if (this.skip) {
             Logger.info(this, "Linting is skipped because eo:skipLinting is TRUE");
         } else {
             this.linting();
@@ -241,8 +231,8 @@ final class Linting implements Step {
         counts.putIfAbsent(Severity.ERROR, 0);
         counts.putIfAbsent(Severity.WARNING, 0);
         final Collection<String> seen = new ConcurrentLinkedQueue<>();
-        if (!this.skipSourceLints.isEmpty()) {
-            Logger.info(this, "Unlinting source lints: %[list]s", this.skipSourceLints);
+        if (!this.sourcelints.isEmpty()) {
+            Logger.info(this, "Unlinting source lints: %[list]s", this.sourcelints);
         }
         final int passed = new Threaded<>(
             programs,
@@ -251,7 +241,7 @@ final class Linting implements Step {
         if (programs.isEmpty()) {
             Logger.info(this, "There are no XMIR programs, nothing to lint individually");
         }
-        if (this.lintAsPackage) {
+        if (this.pkg) {
             Logger.info(
                 this,
                 "XMIR programs linted as a package: %d",
@@ -284,7 +274,7 @@ final class Linting implements Step {
             );
         }
         if (counts.get(Severity.WARNING) > 0) {
-            if (this.failOnWarning) {
+            if (this.warning) {
                 throw new IllegalStateException(
                     String.format(
                         "In %d XMIR files, we found %s (use -Deo.failOnWarning=false to ignore):%n%s",
@@ -314,14 +304,14 @@ final class Linting implements Step {
     ) throws Exception {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
-        final Path base = this.targetDir.resolve(Linting.DIR);
-        final Path target = new LintTarget(xmir, source).under(base);
-        if (this.cacheEnabled) {
+        final Path base = this.target.resolve(Linting.DIR);
+        final Path out = new LintTarget(xmir, source).under(base);
+        if (this.enabled) {
             this.guard.apply(
-                source, target, base.relativize(target),
+                source, out, base.relativize(out),
                 new Cache(
                     new CachePath(
-                        this.cacheDir.resolve(Linting.CACHE),
+                        this.cache.resolve(Linting.CACHE),
                         this.cacheVersion(),
                         new TojoHash(tojo).get()
                     ),
@@ -331,10 +321,10 @@ final class Linting implements Step {
         } else {
             new Saved(
                 this.linted(xmir).toString(),
-                target
+                out
             ).value();
         }
-        final Xnav checked = new Xnav(target);
+        final Xnav checked = new Xnav(out);
         final Collection<Defect> defects = Linting.existing(checked);
         for (final Defect defect : defects) {
             if (Linting.notSuppressed(checked, defect)) {
@@ -348,16 +338,16 @@ final class Linting implements Step {
                 );
             }
         }
-        tojo.withLinted(target);
+        tojo.withLinted(out);
         return 1;
     }
 
     /**
      * Cache-key version segment for the per-file lint cache: the plugin
-     * version combined with {@link #skipSourceLints} and
-     * {@link #skipExperimentalLints}, since both change what
+     * version combined with {@link #sourcelints} and
+     * {@link #experimental}, since both change what
      * {@link #linted(XML)} reports for the exact same source XMIR
-     * (see #6235). {@link #skipSourceLints} is hashed rather than joined
+     * (see #6235). {@link #sourcelints} is hashed rather than joined
      * in verbatim, since a project skipping a dozen full lint names would
      * otherwise push this single path segment past the 255-byte limit
      * ext4 and APFS enforce.
@@ -367,9 +357,9 @@ final class Linting implements Step {
         return String.format(
             "%s-%b-%s",
             this.version,
-            this.skipExperimentalLints,
+            this.experimental,
             new Hashed(
-                this.skipSourceLints.stream().sorted().collect(Collectors.joining(","))
+                this.sourcelints.stream().sorted().collect(Collectors.joining(","))
             ).get()
         );
     }
@@ -392,49 +382,49 @@ final class Linting implements Step {
         for (final TjForeign tojo : this.compile.withXmir()) {
             paths.put(tojo.identifier(), tojo.xmir());
         }
-        final Map<String, XML> pkg = new HashMap<>();
+        final Map<String, XML> progs = new HashMap<>();
         for (final Map.Entry<String, Path> ent : paths.entrySet()) {
-            pkg.put(ent.getKey(), new XMLDocument(ent.getValue()));
+            progs.put(ent.getKey(), new XMLDocument(ent.getValue()));
         }
-        if (!this.skipProgramLints.isEmpty()) {
-            Logger.info(this, "Unliting WPA lints: %[list]s", this.skipProgramLints);
+        if (!this.programlints.isEmpty()) {
+            Logger.info(this, "Unliting WPA lints: %[list]s", this.programlints);
         }
         final List<org.eolang.wpa.Defect> defects;
-        if (this.cacheEnabled) {
+        if (this.enabled) {
             final Path wpa = Path.of("wpa.xmir");
-            final Path base = this.targetDir.resolve(Linting.DIR);
-            final Path target = base.resolve(wpa);
+            final Path base = this.target.resolve(Linting.DIR);
+            final Path out = base.resolve(wpa);
             Files.createDirectories(base);
             this.guard.apply(
-                base, target, wpa,
+                base, out, wpa,
                 new Cache(
                     new CachePath(
-                        this.cacheDir.resolve(Linting.CACHE),
+                        this.cache.resolve(Linting.CACHE),
                         this.version,
                         new WpaCacheKey(
-                            paths, this.skipProgramLints, this.skipExperimentalLints
+                            paths, this.programlints, this.experimental
                         ).get()
                     ).get(),
                     root -> {
                         Logger.info(this, "Linting a package");
                         final Directives all = new Directives().add("defects");
-                        for (final org.eolang.wpa.Defect defect : this.wpa(pkg)) {
+                        for (final org.eolang.wpa.Defect defect : this.wpa(progs)) {
                             Linting.embedded(all, defect);
                         }
                         all.up();
                         return new Xembler(all).xmlQuietly();
                     },
                     p -> p.getFileName().toString().endsWith(".xmir")
-                        && !p.equals(target)
+                        && !p.equals(out)
                 )
             );
-            defects = Linting.read(target);
+            defects = Linting.read(out);
         } else {
             Logger.info(
                 this,
                 "Linting a package without cache, this might be slow, consider enabling cache"
             );
-            defects = this.wpa(pkg);
+            defects = this.wpa(progs);
         }
         for (final org.eolang.wpa.Defect defect : defects) {
             counts.compute(
@@ -444,23 +434,23 @@ final class Linting implements Step {
                 Linting.format(defect.object(), defect.rule(), defect.line(), defect.text())
             );
         }
-        return pkg.size();
+        return progs.size();
     }
 
     /**
      * Run whole-program analysis.
-     * @param pkg Map of program identifiers to their XMIR
+     * @param progs Map of program identifiers to their XMIR
      * @return List of defects found
      */
-    private List<org.eolang.wpa.Defect> wpa(final Map<String, XML> pkg) {
+    private List<org.eolang.wpa.Defect> wpa(final Map<String, XML> progs) {
         final List<org.eolang.wpa.Defect> defects = new ArrayList<>(0);
-        new Program(pkg)
-            .without(this.skipProgramLints.toArray(new String[0]))
+        new Program(progs)
+            .without(this.programlints.toArray(new String[0]))
             .defects()
             .stream()
-            .filter(defect -> this.skipExperimentalLints || !defect.experimental()).forEach(
+            .filter(defect -> this.experimental || !defect.experimental()).forEach(
                 defect -> {
-                    final Node node = pkg.get(defect.object()).inner();
+                    final Node node = progs.get(defect.object()).inner();
                     new Xembler(
                         Linting.embedded(
                             new Directives().xpath("/object").addIf("errors").strict(1),
@@ -490,10 +480,10 @@ final class Linting implements Step {
         final Node node = xmir.inner();
         final Collection<Defect> defects = Linting.existing(new Xnav(node));
         final Collection<Defect> found = new Source(xmir)
-            .without(this.skipSourceLints.toArray(new String[0]))
+            .without(this.sourcelints.toArray(new String[0]))
             .defects()
             .stream().filter(
-                defect -> this.skipExperimentalLints || !defect.experimental()
+                defect -> this.experimental || !defect.experimental()
             ).collect(Collectors.toList());
         defects.addAll(found);
         final Directives dirs = new Directives();


### PR DESCRIPTION
Fixes #7060.

## Change
Renamed the nine `Linting` fields to the names their constructor parameters already use:
`targetDir→target`, `cacheDir→cache`, `cacheEnabled→enabled`, `skipSourceLints→sourcelints`, `skipProgramLints→programlints`, `skipExperimentalLints→experimental`, `failOnWarning→warning`, `lintAsPackage→pkg`, `skipLinting→skip`.

Deleted all nine `@checkstyle MemberNameCheck` comments and the `PMD.LongVariable` suppression.

Local variables that then hid the new field names (`target`, `pkg`) were renamed to `out`/`progs` to satisfy `RequireThisCheck`/`HiddenFieldCheck`.

No name is bound outside the class (constructed via the `Linting` constructor at `MjLint.java:46` and `MjCompile.java:47`), so the plugin's XML configuration surface is unchanged.

## Tests
`LintingTest` and `CompilingTest` pass; `mvn verify -Pqulice` is green.

Note: `InferringTest.understandsProgramOfPack[53]` fails on this branch locally on macOS, but it fails identically on a pristine `master` checkout (verified by stash), so it's pre-existing and environment-specific, not introduced here.