### PR TITLE
Reformat the qulice excludes comment the way xcop wants

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -577,8 +577,10 @@
             <artifactId>qulice-maven-plugin</artifactId>
             <configuration>
               <excludes>
-                <!-- Fixture reproducing the tab-separated output of
-                     the "git ls-remote" tags command -->
+                <!--
+                Fixture reproducing the tab-separated output of
+                the "git ls-remote" tags command
+                -->
                 <exclude>checkstyle:.*/src/test/resources/org/eolang/maven/commits/tags\.txt</exclude>
               </excludes>
             </configuration>


### PR DESCRIPTION
`xcop` is red on `master` since 88fd937, and it blocks every open pull request.

The new comment in the `qulice` profile of `eo-maven-plugin/pom.xml` uses the inline continuation style, which `xcop` rejects:

```
<!-- Fixture reproducing the tab-separated output of
     the "git ls-remote" tags command -->
```

It wants the opening and closing markers on their own lines, with the text at the same indent, the way every other multi-line comment in that file already looks (see the `maven-core` dependency around line 129):

```
<!--
Fixture reproducing the tab-separated output of
the "git ls-remote" tags command
-->
```

The replacement here is byte-for-byte what `xcop` printed as the expected form in the failing run of `master`: https://github.com/objectionary/eo/actions/runs/32212352002
