### PR TITLE
fix(#7061): one-word parameter names in MjTranspile

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -49,17 +49,23 @@ public final class MjTranspile extends MjSafe {
 
     /**
      * Add to source root.
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.addSourcesRoot", defaultValue = "true")
-    private boolean addSourcesRoot;
+    @Parameter(
+        alias = "addSourcesRoot",
+        property = "eo.addSourcesRoot",
+        defaultValue = "true"
+    )
+    private boolean attach;
 
     /**
      * Whether to transpile tests.
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.transpileTests", defaultValue = "true")
-    private boolean transpileTests;
+    @Parameter(
+        alias = "transpileTests",
+        property = "eo.transpileTests",
+        defaultValue = "true"
+    )
+    private boolean tests;
 
     /**
      * Whether to wrap every dispatched object with a location-carrying
@@ -67,10 +73,9 @@ public final class MjTranspile extends MjSafe {
      * Off by default, so a production build stays lean; turn it on (as
      * {@code eo-runtime} does for its tests) to keep precise {@code .eo}
      * locations in panics.
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.trackLocations")
-    private boolean trackLocations;
+    @Parameter(alias = "trackLocations", property = "eo.trackLocations")
+    private boolean located;
 
     /**
      * Whether to wrap every located object in the generated Java into
@@ -89,10 +94,9 @@ public final class MjTranspile extends MjSafe {
      * the covered percentage of dataized {@code .eo} objects drops below
      * a threshold, mirroring how the {@code jacoco} profile binds a
      * {@code check} goal with its own per-metric thresholds.
-     * @checkstyle MemberNameCheck (7 lines)
      */
-    @Parameter(property = "eo.coverageTracking")
-    private boolean coverageTracking;
+    @Parameter(alias = "coverageTracking", property = "eo.coverageTracking")
+    private boolean coverage;
 
     /**
      * The class that a generated class extends instead of {@code PhDefault},
@@ -146,12 +150,12 @@ public final class MjTranspile extends MjSafe {
                     this.cache.toPath(),
                     this.cacheEnabled,
                     this.plugin.getVersion(),
-                    this.transpileTests,
+                    this.tests,
                     this.roots(),
                     new Transpilation(
                         this.plugin.getVersion(),
-                        new Tracking(this.trackSteps, this.trackLocations),
-                        this.coverageTracking,
+                        new Tracking(this.trackSteps, this.located),
+                        this.coverage,
                         this.base(),
                         this.xslMeasures.toPath(),
                         this.targetDir.toPath()
@@ -160,7 +164,7 @@ public final class MjTranspile extends MjSafe {
                 )
             ).exec();
         }
-        if (this.addSourcesRoot) {
+        if (this.attach) {
             this.project.addCompileSourceRoot(
                 this.generatedDir.toPath().toAbsolutePath().toString()
             );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -197,8 +197,8 @@ final class FakeMaven {
             this.params.putIfAbsent("offline", false);
             this.params.putIfAbsent("classesDir", this.classesPath().toFile());
             this.params.putIfAbsent("superclass", "PhDefault");
-            this.params.putIfAbsent("addSourcesRoot", true);
-            this.params.putIfAbsent("transpileTests", true);
+            this.params.putIfAbsent("attach", true);
+            this.params.putIfAbsent("tests", true);
             this.params.putIfAbsent("strictFileNames", true);
         }
         final Moja<T> moja = new Moja<>(mojo);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -117,7 +117,7 @@ final class MjTranspileTest {
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(MjTranspileTest.program())
-                    .with("coverageTracking", true)
+                    .with("coverage", true)
                     .execute(new PpTranspile())
                     .result()
                     .get(MjTranspileTest.compiled())
@@ -134,7 +134,7 @@ final class MjTranspileTest {
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(MjTranspileTest.throwing())
-                    .with("coverageTracking", true)
+                    .with("coverage", true)
                     .execute(new PpTranspile())
                     .result()
                     .get(MjTranspileTest.compiled())
@@ -151,7 +151,7 @@ final class MjTranspileTest {
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(MjTranspileTest.truthy())
-                    .with("coverageTracking", true)
+                    .with("coverage", true)
                     .execute(new PpTranspile())
                     .result()
                     .get(MjTranspileTest.compiled())
@@ -383,7 +383,7 @@ final class MjTranspileTest {
             new TextOf(
                 new FakeMaven(temp)
                     .withProgram(MjTranspileTest.dispatching())
-                    .with("trackLocations", true)
+                    .with("located", true)
                     .execute(new PpTranspile())
                     .result()
                     .get(MjTranspileTest.compiled())
@@ -406,7 +406,7 @@ final class MjTranspileTest {
                 new FakeMaven(temp.resolve("second"))
                     .withProgram(src)
                     .with("cache", cache.toFile())
-                    .with("trackLocations", true)
+                    .with("located", true)
                     .execute(new PpTranspile())
                     .result()
                     .get(MjTranspileTest.compiled())


### PR DESCRIPTION
Part of #7061, after #7085 and #7086. The last four suppressions outside `MjSafe`.

| field | now | XML element | `-D` property |
| --- | --- | --- | --- |
| `addSourcesRoot` | `attach` | `<addSourcesRoot>` | `eo.addSourcesRoot` |
| `transpileTests` | `tests` | `<transpileTests>` | `eo.transpileTests` |
| `trackLocations` | `located` | `<trackLocations>` | `eo.trackLocations` |
| `coverageTracking` | `coverage` | `<coverageTracking>` | `eo.coverageTracking` |

`eo-runtime/pom.xml:290-292` configures `<trackLocations>` and `<coverageTracking>` as XML elements and `eo-integration-tests/src/it/fibonacci/pom.xml:45` configures `<transpileTests>`; all three keep working through `alias`.

`FakeMaven` sets `attach` and `tests` as defaults now, and `MjTranspileTest` names `coverage` and `located` in its `.with()` calls. All 55 tests of `MjTranspileTest` pass.

This touches the same two lines of `FakeMaven` as #7085 does, so whichever lands second needs a rebase; I will do it.
