### PR TITLE
Keep a folded value in the scope it was written in

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Xmir.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Xmir.java
@@ -33,6 +33,17 @@ import org.xml.sax.SAXParseException;
  *
  * @see <a href="https://xml.jcabi.com">xml.jcabi.com</a>
  * @since 0.35.0
+ * @todo #7095:60min Re-base every value the print train relocates. A binding
+ *  folded onto a reference deeper than itself is read again in a scope that
+ *  is not the one it was written in, so its names have to climb the
+ *  difference. Only the based-handle fold in {@code inline-cactoos.xsl} does
+ *  that today; the four other branches of the template it lives in, and the
+ *  three merges in {@code merge-monikers.xsl}, relocate values the same way
+ *  and need the same pass. Each wants a pack of its own before it is wired,
+ *  since the shapes differ: an applied reference keeps its own children, a
+ *  pipe keeps the formation in place. The {@code dropped} mode and its two
+ *  functions should move somewhere both sheets can import rather than being
+ *  copied into the second one.
  */
 public final class Xmir implements XML {
 

--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -268,8 +268,13 @@
               <xsl:if test="@name and not($keep-name)">
                 <xsl:apply-templates select="@name"/>
               </xsl:if>
-              <xsl:apply-templates select="$value/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
-              <xsl:apply-templates select="$value/node()"/>
+              <xsl:variable name="folded" as="node()*">
+                <xsl:apply-templates select="$value/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
+                <xsl:apply-templates select="$value/node()"/>
+              </xsl:variable>
+              <xsl:apply-templates select="$folded" mode="dropped">
+                <xsl:with-param name="drop" select="eo:host-drop($target, .)" tunnel="yes"/>
+              </xsl:apply-templates>
               <!--
               The reference is the base of an application (`b 42 &gt; x` over a
               based `a.plus &gt;&gt; b` handle), so it carries its own argument
@@ -539,6 +544,74 @@
     <xsl:param name="name" as="xs:string"/>
     <xsl:sequence select="empty(eo:references($target, $name))"/>
   </xsl:function>
+  <!--
+  How many formations `$host` sits below `$bound`. A value folded onto a
+  reference deeper than the binding it came from is read again in a scope
+  that is not the one it was written in, so the names in it that reach out
+  of the value have to climb that difference (#7095).
+  -->
+  <xsl:function name="eo:host-drop" as="xs:integer">
+    <xsl:param name="bound" as="element()"/>
+    <xsl:param name="host" as="element()"/>
+    <xsl:sequence select="count($host/ancestor::o[eo:abstract(.)]) - count($bound/ancestor::o[eo:abstract(.)])"/>
+  </xsl:function>
+  <!--
+  The leading run of `ρ` segments, which is how far a base climbs before
+  it names anything.
+  -->
+  <xsl:function name="eo:rho-climb" as="xs:integer">
+    <xsl:param name="segments" as="xs:string*"/>
+    <xsl:sequence select="if (empty($segments) or $segments[1] != $eo:rho) then 0 else 1 + eo:rho-climb(subsequence($segments, 2))"/>
+  </xsl:function>
+  <!--
+  The base `$base` as it must read after the value carrying it dropped
+  `$drop` formations, from a node `$depth` formations inside that value.
+  A climb of `$depth` lands on the value's own root, so a climb that far
+  or further has left the value and gains `$drop` hops. A shorter climb
+  stays inside, and a base rooted anywhere but `ξ`, or naming nothing
+  past its climb, is left alone.
+  -->
+  <xsl:function name="eo:dropped-base" as="xs:string">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="drop" as="xs:integer"/>
+    <xsl:param name="depth" as="xs:integer"/>
+    <xsl:variable name="segments" select="tokenize($base, '\.')"/>
+    <xsl:variable name="climb" select="if ($segments[1] = $eo:xi) then eo:rho-climb(subsequence($segments, 2)) else -1"/>
+    <xsl:sequence select="if ($drop &lt;= 0 or $climb &lt; $depth or count($segments) &lt;= $climb + 1) then $base else string-join(($eo:xi, for $i in 1 to ($climb + $drop) return $eo:rho, subsequence($segments, $climb + 2)), '.')"/>
+  </xsl:function>
+  <!--
+  Rewrites the bases of a folded value, counting how deep inside it each
+  node sits so that a name reaching no further than the value itself is
+  left where it is.
+  @todo #7095:60min Only the based-handle fold below re-bases what it moves.
+   The four other branches of the template above, and the three merges in
+   merge-monikers.xsl, relocate a value the same way and need the same pass;
+   each wants a pack of its own before it is wired, since the shapes differ
+   (an applied reference keeps its own children, a pipe keeps the formation
+   in place). The helper will want to live somewhere both sheets can import
+   rather than being copied into the second one.
+  -->
+  <xsl:template match="o" mode="dropped">
+    <xsl:param name="drop" as="xs:integer" tunnel="yes"/>
+    <xsl:param name="depth" as="xs:integer" select="0"/>
+    <xsl:copy>
+      <xsl:copy-of select="@*[name() != 'base']"/>
+      <xsl:if test="@base">
+        <xsl:attribute name="base" select="eo:dropped-base(@base, $drop, $depth)"/>
+      </xsl:if>
+      <xsl:apply-templates select="node()" mode="dropped">
+        <xsl:with-param name="depth" select="if (eo:abstract(.)) then $depth + 1 else $depth"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*" mode="dropped">
+    <xsl:param name="depth" as="xs:integer" select="0"/>
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" mode="dropped">
+        <xsl:with-param name="depth" select="$depth"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
   <xsl:template match="node()|@*">
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -582,14 +582,8 @@
   <!--
   Rewrites the bases of a folded value, counting how deep inside it each
   node sits so that a name reaching no further than the value itself is
-  left where it is.
-  @todo #7095:60min Only the based-handle fold below re-bases what it moves.
-   The four other branches of the template above, and the three merges in
-   merge-monikers.xsl, relocate a value the same way and need the same pass;
-   each wants a pack of its own before it is wired, since the shapes differ
-   (an applied reference keeps its own children, a pipe keeps the formation
-   in place). The helper will want to live somewhere both sheets can import
-   rather than being copied into the second one.
+  left where it is. Only the based-handle fold uses it so far; see the
+  puzzle on `Xmir` for the branches still to come.
   -->
   <xsl:template match="o" mode="dropped">
     <xsl:param name="drop" as="xs:integer" tunnel="yes"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hosted-binding-keeps-its-scope.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/hosted-binding-keeps-its-scope.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A binding merged into its reference travels into a deeper scope, and the
+# names it reads must go on meaning what they meant where it was written.
+# Here `len` is `b.size` of the `b` that `array` declares, and the formation
+# hosting it declares a `b` of its own, so the merged value has to climb past
+# that one. Printed without the hop, `slice-byte 1` reads `1.size` instead of
+# the size of what `array` was given.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [b] > array
+    b.size >> len!
+    [b] >> slice-byte
+      b.plus len > @
+    slice-byte 1 > @
+
+printed: |
+  [b] > array
+    b.plus ^.b.size! > [b] >>
+    | 1 > @


### PR DESCRIPTION
Closes #7095.

`inline-cactoos.xsl` folds a `>> name` handle onto its reference, and the
reference can sit deeper than the binding did. The names inside the folded
value were carried over untouched, so they were read again in a scope that
was not the one they were written in:

```
[b] > array
  b.size >> len!
  [b] >> slice-byte
    b.plus len > @
  slice-byte 1 > @
```

`len` is the size of the `b` that `array` was given, and the only reference
to it lives in a formation with a `b` of its own. Printed, both `b`s bound
to the inner void, so `slice-byte 1` read `1.plus 1.size` where the source
said `1.plus array.b.size`. Reverse printing is meant to preserve meaning.

The fold now re-bases what it moves:

```xml
<xsl:apply-templates select="$folded" mode="dropped">
  <xsl:with-param name="drop" select="eo:host-drop($target, .)" tunnel="yes"/>
</xsl:apply-templates>
```

A name that climbs at least as far as its own depth inside the value has
left it, and gains one hop per formation the destination sits below the
source. Shorter climbs stay inside the value and are untouched, as is
anything rooted at `Φ`.

This is the based-handle fold only. The other four branches of that
template and the three merges in `merge-monikers.xsl` relocate values the
same way and need the same pass, each with a pack of its own since the
shapes differ — left as a `@todo`, since the helper should move somewhere
both sheets can import rather than be copied.

Found while making parent hops explicit for #7094, where the old printer
masked this: the missing hops were exactly the ones scope resolution puts
back when the text is read again.
