### PR TITLE
fix(#7089): remove empty line before closing brace in Walk

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java
@@ -27,5 +27,4 @@ interface Walk extends List<Path> {
      * @return New Walk
      */
     Walk excludes(Collection<String> globs);
-
 }


### PR DESCRIPTION
Fixes #7089.

The interface introduced in `284f85fa` ends with an empty line before the closing brace, which `RegexpMultilineCheck` rejects — both the EC2 full build and the CI `qulice` job fail on master:

```
Checkstyle: eo-maven-plugin/src/main/java/org/eolang/maven/Walk.java[29]: Empty line before closing brace is not allowed (RegexpMultilineCheck)
```

Removed the empty line. `mvn -pl eo-maven-plugin -Pqulice -DskipTests verify` is green.