### PR TITLE
fix(#7055): keep atom attributes out of the coverage manifest

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -38,6 +38,19 @@ import java.util.LinkedHashSet;
  * root object declares are free this same way, which is why its own
  * declaration line never gets a hit (#6995).</p>
  *
+ * <p>An atom attribute is left out along with everything it declares,
+ * even though {@code to-java.xsl} does wrap it and its voids and the
+ * runtime does record hits for them (#7055). Such an attribute has no
+ * body in {@code .eo} at all — its body is the Java class the
+ * {@code @atom} names — so the lines it occupies say nothing about how
+ * much of the {@code .eo} source the tests exercised. Counting them
+ * reads as coverage of code that is not there: the declaration line of
+ * {@code [] > read /Q.bytes} shows up uncovered while the {@code ? >
+ * offset} lines under it show up covered, both of them merely
+ * declarations. The hits the runtime still appends for those locations
+ * find no place in the manifest and are dropped, the same way a hit of
+ * any location the manifest does not name is.</p>
+ *
  * @since 0.75.0
  */
 final class CoverageManifest {
@@ -60,7 +73,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(ancestor::void)]"
+            "//*[@line and @pos and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(ancestor::void) and not(ancestor-or-self::*[o[@atom]])]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -66,9 +66,9 @@ final class CoverageManifestTest {
     }
 
     @Test
-    void excludesLocationOfAnAtomsLambdaMarker() throws Exception {
+    void excludesLocationsOfAnAtomAttribute() throws Exception {
         MatcherAssert.assertThat(
-            "the lambda marker of an atom attribute never gets a PhCoverage hit, but its location was still found",
+            "an atom attribute has no body in .eo, so neither it nor its lambda marker may be counted, but a location was still found",
             new CoverageManifest().locations(
                 new EoSyntax(
                     String.join(
@@ -79,7 +79,46 @@ final class CoverageManifestTest {
                     )
                 ).parsed()
             ),
-            Matchers.iterableWithSize(1)
+            Matchers.iterableWithSize(0)
+        );
+    }
+
+    @Test
+    void excludesLocationsOfTheVoidsOfAnAtomAttribute() throws Exception {
+        MatcherAssert.assertThat(
+            "the voids an atom attribute declares are declarations of a Java body, so they must not be counted either",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "[] > foo",
+                        "  42 > x",
+                        "  [] > bar /Q.bytes",
+                        "    ? > offset /Q.number",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.everyItem(Matchers.not(Matchers.matchesPattern("^[^:]+:[34]:\\d+$")))
+        );
+    }
+
+    @Test
+    void keepsLocationsOfAnObjectHoldingAnAtomAttribute() throws Exception {
+        MatcherAssert.assertThat(
+            "only the atom attribute itself is left out, while the ordinary attributes beside it are still counted",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "[] > foo",
+                        "  42 > x",
+                        "  [] > bar /Q.bytes",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.hasItem(Matchers.matchesPattern("^[^:]+:2:\\d+$"))
         );
     }
 


### PR DESCRIPTION
Fixes #7055.

`CoverageManifest` excluded the `λ` marker of an atom (`not(@atom)`) but kept the attribute that holds it, and everything that attribute declares. For `chunk.eo` the manifest therefore names:

```
Φ.chunk.read:66:2
Φ.chunk.read.offset:67:4
Φ.chunk.read.length:68:4
Φ.chunk.read.cant-read:69:4
Φ.chunk.resized:70:2
Φ.chunk.resized.capacity:71:4
Φ.chunk.size:72:2
Φ.chunk.write:73:2
Φ.chunk.write.offset:74:4
Φ.chunk.write.data:75:4
```

None of those lines has an `.eo` body: the body of `[] > read /Q.bytes` is the Java class the `@atom` names. On [the report](https://app.codecov.io/gh/objectionary/eo/blob/master/eo-runtime%2Fsrc%2Fmain%2Feo%2Fchunk.eo) they come out split for no reason a reader can act on: 67, 68, 69, 71, 74, 75 covered and 66, 70, 72, 73 uncovered, all ten of them plain declarations.

The XPath now drops any location that is, or sits under, an object holding an `@atom` child. The runtime still appends hits for those locations; `MjCoverageReport` ignores a hit the manifest does not name, the same as it does for any other unnamed one.

Tests: `excludesLocationsOfAnAtomAttribute` (the old `excludesLocationOfAnAtomsLambdaMarker`, which asserted the attribute stays, now asserts it goes), plus one for the voids of an atom attribute and one making sure an ordinary attribute standing beside an atom is still counted.
