### PR TITLE
Write down the parent hops a name climbs

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -322,7 +322,6 @@
     the first segment past that run and "hop-rest" is that segment plus
     any trailing segments.
     -->
-    <xsl:variable name="rho-prefix" select="concat($eo:xi, '.', $eo:rho, '.')"/>
     <xsl:variable name="segments" select="tokenize(@base, '\.')"/>
     <xsl:variable name="rho-count" select="if ($segments[1] = $eo:xi) then eo:rho-run(subsequence($segments, 2)) else 0"/>
     <xsl:variable name="hop-name" select="if (count($segments) &gt; $rho-count + 1) then $segments[$rho-count + 2] else ''"/>
@@ -386,22 +385,6 @@
           through the otherwise branch, both of which resolve correctly.
           -->
           <xsl:value-of select="eo:translate-path($self-rest)"/>
-        </xsl:when>
-        <xsl:when test="starts-with(@base, $rho-prefix) and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and (every $i in 1 to $rho-count satisfies empty(ancestor::o[not(@base)][$i]/o[@name=$hop-name])) and (exists(ancestor::o[not(@base)][$rho-count + 1]/o[@name=$hop-name]) or ancestor::o[not(@base)][$rho-count]/@local = $hop-name)">
-          <!--
-          The run of leading "^." parent hops is redundant: the name is
-          absent from each of the N nearer enclosing formations but
-          present in the (N+1)-th, so plain scope resolution re-derives
-          exactly the very same ρ-chain of length N. Drop the whole run.
-          The second alternative catches a recursive self-reference to a
-          file-local handle hosted as a moniker (#5848): the formation reached
-          after the run carries that very handle name in its "@local", so the
-          hops resolve back to the formation itself and the bare handle name
-          re-derives the same ρ-chain. Without it a recursive `&gt;&gt; name`
-          handle folded into a reversed-dispatch receiver would print its
-          self-reference as `^.name` instead of the readable `name`.
-          -->
-          <xsl:value-of select="eo:translate-path($hop-rest)"/>
         </xsl:when>
         <xsl:when test="not(@local) and $segments[1] = $eo:xi and $rho-count = 0 and $hop-name != '' and $hop-name != $eo:rho and $hop-name != $eo:phi and $hop-name != $eo:xi and $hop-name != $eo:program and empty(ancestor::o[not(@base)][1]/o[@name=$hop-name]) and empty($local-handle)">
           <!--

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-only-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-nested-only-referenced-handle.yaml
@@ -24,4 +24,4 @@ origin: |
 
 printed: |
   [b] > array
-    index.lt b.size! > [index] >> slice-byte
+    index.lt ^.b.size! > [index] >> slice-byte

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-receiver-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/const-receiver-referenced-handle.yaml
@@ -38,7 +38,7 @@ printed: |
         oname.size.gt 6
         eq.
           slice.
-            name >> oname!
+            ^.name >> oname!
             0
             7
           "Windows"

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-applied-receiver.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-applied-receiver.yaml
@@ -22,5 +22,5 @@ origin: |
 printed: |
   [] > foo
     neg. > @
-      bar k > [k] >> bar
+      ^.bar k > [k] >> bar
       | 7

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-before.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-before.yaml
@@ -33,4 +33,4 @@ printed: |
   [] > foo
     read. > @
       [buffer] >> bar
-        bar chunk > x
+        ^.bar chunk > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-nested.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatch-recursive-self-nested.yaml
@@ -31,5 +31,5 @@ printed: |
   [] > foo
     read. > @
       [buffer] >> bar
-        bar chunk > x
+        ^.bar chunk > x
     @.test 66 > z

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/formation-sibling-referenced-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/formation-sibling-referenced-handle.yaml
@@ -28,4 +28,4 @@ printed: |
   [] > foo
     reclen 0 > @
     reclen n > [n] > inclen
-    inclen i > [i] >> reclen
+    ^.inclen i > [i] >> reclen

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-kept-on-shortened-base.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-kept-on-shortened-base.yaml
@@ -39,5 +39,5 @@ printed: |
     app?.a > c
     $.a?.bar > [] > inner
     [x] > outer
-      x?.y > [] > deep
+      ^.x?.y > [] > deep
     com.example.string > s

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/inheritance.yaml
@@ -42,9 +42,9 @@ printed: |
 
   [] > main
     [] > base
-      x.write v > [self v] > f
+      ^.x.write v > [self v] > f
       self.f self v > [self v] > g
       memory 0 > x
     [] > derived
-      base > @
+      ^.base > @
       self.g self v > [self v] > f

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/list-recursive-applied-dispatch-arg.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/list-recursive-applied-dispatch-arg.yaml
@@ -37,6 +37,6 @@ printed: |
         true
         seq *
           tup.head.deleted
-          r tup.tail
+          ^.r tup.tail
       | (walk "**").at.^
       ^

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/multi-hop-parent.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/multi-hop-parent.yaml
@@ -20,4 +20,4 @@ printed: |
 
   [x] > foo
     [] > bar
-      x > [] > baz
+      ^.^.x > [] > baz

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before-separated.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before-separated.yaml
@@ -38,6 +38,6 @@ printed: |
     a.b.c > f
     k.t > p
     [t] >> bar
-      bar 55 > ii
+      ^.bar 55 > ii
       test 78 > kk
     | > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-before.yaml
@@ -29,5 +29,5 @@ origin: |
 printed: |
   [] > foo
     [t] >> bar
-      bar 55 > ii
+      ^.bar 55 > ii
     | > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-between-handles.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self-between-handles.yaml
@@ -29,8 +29,8 @@ origin: |
 printed: |
   [] > foo
     [] >> bar
-      bbb bar > z
+      bbb ^.bar > z
     | > x
     [] >> zoo
-      kkk zoo > w
+      kkk ^.zoo > w
     | > y

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive-self.yaml
@@ -27,5 +27,5 @@ origin: |
 printed: |
   [] > foo
     [] >> bar
-      bbb bar > z
+      bbb ^.bar > z
     | > x

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-recursive.yaml
@@ -16,5 +16,5 @@ origin: |
     | list > @
 printed: |
   [] > app
-    rec t > [t] >> rec
+    ^.rec t > [t] >> rec
     | list > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-vertical-in-argument.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-vertical-in-argument.yaml
@@ -46,7 +46,7 @@ printed: |
       *
       stop.if > [accum current] >> rec-split
         accum
-        rec-split
+        ^.rec-split
           accum
           current.plus 1
       |

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-local-handle.yaml
@@ -51,7 +51,7 @@ printed: |
       tup.length.eq 0
       -1
       if.
-        tup.head.eq wanted
+        tup.head.eq ^.wanted
         tup.tail.length
-        reclast tup.tail
+        ^.reclast tup.tail
     | list > @

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/redundant-parent.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/redundant-parent.yaml
@@ -21,5 +21,5 @@ printed: |
   +package org.eolang
 
   [x] > foo
-    x > [] > bar
+    ^.x > [] > bar
     ^.x > [x] > baz

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute.yaml
@@ -26,4 +26,4 @@ printed: |
   [] > dataized /Q.bytes
     ? > x
 
-    x.eq x ++> tests-something
+    ^.x.eq ^.x ++> tests-something

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/throws-test-attribute.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/throws-test-attribute.yaml
@@ -26,4 +26,4 @@ printed: |
   [] > dataized /Q.bytes
     ? > x
 
-    x.eq x --> on-something
+    ^.x.eq ^.x --> on-something

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/void-local-handle.yaml
@@ -36,6 +36,6 @@ printed: |
       tup.length.eq 0
       -1
       if.
-        tup.head.eq wanted
+        tup.head.eq ^.wanted
         tup.tail.length
-        reclast tup.tail
+        ^.reclast tup.tail

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -15,13 +15,13 @@
   if > @
     01-
     00-
-  if > [x] > and
+  ^.if > [x] > and
     01-.eq x
     false
   if > not
     false
     true
-  if > [x] > or
+  ^.if > [x] > or
     true
     01-.eq x
 
@@ -81,7 +81,7 @@
 
   ++> can-extract-an-attribute-from-a-decoratee
     a.foo.eq 43 > @
-    return > [] > a
+    ^.return > [] > a
       42.plus 1
     [foo] > return
 
@@ -198,7 +198,7 @@
       42
     [x] > a
       take > @
-      x > [] > take
+      ^.x > [] > take
 
   --> stops-on-applying-to-a-closed-object
     closed true > @

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -10,7 +10,7 @@
   buf > @
   buffer > [str] > with
     string
-      buf.as-bytes.concat str.as-bytes
+      ^.buf.as-bytes.concat str.as-bytes
 
   eq. ++> can-build-a-simple-string
     with.

--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -15,9 +15,9 @@
     b >> data!
   if. > [tup index] >> slice-byte
     index.lt len
-    slice-byte
+    ^.slice-byte
       tup.with
-        b.slice index 1
+        ^.b.slice index 1
       as-number.
         index.plus 1
     tup

--- a/eo-runtime/src/main/eo/bytes/as-hex.eo
+++ b/eo-runtime/src/main/eo/bytes/as-hex.eo
@@ -18,9 +18,9 @@
       h.plus 55
   [index acc] >> rec-hex
     if. > @
-      index.eq b.size
+      index.eq ^.b.size
       acc
-      rec-hex
+      ^.rec-hex
         as-number.
           index.plus 1
         if.
@@ -31,7 +31,7 @@
             pair
     as-ascii. > bval
       string
-        b.slice index 1
+        ^.b.slice index 1
     concat. > pair
       hex-digit
         floor.

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -33,17 +33,17 @@
   [size] > read
     @. > @
       read.
-        input-block b --
+        input-block ^.b --
         size
     [data buffer] > input-block
       buffer > @
       [size] > read
         if. > @
           available.eq 0
-          input-block -- --
-          input-block
+          ^.^.input-block -- --
+          ^.^.input-block
             as-bytes.
-              data.slice
+              ^.data.slice
                 if. >> next!
                   gt.
                     number available
@@ -52,10 +52,10 @@
                   available
                 minus.
                   number
-                    data.size >> available!
+                    ^.data.size >> available!
                   number next
             as-bytes.
-              data.slice 0 next
+              ^.data.slice 0 next
 
   ++> can-make-an-input-from-bytes-and-read-it
     and. > @

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -17,7 +17,7 @@
     if. > @
       index.eq b.size!
       acc.as-number
-      rec-hash-code
+      ^.rec-hash-code
         plus.
           31.as-i64.times acc
           as-i64.

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -31,38 +31,38 @@
   get > @
   [source target length] > copy
     seq * > @
-      read source length >> data!
+      ^.read source length >> data!
       if.
         gt.
           target.plus length
-          size
+          ^.size
         write.
-          resized
+          ^.resized
             target.plus length
           target
           data
-        write target data
+        ^.write target data
   read > get
     0
     size
   if. > [object] > put
     and.
-      size.gt 0
-      object.size.gt size
+      ^.size.gt 0
+      object.size.gt ^.size
     T
       "Can't put %d bytes into a chunk sized %d bytes; call .resized first to grow it".printf
-        * object.size size
+        * object.size ^.size
     if.
-      size.eq 0
+      ^.size.eq 0
       seq *
         write.
-          resized object.size
+          ^.resized object.size
           0
           object
-        get
+        ^.get
       seq *
-        write 0 object
-        get
+        ^.write 0 object
+        ^.get
   [] > read /Q.bytes
     ? > offset /Q.number
     ? > length /Q.number

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -28,16 +28,16 @@
         seq * > [buffer] > write
           if.
             gt.
-              offset.plus buffer.size
-              allocated.size
+              ^.offset.plus buffer.size
+              ^.^.^.allocated.size
             write.
-              allocated.resized
-                offset.plus buffer.size
-              offset
+              ^.^.^.allocated.resized
+                ^.offset.plus buffer.size
+              ^.offset
               buffer
-            allocated.write offset buffer
-          output-block
-            offset.plus buffer.size
+            ^.^.^.allocated.write ^.offset buffer
+          ^.^.output-block
+            ^.offset.plus buffer.size
       | 0
       buffer
 

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -78,7 +78,7 @@
                       "Failed to read from standard input"
                     received.output
                   received
-                  input-block chunk
+                  ^.^.input-block chunk
                 called. > received
                   win32 *1
                     "_read"
@@ -97,7 +97,7 @@
                     code.eq -1
                     T
                       "Failed to write to standard output"
-                    output-block
+                    ^.^.output-block
                   code
                   remainder
                 code. > code
@@ -108,9 +108,9 @@
                     buffer.size
                 if. > remainder
                   code.lt buffer.size
-                  output-block.write
+                  ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
-                  output-block
+                  ^.^.output-block
             buffer
     [] >>
       [size] > read
@@ -126,7 +126,7 @@
                       "Failed to read from standard input"
                     received.output
                   received
-                  input-block chunk
+                  ^.^.input-block chunk
                 called. > received
                   posix *1
                     "read"
@@ -145,7 +145,7 @@
                     code.eq -1
                     T
                       "Failed to write to standard output"
-                    output-block
+                    ^.^.output-block
                   code
                   remainder
                 code. > code
@@ -156,9 +156,9 @@
                     buffer.size
                 if. > remainder
                   code.lt buffer.size
-                  output-block.write
+                  ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
-                  output-block
+                  ^.^.output-block
             buffer
 
   ++> can-chain-writes-across-output-blocks

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -51,8 +51,8 @@
             cached.as-bytes
             cached.as-bool
             m
-          m.put > [] > func
-            m.as-number.plus 1
+          ^.m.put > [] > func
+            ^.m.as-number.plus 1
       1
 
   ++> can-behave-as-a-const-when-dataized-as-bytes

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -24,15 +24,15 @@
         if.
           errno.eq
             os.is-windows.if win32.eexist posix.eexist
-          attempted
+          ^.attempted
             index.plus 1
           T
             "Can't create a unique file in %s, OS error %d".printf
-              * dir errno
+              * ^.dir errno
         seq *
-          closed descriptor
+          ^.closed descriptor
           path
-      opened path > descriptor!
+      ^.opened path > descriptor!
       code. > errno
         os.is-windows.if
           win32
@@ -41,17 +41,17 @@
           posix
             "errno"
             *
-      candidate index > path!
+      ^.candidate index > path!
     | 0 > @
     [index] > candidate
       path.separator.joined > @
-        * dir name
+        * ^.dir name
       "%d-%d-%d-%f".printf > name!
         *
-          time
-          process
+          ^.time
+          ^.process
           index
-          random
+          ^.random
     code. > [descriptor] > closed
       os.is-windows.if
         win32 *1
@@ -81,8 +81,8 @@
       Q.file touch.as-bytes
       T
         "Directory %s does not exist, can't create temporary file".printf
-          * file
-    retried > [] > touch
+          * ^.file
+    ^.^.retried > [] > touch
       ^.^.path
       clock.as-number
       code.
@@ -99,23 +99,23 @@
       [rest] >> stepped
         if. > @
           rest.length.eq 0
-          picked accum prefix
+          picked ^.accum ^.prefix
           if.
             and.
               entry.is-directory false
               not.
                 entry.is-symlink false
-            walked earlier sub child.as-dir
+            ^.^.walked earlier sub child.as-dir
             picked earlier sub
-        dir.as-path.resolved name > child
-        stepped rest.tail > earlier
+        ^.dir.as-path.resolved name > child
+        ^.stepped rest.tail > earlier
         child.as-file > entry
         rest.head > name
         if. > sub
-          prefix.length.eq 0
+          ^.prefix.length.eq 0
           name
           path.separator.joined
-            * prefix name
+            * ^.prefix name
       | dir.listed > @
     | > @
       *
@@ -159,22 +159,22 @@
         * "\\" char
       char
     if. > [from] >> closes
-      from.gte glob.length
+      from.gte ^.glob.length
       false
       if.
         eq.
-          glob.at
+          ^.glob.at
             from
             "" > [absent]
           "]"
         true
-        closes
+        ^.closes
           from.plus 1
     [index acc braced classed] >> translated
       if. > @
-        index.gte glob.length
+        index.gte ^.glob.length
         acc
-        translated
+        ^.translated
           index.plus advance
           "".joined
             * acc token
@@ -204,18 +204,18 @@
               char.eq ","
             "|"
             escaped char
-      glob.at index > char
+      ^.glob.at index > char
       classed.not.and > double
         and.
           char.eq "*"
           eq.
-            glob.at
+            ^.glob.at
               index.plus 1
               "" > [message]
             "*"
       opening.and > negated
         eq.
-          glob.at
+          ^.glob.at
             index.plus 1
             "" > [missing]
           "!"

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -16,7 +16,7 @@
         true
         seq *
           tup.head.deleted
-          r tup.tail
+          ^.r tup.tail
       | (d.walk "**").at.^
       d
     d

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -16,14 +16,14 @@
         os.is-windows.if
           win32 *1
             "_access"
-            path
+            ^.path
             0
           posix *1
             "access"
-            path
+            ^.path
             0
       0
-    is-symlink false
+    ^.is-symlink false
   [cant-check] > is-directory
     if. > @
       info.code.eq 0
@@ -36,10 +36,10 @@
       os.is-windows.if
         win32 *1
           "_stat64"
-          path
+          ^.path
         posix *1
           "stat"
-          path
+          ^.path
   [cant-check] > is-symlink
     os.is-windows.if > @
       if.
@@ -59,17 +59,17 @@
     code. > attributes
       win32 *1
         "GetFileAttributesW"
-        path
+        ^.path
     called. > info
       posix *1
         "lstat"
-        path
+        ^.path
   [mode scope cant-open] > open
     known.not.if > @
       T
         "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
-        existing.and exists.not
+        existing.and ^.exists.not
         cant-open
           "File must exist for given access mod: '%s'".printf
             *
@@ -109,13 +109,13 @@
       [syscall] > open-through
         if. > @
           descriptor.eq -1
-          cant-open
+          ^.^.cant-open
             "Couldn't open file '%s': %s".printf
-              * path opened.output
+              * ^.^.^.path opened.output
           if.
             recovered
               seq *
-                scope
+                ^.^.scope
                   stream descriptor
                 true
               false
@@ -128,16 +128,16 @@
               code.
                 syscall.close
                   * descriptor
-              cant-open
+              ^.^.cant-open
                 "The scope given to '%s'.open() failed; the descriptor was closed before propagating the failure".printf
-                  * path
-        appending.if syscall.append 0 > append
-        existing.not.if syscall.creat 0 > creat
+                  * ^.^.^.path
+        ^.^.appending.if syscall.append 0 > append
+        ^.^.existing.not.if syscall.creat 0 > creat
         opened.code > descriptor
         if. > direction
-          readable.and writable
+          ^.^.readable.and ^.^.writable
           syscall.rdwr
-          writable.if syscall.wronly syscall.rdonly
+          ^.^.writable.if syscall.wronly syscall.rdonly
         plus. > flags
           plus.
             direction.plus creat
@@ -145,7 +145,7 @@
           append
         called. > opened
           syscall.open
-            * path flags syscall.mode
+            * ^.^.^.path flags syscall.mode
         [descriptor] > stream
           [size] > read
             read. > @
@@ -154,7 +154,7 @@
             [buffer] > input-block
               buffer > @
               [size] > read
-                readable.not.if > @
+                ^.^.^.^.^.^.readable.not.if > @
                   T
                     "Can't read from file with provided access mode '%s'".printf
                       * access
@@ -165,16 +165,16 @@
                         "Failed to read from file"
                       received.output
                     received
-                    input-block chunk
+                    ^.^.input-block chunk
                 called. > received
-                  syscall.read
-                    * descriptor size
+                  ^.^.^.^.syscall.read
+                    * ^.^.^.descriptor size
           [buffer] > write
             output-block.write buffer > @
             [] > output-block
               true > @
               [buffer] > write
-                writable.not.if > @
+                ^.^.^.^.^.^.writable.not.if > @
                   T
                     "Can't write to file with provided access mode '%s'".printf
                       * access
@@ -183,18 +183,18 @@
                       code.eq -1
                       T
                         "Failed to write to file"
-                      output-block
+                      ^.^.output-block
                     code
                     remainder
                 code. > code
-                  syscall.write
-                    * descriptor buffer buffer.size
+                  ^.^.^.^.syscall.write
+                    * ^.^.^.descriptor buffer buffer.size
                 if. > remainder
                   code.lt buffer.size
-                  output-block.write
+                  ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
-                  output-block
-        truncate.if syscall.trunc 0 > trunc
+                  ^.^.output-block
+        ^.^.truncate.if syscall.trunc 0 > trunc
     and. > readable
       not.
         as-bool.
@@ -232,11 +232,11 @@
       true
       seq *
         recovered
-          tmp.open
+          ^.tmp.open
             "r"
             T "boom" > [f]
           true
-        drain
+        ^.drain
           n.minus 1
     mktemp.tmpfile > tmp
 
@@ -281,7 +281,7 @@
                 "w"
                 f.write "Hello, world" > [f]
               "r"
-              m.put > [f] >>
+              ^.m.put > [f] >>
                 f.read 12
             m
       "Hello, world"
@@ -297,7 +297,7 @@
                 "w"
                 f.write "Hello, world" > [f]
               "r"
-              m.put > [f] >>
+              ^.m.put > [f] >>
                 read.
                   f.read 7
                   5
@@ -316,9 +316,9 @@
           [m] >>
             seq * > @
               open.
-                file source
+                file ^.source
                 "r"
-                m.put > [f] >>
+                ^.m.put > [f] >>
                   f.read 13
               m
     temp.path > source
@@ -451,9 +451,9 @@
           [m] >>
             seq * > @
               open.
-                file source
+                file ^.source
                 "r"
-                m.put > [f] >>
+                ^.m.put > [f] >>
                   f.read 14
               m
         "Shrek is love!"

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -14,11 +14,11 @@
       concat.
         if. >>
           eq.
-            as-bytes.and 80-00
+            ^.as-bytes.and 80-00
             00-00
           00-00
           FF-FF
-        as-bytes
+        ^.as-bytes
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
   [x cant-divide] > div
@@ -28,7 +28,7 @@
         00-00
       cant-divide
         "Can't divide %d by i16 zero".printf
-          * as-i32.as-i64.as-number
+          * ^.as-i32.as-i64.as-number
       if.
         or.
           eq.
@@ -38,7 +38,7 @@
         i16
           slice.
             as-bytes. >> b
-              as-i32.div other.as-i32
+              ^.as-i32.div other.as-i32
             2
             2
         plus.
@@ -46,11 +46,11 @@
             b.slice 0 2
           i16
             b.slice 2 2
-  as-i32.gt x.as-i16.as-i32 > [x] > gt
-  as-i32.gte x.as-i16.as-i32 > [x] > gte
-  as-i32.lt x.as-i16.as-i32 > [x] > lt
-  as-i32.lte x.as-i16.as-i32 > [x] > lte
-  plus x.as-i16.neg > [x] > minus
+  ^.as-i32.gt x.as-i16.as-i32 > [x] > gt
+  ^.as-i32.gte x.as-i16.as-i32 > [x] > gte
+  ^.as-i32.lt x.as-i16.as-i32 > [x] > lt
+  ^.as-i32.lte x.as-i16.as-i32 > [x] > lte
+  ^.plus x.as-i16.neg > [x] > minus
   times -1.as-i64.as-i32.as-i16 > neg
   [x] > plus
     if. > @
@@ -62,7 +62,7 @@
       i16
         slice.
           as-bytes. >> b
-            as-i32.plus x.as-i16.as-i32
+            ^.as-i32.plus x.as-i16.as-i32
           2
           2
       plus.
@@ -73,7 +73,7 @@
   i16 > [x] > times
     slice.
       as-bytes.
-        as-i32.times x.as-i16.as-i32
+        ^.as-i32.times x.as-i16.as-i32
       2
       2
 

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -15,19 +15,19 @@
       left
       cant-convert
         "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
-          * as-i64.as-number
+          * ^.as-i64.as-number
     i16 > left
-      as-bytes.slice 2 2
+      ^.as-bytes.slice 2 2
   [] > as-i64
     i64 > @
       concat.
         if. >>
           eq.
-            as-bytes.and 80-00-00-00
+            ^.as-bytes.and 80-00-00-00
             00-00-00-00
           00-00-00-00
           FF-FF-FF-FF
-        as-bytes
+        ^.as-bytes
   as-i64.as-number > as-number
   [x cant-divide] > div
     if. > @
@@ -36,7 +36,7 @@
         00-00-00-00
       cant-divide
         "Can't divide %d by i32 zero".printf
-          * as-i64.as-number
+          * ^.as-i64.as-number
       if.
         or.
           eq.
@@ -46,7 +46,7 @@
         i32
           slice.
             as-bytes. >> b
-              as-i64.div other.as-i64
+              ^.as-i64.div other.as-i64
             4
             4
         plus.
@@ -54,11 +54,11 @@
             b.slice 0 4
           i32
             b.slice 4 4
-  as-i64.gt x.as-i32.as-i64 > [x] > gt
-  as-i64.gte x.as-i32.as-i64 > [x] > gte
-  as-i64.lt x.as-i32.as-i64 > [x] > lt
-  as-i64.lte x.as-i32.as-i64 > [x] > lte
-  plus x.as-i32.neg > [x] > minus
+  ^.as-i64.gt x.as-i32.as-i64 > [x] > gt
+  ^.as-i64.gte x.as-i32.as-i64 > [x] > gte
+  ^.as-i64.lt x.as-i32.as-i64 > [x] > lt
+  ^.as-i64.lte x.as-i32.as-i64 > [x] > lte
+  ^.plus x.as-i32.neg > [x] > minus
   times -1.as-i64.as-i32 > neg
   [x] > plus
     if. > @
@@ -70,7 +70,7 @@
       i32
         slice.
           as-bytes. >> b
-            as-i64.plus x.as-i32.as-i64
+            ^.as-i64.plus x.as-i32.as-i64
           4
           4
       plus.
@@ -81,7 +81,7 @@
   i32 > [x] > times
     slice.
       as-bytes.
-        as-i64.times x.as-i32.as-i64
+        ^.as-i64.times x.as-i32.as-i64
       4
       4
 

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -15,16 +15,16 @@
       ^.eq
         as-i64.
           i32 >> left
-            as-bytes.slice 4 4
+            ^.as-bytes.slice 4 4
       left
       cant-convert
         "Can't convert i64 number %d to i32 because it's out of i32 bounds".printf
-          * as-number
+          * ^.as-number
     i32 > left
-      as-bytes.slice 4 4
+      ^.as-bytes.slice 4 4
   [] > as-number
     if. > @
-      as-bytes.eq 00-00-00-00-00-00-00-00
+      ^.as-bytes.eq 00-00-00-00-00-00-00-00
       0
       number
         sign.or
@@ -55,9 +55,9 @@
       sign.eq 80-00-00-00-00-00-00-00
       as-bytes.
         plus.
-          i64 as-bytes.not
+          i64 ^.as-bytes.not
           i64 00-00-00-00-00-00-00-01
-      as-bytes
+      ^.as-bytes
     if. > mantissa
       highest.lte 52
       and.
@@ -80,7 +80,7 @@
       if. > @
         step.lt 1
         acc
-        scan
+        ^.scan
           empty.if m shifted
           empty.if
             acc
@@ -94,7 +94,7 @@
       43-30-00-00-00-00-00-00
       32
       00-00-00-00-00-00-00-20
-    as-bytes.and 80-00-00-00-00-00-00-00 > sign!
+    ^.as-bytes.and 80-00-00-00-00-00-00-00 > sign!
     not. > sticky
       eq.
         magnitude.left
@@ -104,21 +104,21 @@
     if. > @
       not.
         eq.
-          as-bytes.and 80-00-00-00-00-00-00-00 >> sign
+          ^.as-bytes.and 80-00-00-00-00-00-00-00 >> sign
           x.as-bytes.and 80-00-00-00-00-00-00-00
       sign.eq 00-00-00-00-00-00-00-00
       and.
         eq.
           and.
             as-bytes.
-              minus x >> difference
+              ^.minus x >> difference
             80-00-00-00-00-00-00-00
           00-00-00-00-00-00-00-00
         not.
           difference.as-bytes.eq 00-00-00-00-00-00-00-00
   [x] > gte
     or. > @
-      gt
+      ^.gt
         x >> value!
       ^.eq value
   gt. > [x] > lt
@@ -126,28 +126,28 @@
     ^
   [x] > lte
     or. > @
-      lt
+      ^.lt
         x >> value!
       ^.eq value
-  plus (i64 x!).neg > [x] > minus
+  ^.plus (i64 x!).neg > [x] > minus
   times -1.as-i64 > neg
   [x] > plus
     if. > [a b] >> carried
       b.eq 00-00-00-00-00-00-00-00
       i64 a
-      carried
+      ^.carried
         a.xor b
         left.
           a.and b
           1
     | > @
-      as-bytes
+      ^.as-bytes
       x.as-bytes
   [x] > times
     if. > [acc a b] > looped
       b.eq 00-00-00-00-00-00-00-00
       i64 acc
-      looped
+      ^.looped
         if.
           eq.
             b.and 00-00-00-00-00-00-00-01
@@ -161,7 +161,7 @@
         b.right 1
     | > @
       00-00-00-00-00-00-00-00
-      as-bytes
+      ^.as-bytes
       x.as-bytes
 
   eq. ++> can-add-mixed-signs

--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -43,7 +43,7 @@
               shifted-sign.xor divisor-sign >> signs-differ!
               next-rem.xor 80-00-00-00-00-00-00-00 >> trial-nonnegative!
           80-00-00-00-00-00-00-00
-        looped
+        ^.looped
           index.minus 1
           as-bytes. >> next-rem!
             plus.
@@ -51,13 +51,13 @@
               i64 subtrahend
           quot.or >>!
             bit index
-        looped
+        ^.looped
           index.minus 1
           or. >> shifted!
             remainder.left 1
             and.
               right.
-                magnitude n.as-bytes
+                magnitude ^.n.as-bytes
                 index
               00-00-00-00-00-00-00-01
           quot

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -15,11 +15,11 @@
       concat.
         if. >>
           eq.
-            as-bytes.and 80-
+            ^.as-bytes.and 80-
             00-
           00-
           FF-
-        as-bytes
+        ^.as-bytes
   as-i16.as-number > as-number
   [x cant-divide] > div
     if. > @
@@ -28,34 +28,34 @@
         00-
       cant-divide
         "Can't divide %d by i8 zero".printf
-          * as-number
+          * ^.as-number
       i8
         slice.
           as-bytes.
-            as-i16.div other.as-i16
+            ^.as-i16.div other.as-i16
           1
           1
-  as-i16.gt x.as-i8.as-i16 > [x] > gt
-  as-i16.gte x.as-i8.as-i16 > [x] > gte
-  as-i16.lt x.as-i8.as-i16 > [x] > lt
-  as-i16.lte x.as-i8.as-i16 > [x] > lte
+  ^.as-i16.gt x.as-i8.as-i16 > [x] > gt
+  ^.as-i16.gte x.as-i8.as-i16 > [x] > gte
+  ^.as-i16.lt x.as-i8.as-i16 > [x] > lt
+  ^.as-i16.lte x.as-i8.as-i16 > [x] > lte
   i8 > [x] > minus
     slice.
       as-bytes.
-        as-i16.minus x.as-i8.as-i16
+        ^.as-i16.minus x.as-i8.as-i16
       1
       1
   times FF-.as-i8 > neg
   i8 > [x] > plus
     slice.
       as-bytes.
-        as-i16.plus x.as-i8.as-i16
+        ^.as-i16.plus x.as-i8.as-i16
       1
       1
   i8 > [x] > times
     slice.
       as-bytes.
-        as-i16.times x.as-i8.as-i16
+        ^.as-i16.times x.as-i8.as-i16
       1
       1
 

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -19,7 +19,7 @@
   malloc.of > @
     0
     seq * > [m] >>
-      origin.copied m.to-output
+      ^.origin.copied m.to-output
       m
   ^ > origin
 

--- a/eo-runtime/src/main/eo/input/dead.eo
+++ b/eo-runtime/src/main/eo/input/dead.eo
@@ -14,7 +14,7 @@
   [size] > read
     [] >> input-block
       -- > @
-      input-block > [size] > read
+      ^.^.input-block > [size] > read
     | > @
 
   eq. ++> can-be-taken-off-any-input

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -13,7 +13,7 @@
     if. > @
       chunk.size.eq 0
       length
-      rec-read
+      ^.rec-read
         chunk
         length.plus chunk.size
     ^. > chunk

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -27,8 +27,8 @@
   [size] > read
     read. > @
       input-block
-        origin
-        output
+        ^.origin
+        ^.output
         --
       size
     [input output buffer] > input-block
@@ -36,9 +36,9 @@
       [size] > read
         seq * > @
           written
-          input-block chunk written chunk.as-bytes
-        ^. (input.read size).read > chunk
-        ^. (output.write chunk).write > written
+          ^.^.input-block chunk written chunk.as-bytes
+        ^. (^.input.read size).read > chunk
+        ^. (^.output.write chunk).write > written
 
   eq. ++> can-read-from-bytes-and-write-to-memory
     malloc.of
@@ -77,8 +77,8 @@
               read.
                 tee.
                   input ((input 01-02-03-04-05.as-input).tee m2.to-output)
-                  m1.to-output
+                  ^.m1.to-output
                 5
-              m1.write 5 2A-
-              m1
+              ^.m1.write 5 2A-
+              ^.m1
       01-02-03-04-05-2A

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -70,7 +70,7 @@
         object >> bts!
       seq * > [m] >>
         m.write 0 bts
-        scope m
+        ^.scope m
   [] > of /Q.bytes
     ? > size /Q.number
     ? > scope /{Q.chunk}
@@ -81,7 +81,7 @@
       [b]
         malloc.of > @
           10
-          b.put > [m] >>
+          ^.b.put > [m] >>
             m.size.eq 10
 
   malloc.empty ++> can-allocate-an-empty-block
@@ -102,8 +102,8 @@
         a.neg.neg.neg.neg.eq 42
         m
       seq * > [] > a
-        m.put
-          m.as-number.plus 1
+        ^.m.put
+          ^.m.as-number.plus 1
         42
 
   ++> can-concat-strings-with-an-offset
@@ -115,7 +115,7 @@
           seq * > [m] >>
             m.write 0 "XXX"
             m.write 1 "Y"
-            b.put
+            ^.b.put
               eq.
                 m.read 0 3
                 "XYX"
@@ -156,8 +156,8 @@
             * second second
           malloc.of > second
             1
-            f.put > [s] >>
-              f.as-number.plus 1
+            ^.f.put > [s] >>
+              ^.f.as-number.plus 1
 
   ++> can-decrease-the-block-size
     malloc.of > @
@@ -165,7 +165,7 @@
       [b]
         malloc.for > @
           01-02-03-04-05
-          b.put > [m] >>
+          ^.b.put > [m] >>
             and.
               eq. (m.resized 3).size 3
               m.get.eq 01-02-03
@@ -177,7 +177,7 @@
         [m] >>
           m.put > @
             num.times num
-          number (inc m)! > num
+          number (^.inc m)! > num
       64
     seq * > [x] > inc
       x.put
@@ -200,7 +200,7 @@
       [b]
         malloc.for > @
           01-02-03-04
-          b.put > [m] >>
+          ^.b.put > [m] >>
             and.
               eq. (m.resized 6).size 6
               m.get.eq 01-02-03-04-00-00
@@ -252,7 +252,7 @@
           10
           seq * > [m] >>
             m.write 2 "Hello"
-            b.put
+            ^.b.put
               eq.
                 m.read 2 5
                 "Hello"
@@ -277,7 +277,7 @@
       seq *
         n.put
           n.as-number.minus 1
-        func n
+        ^.func n
       n
 
   eq. ++> can-return-the-size-from-a-scope
@@ -306,7 +306,7 @@
               0
               "Hello, "
             m.write 7 "Jeff!"
-            b.put
+            ^.b.put
               eq.
                 m.read 0 12
                 "Hello, Jeff!"

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -29,8 +29,8 @@
               [] >>
                 ^.hash > hash
                 ^.kbts > kbts
-                tup.head.key > key
-                tup.head.value > value
+                ^.tup.head.key > key
+                ^.tup.head.value > value
           hash. >> hash!
             tup.head.key.as-bytes >> kbts!
           prev.filtered > others
@@ -39,17 +39,17 @@
                 ent.hash.eq hash
                 ent.kbts.eq kbts
           @. > prev
-            rec-rebuild tup.tail
+            ^.rec-rebuild tup.tail
         | pairs
   [entries] > ctor
     [key] > found
       if. > @
-        size.eq 0
+        ^.size.eq 0
         not-found
         [tup] >> rec-key-search
           if. > @
             tup.length.eq 0
-            not-found
+            ^.not-found
             prev.exists.if
               prev
               if.
@@ -58,11 +58,11 @@
                   tup.head.kbts.eq kbts
                 [] >>
                   true > exists
-                  tup.head.value > [cant-get] > get
-                not-found
+                  ^.^.tup.head.value > [cant-get] > get
+                ^.not-found
           @. > prev
-            rec-key-search tup.tail
-        | entries
+            ^.rec-key-search tup.tail
+        | ^.entries
       hash. >> hash!
         key.as-bytes >> kbts!
       [] > not-found
@@ -71,7 +71,7 @@
           "Object by hash code %d from given key does not exists".printf
             * hash
     exists. > [key] > has
-      found key
+      ^.found key
     entries.mapped > keys
       entry.key > [entry]
     entries.length > size
@@ -80,7 +80,7 @@
     [key value] > with
       map.ctor > @
         with.
-          entries.filtered
+          ^.entries.filtered
             not. > [entry] >>
               and.
                 hash.eq entry.hash
@@ -94,7 +94,7 @@
         key.as-bytes >> kbts!
     [key] > without
       map.ctor > @
-        entries.filtered
+        ^.entries.filtered
           not. > [entry] >>
             and.
               hash.eq entry.hash

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -94,7 +94,7 @@
         if. > [n minus1 minus2] >> rec
           n.eq 3
           minus1.plus minus2
-          rec
+          ^.rec
             n.minus 1
             minus1.plus minus2
             minus1
@@ -112,9 +112,9 @@
       n.lt 3
       1
       plus.
-        fibo
+        ^.fibo
           n.minus 1
-        fibo
+        ^.fibo
           n.minus 2
 
   42.as-bytes.eq 42 ++> can-compare-its-bytes-to-an-integer

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -38,11 +38,11 @@
                           times.
                             minus. (depth.times 2) 1
                             minus. (depth.times 2) 1
-                          squared
+                          ^.squared
                         times.
                           depth.times 2
                           plus. (depth.times 2) 1
-                      poly (depth.plus 1)
+                      ^.poly (depth.plus 1)
                 times. > squared!
                   number bts
                   number bts

--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -37,17 +37,17 @@
               T message > [message] >> failure
           [n] >> digits
             if. > @
-              n.lt ten
+              n.lt ^.ten
               as-char.
                 n.as-number.plus 48
               concat.
-                digits q
+                ^.digits q
                 as-char.
                   plus.
                     as-number.
-                      n.minus (q.times ten)
+                      n.minus (q.times ^.ten)
                     48
-            n.div ten failure > bits!
+            n.div ^.ten failure > bits!
             i64 bits > q
           | (n.as-i64 failure)
   ^ > n

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -31,11 +31,11 @@
           if. > @
             digits.eq scale
             if. > [unit rest] >> written
-              places.eq 0
+              ^.^.places.eq 0
               unit.as-decimal
               concat.
                 unit.as-decimal.concat ".".as-bytes
-                rec-pad rest places --
+                rec-pad rest ^.^.places --
             | (whole.plus 1) 0
             written whole digits
           floor. > digits
@@ -44,7 +44,7 @@
                 a.minus whole
                 scale
               0.5
-          pow10 places > scale
+          pow10 ^.places > scale
           a.floor > whole
         | 0
       if.
@@ -54,7 +54,7 @@
             floor.
               plus.
                 a.times
-                  pow10 places
+                  pow10 ^.places
                 0.5
             0
           positive a
@@ -67,14 +67,14 @@
     p.eq 0
     1
     times.
-      pow10
+      ^.pow10
         as-number.
           p.minus 1
       10
   if. > [value count acc] >> rec-pad
     count.eq 0
     acc
-    rec-pad
+    ^.rec-pad
       floor.
         value.div 10
       as-number.

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -45,7 +45,7 @@
   if. > [m count] >> rec-exponent
     m.lt 10
     count
-    rec-exponent
+    ^.rec-exponent
       m.div 10
       as-number.
         count.plus 1

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -21,21 +21,21 @@
           seq * > @
             while
               if. > [i] >>
-                i.lt n
+                i.lt ^.^.n
                 seq *
-                  sum.put
-                    sum.as-number.plus
+                  ^.sum.put
+                    ^.sum.as-number.plus
                       subsection
-                        a.plus (i.times step)
-                        a.plus ((i.plus 1).times step)
+                        ^.^.a.plus (i.times ^.step)
+                        ^.^.a.plus ((i.plus 1).times ^.step)
                   true
                 false
               true > [i]
             sum
           as-number. > step
             div.
-              b.minus a
-              n
+              ^.b.minus ^.a
+              ^.n
     T
       "the number of partitions must be a finite positive integer"
   times. > [a b] >> subsection
@@ -43,13 +43,13 @@
       b.minus a
       6
     plus.
-      fun a
+      ^.fun a
       plus.
         4.times
-          fun
+          ^.fun
             0.5.times
               a.plus b
-        fun b
+        ^.fun b
 
   ++> can-integrate-a-cubic-function
     close-to > @

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -36,33 +36,33 @@
         series p
     if. > [level p] > climb
       level.lt 0
-      series p
+      ^.series p
       if.
         p.gte
-          epow level
+          ^.epow level
         plus.
-          climb
+          ^.climb
             level.minus 1
             p.div
-              epow level
-          step level
-        climb
+              ^.epow level
+          ^.step level
+        ^.climb
           level.minus 1
           p
     if. > [level p] > descend
       level.lt 0
-      series p
+      ^.series p
       if.
         p.lt
           1.div
-            epow level
+            ^.epow level
         minus.
-          descend
+          ^.descend
             level.minus 1
             p.times
-              epow level
-          step level
-        descend
+              ^.epow level
+          ^.step level
+        ^.descend
           level.minus 1
           p
     [level] > epow
@@ -70,7 +70,7 @@
         level.eq 0
         e
         prev.times prev
-      epow > prev
+      ^.epow > prev
         level.minus 1
     [m] > series
       2.times > @
@@ -85,8 +85,8 @@
               k.times 2
               1
           times.
-            t.times t
-            horner
+            ^.t.times ^.t
+            ^.horner
               k.plus 1
       div. > t
         m.minus 1
@@ -96,7 +96,7 @@
         level.eq 0
         1
         prev.plus prev
-      step > prev
+      ^.step > prev
         level.minus 1
   number ^.as-bytes > n
 

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -43,12 +43,12 @@
               if. > [chunk] > grow
                 chunk.gte dividend.abs
                 chunk
-                grow
+                ^.grow
                   chunk.plus chunk
               if. > [chunk rest] > shrink
                 chunk.lt divisor.abs
                 rest
-                shrink
+                ^.shrink
                   chunk.div 2
                   if.
                     rest.gte chunk

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -53,8 +53,8 @@
                             number half
                             number half
                           b.times
-                            ipow b (n.minus 1)
-                      ipow b (n.div 2) > half!
+                            ^.ipow b (n.minus 1)
+                      ^.ipow b (n.div 2) > half!
                     | base expo.abs
                   ipow base expo.abs
                 if.
@@ -75,10 +75,10 @@
                         times.
                           div.
                             minus.
-                              number arg
-                              number k
+                              number ^.arg
+                              number ^.k
                             j
-                          fraction (j.plus 1)
+                          ^.fraction (j.plus 1)
                     floor. ((number arg).plus 0.5) > k!
                   | (expo.times base.ln)
                   nan

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -40,7 +40,7 @@
               plus.
                 depth.times 2
                 1
-          factor
+          ^.factor
             depth.plus 1
     | 1
 

--- a/eo-runtime/src/main/eo/output/dead.eo
+++ b/eo-runtime/src/main/eo/output/dead.eo
@@ -13,7 +13,7 @@
   [buffer] > write
     [] >> output-block
       true > @
-      output-block > [buffer] > write
+      ^.^.output-block > [buffer] > write
     | > @
 
   malloc.of ++> can-be-taken-off-any-output

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -24,11 +24,11 @@
           or.
             pth.size.eq 0
             index.eq 0
-          trimmed >> pth!
+          ^.trimmed >> pth!
           as-bytes.
             text.slice
               plus. >> index!
-                text.last-index-of separator
+                text.last-index-of ^.separator
                 1
               text.length.minus
                 number index
@@ -37,17 +37,17 @@
       string > @
         if.
           pth.size.eq 0
-          trimmed >> pth!
+          ^.trimmed >> pth!
           if.
             len.eq -1
             "."
             if.
               len.eq 0
-              separator
+              ^.separator
               as-bytes.
                 text.slice
                   0
-                  text.last-index-of separator >> len!
+                  text.last-index-of ^.separator >> len!
       string pth > text
     sys.drive uri > drive
     if. > driveless
@@ -73,39 +73,39 @@
               text.length.minus
                 number index
       string > text
-        basename >> base!
+        ^.basename >> base!
     and. > is-absolute
       driveless.size.gt 0
       eq.
         driveless.slice 0 1
         separator
     [] > normalized
-      impl > @
-        sys
+      ^.^.impl > @
+        ^.sys
         if.
           normalized.eq
-            separator.concat separator
-          separator
+            ^.separator.concat ^.separator
+          ^.separator
           if.
             normalized.size.eq 0
             "."
             string normalized
       as-bytes. > normalized!
         if.
-          driveless.size.eq 0
+          ^.driveless.size.eq 0
           if.
-            drive.size.eq 0
+            ^.drive.size.eq 0
             "."
-            drive
+            ^.drive
           concat.
             concat.
-              drive.concat
-                is-absolute.if
-                  unc.if (separator.concat separator) separator
+              ^.drive.concat
+                ^.is-absolute.if
+                  ^.unc.if (^.separator.concat ^.separator) ^.separator
                   --
-              separator.joined >> body!
+              ^.separator.joined >> body!
                 reduced.
-                  driveless.split separator
+                  ^.driveless.split ^.separator
                   *
                   if. > [accum segment] >>
                     segment.eq ".."
@@ -114,67 +114,67 @@
                         accum.length.gt 0
                         not. (accum.head.eq "..")
                       if.
-                        unc.and (accum.length.lte 2)
+                        ^.^.unc.and (accum.length.lte 2)
                         accum
                         accum.tail
-                      is-absolute.not.if (accum.with segment) accum
+                      ^.^.is-absolute.not.if (accum.with segment) accum
                     if.
                       or.
                         segment.eq "."
                         segment.eq ""
                       accum
                       accum.with segment
-            trailing.if separator --
+            trailing.if ^.separator --
       and. > trailing
         ubts.size.gt 0
         eq.
           slice.
-            uri >> ubts!
+            ^.uri >> ubts!
             ubts.size.plus -1
             1
-          separator
+          ^.separator
     [other] > resolved
       normalized. > @
-        impl
-          sys
+        ^.^.impl
+          ^.sys
           string
             if.
               valid.size.eq 0
-              uri
+              ^.uri
               if.
-                gt. (sys.drive valid).size 0
+                gt. (^.sys.drive valid).size 0
                 valid
                 if.
                   starts-with.
                     string valid
-                    separator.concat separator
+                    ^.separator.concat ^.separator
                   valid
                   if.
                     eq.
                       valid.slice 0 1
-                      separator
-                    drive.concat valid
-                    concat. (uri.concat separator) valid
+                      ^.separator
+                    ^.drive.concat valid
+                    concat. (^.uri.concat ^.separator) valid
       string > valid!
         as-bytes.
-          sys.sanitized other
+          ^.sys.sanitized other
     sys.separator > separator
     if. > [tail] > stripped
       or.
         tail.size.eq 0
-        tail.eq separator
+        tail.eq ^.separator
       tail
       if.
-        tail.ends-with separator
-        stripped
+        tail.ends-with ^.separator
+        ^.stripped
           string
             as-bytes.
               tail.slice
                 0
-                tail.length.minus separator.length
+                tail.length.minus ^.separator.length
         tail
     string > [] > trimmed
-      stripped uri
+      ^.stripped ^.uri
     and. > unc
       driveless.size.gt 1
       driveless.starts-with
@@ -182,13 +182,13 @@
   [paths] > joined
     normalized. > @
       os.is-windows.if
-        win32 jpath
-        posix jpath
+        ^.win32 jpath
+        ^.posix jpath
     string > jpath
       as-bytes.
-        separator.joined paths
+        ^.separator.joined paths
   [uri] > posix
-    impl > @
+    ^.impl > @
       sys
       uri
     "/" > separator
@@ -200,7 +200,7 @@
     win32.separator
     posix.separator
   [uri] > win32
-    impl > @
+    ^.impl > @
       sys
       sys.sanitized uri
     "\\" > separator
@@ -216,7 +216,7 @@
             -1
           string
             uri >> ubts!
-          string (pth.replaced "/\\//".regex separator)!
+          string (pth.replaced "/\\//".regex ^.separator)!
         string ubts > pth
       ^.separator > separator
 

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -31,7 +31,7 @@
   2 > rdwr
   [code output] > return
     output > @
-    return > called
+    ^.return > called
       code
       output
   [family port address] > sockaddr-in

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -30,8 +30,8 @@
   if. > @
     start.lt end
     if. > [acc current] >> appended
-      current.lt end
-      appended
+      current.lt ^.end
+      ^.appended
         acc.with current
         current.next
       acc
@@ -57,7 +57,7 @@
         build 1 > @
         [i] > build
           i > @
-          build > next
+          ^.build > next
             1.plus @
       10
 
@@ -77,7 +77,7 @@
         x 1 > @
         [i] > x
           i > @
-          x > next
+          ^.x > next
             0.5.plus @
       5
 
@@ -89,7 +89,7 @@
         b 1 > @
         [num] > b
           num > @
-          b > next
+          ^.b > next
             5.plus @
       10
 

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -18,10 +18,10 @@
     r.start.is-integer.and r.end.is-integer
     range
       [] >>
-        build r.start > @
+        build ^.r.start > @
         [num] > build
           num > @
-          build > next
+          ^.build > next
             1.plus @
       r.end
     T

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -49,7 +49,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [m] >>
             gt.
               seq *
                 m.put
@@ -63,7 +63,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [m] >>
             lt.
               seq *
                 m.put
@@ -77,7 +77,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [m] >>
             eq.
               seq *
                 m.put 0
@@ -92,7 +92,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [m] >>
             eq.
               seq *
                 at.
@@ -109,7 +109,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [m] >>
             lt.
               seq *
                 m.put
@@ -123,7 +123,7 @@
       [b]
         malloc.for > @
           0
-          b.put > [m] >>
+          ^.b.put > [m] >>
             lte.
               seq *
                 m.put

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -9,12 +9,12 @@
 [lst] > set
   [mp] >> ctor
     mp.keys > @
-    mp.has item > [item] > has
+    ^.mp.has item > [item] > has
     mp.size > size
     set.ctor > [item] > with
-      mp.with item true
+      ^.mp.with item true
     set.ctor > [item] > without
-      mp.without item
+      ^.mp.without item
   | > @
     map
       lst.mapped

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -54,28 +54,28 @@
       code. > addr
         sys.raw *1
           "inet_addr"
-          address
+          ^.address
       addr.as-i32 > addrint
       [descriptor] > closed-socket
         if. > @
           closed.eq -1
           T
             "Couldn't close the socket #%d because %s".printf
-              * descriptor sys.message
+              * descriptor ^.sys.message
           true
         code. > closed
-          sys.raw *1
-            sys.close
+          ^.sys.raw *1
+            ^.sys.close
             descriptor
       [scope cant-connect] > connect
-        safe-socket > @
+        ^.safe-socket > @
           [] >>
             if. > @
               connected.eq -1
-              cant-connect
+              ^.cant-connect
                 "Couldn't connect to %s:%d on socket #%d because %s".printf
                   * sock.address sock.port sock.sd sock.sys.message
-              scope
+              ^.scope
                 sock.scoped-socket sock.sd
             code. > connected
               sock.sys.raw *1
@@ -86,37 +86,37 @@
             ^.^.^ > sock
           cant-connect
       [scope cant-listen] > listen
-        safe-socket > @
+        ^.safe-socket > @
           [] >>
             if. > @
               bound.eq -1
-              cant-listen
+              ^.cant-listen
                 "Couldn't bind the socket #%d to %s:%d because %s".printf
                   * sock.sd sock.address sock.port sock.sys.message
               if.
                 listened.eq -1
-                cant-listen
+                ^.cant-listen
                   "Failed to listen to %s:%d on the socket #%d because %s".printf
                     * sock.address sock.port sock.sd sock.sys.message
-                scope
+                ^.scope
                   [] >>
-                    sock.scoped-socket sock.sd > @
+                    ^.sock.scoped-socket ^.sock.sd > @
                     [scope cant-accept] > accept
                       if. > @
                         client.eq -1
                         cant-accept
                           "Failed to accept a connection on the socket #%d because %s".printf
-                            * sock.sd sock.sys.message
+                            * ^.^.sock.sd ^.^.sock.sys.message
                         seq *
-                          scope (sock.scoped-socket client) >> handled!
-                          sock.closed-socket client
+                          scope (^.^.sock.scoped-socket client) >> handled!
+                          ^.^.sock.closed-socket client
                           handled
                       code. > client
-                        sock.sys.raw *1
+                        ^.^.sock.sys.raw *1
                           "accept"
-                          sock.sd
-                          sock.sockaddr
-                          sock.sockaddr.size
+                          ^.^.sock.sd
+                          ^.^.sock.sockaddr
+                          ^.^.sock.sockaddr.size
             code. > bound
               sock.sys.raw *1
                 "bind"
@@ -133,26 +133,26 @@
       [scope cant] > safe-socket
         if. > @
           not.
-            sys.startup.eq 0
+            ^.sys.startup.eq 0
           cant
             "Couldn't start up the sockets subsystem because %s".printf
-              * sys.message
+              * ^.sys.message
           seq *
             if. >> result!
-              sd.eq -1
+              ^.sd.eq -1
               cant
                 "Couldn't create a socket because %s".printf
-                  * sys.message
+                  * ^.sys.message
               seq *
                 if. >> used!
-                  addr.eq sys.none
+                  ^.addr.eq ^.sys.none
                   cant
                     "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
-                      * address sys.message
+                      * ^.^.address ^.sys.message
                   scope
-                closed-socket sd
+                ^.closed-socket ^.sd
                 used
-            sys.cleanup
+            ^.sys.cleanup
             result
       [descriptor] > scoped-socket
         ^.^.as-input recv > as-input
@@ -162,12 +162,12 @@
             received.code.eq -1
             cant-receive
               "Failed to receive data from the socket #%d because %s".printf
-                * descriptor sys.message
+                * ^.descriptor ^.^.sys.message
             received.output
           called. > received
-            sys.raw *1
+            ^.^.sys.raw *1
               "recv"
-              descriptor
+              ^.descriptor
               size
               0
         [buffer cant-send] > send
@@ -175,12 +175,12 @@
             sent.eq -1
             cant-send
               "Failed to send a message through the socket #%d because %s".printf
-                * descriptor sys.message
+                * ^.descriptor ^.^.sys.message
             sent
           code. > sent
-            sys.raw *1
+            ^.^.sys.raw *1
               "send"
-              descriptor
+              ^.descriptor
               buffer >> buff!
               buff.size
               0
@@ -192,7 +192,7 @@
           sys.tcp
       sys.sockaddr-in > sockaddr
         sys.inet.as-i16
-        htons checked-port
+        ^.htons ^.checked-port
         addrint
     |
       []
@@ -244,9 +244,9 @@
         [size] > read
           seq * > @
             chunk
-            input-block chunk
+            ^.^.input-block chunk
           as-bytes. > chunk
-            recv size
+            ^.^.^.recv size
   [send] > as-output
     [buffer] > write
       @. > @
@@ -258,24 +258,24 @@
             * sent remainder
           if. > remainder
             sent.lt buffer.size
-            output-block.write
+            ^.^.output-block.write
               buffer.slice
                 sent
                 buffer.size.minus sent
-            output-block
-          send buffer > sent
-  port.is-integer.not.if > [] > checked-port
+            ^.^.output-block
+          ^.^.^.send buffer > sent
+  ^.port.is-integer.not.if > [] > checked-port
     T
       "Port must be an integer in 0 to 65535, but was %f".printf
-        * port
+        * ^.port
     if.
       or.
-        port.lt 0
-        port.gt 65535
+        ^.port.lt 0
+        ^.port.gt 65535
       T
         "Port %d is out of range; it must be 0 to 65535".printf
-          * port
-      port
+          * ^.port
+      ^.port
   [port] > htons
     as-i16. > @
       or.

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -34,7 +34,7 @@
                     code.eq -1
                     T
                       "Failed to write to standard error"
-                    output-block
+                    ^.^.output-block
                   code
                   remainder
                 code. > code
@@ -45,9 +45,9 @@
                     buffer.size
                 if. > remainder
                   code.lt buffer.size
-                  output-block.write
+                  ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
-                  output-block
+                  ^.^.output-block
         [] >>
           [buffer] > write
             @. > @
@@ -60,7 +60,7 @@
                     code.eq -1
                     T
                       "Failed to write to standard error"
-                    output-block
+                    ^.^.output-block
                   code
                   remainder
                 code. > code
@@ -71,9 +71,9 @@
                     buffer.size
                 if. > remainder
                   code.lt buffer.size
-                  output-block.write
+                  ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
-                  output-block
+                  ^.^.output-block
       text
     true
 

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -26,8 +26,8 @@
     [scan buffer is-first] >> rec-read
       scan.eof.if > @
         string buffer
-        rec-read
-          line-or-eof
+        ^.rec-read
+          ^.^.line-or-eof
           is-first.if
             buffer.concat scan.line
             concat.
@@ -35,7 +35,7 @@
               scan.line
           false
     | > @
-      line-or-eof
+      ^.line-or-eof
       ""
       true
   [] > line-or-eof
@@ -54,11 +54,11 @@
                 next.as-bytes.eq "\n"
               char.eq "\n"
           string buffer
-          rec-read
+          ^.rec-read
             next
             buffer.concat char
         input.as-bytes > char
         @. > next
           input.read 1
       | first --
-  line-or-eof.line > [] > next-line
+  ^.line-or-eof.line > [] > next-line

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -10,7 +10,7 @@
 [substrings] > contains-all
   reduced. > @
     substrings.mapped
-      text.contains x > [x] >>
+      ^.text.contains x > [x] >>
     true
     x.and a > [a x]
   ^ > text

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -10,7 +10,7 @@
 [substrings] > contains-any
   reduced. > @
     substrings.mapped
-      text.contains x > [x] >>
+      ^.text.contains x > [x] >>
     false
     x.or a > [a x]
   ^ > text

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -24,7 +24,7 @@
           end.eq index
           includes
           includes.or
-            rec-contains (index.plus 1).as-number
+            ^.rec-contains (index.plus 1).as-number
         eq. > includes
           txt.slice index size
           part

--- a/eo-runtime/src/main/eo/string/english.eo
+++ b/eo-runtime/src/main/eo/string/english.eo
@@ -21,7 +21,7 @@
   s > @
   [] > lower
     string > @
-      s.as-bytes.array.reduced
+      ^.s.as-bytes.array.reduced
         --
         [accum byte] >>
           accum.concat > @
@@ -43,7 +43,7 @@
   ^ > s
   [] > upper
     string > @
-      s.as-bytes.array.reduced
+      ^.s.as-bytes.array.reduced
         --
         [accum byte] >>
           accum.concat > @

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -38,7 +38,7 @@
       includes.if idx -1
       includes.if
         idx
-        rec-index-of (idx.plus 1).as-number
+        ^.rec-index-of (idx.plus 1).as-number
     eq. > includes
       txt.slice idx size
       part

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -17,9 +17,9 @@
         if. > @
           tup.length.eq 0
           acc
-          with-delimiter
+          ^.with-delimiter
             concat.
-              concat. (dataized tup.head) text!
+              concat. (dataized tup.head) ^.text!
               acc
             tup.tail
       | items.head items.tail

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -38,7 +38,7 @@
       includes.if idx -1
       includes.if
         idx
-        rec-index-of (idx.plus -1).as-number
+        ^.rec-index-of (idx.plus -1).as-number
     eq. > includes
       txt.slice idx size
       part

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -31,7 +31,7 @@
           eq.
             lead.and 80-
             00-
-          reclen
+          ^.reclen
             index.plus 1
             accum.plus 1
           if.
@@ -56,7 +56,7 @@
                 T
                   "Unknown byte format (%x), can't recognize character".printf
                     * lead
-      text.as-bytes.slice > b1
+      ^.text.as-bytes.slice > b1
         index.plus 1
         1
       eq. > b1808f
@@ -78,13 +78,13 @@
       eq. > b1cont
         b1.and C0-
         80-
-      text.as-bytes.slice > b2
+      ^.text.as-bytes.slice > b2
         index.plus 2
         1
       eq. > b2cont
         b2.and C0-
         80-
-      text.as-bytes.slice > b3
+      ^.text.as-bytes.slice > b3
         index.plus 3
         1
       eq. > b3cont
@@ -92,7 +92,7 @@
         80-
       b2cont.and > fourvalid
         b3cont.and second4
-      text.as-bytes.slice index 1 > lead
+      ^.text.as-bytes.slice index 1 > lead
       eq. > leadc0c1
         lead.and FE-
         C0-
@@ -125,7 +125,7 @@
         *
           csize
           idx
-          text.as-bytes
+          ^.text.as-bytes
     valid.if
       reclen
         idx.plus csize
@@ -133,7 +133,7 @@
       T
         "Malformed UTF-8 sequence (%x) at %d index".printf
           *
-            text.as-bytes.slice idx csize
+            ^.text.as-bytes.slice idx csize
             idx
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -34,15 +34,15 @@
         * text
         [accum start current count] >> rec-nsplit
           if. > @
-            text.size.eq current
+            ^.text.size.eq current
             appended
             if.
               or.
                 size.eq 0
                 gt.
                   current.plus size
-                  text.size
-              rec-nsplit
+                  ^.text.size
+              ^.rec-nsplit
                 accum
                 start
                 as-number.
@@ -50,12 +50,12 @@
                 count
               if.
                 and.
-                  delimiter.eq
+                  ^.delimiter.eq
                     bts.slice current size
                   lt.
                     number count
-                    minus. (number limit) 1
-                rec-nsplit
+                    minus. (number ^.limit) 1
+                ^.rec-nsplit
                   appended
                   as-number.
                     current.plus size
@@ -63,7 +63,7 @@
                     current.plus size
                   as-number.
                     count.plus 1
-                rec-nsplit
+                ^.rec-nsplit
                   accum
                   start
                   as-number.

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -63,7 +63,7 @@
             number cursor
             auto
             acc
-          walk
+          ^.walk
             as-number.
               plus.
                 number cursor
@@ -93,14 +93,14 @@
           code i
         57.gte
           code i
-      digits-end
+      ^.digits-end
         as-number.
           i.plus 1
       i
   if. > [from to acc] >> digits-value
     from.gte to
     acc
-    digits-value
+    ^.digits-value
       as-number.
         from.plus 1
       to
@@ -121,7 +121,7 @@
           byte i
         30-.eq
           byte i
-      flags-end
+      ^.flags-end
         as-number.
           i.plus 1
       i
@@ -137,7 +137,7 @@
         number span
       T
         "The format %s ends with an incomplete specifier, a conversion character is missing".printf
-          * format
+          * ^.format
       if.
         25-.eq conv
         walk
@@ -157,17 +157,17 @@
           seq *
             value
             acc.concat padded
-    args.at > arg
+    ^.args.at > arg
       number idx
     byte > conv!
       number end
     if. > converted!
       73-.eq conv
       as-bytes. > [text] >> capped
-        precise.as-bool.if
+        ^.precise.as-bool.if
           truncated.
             string text
-            number precision
+            number ^.precision
             failure
           text
       |
@@ -264,13 +264,13 @@
     if. > padded!
       if. > [i c] >> flagged
         i.gte
-          number digits
+          number ^.digits
         false
         if.
           c.eq
             byte i
           true
-          flagged
+          ^.flagged
             as-number.
               i.plus 1
             c
@@ -324,7 +324,7 @@
             index.plus 1
       T
         "The positional argument index in the format %s is too large".printf
-          * format
+          * ^.format
       if.
         positional.as-bool.and
           lt.
@@ -339,14 +339,14 @@
         if.
           gte.
             number idx
-            args.length
+            ^.args.length
           T
             "The argument index %d in the format is out of bounds, only %d given".printf
               *
                 plus.
                   number idx
                   1
-                args.length
+                ^.args.length
           if.
             precise.as-bool.and
               64-.eq conv

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -29,21 +29,21 @@
     ? > cant-compile /{Q.string}
   ^ > expression
   [serialized] > pattern
-    pattern serialized > compiled
+    ^.pattern serialized > compiled
     [txt] > match
       [position start from to groups] > matched
         groups.length > count
         start.gte 0 > exists
-        groups.at index > [index] > group
+        ^.groups.at index > [index] > group
         $ > matched
         exists.if > next
           if.
             and.
               from.eq to
-              to.eq txt.length
-            missing
+              to.eq ^.txt.length
+            ^.missing
             matched.
-              matched-from-index
+              ^.matched-from-index
                 position.plus 1
                 if.
                   from.eq to
@@ -94,11 +94,11 @@
       parsed.group 1 > group1!
       parsed.group 2 > group2!
       next. > parsed
-        "/^\\/([\\s\\S]*)\\/([dimsux]*)$/".regex.compiled.match expression
+        "/^\\/([\\s\\S]*)\\/([dimsux]*)$/".regex.compiled.match ^.^.expression
       "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
         * group1 group2
-      commented.regex.compile retry-quoted > [message] > retry-commented
-      quoted.regex.compile > [message] > retry-quoted
+      ^.commented.regex.compile ^.retry-quoted > [message] > retry-commented
+      ^.quoted.regex.compile > [message] > retry-quoted
 
   eq. ++> can-advance-after-a-zero-width-match
     1
@@ -229,7 +229,7 @@
 
   next. --> rejects-serialized-bytes-of-the-wrong-type
     match.
-      pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
+      ^.pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
       "hello"
 
   "/pattern".regex.compiled --> stops-on-a-missing-closing-slash

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -30,8 +30,8 @@
             twice
             concat.
               half.concat >> twice
-                rec-repeated (n.div 2).floor >> half!
-              text.as-bytes
+                ^.rec-repeated (n.div 2).floor >> half!
+              ^.text.as-bytes
       | times
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -14,14 +14,14 @@
   matched.exists.not.if > @
     string text! >> reinit
     block.exists.if > [block accum start] >> rec-replaced
-      rec-replaced
+      ^.rec-replaced
         block.next
         concat.
           accum.concat
             reinit.slice
               start
               block.from.minus start
-          replacement
+          ^.replacement
         block.to
       string
         accum.concat

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -35,7 +35,7 @@
               "+"
             folded
             folded
-        fold-digits > folded
+        ^.^.fold-digits > folded
           signed.if
             txt.slice
               1
@@ -60,15 +60,15 @@
         not.
           dot.eq -1
         plus.
-          fold-digits
+          ^.fold-digits
             mantissa.slice 0 dot
           div.
-            fold-digits
+            ^.fold-digits
               mantissa.slice
                 dot.plus 1
                 places
             10.power places
-        fold-digits mantissa
+        ^.fold-digits mantissa
       if. > mantissa
         eloc.eq -1
         esign
@@ -114,26 +114,26 @@
         negative.if negated folded
       [a b] > digits-lte
         if. > [index] >> rec
-          index.eq a.length
+          index.eq ^.a.length
           true
           if.
             lt.
               as-ascii.
-                a.slice index 1
+                ^.a.slice index 1
               as-ascii.
-                b.slice index 1
+                ^.b.slice index 1
             true
             if.
               gt.
                 as-ascii.
-                  a.slice index 1
+                  ^.a.slice index 1
                 as-ascii.
-                  b.slice index 1
+                  ^.b.slice index 1
               false
-              rec
+              ^.rec
                 index.plus 1
         | 0 > @
-      fold-digits normalized > folded
+      ^.fold-digits normalized > folded
       folded.times -1 > negated
       eq. > negative
         text.slice 0 1
@@ -155,20 +155,20 @@
         "/^0+/".regex
         ""
     [group acc] >> convert
-      matched.exists.not.if > @
+      ^.matched.exists.not.if > @
         *
         if.
-          group.gt specifiers.length
+          group.gt ^.specifiers.length
           acc
           next
-      convert > next
+      ^.convert > next
         group.plus 1
         acc.with
-          converted
-            specifiers.at
+          ^.converted
+            ^.specifiers.at
               group.minus 1
               T
-            matched.group group
+            ^.matched.group group
     | > @
       1
       *
@@ -177,28 +177,28 @@
       text
       if.
         spec.eq "d"
-        as-integer text
-        as-float text
+        ^.as-integer text
+        ^.as-float text
     [text] > fold-digits
       [index acc] >> rec
         if. > @
-          index.eq text.length
+          index.eq ^.text.length
           acc
           next
-        rec > next
+        ^.rec > next
           index.plus 1
           plus.
             acc.times 10
             minus.
               as-ascii.
-                text.slice index 1
+                ^.text.slice index 1
               48
       | 0 0 > @
     match. > found
       regex.
         "/".chained
           * "^" pattern "/"
-      read
+      ^.read
     found.next > matched
   | > @
     tokens.at
@@ -231,7 +231,7 @@
     ch
   [position accumulated found pending] >> tokenize
     if. > @
-      position.gte format.length
+      position.gte ^.format.length
       pending.if *1
         T
           "The format string ends with a dangling percent and no specifier after it"
@@ -240,7 +240,7 @@
       pending.if
         if.
           ch.eq "%"
-          tokenize
+          ^.tokenize
             position.plus 1
             accumulated.chained
               * "%"
@@ -248,7 +248,7 @@
             false
           if.
             ch.eq "d"
-            tokenize
+            ^.tokenize
               position.plus 1
               accumulated.chained
                 * "([+-]?\\d+)"
@@ -256,7 +256,7 @@
               false
             if.
               ch.eq "f"
-              tokenize
+              ^.tokenize
                 position.plus 1
                 accumulated.chained
                   * "([+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?)"
@@ -264,7 +264,7 @@
                 false
               if.
                 ch.eq "s"
-                tokenize
+                ^.tokenize
                   position.plus 1
                   accumulated.chained
                     * "(\\S+)"
@@ -273,19 +273,19 @@
                 T "Unsupported format specifier"
         if.
           ch.eq "%"
-          tokenize
+          ^.tokenize
             position.plus 1
             accumulated
             found
             true
-          tokenize
+          ^.tokenize
             position.plus 1
             accumulated.chained
               *
                 escaped ch
             found
             false
-    format.slice > ch
+    ^.format.slice > ch
       position
       1
   | >> tokens

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -59,42 +59,42 @@
           T cause
           if.
             eq.
-              byte.and p1
-              r1
-            recidx
-              increase index 1 true
+              byte.and ^.p1
+              ^.r1
+            ^.recidx
+              ^.increase index 1 true
               accum.plus 1
               result
               cause
             if.
               eq.
-                byte.and p2
-                r2
-              recidx
-                increase index 2 twovalid
+                byte.and ^.p2
+                ^.r2
+              ^.recidx
+                ^.increase index 2 twovalid
                 accum.plus 1
                 result
                 cause
               if.
                 eq.
-                  byte.and p3
-                  r3
-                recidx
-                  increase index 3 threevalid
+                  byte.and ^.p3
+                  ^.r3
+                ^.recidx
+                  ^.increase index 3 threevalid
                   accum.plus 1
                   result
                   cause
                 if.
-                  eq. (byte.and p4) r4
-                  recidx
-                    increase index 4 fourvalid
+                  eq. (byte.and ^.p4) ^.r4
+                  ^.recidx
+                    ^.increase index 4 fourvalid
                     accum.plus 1
                     result
                     cause
                   T
                     "Unknown byte format (%x), can't recognize character".printf
                       * byte
-      text.as-bytes.slice > b1
+      ^.text.as-bytes.slice > b1
         index.plus 1
         1
       eq. > b1808f
@@ -116,19 +116,19 @@
       eq. > b1cont
         b1.and C0-
         80-
-      text.as-bytes.slice > b2
+      ^.text.as-bytes.slice > b2
         index.plus 2
         1
       eq. > b2cont
         b2.and C0-
         80-
-      text.as-bytes.slice > b3
+      ^.text.as-bytes.slice > b3
         index.plus 3
         1
       eq. > b3cont
         b3.and C0-
         80-
-      text.as-bytes.slice index 1 > byte
+      ^.text.as-bytes.slice index 1 > byte
       b2cont.and > fourvalid
         b3cont.and second4
       eq. > leadc0c1
@@ -170,13 +170,13 @@
         *
           csize
           index
-          text.as-bytes
+          ^.text.as-bytes
     valid.if
       index.plus csize
       T
         "Malformed UTF-8 sequence (%x) at %d index".printf
           *
-            text.as-bytes.slice index csize
+            ^.text.as-bytes.slice index csize
             index
   number len! > nlen
   number start! > nstart

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -30,7 +30,7 @@
               gt.
                 current.plus size
                 len
-            rec-split
+            ^.rec-split
               accum
               start
               as-number.
@@ -38,13 +38,13 @@
             if.
               delim.eq
                 bts.slice current size
-              rec-split
+              ^.rec-split
                 appended
                 as-number.
                   current.plus size
                 as-number.
                   current.plus size
-              rec-split accum start (current.plus 1).as-number
+              ^.rec-split accum start (current.plus 1).as-number
         accum.with > appended
           string
             bts.slice

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -29,7 +29,7 @@
       index
       if.
         is-ws (b.slice index 1)!
-        first-non-ws-index (index.plus 1).as-number
+        ^.first-non-ws-index (index.plus 1).as-number
         index
   or. > [c] >> is-ws
     c.eq 20-

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -26,7 +26,7 @@
             0
             if.
               is-ws (b.slice index 1)!
-              first-non-ws-index (index.plus -1).as-number
+              ^.first-non-ws-index (index.plus -1).as-number
               index.plus 1
         | ((number len).plus -1)
   or. > [c] >> is-ws

--- a/eo-runtime/src/main/eo/string/turkish.eo
+++ b/eo-runtime/src/main/eo/string/turkish.eo
@@ -24,14 +24,14 @@
   lower. > [] > lower
     english.
       replaced.
-        s.replaced "/I/".regex "ı"
+        ^.s.replaced "/I/".regex "ı"
         "/İ/".regex
         "i"
   ^ > s
   upper. > [] > upper
     english.
       replaced.
-        s.replaced "/i/".regex "İ"
+        ^.s.replaced "/i/".regex "İ"
         "/ı/".regex
         "I"
 

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -40,10 +40,10 @@
                   previous.match
                 previous
                 [] >>
-                  tup.head.head > head
-                  tup.head.tail.head > match!
+                  ^.tup.head.head > head
+                  ^.tup.head.tail.head > match!
               @. > previous
-                rec-case tup.tail
+                ^.rec-case tup.tail
             | cases
       found.head
       fallback
@@ -59,13 +59,13 @@
     eq. > @
       switch *
         *
-          c1 > [] >>
+          ^.c1 > [] >>
           22
         *
-          c2 > [] >>
+          ^.c2 > [] >>
           0
         *
-          c3 > [] >>
+          ^.c3 > [] >>
           "true case"
       "true case"
     false > c1

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -15,21 +15,21 @@
           if. >> index!
             0.gt
               i >> idx!
-            length.plus idx
+            ^.length.plus idx
             idx
-        length.lte index
+        ^.length.lte index
       fallback
         "Given index is out of tuple bounds"
       if. > [tup] >> at-fast
         0.eq tup.length
-        fallback
+        ^.fallback
           "Given index is out of tuple bounds"
         if.
           eq.
             tup.length.plus -1
             index
           tup.head
-          at-fast tup.tail
+          ^.at-fast tup.tail
       | ^
   tuple > empty
     T
@@ -39,19 +39,19 @@
     0
   [other] > eq
     and. > @
-      length.eq other.length
+      ^.length.eq other.length
       if. > [first second] >> receq
         first.length.eq 0
         true
         and.
           first.head.eq second.head
-          receq first.tail second.tail
+          ^.receq first.tail second.tail
       | ^ other
   tuple > [x] > with
     ^
     x
     as-number.
-      length.plus 1
+      ^.length.plus 1
 
   ++> can-add-an-item
     and. > @

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -11,7 +11,7 @@
 
 [func] > each
   ^.eachi > @
-    func item > [item index] >>
+    ^.func item > [item index] >>
 
   ++> can-iterate-over-a-list
     eq. > @
@@ -20,8 +20,8 @@
         [m]
           each. > @
             * 1 2 3
-            m.put > [i] >>
-              m.as-number.plus i
+            ^.m.put > [i] >>
+              ^.m.as-number.plus i
       6
 
   eq. ++> can-return-the-result-of-the-last-call
@@ -40,8 +40,8 @@
         [m]
           each. > @
             * 10 20 30
-            m.put > [i] >>
-              m.as-number.plus i
+            ^.m.put > [i] >>
+              ^.m.as-number.plus i
       60
 
   ++> can-walk-a-single-element-list
@@ -51,8 +51,8 @@
         [m]
           each. > @
             * 7
-            m.put > [i] >>
-              m.as-number.plus i
+            ^.m.put > [i] >>
+              ^.m.as-number.plus i
       7
 
   tuple.empty.each ++> can-walk-an-empty-list

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -16,7 +16,7 @@
     true
     seq * > [acc item index] >>
       acc
-      func item index
+      ^.func item index
 
   ++> can-iterate-over-a-list-with-indexes
     eq. > @
@@ -25,8 +25,8 @@
         [m]
           eachi. > @
             * 1 2 3
-            m.put > [item index] >>
+            ^.m.put > [item index] >>
               plus.
-                m.as-number.plus item
+                ^.m.as-number.plus item
                 index
       9

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -13,7 +13,7 @@
 
 [func] > filtered
   ^.filteredi > @
-    func item > [item index] >>
+    ^.func item > [item index] >>
 
   eq. ++> can-filter-a-list
     filtered.

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -18,10 +18,10 @@
       tup.length.eq 0
       *
       if.
-        func tup.head tup.tail.length
+        ^.func tup.head tup.tail.length
         next.with tup.head
         next
-    recfilter tup.tail > next
+    ^.recfilter tup.tail > next
   | ^ > @
 
   eq. ++> can-filter-by-a-less-than-condition

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -24,7 +24,7 @@
           if. > [tup] >> rechead
             tup.length.eq idx
             tup
-            rechead tup.tail
+            ^.rechead tup.tail
           | list
     T
       "Given index must be an integer"

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -17,10 +17,10 @@
         if.
           next.eq -1
           if.
-            tup.head.eq wanted
+            tup.head.eq ^.wanted
             tup.length.minus 1
             -1
-          recidx tup.tail >> next!
+          ^.recidx tup.tail >> next!
     | ^
 
   eq. ++> can-find-no-index-of-an-absent-item

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -13,9 +13,9 @@
     t.length.eq 0
     -1
     if.
-      t.head.eq wanted
+      t.head.eq ^.wanted
       t.length.minus 1
-      rec t.tail
+      ^.rec t.tail
   | ^ > @
 
   eq. ++> can-find-the-last-index-of-an-item

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -11,7 +11,7 @@
 
 [func] > mapped
   ^.mappedi > @
-    func item > [item idx] >>
+    ^.func item > [item idx] >>
 
   eq. ++> can-map-a-list
     mapped.

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -14,7 +14,7 @@
   ^.reducedi > @
     *
     accum.with > [accum item idx] >>
-      func item idx
+      ^.func item idx
 
   eq. ++> can-map-a-list-with-indexes
     mappedi.

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -13,7 +13,7 @@
 [start func] > reduced
   ^.reducedi > @
     start
-    func > [accum item index] >>
+    ^.func > [accum item index] >>
       accum
       item
 

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -15,12 +15,12 @@
     start
     if. > [tup] >> rec-reducedi
       tup.length.eq 1
-      func
-        start
+      ^.func
+        ^.start
         tup.head
         0
-      func
-        rec-reducedi tup.tail
+      ^.func
+        ^.rec-reducedi tup.tail
         tup.head
         tup.tail.length
     | list
@@ -106,8 +106,8 @@
         [acc x i]
           check x > @
           if. > [el] > check
-            x.lt 100
-            acc.plus x
-            acc.minus x
+            ^.x.lt 100
+            ^.acc.plus ^.x
+            ^.acc.minus ^.x
       10.plus
         0.minus 500

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -11,7 +11,7 @@
   ^.reduced > @
     *
     if. > [accum item] >>
-      element.eq item
+      ^.element.eq item
       accum
       accum.with item
 

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -12,7 +12,7 @@
     ^.reducedi
       *
       if. > [accum item index] >>
-        i.eq index
+        ^.i.eq index
         accum
         accum.with item
     T

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -11,7 +11,7 @@
 [as-bytes] > u16
   as-bytes > @
   i32 > [] > as-i32
-    00-00.concat as-bytes
+    00-00.concat ^.as-bytes
   as-i32.as-number > as-number
   [x cant-divide] > div
     if. > @
@@ -20,33 +20,33 @@
         00-00
       cant-divide
         "Can't divide %d by u16 zero".printf
-          * as-number
+          * ^.as-number
       u16
         slice.
           as-bytes.
-            as-i32.div other.as-i32
+            ^.as-i32.div other.as-i32
           2
           2
-  as-i32.gt x.as-u16.as-i32 > [x] > gt
-  as-i32.gte x.as-u16.as-i32 > [x] > gte
-  as-i32.lt x.as-u16.as-i32 > [x] > lt
-  as-i32.lte x.as-u16.as-i32 > [x] > lte
+  ^.as-i32.gt x.as-u16.as-i32 > [x] > gt
+  ^.as-i32.gte x.as-u16.as-i32 > [x] > gte
+  ^.as-i32.lt x.as-u16.as-i32 > [x] > lt
+  ^.as-i32.lte x.as-u16.as-i32 > [x] > lte
   u16 > [x] > minus
     slice.
       as-bytes.
-        as-i32.minus x.as-u16.as-i32
+        ^.as-i32.minus x.as-u16.as-i32
       2
       2
   u16 > [x] > plus
     slice.
       as-bytes.
-        as-i32.plus x.as-u16.as-i32
+        ^.as-i32.plus x.as-u16.as-i32
       2
       2
   u16 > [x] > times
     slice.
       as-bytes.
-        as-i32.times x.as-u16.as-i32
+        ^.as-i32.times x.as-u16.as-i32
       2
       2
 

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -11,7 +11,7 @@
 [as-bytes] > u32
   as-bytes > @
   i64 > [] > as-i64
-    00-00-00-00.concat as-bytes
+    00-00-00-00.concat ^.as-bytes
   as-i64.as-number > as-number
   [x cant-divide] > div
     if. > @
@@ -20,33 +20,33 @@
         00-00-00-00
       cant-divide
         "Can't divide %d by u32 zero".printf
-          * as-number
+          * ^.as-number
       u32
         slice.
           as-bytes.
-            as-i64.div other.as-i64
+            ^.as-i64.div other.as-i64
           4
           4
-  as-i64.gt x.as-u32.as-i64 > [x] > gt
-  as-i64.gte x.as-u32.as-i64 > [x] > gte
-  as-i64.lt x.as-u32.as-i64 > [x] > lt
-  as-i64.lte x.as-u32.as-i64 > [x] > lte
+  ^.as-i64.gt x.as-u32.as-i64 > [x] > gt
+  ^.as-i64.gte x.as-u32.as-i64 > [x] > gte
+  ^.as-i64.lt x.as-u32.as-i64 > [x] > lt
+  ^.as-i64.lte x.as-u32.as-i64 > [x] > lte
   u32 > [x] > minus
     slice.
       as-bytes.
-        as-i64.minus x.as-u32.as-i64
+        ^.as-i64.minus x.as-u32.as-i64
       4
       4
   u32 > [x] > plus
     slice.
       as-bytes.
-        as-i64.plus x.as-u32.as-i64
+        ^.as-i64.plus x.as-u32.as-i64
       4
       4
   u32 > [x] > times
     slice.
       as-bytes.
-        as-i64.times x.as-u32.as-i64
+        ^.as-i64.times x.as-u32.as-i64
       4
       4
 

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -14,43 +14,43 @@
   as-bytes > @
   plus. > [] > as-number
     as-number.
-      i64 as-bytes
+      i64 ^.as-bytes
     if.
       eq.
-        as-bytes.and 80-00-00-00-00-00-00-00
+        ^.as-bytes.and 80-00-00-00-00-00-00-00
         80-00-00-00-00-00-00-00
       1.8446744073709552e19
       0
   as-bytes.xor 80-00-00-00-00-00-00-00 > flip
   gt. > [x] > gt
-    i64 flip
+    i64 ^.flip
     i64 x.as-u64.flip
   gte. > [x] > gte
-    i64 flip
+    i64 ^.flip
     i64 x.as-u64.flip
   lt. > [x] > lt
-    i64 flip
+    i64 ^.flip
     i64 x.as-u64.flip
   lte. > [x] > lte
-    i64 flip
+    i64 ^.flip
     i64 x.as-u64.flip
   [x] > minus
     u64 > @
       as-bytes.
         minus. >>
-          i64 as-bytes
+          i64 ^.as-bytes
           i64 x.as-u64.as-bytes
   [x] > plus
     u64 > @
       as-bytes.
         plus. >>
-          i64 as-bytes
+          i64 ^.as-bytes
           i64 x.as-u64.as-bytes
   [x] > times
     u64 > @
       as-bytes.
         times. >>
-          i64 as-bytes
+          i64 ^.as-bytes
           i64 x.as-u64.as-bytes
 
   eq. ++> can-add-one-to-one

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -11,7 +11,7 @@
 [as-bytes] > u8
   as-bytes > @
   i16 > [] > as-i16
-    00-.concat as-bytes
+    00-.concat ^.as-bytes
   as-i16.as-number > as-number
   [x cant-divide] > div
     if. > @
@@ -20,33 +20,33 @@
         00-
       cant-divide
         "Can't divide %d by u8 zero".printf
-          * as-number
+          * ^.as-number
       u8
         slice.
           as-bytes.
-            as-i16.div other.as-i16
+            ^.as-i16.div other.as-i16
           1
           1
-  as-i16.gt x.as-u8.as-i16 > [x] > gt
-  as-i16.gte x.as-u8.as-i16 > [x] > gte
-  as-i16.lt x.as-u8.as-i16 > [x] > lt
-  as-i16.lte x.as-u8.as-i16 > [x] > lte
+  ^.as-i16.gt x.as-u8.as-i16 > [x] > gt
+  ^.as-i16.gte x.as-u8.as-i16 > [x] > gte
+  ^.as-i16.lt x.as-u8.as-i16 > [x] > lt
+  ^.as-i16.lte x.as-u8.as-i16 > [x] > lte
   u8 > [x] > minus
     slice.
       as-bytes.
-        as-i16.minus x.as-u8.as-i16
+        ^.as-i16.minus x.as-u8.as-i16
       1
       1
   u8 > [x] > plus
     slice.
       as-bytes.
-        as-i16.plus x.as-u8.as-i16
+        ^.as-i16.plus x.as-u8.as-i16
       1
       1
   u8 > [x] > times
     slice.
       as-bytes.
-        as-i16.times x.as-u8.as-i16
+        ^.as-i16.times x.as-u8.as-i16
       1
       1
 

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -35,14 +35,14 @@
     [index] >> loop
       if. > @
         as-bool.
-          condition
+          ^.condition
             index.plus 1
         seq *
           current
-          loop
+          ^.loop
             index.plus 1
         current
-      body index > current
+      ^.body index > current
     | 0
     false
 
@@ -53,7 +53,7 @@
         [m]
           while > @
             i.eq 0 > [i]
-            m.put i > [i] >>
+            ^.m.put i > [i] >>
 
   ++> can-iterate-a-tuple-with-an-external-iterator
     data.eq array.length > @
@@ -69,13 +69,13 @@
           0
           [iter] >>
             while > @
-              max.gt iter > [i] >>
+              ^.^.^.max.gt ^.iter > [i] >>
               seq * > [i] >>
-                acc.put
-                  acc.as-number.plus
-                    array.at iter
-                iter.put
-                  iter.as-number.plus 1
+                ^.^.acc.put
+                  ^.^.acc.as-number.plus
+                    ^.^.^.array.at ^.iter
+                ^.iter.put
+                  ^.iter.as-number.plus 1
     array.length.plus -1 > max
 
   ++> can-iterate-a-tuple-with-an-internal-iterator
@@ -92,17 +92,17 @@
           0
           [iter] >>
             if. > @
-              max.eq 0
-              acc.put
-                acc.as-number.plus
-                  array.at 0
+              ^.^.max.eq 0
+              ^.acc.put
+                ^.acc.as-number.plus
+                  ^.^.array.at 0
               while
-                max.gt iter > [i] >>
+                ^.^.^.max.gt ^.iter > [i] >>
                 seq * > [i] >>
-                  acc.put
-                    acc.as-number.plus (array.at i)
-                  iter.put
-                    iter.as-number.plus 1
+                  ^.^.acc.put
+                    ^.^.acc.as-number.plus (^.^.^.array.at i)
+                  ^.iter.put
+                    ^.iter.as-number.plus 1
     array.length.plus -1 > max
 
   ++> can-iterate-a-tuple-without-a-body-many-times
@@ -120,15 +120,15 @@
             seq * > @
               while
                 if. > [i] >>
-                  max.gt iter
+                  ^.^.^.max.gt ^.iter
                   seq *
-                    acc.put
-                      acc.as-number.plus (array.at iter.as-number)
-                    iter.put (iter.as-number.plus 1)
+                    ^.^.acc.put
+                      ^.^.acc.as-number.plus (^.^.^.array.at ^.iter.as-number)
+                    ^.iter.put (^.iter.as-number.plus 1)
                     true
                   false
                 true > [i]
-              acc
+              ^.acc
     array.length > max
 
   ++> can-iterate-a-tuple-without-a-body-once
@@ -143,15 +143,15 @@
             seq * > @
               while
                 if. > [i] >>
-                  max.gt iter
+                  ^.^.^.max.gt ^.iter
                   seq *
-                    acc.put
-                      acc.as-number.plus (array.at iter.as-number)
-                    iter.put (iter.as-number.plus 1)
+                    ^.^.acc.put
+                      ^.^.acc.as-number.plus (^.^.^.array.at ^.iter.as-number)
+                    ^.iter.put (^.iter.as-number.plus 1)
                     true
                   false
                 true > [i]
-              acc
+              ^.acc
     array.length > max
 
   ++> can-loop-on-a-bool-expression-kept-in-malloc
@@ -160,8 +160,8 @@
         true
         [m]
           while > @
-            m > [i] >>
-            m.put false > [i] >>
+            ^.m > [i] >>
+            ^.m.put false > [i] >>
       false
 
   ++> can-loop-over-a-simple-iteration
@@ -171,7 +171,7 @@
         [m]
           while > @
             i.lt 10 > [i]
-            m.put i > [i] >>
+            ^.m.put i > [i] >>
       9
 
   not. ++> can-loop-when-the-condition-is-false-first
@@ -185,9 +185,9 @@
         0
         [m]
           while > @
-            2.gt m > [i] >>
-            m.put > [i] >>
-              m.as-number.plus 1
+            2.gt ^.m > [i] >>
+            ^.m.put > [i] >>
+              ^.m.as-number.plus 1
       3
 
   not. ++> can-return-the-last-dataized-object-with-a-false-condition

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -32,7 +32,7 @@
   00-00-00-00-00-00-04-00 > reparse
   [code output] > return
     output > @
-    return > called
+    ^.return > called
       code
       output
   [family port address] > sockaddr-in


### PR DESCRIPTION
Closes #7094.

`eo-runtime` reads a receiver 920 times and writes down about 164 of them.
The rest are hops `build-fqns.xsl` inserts and `to-eo-tree.xsl` takes back
out, so the file a reader opens says less than the program means. The two
are exact inverses, and the printer's own comment said when it dropped a
run:

```
The run of leading "^." parent hops is redundant: the name is
absent from each of the N nearer enclosing formations but
present in the (N+1)-th, so plain scope resolution re-derives
exactly the very same ρ-chain of length N. Drop the whole run.
```

That branch is gone, and `eo:format` wrote the hops into the sources. The
deepest were in `file.eo`, six levels climbed under a bare name:

```
^.^.^.^.^.^.readable.not.if > @
  ^.^.^.^.syscall.read
```

84 of 171 sources changed, one hop per line, 594 lines either way. 21 of
the 144 print packs record the new canonical form; `multi-hop-parent` and
`redundant-parent` still hold, the second now saying that a redundant hop
is kept rather than dropped.

Nothing about meaning moves, and that is checkable rather than assertable,
since printing is the inverse of parsing here. Comparing `loc`, `base`,
`name` and `as` on all 40138 `<o>` nodes of the parsed tree, before against
after, leaves 13 nodes differing, every one an auto-generated cactus name
tracking its object's new column — `a🌵132-12` becomes `a🌵132-14`.
Normalise those and the two sides hash the same. Such names never enter the
visible namespace, so nothing can be written against them, but the shift is
worth knowing about.

The sources and the sheet have to travel together: the moment the canonical
form changes, `MjFormat` refuses the old text with `84 of 171 EO source(s)
are not formatted canonically`.

Stopping `build-fqns.xsl` from inserting the hops at all is the follow-up
this makes possible. Until then the compiler still puts them in; it just no
longer hides that it did.
