### PR TITLE
fix(#7061): one-word penalty parameter names, declared once

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjFormat.java
@@ -11,8 +11,6 @@ import com.jcabi.xml.XML;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
-import java.util.EnumMap;
-import java.util.Map;
 import java.util.Optional;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -20,7 +18,6 @@ import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 import org.eolang.parser.EoSyntax;
-import org.eolang.printer.PenaltyKey;
 import org.eolang.printer.Xmir;
 
 /**
@@ -59,7 +56,7 @@ import org.eolang.printer.Xmir;
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
     threadSafe = true
 )
-public final class MjFormat extends MjSafe {
+public final class MjFormat extends MjPenalties {
 
     /**
      * The most parse-and-print passes taken to settle the moniker layout
@@ -81,33 +78,6 @@ public final class MjFormat extends MjSafe {
      */
     @Parameter(property = "eo.autoFix", required = true, defaultValue = "false")
     private boolean autoFix;
-
-    /**
-     * Points charged for each level of indentation on a line.
-     * @checkstyle MemberNameCheck (10 lines)
-     */
-    @Parameter(property = "eo.penaltyIndent")
-    private Integer penaltyIndent;
-
-    /**
-     * Points charged for each opening parenthesis.
-     * @checkstyle MemberNameCheck (10 lines)
-     */
-    @Parameter(property = "eo.penaltyBracket")
-    private Integer penaltyBracket;
-
-    /**
-     * Points charged for each character past the allowed width.
-     * @checkstyle MemberNameCheck (10 lines)
-     */
-    @Parameter(property = "eo.penaltyExcess")
-    private Integer penaltyExcess;
-
-    /**
-     * The column after which characters start being charged.
-     */
-    @Parameter(property = "eo.width")
-    private Integer width;
 
     /**
      * Ctor.
@@ -346,32 +316,6 @@ public final class MjFormat extends MjSafe {
     private static boolean severe(final Xnav error) {
         final String severity = error.attribute("severity").text().orElse("");
         return "error".equals(severity) || "critical".equals(severity);
-    }
-
-    /**
-     * Assemble the overridden penalty weights from the Maven properties.
-     *
-     * <p>Only the properties that the user actually set are put into the
-     * map; every absent key falls back to its {@link PenaltyKey#fallback()}
-     * default inside the printer.</p>
-     *
-     * @return The weights, keyed by {@link PenaltyKey}
-     */
-    private Map<PenaltyKey, Integer> weights() {
-        final Map<PenaltyKey, Integer> map = new EnumMap<>(PenaltyKey.class);
-        if (this.penaltyIndent != null) {
-            map.put(PenaltyKey.INDENT, this.penaltyIndent);
-        }
-        if (this.penaltyBracket != null) {
-            map.put(PenaltyKey.BRACKET, this.penaltyBracket);
-        }
-        if (this.penaltyExcess != null) {
-            map.put(PenaltyKey.EXCESS, this.penaltyExcess);
-        }
-        if (this.width != null) {
-            map.put(PenaltyKey.WIDTH, this.width);
-        }
-        return map;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPenalties.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPenalties.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.EnumMap;
+import java.util.Map;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.eolang.printer.PenaltyKey;
+
+/**
+ * A goal that lays EO text out with the printer's penalty weights.
+ *
+ * <p>{@link MjPrint} and {@link MjFormat} both print XMIR back to EO,
+ * and the layout that comes out is decided by the same four numbers, so
+ * one declaration serves both and neither can drift from the other.</p>
+ *
+ * @since 0.75.0
+ */
+abstract class MjPenalties extends MjSafe {
+
+    /**
+     * Points charged for each level of indentation on a line.
+     */
+    @Parameter(alias = "penaltyIndent", property = "eo.penaltyIndent")
+    private Integer indent;
+
+    /**
+     * Points charged for each opening parenthesis.
+     */
+    @Parameter(alias = "penaltyBracket", property = "eo.penaltyBracket")
+    private Integer bracket;
+
+    /**
+     * Points charged for each character past the allowed width.
+     */
+    @Parameter(alias = "penaltyExcess", property = "eo.penaltyExcess")
+    private Integer excess;
+
+    /**
+     * The column after which characters start being charged.
+     */
+    @Parameter(property = "eo.width")
+    private Integer width;
+
+    /**
+     * Assemble the overridden penalty weights from the Maven properties.
+     *
+     * <p>Only the properties the user set are put into the map; an absent
+     * key falls back to its {@link PenaltyKey#fallback()} default.</p>
+     *
+     * @return The weights, keyed by {@link PenaltyKey}
+     */
+    final Map<PenaltyKey, Integer> weights() {
+        final Map<PenaltyKey, Integer> map = new EnumMap<>(PenaltyKey.class);
+        if (this.indent != null) {
+            map.put(PenaltyKey.INDENT, this.indent);
+        }
+        if (this.bracket != null) {
+            map.put(PenaltyKey.BRACKET, this.bracket);
+        }
+        if (this.excess != null) {
+            map.put(PenaltyKey.EXCESS, this.excess);
+        }
+        if (this.width != null) {
+            map.put(PenaltyKey.WIDTH, this.width);
+        }
+        return map;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPrint.java
@@ -10,15 +10,12 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.EnumMap;
-import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.cactoos.text.TextOf;
-import org.eolang.printer.PenaltyKey;
 import org.eolang.printer.Xmir;
 
 /**
@@ -37,7 +34,7 @@ import org.eolang.printer.Xmir;
     defaultPhase = LifecyclePhase.PROCESS_SOURCES,
     threadSafe = true
 )
-public final class MjPrint extends MjSafe {
+public final class MjPrint extends MjPenalties {
 
     /**
      * Pattern to catch the trailing .xmir extension.
@@ -65,33 +62,6 @@ public final class MjPrint extends MjSafe {
         defaultValue = "${project.build.directory}/generated-sources/eo"
     )
     private File printOutputDir;
-
-    /**
-     * Points charged for each level of indentation on a line.
-     * @checkstyle MemberNameCheck (10 lines)
-     */
-    @Parameter(property = "eo.penaltyIndent")
-    private Integer penaltyIndent;
-
-    /**
-     * Points charged for each opening parenthesis.
-     * @checkstyle MemberNameCheck (10 lines)
-     */
-    @Parameter(property = "eo.penaltyBracket")
-    private Integer penaltyBracket;
-
-    /**
-     * Points charged for each character past the allowed width.
-     * @checkstyle MemberNameCheck (10 lines)
-     */
-    @Parameter(property = "eo.penaltyExcess")
-    private Integer penaltyExcess;
-
-    /**
-     * The column after which characters start being charged.
-     */
-    @Parameter(property = "eo.width")
-    private Integer width;
 
     /**
      * Ctor.
@@ -141,31 +111,5 @@ public final class MjPrint extends MjSafe {
             home.resolve(relative).toFile().length()
         );
         return 1;
-    }
-
-    /**
-     * Assemble the overridden penalty weights from the Maven properties.
-     *
-     * <p>Only the properties that the user actually set are put into the
-     * map; every absent key falls back to its {@link PenaltyKey#fallback()}
-     * default inside the printer.</p>
-     *
-     * @return The weights, keyed by {@link PenaltyKey}
-     */
-    private Map<PenaltyKey, Integer> weights() {
-        final Map<PenaltyKey, Integer> map = new EnumMap<>(PenaltyKey.class);
-        if (this.penaltyIndent != null) {
-            map.put(PenaltyKey.INDENT, this.penaltyIndent);
-        }
-        if (this.penaltyBracket != null) {
-            map.put(PenaltyKey.BRACKET, this.penaltyBracket);
-        }
-        if (this.penaltyExcess != null) {
-            map.put(PenaltyKey.EXCESS, this.penaltyExcess);
-        }
-        if (this.width != null) {
-            map.put(PenaltyKey.WIDTH, this.width);
-        }
-        return map;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ArchitectureTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ArchitectureTest.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.domain.JavaConstructorCall;
+import com.tngtech.archunit.core.domain.JavaModifier;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
 import com.tngtech.archunit.lang.syntax.elements.GivenClassesConjunction;
@@ -78,13 +79,13 @@ final class ArchitectureTest {
     }
 
     /**
-     * All the project Mojos.
+     * All the project Mojos, the concrete goals; an abstract one is a base.
      * @return Mojos classes conjunction
      */
     private static GivenClassesConjunction mojos() {
         return ArchRuleDefinition.classes()
             .that().haveSimpleNameStartingWith("Mj")
-            .and().doNotHaveSimpleName("MjSafe")
+            .and().doNotHaveModifier(JavaModifier.ABSTRACT)
             .and().haveSimpleNameNotEndingWith("Test")
             .and().haveSimpleNameNotEndingWith("IT");
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -190,9 +190,9 @@ final class MjPrintTest {
      */
     private static String param(final String key) {
         return new MapOf<>(
-            new MapEntry<>("INDENT", "penaltyIndent"),
-            new MapEntry<>("BRACKET", "penaltyBracket"),
-            new MapEntry<>("EXCESS", "penaltyExcess"),
+            new MapEntry<>("INDENT", "indent"),
+            new MapEntry<>("BRACKET", "bracket"),
+            new MapEntry<>("EXCESS", "excess"),
             new MapEntry<>("WIDTH", "width")
         ).getOrDefault(key, "");
     }


### PR DESCRIPTION
Part of #7061, after #7085, #7086 and #7088. The last six suppressions outside `MjSafe`, on `penaltyIndent`, `penaltyBracket` and `penaltyExcess` in `MjPrint` and `MjFormat`.

These two could not simply be renamed in place. Both mojos declare the same four penalty parameters and read them back through a `weights()` method that is identical down to the last character, so touching that block in both files at once makes SonarCloud see 20.7% duplication on new code against a 3% gate (see the first run of #7086). The block has to stop being duplicated before the names can move.

So it moves into `MjPenalties`, an abstract goal that `MjPrint` and `MjFormat` now extend. Both print XMIR back to EO through `Xmir#toEO()` and the layout that comes out is decided by the same four numbers, so one declaration serves both, and neither goal can drift away from the other's idea of the layout any more. Maven injects `@Parameter` fields declared in a superclass exactly as it does for `MjSafe`'s own, and `FakeMaven.mojoFields` already walks the whole hierarchy, so the tests reach them unchanged.

| field | now | XML element | `-D` property |
| --- | --- | --- | --- |
| `penaltyIndent` | `indent` | `<penaltyIndent>` | `eo.penaltyIndent` |
| `penaltyBracket` | `bracket` | `<penaltyBracket>` | `eo.penaltyBracket` |
| `penaltyExcess` | `excess` | `<penaltyExcess>` | `eo.penaltyExcess` |

`width` travels with them, needing no rename and no alias.

`MjPrintTest.param()` maps a pack's penalty key to the mojo parameter name, so its three literals move too.

`ArchitectureTest.mojos()` used to carve `MjSafe` out of the mojo rules by name, since a base is neither public, nor annotated with `@Mojo`, nor a goal. It now carves out every abstract `Mj*` instead, which covers `MjSafe` and `MjPenalties` alike and needs no further edit the next time a base appears.

After this, every `MemberNameCheck` suppression outside `MjSafe` is gone. `MjSafe`'s own 27 need the grouping from #6459 first.

Note: `MjPrintTest.printsXmirToEo` fails on my machine on master as well, because it reads a pack directory out of `eo-printer/src/test/resources` that is not on my local classpath. The other 13 tests of that class and all 10 of `MjFormatTest` pass.
