### PR TITLE
fix(#7061): one-word parameter names in MjPrint and MjFormat

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -33,7 +33,7 @@ import org.eolang.printer.Xmir;
  * fixpoint, so the canonical form is the fixpoint of parse-and-print), and
  * compares that against what is on disk. In its default "check" mode, it
  * prints a colored unified {@link Diff} for every file that diverges from
- * the canonical form and fails the build. When {@link #autoFix} is turned
+ * the canonical form and fails the build. When {@link #autofix} is turned
  * on (via the {@code eo.autoFix} property), it overwrites the divergent
  * files with their canonical form instead of failing, much like
  * {@code gofmt -w} or {@code spotless:apply}.</p>
@@ -77,10 +77,14 @@ public final class MjFormat extends MjSafe {
     /**
      * Overwrite divergent sources with their canonical form instead of
      * failing the build.
-     * @checkstyle MemberNameCheck (10 lines)
      */
-    @Parameter(property = "eo.autoFix", required = true, defaultValue = "false")
-    private boolean autoFix;
+    @Parameter(
+        alias = "autoFix",
+        property = "eo.autoFix",
+        required = true,
+        defaultValue = "false"
+    )
+    private boolean autofix;
 
     /**
      * Points charged for each level of indentation on a line.
@@ -144,7 +148,7 @@ public final class MjFormat extends MjSafe {
             diverged = 0;
         } else {
             diverged = 1;
-            if (this.autoFix) {
+            if (this.autofix) {
                 new Saved(canonical, source).value();
                 Logger.info(this, "Reformatted %[file]s", source);
             } else {
@@ -387,7 +391,7 @@ public final class MjFormat extends MjSafe {
                 "All %d EO source(s) are formatted canonically, took %[ms]s to check",
                 total, millis
             );
-        } else if (this.autoFix) {
+        } else if (this.autofix) {
             Logger.info(
                 this,
                 "Reformatted %d of %d EO source(s), took %[ms]s",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
@@ -27,8 +27,8 @@ import org.eolang.printer.Xmir;
  * <p>This goal goes through all XMIR sources found in the specified directory,
  * converts them back to EO format, and saves the resulting EO files
  * in the specified output directory, preserving the original directory structure.
- * Input XMIR files are found in {@link #printSourcesDir},
- * output EO files are saved in {@link #printOutputDir}.</p>
+ * Input XMIR files are found in {@link #sources},
+ * output EO files are saved in {@link #output}.</p>
  *
  * @since 0.33.0
  */
@@ -46,25 +46,25 @@ public final class MjPrint extends MjSafe {
 
     /**
      * Directory with XMIR sources to print.
-     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter(
+        alias = "printSourcesDir",
         property = "eo.printSourcesDir",
         required = true,
         defaultValue = "${project.basedir}/src/main/xmir"
     )
-    private File printSourcesDir;
+    private File sources;
 
     /**
      * Directory where printed EO files are placed.
-     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter(
+        alias = "printOutputDir",
         property = "eo.printOutputDir",
         required = true,
         defaultValue = "${project.build.directory}/generated-sources/eo"
     )
-    private File printOutputDir;
+    private File output;
 
     /**
      * Points charged for each level of indentation on a line.
@@ -103,7 +103,7 @@ public final class MjPrint extends MjSafe {
     @Override
     void exec() throws IOException {
         final int total = new Threaded<>(
-            new WkDefault(this.printSourcesDir.toPath()).includes(Set.of("**.xmir")),
+            new WkDefault(this.sources.toPath()).includes(Set.of("**.xmir")),
             this::print
         ).total();
         if (total == 0) {
@@ -120,10 +120,10 @@ public final class MjPrint extends MjSafe {
      * @throws Exception If fails
      */
     private int print(final Path source) throws Exception {
-        final Path home = this.printOutputDir.toPath();
+        final Path home = this.output.toPath();
         final Path relative = Paths.get(
             MjPrint.XMIR.matcher(
-                this.printSourcesDir.toPath().relativize(source).toString()
+                this.sources.toPath().relativize(source).toString()
             ).replaceFirst(".eo")
         );
         new Saved(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -75,7 +75,7 @@ final class MjFormatTest {
             "the divergent source must be rewritten into its canonical form",
             new TextOf(
                 new FakeMaven(temp)
-                    .with("autoFix", true)
+                    .with("autofix", true)
                     .withProgram(MjFormatTest.divergent(new HelloWorld().asString()))
                     .execute(MjFormat.class)
                     .result()
@@ -90,7 +90,7 @@ final class MjFormatTest {
         final int total = 24;
         final String canonical = MjFormatTest.canonical(new HelloWorld().asString());
         final String divergent = MjFormatTest.divergent(new HelloWorld().asString());
-        final FakeMaven maven = new FakeMaven(temp).with("autoFix", true);
+        final FakeMaven maven = new FakeMaven(temp).with("autofix", true);
         for (int idx = 0; idx < total; ++idx) {
             maven.withProgram(divergent);
         }
@@ -169,7 +169,7 @@ final class MjFormatTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)
-                .with("autoFix", true)
+                .with("autofix", true)
                 .withProgram(MjFormatTest.droppedBinding())
                 .execute(MjFormat.class),
             "a source the parser only recovered by dropping a binding must not be rewritten"
@@ -181,7 +181,7 @@ final class MjFormatTest {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new FakeMaven(temp)
-                .with("autoFix", true)
+                .with("autofix", true)
                 .withProgram(MjFormatTest.placeholder())
                 .execute(MjFormat.class),
             "a source the parser only recovered with a placeholder must not be rewritten"

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -54,8 +54,8 @@ final class MjPrintTest {
         }
         final Path output = temp.resolve("output");
         new FakeMaven(temp)
-            .with("printSourcesDir", temp.resolve(resources).toFile())
-            .with("printOutputDir", output.toFile())
+            .with("sources", temp.resolve(resources).toFile())
+            .with("output", output.toFile())
             .execute(new PpPrint())
             .result();
         for (final Path source : walk) {
@@ -92,8 +92,8 @@ final class MjPrintTest {
         ).value();
         final Path output = temp.resolve("eo");
         new FakeMaven(temp)
-            .with("printSourcesDir", temp.resolve("xmir").toFile())
-            .with("printOutputDir", output.toFile())
+            .with("sources", temp.resolve("xmir").toFile())
+            .with("output", output.toFile())
             .execute(new PpPrint())
             .result();
         MatcherAssert.assertThat(
@@ -123,8 +123,8 @@ final class MjPrintTest {
         new Saved(new InputOf("not xml at all"), temp.resolve("xmir/README.md")).value();
         final Path output = temp.resolve("eo");
         new FakeMaven(temp)
-            .with("printSourcesDir", temp.resolve("xmir").toFile())
-            .with("printOutputDir", output.toFile())
+            .with("sources", temp.resolve("xmir").toFile())
+            .with("output", output.toFile())
             .execute(new PpPrint())
             .result();
         MatcherAssert.assertThat(
@@ -163,8 +163,8 @@ final class MjPrintTest {
             temp.resolve("xmir/foo/x/main.xmir")
         ).value();
         final FakeMaven maven = new FakeMaven(temp)
-            .with("printSourcesDir", temp.resolve("xmir").toFile())
-            .with("printOutputDir", temp.resolve("eo").toFile())
+            .with("sources", temp.resolve("xmir").toFile())
+            .with("output", temp.resolve("eo").toFile())
             .with("printReversed", reversed);
         final Object pins = xtory.map().get("penalties");
         if (pins != null) {


### PR DESCRIPTION
Part of #7061, after #7085. Three of the 48 suppressions, in `MjPrint` and `MjFormat`.

| file | field | now | XML element | `-D` property |
| --- | --- | --- | --- | --- |
| `MjPrint` | `printSourcesDir` | `sources` | `<printSourcesDir>` | `eo.printSourcesDir` |
| `MjPrint` | `printOutputDir` | `output` | `<printOutputDir>` | `eo.printOutputDir` |
| `MjFormat` | `autoFix` | `autofix` | `<autoFix>` | `eo.autoFix` |

`alias` carries the old name, so `-Deo.autoFix` and a `<printOutputDir>` element keep working exactly as before, the same way `MjSafe` already does it for `trackTransformationSteps`.

`MjPrintTest` and `MjFormatTest` address the fields by name through `FakeMaven.with()`, so their literals move too.

The other six suppressions in these two files sit on `penaltyIndent`, `penaltyBracket` and `penaltyExcess`, which `MjPrint` and `MjFormat` declare identically and read back through an identical `weights()` method. Renaming that block in both at once makes SonarCloud count it as duplicated new code (20.7% against a 3% gate), so it comes in its own PR that removes the duplication first.

Note: `MjPrintTest.printsXmirToEo` fails on my machine on master as well, because it reads a pack directory out of `eo-printer/src/test/resources` that is not on my local classpath. Not related to this change.
