### PR TITLE
fix(#7089): restore the LooseCoupling suppressions on Walk

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
@@ -50,6 +50,7 @@ final class Walk extends ListEnvelope<Path> {
      * @param globs List of them
      * @return New Walk
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     Walk includes(final Collection<String> globs) {
         return new Walk(
             this.home,
@@ -67,6 +68,7 @@ final class Walk extends ListEnvelope<Path> {
      * @param globs List of them
      * @return New Walk
      */
+    @SuppressWarnings("PMD.LooseCoupling")
     Walk excludes(final Collection<String> globs) {
         return new Walk(
             this.home,


### PR DESCRIPTION
Fixes #7089.

f463cebf9b dropped both `@SuppressWarnings("PMD.LooseCoupling")` on the grounds that the parameter is already a `Collection<String>`. The rule fires on the return type instead: PMD names `Walk` and points at lines 53 and 70, the two method declarations. `qulice` has been red on master since, on every pull request regardless of what it touches.

Putting the two annotations back is all that is needed.
