### PR TITLE
fix(#7061): one-word parameter names in three mojos

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
@@ -26,9 +26,9 @@ import org.cactoos.text.UncheckedText;
 /**
  * Generate the atom return types table from XMIR sources.
  *
- * <p>Walks the XMIR sources in {@link #atomsInputDir}, extracts the
+ * <p>Walks the XMIR sources in {@link #sources}, extracts the
  * {@code forma} of every lambda atom together with its declared return
- * type, and writes the result as a CSV file at {@link #atomsOutput}.
+ * type, and writes the result as a CSV file at {@link #table}.
  * Each output line has the form {@code <forma>,<return-type>}; entries
  * are sorted by {@code forma} to make the file stable across builds.</p>
  *
@@ -48,25 +48,25 @@ public final class MjAtomsTable extends MjSafe {
 
     /**
      * Directory with XMIR sources to scan for atoms.
-     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter(
+        alias = "atomsInputDir",
         property = "eo.atomsInputDir",
         required = true,
         defaultValue = "${project.build.directory}/eo/1-parse"
     )
-    private File atomsInputDir;
+    private File sources;
 
     /**
      * Output CSV file with the atoms table.
-     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter(
+        alias = "atomsOutput",
         property = "eo.atomsOutput",
         required = true,
         defaultValue = "${project.build.outputDirectory}/org/eolang/atoms.csv"
     )
-    private File atomsOutput;
+    private File table;
 
     /**
      * Ctor.
@@ -77,7 +77,7 @@ public final class MjAtomsTable extends MjSafe {
 
     @Override
     void exec() throws IOException {
-        final Path home = this.atomsInputDir.toPath();
+        final Path home = this.sources.toPath();
         if (!Files.isDirectory(home)) {
             Logger.info(
                 this,
@@ -114,12 +114,12 @@ public final class MjAtomsTable extends MjSafe {
             this,
             "Wrote %d atom return type(s) to %[file]s",
             table.size(),
-            this.atomsOutput.toPath()
+            this.table.toPath()
         );
     }
 
     private void write(final Map<String, String> table) throws IOException {
-        final Path target = this.atomsOutput.toPath();
+        final Path target = this.table.toPath();
         final Path parent = target.getParent();
         if (parent != null) {
             Files.createDirectories(parent);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjAtomsTable.java
@@ -28,7 +28,7 @@ import org.cactoos.text.UncheckedText;
  *
  * <p>Walks the XMIR sources in {@link #sources}, extracts the
  * {@code forma} of every lambda atom together with its declared return
- * type, and writes the result as a CSV file at {@link #table}.
+ * type, and writes the result as a CSV file at {@link #csv}.
  * Each output line has the form {@code <forma>,<return-type>}; entries
  * are sorted by {@code forma} to make the file stable across builds.</p>
  *
@@ -66,7 +66,7 @@ public final class MjAtomsTable extends MjSafe {
         required = true,
         defaultValue = "${project.build.outputDirectory}/org/eolang/atoms.csv"
     )
-    private File table;
+    private File csv;
 
     /**
      * Ctor.
@@ -114,12 +114,12 @@ public final class MjAtomsTable extends MjSafe {
             this,
             "Wrote %d atom return type(s) to %[file]s",
             table.size(),
-            this.table.toPath()
+            this.csv.toPath()
         );
     }
 
     private void write(final Map<String, String> table) throws IOException {
-        final Path target = this.table.toPath();
+        final Path target = this.csv.toPath();
         final Path parent = target.getParent();
         if (parent != null) {
             Files.createDirectories(parent);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -50,20 +50,19 @@ public final class MjCoverageReport extends MjSafe {
 
     /**
      * The raw {@code loc:line:pos} hits file {@code PhCoverage} appended to.
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.coverageFile")
-    private File coverageFile;
+    @Parameter(alias = "coverageFile", property = "eo.coverageFile")
+    private File hits;
 
     /**
      * Where to write the LCOV tracefile.
-     * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
+        alias = "lcovFile",
         property = "eo.lcovFile",
         defaultValue = "${project.build.directory}/coverage.info"
     )
-    private File lcovFile;
+    private File lcov;
 
     /**
      * The minimum percentage of dataized {@code .eo} objects that must be
@@ -73,10 +72,9 @@ public final class MjCoverageReport extends MjSafe {
      * into; {@code eo-runtime} raises it once tracking is on, mirroring
      * how the {@code jacoco} profile binds a {@code check} goal with its
      * own per-metric thresholds.
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.minCoverage", defaultValue = "0")
-    private double minCoverage;
+    @Parameter(alias = "minCoverage", property = "eo.minCoverage", defaultValue = "0")
+    private double minimum;
 
     /**
      * Ctor.
@@ -87,11 +85,11 @@ public final class MjCoverageReport extends MjSafe {
 
     @Override
     public void exec() throws IOException {
-        if (this.coverageFile == null || !this.coverageFile.exists()) {
+        if (this.hits == null || !this.hits.exists()) {
             Logger.info(
                 this,
                 "No coverage hits file at %[file]s, skipping the LCOV report",
-                this.coverageFile
+                this.hits
             );
         } else {
             this.report();
@@ -119,25 +117,25 @@ public final class MjCoverageReport extends MjSafe {
                 }
             }
         }
-        final List<String> hits = Files.readAllLines(this.coverageFile.toPath());
-        for (final String hit : hits) {
+        final List<String> records = Files.readAllLines(this.hits.toPath());
+        for (final String hit : records) {
             final String source = fileof.get(hit);
             if (source != null) {
                 perfile.get(source).merge(lineof.get(hit), 1, Integer::sum);
             }
         }
         final LcovReport report = new LcovReport(perfile);
-        new Saved(report.text(), this.lcovFile.toPath()).value();
+        new Saved(report.text(), this.lcov.toPath()).value();
         final double covered = report.covered();
         Logger.info(
             this, "EO object coverage: %.1f%%, LCOV report saved to %[file]s",
-            covered, this.lcovFile
+            covered, this.lcov
         );
-        if (covered < this.minCoverage) {
+        if (covered < this.minimum) {
             throw new IOException(
                 String.format(
                     "EO object coverage is %.1f%%, below the required %.1f%% minimum",
-                    covered, this.minCoverage
+                    covered, this.minimum
                 )
             );
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -46,10 +46,9 @@ public final class MjRegister extends MjSafe {
      * pretty global (or even a root one).
      * @implNote {@code property} attribute is omitted for collection
      *  properties since there is no way of passing it via command line.
-     * @checkstyle MemberNameCheck (15 lines)
      */
-    @Parameter(defaultValue = "**.eo")
-    private Set<String> includeSources;
+    @Parameter(alias = "includeSources", defaultValue = "**.eo")
+    private Set<String> included;
 
     /**
      * List of exclusion GLOB filters for finding EO files
@@ -58,21 +57,20 @@ public final class MjRegister extends MjSafe {
      * @implNote {@code defaultValue} attribute is omitted, because an empty
      *  one is not rendered into the descriptor of the plugin by
      *  the {@code maven-plugin-plugin}, thus this may stay {@code NULL}.
-     * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter
-    private Set<String> excludeSources;
+    @Parameter(alias = "excludeSources")
+    private Set<String> excluded;
 
     /**
      * Whether it should fail on file names not matching required pattern.
-     * @checkstyle MemberNameCheck (7 lines)
      */
     @Parameter(
+        alias = "strictFileNames",
         property = "eo.strictFileNames",
         required = true,
         defaultValue = "true"
     )
-    private boolean strictFileNames;
+    private boolean strict;
 
     /**
      * Ctor.
@@ -100,13 +98,13 @@ public final class MjRegister extends MjSafe {
                 "Registered %d EO sources from %[file]s to %[file]s, included %s, excluded %s",
                 new Threaded<>(
                     new WkDefault(this.sourcesDir.toPath())
-                        .includes(this.includeSources)
+                        .includes(this.included)
                         .excludes(this.excludes()),
                     file -> this.register(file, unplace, tojos)
                 ).total(),
                 this.sourcesDir,
                 this.foreign,
-                this.includeSources,
+                this.included,
                 this.excludes()
             );
         }
@@ -114,10 +112,10 @@ public final class MjRegister extends MjSafe {
 
     private Set<String> excludes() {
         final Set<String> globs;
-        if (this.excludeSources == null) {
+        if (this.excluded == null) {
             globs = new SetOf<>();
         } else {
-            globs = this.excludeSources;
+            globs = this.excluded;
         }
         return globs;
     }
@@ -126,7 +124,7 @@ public final class MjRegister extends MjSafe {
         final Path file, final Unplace unplace, final TjsForeign tojos
     ) {
         if (
-            this.strictFileNames
+            this.strict
                 && !MjRegister.PATTERN.matcher(file.getFileName().toString()).matches()
         ) {
             throw new IllegalArgumentException(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -200,8 +200,8 @@ final class FakeMaven {
             this.params.putIfAbsent("superclass", "PhDefault");
             this.params.putIfAbsent("attach", true);
             this.params.putIfAbsent("tests", true);
-            this.params.putIfAbsent("strictFileNames", true);
-            this.params.putIfAbsent("includeSources", new SetOf<>("**.eo"));
+            this.params.putIfAbsent("strict", true);
+            this.params.putIfAbsent("included", new SetOf<>("**.eo"));
         }
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.allowedParams(mojo).entrySet()) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
@@ -42,7 +42,7 @@ final class MjAtomsTableTest {
         ).value();
         new FakeMaven(temp)
             .with("sources", temp.resolve("xmir").toFile())
-            .with("table", temp.resolve("classes/org/eolang/atoms.csv").toFile())
+            .with("csv", temp.resolve("classes/org/eolang/atoms.csv").toFile())
             .execute(MjAtomsTable.class);
         MatcherAssert.assertThat(
             "Generated CSV must contain entries for every declared atom",
@@ -60,10 +60,10 @@ final class MjAtomsTableTest {
         try {
             new FakeMaven(temp)
                 .with("sources", temp.resolve("nothing").toFile())
-                .with("table", output.toFile())
+                .with("csv", output.toFile())
                 .execute(MjAtomsTable.class);
             MatcherAssert.assertThat(
-                "A parentless table must not throw and must produce the file",
+                "A parentless csv must not throw and must produce the file",
                 Files.exists(output),
                 Matchers.is(true)
             );
@@ -76,7 +76,7 @@ final class MjAtomsTableTest {
     void writesEmptyTableWhenNoXmirSources(@Mktmp final Path temp) throws Exception {
         new FakeMaven(temp)
             .with("sources", temp.resolve("nothing").toFile())
-            .with("table", temp.resolve("classes/org/eolang/atoms.csv").toFile())
+            .with("csv", temp.resolve("classes/org/eolang/atoms.csv").toFile())
             .execute(MjAtomsTable.class);
         MatcherAssert.assertThat(
             "Output CSV should be empty when there are no XMIR sources",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjAtomsTableTest.java
@@ -41,8 +41,8 @@ final class MjAtomsTableTest {
             temp.resolve("xmir/foo/thing.xmir")
         ).value();
         new FakeMaven(temp)
-            .with("atomsInputDir", temp.resolve("xmir").toFile())
-            .with("atomsOutput", temp.resolve("classes/org/eolang/atoms.csv").toFile())
+            .with("sources", temp.resolve("xmir").toFile())
+            .with("table", temp.resolve("classes/org/eolang/atoms.csv").toFile())
             .execute(MjAtomsTable.class);
         MatcherAssert.assertThat(
             "Generated CSV must contain entries for every declared atom",
@@ -59,11 +59,11 @@ final class MjAtomsTableTest {
         final Path output = Path.of("mjatomstable-6447-test.csv");
         try {
             new FakeMaven(temp)
-                .with("atomsInputDir", temp.resolve("nothing").toFile())
-                .with("atomsOutput", output.toFile())
+                .with("sources", temp.resolve("nothing").toFile())
+                .with("table", output.toFile())
                 .execute(MjAtomsTable.class);
             MatcherAssert.assertThat(
-                "A parentless atomsOutput must not throw and must produce the file",
+                "A parentless table must not throw and must produce the file",
                 Files.exists(output),
                 Matchers.is(true)
             );
@@ -75,8 +75,8 @@ final class MjAtomsTableTest {
     @Test
     void writesEmptyTableWhenNoXmirSources(@Mktmp final Path temp) throws Exception {
         new FakeMaven(temp)
-            .with("atomsInputDir", temp.resolve("nothing").toFile())
-            .with("atomsOutput", temp.resolve("classes/org/eolang/atoms.csv").toFile())
+            .with("sources", temp.resolve("nothing").toFile())
+            .with("table", temp.resolve("classes/org/eolang/atoms.csv").toFile())
             .execute(MjAtomsTable.class);
         MatcherAssert.assertThat(
             "Output CSV should be empty when there are no XMIR sources",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCleanTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCleanTest.java
@@ -50,7 +50,7 @@ final class MjCleanTest {
     void makesFullCompilingLifecycleSuccessfully(@Mktmp final Path temp) throws IOException {
         new FakeMaven(temp)
             .withHelloWorld()
-            .with("includeSources", new SetOf<>("**.eo"))
+            .with("included", new SetOf<>("**.eo"))
             .with("classesDir", temp.resolve("out").toFile())
             .with("placed", temp.resolve("list").toFile())
             .with("cache", temp.resolve("cache/parsed").toFile())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -46,8 +46,8 @@ final class MjCoverageReportTest {
         final Path hits = temp.resolve("coverage.txt");
         Files.writeString(hits, String.format("%s%n", location));
         final Path lcov = temp.resolve("coverage.info");
-        maven.with("coverageFile", hits.toFile())
-            .with("lcovFile", lcov.toFile())
+        maven.with("hits", hits.toFile())
+            .with("lcov", lcov.toFile())
             .execute(MjCoverageReport.class);
         MatcherAssert.assertThat(
             "the LCOV report must record at least one hit line, but LH:0 everywhere",
@@ -65,9 +65,9 @@ final class MjCoverageReportTest {
         Files.writeString(hits, "");
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> maven.with("coverageFile", hits.toFile())
-                .with("lcovFile", temp.resolve("coverage.info").toFile())
-                .with("minCoverage", 1.0d)
+            () -> maven.with("hits", hits.toFile())
+                .with("lcov", temp.resolve("coverage.info").toFile())
+                .with("minimum", 1.0d)
                 .execute(MjCoverageReport.class),
             "coverage-report must fail the build when coverage is below the minimum, but it didnt"
         );
@@ -101,8 +101,8 @@ final class MjCoverageReportTest {
         final Path hits = temp.resolve("coverage.txt");
         Files.writeString(hits, "");
         final Path lcov = temp.resolve("coverage.info");
-        maven.with("coverageFile", hits.toFile())
-            .with("lcovFile", lcov.toFile())
+        maven.with("hits", hits.toFile())
+            .with("lcov", lcov.toFile())
             .execute(MjCoverageReport.class);
         MatcherAssert.assertThat(
             "the meta directives of the package file must not be reported as DA misses, while its merged member must get a coverage block of its own",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjRegisterTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjRegisterTest.java
@@ -48,7 +48,7 @@ final class MjRegisterTest {
             "The resource with incorrect id must exist, but it doesn't",
             new FakeMaven(temp)
                 .with("sourcesDir", temp.resolve("src/eo").toFile())
-                .with("strictFileNames", false)
+                .with("strict", false)
                 .execute(new PpRegister()).foreign().getById("org.eolang.maven..abc")
                 .exists("id"),
             Matchers.is(true)


### PR DESCRIPTION
Part of #7061. Three of the seven mojos, eight of the 48 suppressions. The 200-line PR limit is why the rest are not here; `MjPrint`, `MjFormat` and `MjTranspile` follow in a separate PR, and `MjSafe` needs the grouping from #6459 first.

| file | field | now | XML element | `-D` property |
| --- | --- | --- | --- | --- |
| `MjAtomsTable` | `atomsInputDir` | `sources` | `<atomsInputDir>` | `eo.atomsInputDir` |
| `MjAtomsTable` | `atomsOutput` | `csv` | `<atomsOutput>` | `eo.atomsOutput` |
| `MjCoverageReport` | `coverageFile` | `hits` | `<coverageFile>` | `eo.coverageFile` |
| `MjCoverageReport` | `lcovFile` | `lcov` | `<lcovFile>` | `eo.lcovFile` |
| `MjCoverageReport` | `minCoverage` | `minimum` | `<minCoverage>` | `eo.minCoverage` |
| `MjRegister` | `includeSources` | `included` | `<includeSources>` | none |
| `MjRegister` | `excludeSources` | `excluded` | `<excludeSources>` | none |
| `MjRegister` | `strictFileNames` | `strict` | `<strictFileNames>` | `eo.strictFileNames` |

Nothing a user writes moves: `alias` pins the element name and `property` pins the flag, the same way `MjSafe` already does for `trackTransformationSteps`, `skipExperimentalLints` and `ignoreVersionConflicts`. `eo-runtime/pom.xml:348` still configures `<minCoverage>` and keeps working through the alias.

The test literals move along with the fields, since `FakeMaven.with()` addresses them by field name: `MjAtomsTableTest`, `MjCoverageReportTest`, `MjRegisterTest`, `MjCleanTest` and the `strict` default in `FakeMaven` itself. All eight `@checkstyle MemberNameCheck` comments in these three files are gone.

The one rename that needed more than a rename is `coverageFile`: `report()` held a local `hits` list of the file's lines, which the field now claims, so the local is `records`.


The `qulice` and `xcop` checks are red on master itself right now, on `Walk.java` (`LooseCoupling`, from f463cebf9b) and on the comment formatting in `eo-maven-plugin/pom.xml` (which #7070 fixes). Neither comes from this branch.
