### PR TITLE
fix(#7030): treat a whitespace-only line as blank in Span

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -299,10 +299,6 @@ final class Eo implements Iterable<Directive> {
      * indent transitions run before classification when the stack is
      * non-empty.</p>
      *
-     * <p>The R-2.2.4 tab diagnostic speaks about the whitespace leading
-     * up to content, so a line made of whitespace alone stays out of it:
-     * such a line is a blank separator and gets dispatched as one.</p>
-     *
      * @param span The source span
      * @param stack The indent stack
      * @param globals The global parser state

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -299,6 +299,10 @@ final class Eo implements Iterable<Directive> {
      * indent transitions run before classification when the stack is
      * non-empty.</p>
      *
+     * <p>The R-2.2.4 tab diagnostic speaks about the whitespace leading
+     * up to content, so a line made of whitespace alone stays out of it:
+     * such a line is a blank separator and gets dispatched as one.</p>
+     *
      * @param span The source span
      * @param stack The indent stack
      * @param globals The global parser state
@@ -311,7 +315,7 @@ final class Eo implements Iterable<Directive> {
         boolean failed = false;
         if (globals.inTextBlock()) {
             Eo.continueTextBlock(span, stack, globals, emit);
-        } else if (span.tab()) {
+        } else if (span.tab() && !span.blank()) {
             emit.error(span.line(), 0, "tab character in leading whitespace");
             failed = true;
         } else if (!span.blank() && span.indent() % 2 == 1) {

--- a/eo-parser/src/main/java/org/eolang/parser/Span.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Span.java
@@ -9,8 +9,8 @@ package org.eolang.parser;
  *
  * <p>A {@code Span} is a value object carrying a single source line's text
  * (without trailing line terminator), its 1-indexed line number, and the
- * count of leading-space characters that precede the first non-space
- * character. The text never contains {@code \n} or {@code \r}; the
+ * count of leading-whitespace characters that precede the first
+ * non-whitespace character. The text never contains {@code \n} or {@code \r}; the
  * {@link Source} that produced this span has already normalised line
  * endings (R-2.1.2).</p>
  *
@@ -38,7 +38,8 @@ final class Span {
     private final int number;
 
     /**
-     * Count of leading space characters before the first non-space.
+     * Count of leading whitespace characters before the first
+     * non-whitespace one.
      */
     private final int indent;
 
@@ -60,7 +61,7 @@ final class Span {
      * Primary ctor.
      * @param body Line text
      * @param line Line number
-     * @param leading Count of leading space chars
+     * @param leading Count of leading whitespace chars
      * @param tabbed True if any leading char is a tab
      */
     private Span(final String body, final int line, final int leading, final boolean tabbed) {
@@ -95,7 +96,7 @@ final class Span {
     }
 
     /**
-     * Leading-space count.
+     * Leading-whitespace count.
      * @return Indent
      */
     int indent() {
@@ -127,8 +128,8 @@ final class Span {
     }
 
     /**
-     * The first non-space character, or {@code '\0'} for a blank line.
-     * @return First non-space character
+     * The first non-whitespace character, or {@code '\0'} for a blank line.
+     * @return First non-whitespace character
      */
     char head() {
         final char first;
@@ -141,13 +142,20 @@ final class Span {
     }
 
     /**
-     * Compute leading-space count.
+     * Compute leading-whitespace count.
+     *
+     * <p>Every whitespace character counts, not only {@code ' '}. A line
+     * made of whitespace alone must yield {@code indent == text.length()},
+     * as {@link #blank()} reads blankness off exactly that equality; a
+     * tab-only line counted as space-only would report itself non-blank
+     * with indent zero and mislead the consumers of both queries.</p>
+     *
      * @param body Line text
-     * @return Number of leading {@code ' '} characters
+     * @return Number of leading whitespace characters
      */
     private static int leading(final String body) {
         int count = 0;
-        while (count < body.length() && body.charAt(count) == ' ') {
+        while (count < body.length() && Character.isWhitespace(body.charAt(count))) {
             count = count + 1;
         }
         return count;

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -177,6 +177,15 @@ final class EoTest {
     }
 
     @Test
+    void parsesSiblingAfterTabOnlyLineInFailedBlock() {
+        MatcherAssert.assertThat(
+            "a tab-only line inside the block of a failed line must not swallow the next sibling",
+            EoTest.render("[] > foo", "  ???", "	", "  d > y"),
+            XhtmlMatchers.hasXPath("/object/o[@name='foo']/o[@name='y']")
+        );
+    }
+
+    @Test
     void parsesWithUnixAndWindowsLineEndings() {
         final String carriage = String.valueOf((char) 13);
         MatcherAssert.assertThat(

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -180,7 +180,7 @@ final class EoTest {
     void parsesSiblingAfterTabOnlyLineInFailedBlock() {
         MatcherAssert.assertThat(
             "a tab-only line inside the block of a failed line must not swallow the next sibling",
-            EoTest.render("[] > foo", "  ???", "	", "  d > y"),
+            EoTest.render("[] > foo", "  ???", "\t", "  d > y"),
             XhtmlMatchers.hasXPath("/object/o[@name='foo']/o[@name='y']")
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
@@ -96,6 +96,33 @@ final class SpanTest {
     }
 
     @Test
+    void detectsTabOnlyLineAsBlank() {
+        MatcherAssert.assertThat(
+            "a line made of a single tab is entirely whitespace and must report blank",
+            new Span("	", 4).blank(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void countsTabsInIndent() {
+        MatcherAssert.assertThat(
+            "every leading whitespace character counts towards the indent, tabs included",
+            new Span("		", 4).indent(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void exposesEmptyBodyForTabOnlyLine() {
+        MatcherAssert.assertThat(
+            "body of a tab-only line cannot contain anything",
+            new Span(" 	 ", 1).body(),
+            Matchers.equalTo("")
+        );
+    }
+
+    @Test
     void detectsTabInLeadingWhitespace() {
         MatcherAssert.assertThat(
             "a tab inside the leading-whitespace region must be reported",

--- a/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
@@ -99,7 +99,7 @@ final class SpanTest {
     void detectsTabOnlyLineAsBlank() {
         MatcherAssert.assertThat(
             "a line made of a single tab is entirely whitespace and must report blank",
-            new Span("	", 4).blank(),
+            new Span("\t", 4).blank(),
             Matchers.is(true)
         );
     }
@@ -108,7 +108,7 @@ final class SpanTest {
     void countsTabsInIndent() {
         MatcherAssert.assertThat(
             "every leading whitespace character counts towards the indent, tabs included",
-            new Span("		", 4).indent(),
+            new Span("\t\t", 4).indent(),
             Matchers.equalTo(2)
         );
     }
@@ -117,7 +117,7 @@ final class SpanTest {
     void exposesEmptyBodyForTabOnlyLine() {
         MatcherAssert.assertThat(
             "body of a tab-only line cannot contain anything",
-            new Span(" 	 ", 1).body(),
+            new Span(" \t ", 1).body(),
             Matchers.equalTo("")
         );
     }


### PR DESCRIPTION
Fixes #7030.

`Span.leading()` counted only literal `' '` characters, so a tab-only line got `indent == 0` while `text.length() == 1`, and `blank()` (which reads `indent == text.length()`) reported `false`. That contradicts the class contract in the javadoc and corrupts `Recovery`, which trusts `blank()` to know which lines belong to a skipped block.

Two changes:

1. `Span.leading()` now counts every leading whitespace character, not only spaces. A whitespace-only line therefore yields `indent == text.length()` and `blank() == true`, as documented. `tab()` is untouched, so the R-2.2.4 diagnostic still fires on `\tfoo`.

2. `Eo.process()` raises `tab character in leading whitespace` only for a line that carries content. Without this the tab-only line, now correctly blank, is still handed back by `Recovery.rewound()` as a separator, fails there, and restarts the skip with its own indent, swallowing the sibling again. R-2.2.4 speaks about the whitespace leading up to content, and a line made of whitespace alone has none.

For the source from the issue:

```
[] > foo
  ???
<TAB>
  d > y
```

`d > y` now lands under `foo` instead of disappearing, and only the genuine `trailing garbage after expression` error is reported.

Tests: three in `SpanTest` (tab-only line is blank, tabs count towards indent, `body()` of a tab-only line is empty) and one in `EoTest` reproducing the source above. Whole `eo-parser` suite is green locally.
