### PR TITLE
fix(#7061): use one-word names for MjSafe parameters

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -77,9 +77,9 @@ public final class MjCompile extends MjSafe {
                             tojos,
                             this.targetDir.toPath().resolve(MjResolve.DIR),
                             new CentralMaven(this.system, this.session, this.repositories),
-                            this.discoverSelf,
+                            this.discover,
                             this.skipZeroVersions,
-                            this.resolveJna,
+                            this.jna,
                             this.ignoreRuntime,
                             this.runtime(),
                             this.ignoreConflicts

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPull.java
@@ -41,7 +41,7 @@ public final class MjPull extends MjSafe {
                 this.objectionary(),
                 this.cache.toPath().resolve(Pulling.CACHE),
                 this.plugin.getVersion(),
-                this.overWrite,
+                this.overwrite,
                 this.cacheEnabled,
                 this.offline
             ).exec();

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjResolve.java
@@ -62,9 +62,9 @@ public final class MjResolve extends MjSafe {
                 tojos,
                 this.targetDir.toPath().resolve(MjResolve.DIR),
                 this.central,
-                this.discoverSelf,
+                this.discover,
                 this.skipZeroVersions,
-                this.resolveJna,
+                this.jna,
                 this.ignoreRuntime,
                 this.runtime(),
                 this.ignoreConflicts

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -86,10 +86,14 @@ abstract class MjSafe extends AbstractMojo {
 
     /**
      * Format of "foreign" file ("json" or "csv").
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.foreignFormat", required = true, defaultValue = "csv")
-    protected String foreignFormat = "csv";
+    @Parameter(
+        alias = "foreignFormat",
+        property = "eo.foreignFormat",
+        required = true,
+        defaultValue = "csv"
+    )
+    protected String foreignfmt = "csv";
 
     /**
      * Directory in which .eo files are located.
@@ -133,10 +137,14 @@ abstract class MjSafe extends AbstractMojo {
 
     /**
      * Format of "placed" file ("json" or "csv").
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.placedFormat", required = true, defaultValue = "json")
-    protected String placedFormat = "json";
+    @Parameter(
+        alias = "placedFormat",
+        property = "eo.placedFormat",
+        required = true,
+        defaultValue = "json"
+    )
+    protected String placedfmt = "json";
 
     /**
      * Generated sourced directory.
@@ -153,7 +161,6 @@ abstract class MjSafe extends AbstractMojo {
      * The path of the file where XSL measurements (time of execution
      * in milliseconds) will be stored.
      * @since 0.41.0
-     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter(
         alias = "xslMeasuresFile",
@@ -161,7 +168,7 @@ abstract class MjSafe extends AbstractMojo {
         required = true,
         defaultValue = "${project.build.directory}/eo/xsl-measures.csv"
     )
-    protected File xslMeasures;
+    protected File measures;
 
     /**
      * Mojo execution timeout in seconds.
@@ -254,10 +261,14 @@ abstract class MjSafe extends AbstractMojo {
     /**
      * Pull again even if the .eo file is already present?
      * @since 0.10.0
-     * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter(property = "eo.overWrite", required = true, defaultValue = "false")
-    protected boolean overWrite;
+    @Parameter(
+        alias = "overWrite",
+        property = "eo.overWrite",
+        required = true,
+        defaultValue = "false"
+    )
+    protected boolean overwrite;
 
     /**
      * Skip artifact with the version 0.0.0.
@@ -283,10 +294,14 @@ abstract class MjSafe extends AbstractMojo {
     /**
      * Shall we discover JAR artifacts for .EO sources?
      * @since 0.12.0
-     * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter(property = "eo.discoverSelf", required = true, defaultValue = "false")
-    protected boolean discoverSelf;
+    @Parameter(
+        alias = "discoverSelf",
+        property = "eo.discoverSelf",
+        required = true,
+        defaultValue = "false"
+    )
+    protected boolean discover;
 
     /**
      * List of inclusion GLOB filters for finding class files while placing them from where
@@ -397,17 +412,15 @@ abstract class MjSafe extends AbstractMojo {
 
     /**
      * Resolve default JNA dependency or not.
-     * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    protected boolean resolveJna = true;
+    protected boolean jna = true;
 
     /**
      * Resolve dependencies in central or not.
-     * @checkstyle MemberNameCheck (7 lines)
      * @checkstyle VisibilityModifierCheck (7 lines)
      */
-    protected boolean resolveInCentral = true;
+    protected boolean centrally = true;
 
     /**
      * Objectionary.
@@ -465,7 +478,7 @@ abstract class MjSafe extends AbstractMojo {
      */
     protected final TjsForeign tojos() {
         return new TjsForeign(
-            () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignFormat),
+            () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignfmt),
             () -> this.scope
         );
     }
@@ -477,7 +490,7 @@ abstract class MjSafe extends AbstractMojo {
      */
     protected final TjsPlaced placed() {
         return new TjsPlaced(
-            () -> Catalogs.INSTANCE.make(this.placed.toPath(), this.placedFormat)
+            () -> Catalogs.INSTANCE.make(this.placed.toPath(), this.placedfmt)
         );
     }
 
@@ -487,7 +500,7 @@ abstract class MjSafe extends AbstractMojo {
      */
     protected final TjsForeign compileTojos() {
         return new TjsForeign(
-            () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignFormat),
+            () -> Catalogs.INSTANCE.make(this.foreign.toPath(), this.foreignfmt),
             () -> "compile"
         );
     }
@@ -507,7 +520,7 @@ abstract class MjSafe extends AbstractMojo {
      * @return Scalar supplying the runtime dependency
      */
     Scalar<Dep> runtime() {
-        return new RtChosen(this.project, this.resolveInCentral);
+        return new RtChosen(this.project, this.centrally);
     }
 
     /**
@@ -537,7 +550,7 @@ abstract class MjSafe extends AbstractMojo {
                     this.objectionary(),
                     this.cache.toPath().resolve(Pulling.CACHE),
                     this.plugin.getVersion(),
-                    this.overWrite,
+                    this.overwrite,
                     this.cacheEnabled,
                     this.offline
                 )

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -183,7 +183,7 @@ public final class MjTranspile extends MjSafe {
                         new Tracking(this.trackSteps, this.located),
                         this.coverage,
                         this.base(),
-                        this.xslMeasures.toPath(),
+                        this.measures.toPath(),
                         this.targetDir.toPath(),
                         this.tables.toPath(),
                         this.lowered()

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -165,25 +165,25 @@ final class FakeMaven {
         if (this.defaults) {
             this.params.putIfAbsent("targetDir", this.targetPath().toFile());
             this.params.putIfAbsent(
-                "xslMeasures", this.targetPath().resolve("measures.csv").toFile()
+                "measures", this.targetPath().resolve("measures.csv").toFile()
             );
             this.params.putIfAbsent("foreign", this.foreignPath().toFile());
-            this.params.putIfAbsent("foreignFormat", "csv");
+            this.params.putIfAbsent("foreignfmt", "csv");
             final MavenProjectStub stub = new MavenProjectStub();
             stub.setCompileSourceRoots(new ArrayList<>(0));
             this.params.putIfAbsent("project", stub);
             this.params.putIfAbsent("transpiledFormat", "csv");
             this.params.putIfAbsent("skipZeroVersions", true);
             this.params.putIfAbsent("cacheEnabled", true);
-            this.params.putIfAbsent("discoverSelf", false);
+            this.params.putIfAbsent("discover", false);
             this.params.putIfAbsent("ignoreConflicts", false);
             this.params.putIfAbsent("central", new DummyCentral());
-            this.params.putIfAbsent("resolveInCentral", false);
+            this.params.putIfAbsent("centrally", false);
             this.params.putIfAbsent(
                 "placed",
                 this.workspace.resolve(Paths.get("placed.json")).toFile()
             );
-            this.params.putIfAbsent("placedFormat", "json");
+            this.params.putIfAbsent("placedfmt", "json");
             this.params.putIfAbsent(
                 "sourcesDir", this.workspace.resolve(".").toFile()
             );
@@ -200,7 +200,7 @@ final class FakeMaven {
             this.params.putIfAbsent(
                 "pages", this.targetPath().getParent().resolve("site/inference").toFile()
             );
-            this.params.putIfAbsent("placedFormat", "csv");
+            this.params.putIfAbsent("placedfmt", "csv");
             this.params.putIfAbsent("plugin", FakeMaven.pluginDescriptor());
             this.params.putIfAbsent(
                 "objectionary",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPlaceTest.java
@@ -161,7 +161,7 @@ final class MjPlaceTest {
         MatcherAssert.assertThat(
             "PlaceMojo have to place the runtime file, but doesn't",
             new FakeMaven(temp).withHelloWorld()
-                .with("resolveJna", false)
+                .with("jna", false)
                 .execute(new PpPlace())
                 .result()
                 .get(this.targetClasses()),
@@ -175,7 +175,7 @@ final class MjPlaceTest {
             "PlaceMojo have not to place the runtime file, but doesn't",
             new FakeMaven(temp).withHelloWorld()
                 .with("ignoreRuntime", true)
-                .with("resolveJna", false)
+                .with("jna", false)
                 .execute(new PpPlace())
                 .result()
                 .get(this.targetClasses()),


### PR DESCRIPTION
Fixes part of #7061.

## Changes

- rename seven remaining `MjSafe` fields to one-word lowercase names
- preserve Maven XML and property compatibility through `@Parameter` aliases
- update inherited references and test fixtures
- remove the corresponding `MemberNameCheck` suppressions

## Tests

- 147 targeted tests passed with no failures or errors
- Qulice checked 234 Java files against 1020 rules successfully
- `check-parameters-names.groovy` passed
- `git diff --check` passed