### PR TITLE
#7113: shorten Openness constants to drop PMD.LongVariable

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -915,7 +915,7 @@ final class Eo implements Iterable<Directive> {
             Eo.closeCompactTuple(level, emit);
         }
         if (level.kind() == Kind.ONLY_PHI_FORMATION
-            && level.openness() != Openness.HORIZONTAL_COMPLETED) {
+            && level.openness() != Openness.HCOMPLETED) {
             emit.close();
         }
         emit.close();

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -11,8 +11,8 @@ package org.eolang.parser;
  * extend the level's expression (e.g., a {@link Kind#HEAD} entry promotes
  * to {@link Kind#VAPPLICATION} once its first deeper child arrives; its
  * {@code openness} progresses from {@link Openness#OPEN OPEN} to
- * {@link Openness#VERTICAL_COMPLETED VERTICAL_COMPLETED} when the child
- * block ends).</p>
+ * {@link Openness#VCOMPLETED VCOMPLETED} when the child block
+ * ends).</p>
  *
  * <p>Per the parser-pragmatism rule, this class deliberately holds more
  * than four fields and is mutable in-place: an immutable {@code Level} +

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -22,7 +22,7 @@ import java.util.List;
  * <li>{@link Kind#HMETHOD} — head with {@code .method} chain, 0
  * horizontal args. Open for deeper-indent children.</li>
  * <li>{@link Kind#HAPPLICATION} — head (with or without chain) plus one
- * or more horizontal args. {@link Openness#HORIZONTAL_COMPLETED}.</li>
+ * or more horizontal args. {@link Openness#HCOMPLETED}.</li>
  * </ul>
  *
  * <p>Emission follows §9.0.3: method-dispatch chains emit as
@@ -77,7 +77,7 @@ final class LnApplication implements Line {
         final Kind kind = LnApplication.classify(head, chain, args);
         final Openness openness;
         if (kind == Kind.HAPPLICATION) {
-            openness = Openness.HORIZONTAL_COMPLETED;
+            openness = Openness.HCOMPLETED;
         } else {
             openness = Openness.OPEN;
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -20,7 +20,7 @@ import java.util.List;
  * or deeper-indent vapplication children.</li>
  * <li>{@link Kind#VMETHOD_WITH_HARGS} when this {@code .method}
  * carries one or more horizontal args — the chain becomes
- * {@link Openness#HORIZONTAL_COMPLETED}.</li>
+ * {@link Openness#HCOMPLETED}.</li>
  * </ul>
  *
  * <p>Rejection paths owned here:</p>
@@ -109,7 +109,7 @@ final class LnMethod implements Line {
             openness = Openness.OPEN;
         } else {
             kind = Kind.VMETHOD_WITH_HARGS;
-            openness = Openness.HORIZONTAL_COMPLETED;
+            openness = Openness.HCOMPLETED;
         }
         top.become(kind);
         top.close(openness);
@@ -133,7 +133,7 @@ final class LnMethod implements Line {
                 "method continuation has no expression to attach to"
             );
         }
-        if (stack.top().openness() == Openness.HORIZONTAL_COMPLETED) {
+        if (stack.top().openness() == Openness.HCOMPLETED) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "method continuation not allowed after horizontal application, try vertical application instead"

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -38,8 +38,8 @@ import java.util.List;
  * vertical application arguments (§4.5) — {@code foo > [x] > bar} with
  * a body block is {@code [x] > bar} whose φ is {@code foo} applied to
  * that block. With horizontal args the φ is already a full application
- * and the line is {@link Openness#HORIZONTAL_COMPLETED} — no body is
- * accepted. An only-phi argument may not carry a name suffix (the
+ * and the line is {@link Openness#HCOMPLETED} — no body is accepted.
+ * An only-phi argument may not carry a name suffix (the
  * formation binds only φ); the {@link Stack} flags such arguments and
  * the close-time check in {@link Eo} rejects a name on them.</p>
  *
@@ -228,8 +228,8 @@ final class LnOnlyPhi implements Line {
      * Whether the only-phi LHS carries no horizontal args, so its φ
      * stays {@link Openness#OPEN} for deeper-indent vertical arguments
      * (§4.5); otherwise the φ is a full application and the formation is
-     * {@link Openness#HORIZONTAL_COMPLETED}. The LHS may be a reversed
-     * dispatch ({@code if. > [t] >> rec}), whose trailing dot is skipped
+     * {@link Openness#HCOMPLETED}. The LHS may be a reversed dispatch
+     * ({@code if. > [t] >> rec}), whose trailing dot is skipped
      * exactly as {@link Emissions#expression} does so both agree on the
      * arg boundary. Consumes the token stream; callers rewind before
      * emitting.
@@ -281,7 +281,7 @@ final class LnOnlyPhi implements Line {
         if (open) {
             openness = Openness.OPEN;
         } else {
-            openness = Openness.HORIZONTAL_COMPLETED;
+            openness = Openness.HCOMPLETED;
         }
         return new Transition(stack, this.span).apply(
             Kind.ONLY_PHI_FORMATION, openness, new Admission(suffix.named(), suffix.test())

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -25,8 +25,8 @@ import java.util.List;
  *
  * <p>Two forms by whether horizontal args are present (R-3.14.3): the
  * <em>horizontal</em> form {@code | a b} carries its args on the line and
- * closes for children ({@link Openness#VERTICAL_COMPLETED}); the
- * <em>vertical</em> form {@code |} with a deeper-indent body opens for a
+ * closes for children ({@link Openness#VCOMPLETED}); the <em>vertical</em>
+ * form {@code |} with a deeper-indent body opens for a
  * vertical-argument block exactly as a {@code vapplication} head, so it
  * stays {@link Openness#OPEN}. Either way a following {@code .method} or
  * pipe may extend it.</p>
@@ -80,7 +80,7 @@ final class LnPipe implements Line {
         if (args.isEmpty()) {
             openness = Openness.OPEN;
         } else {
-            openness = Openness.VERTICAL_COMPLETED;
+            openness = Openness.VCOMPLETED;
         }
         new Transition(stack, this.span).apply(
             Kind.PIPE_APPLICATION, openness, new Admission(suffix.named(), suffix.test())

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -21,8 +21,7 @@ import java.util.List;
  * <li><strong>Horizontal</strong> ({@code name. arg1 arg2}) —
  * {@code arg1} is the receiver, {@code arg2…} are method args. Outer
  * kind {@link Kind#REVERSED_WITH_HARGS},
- * {@link Openness#HORIZONTAL_COMPLETED}. No deeper-indent
- * children.</li>
+ * {@link Openness#HCOMPLETED}. No deeper-indent children.</li>
  * <li><strong>Vertical</strong> ({@code name.} with no hargs) — the
  * next deeper-indent line is the receiver (R-5.2.9), subsequent
  * deeper-indent siblings are method args. Outer kind
@@ -93,7 +92,7 @@ final class LnReversed implements Line {
             openness = Openness.OPEN;
         } else {
             kind = Kind.REVERSED_WITH_HARGS;
-            openness = Openness.HORIZONTAL_COMPLETED;
+            openness = Openness.HCOMPLETED;
         }
         this.transition(stack, suffix, kind, openness);
         Bindings.observeChild(stack, outer, this.span);

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -98,7 +98,7 @@ final class LnTextBlock implements Line {
     private void transition(final Stack stack, final Suffix suffix) {
         new Transition(stack, this.span).apply(
             Kind.TEXT_BLOCK,
-            Openness.VERTICAL_COMPLETED,
+            Openness.VCOMPLETED,
             new Admission(suffix.named(), suffix.test())
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -44,8 +44,7 @@ package org.eolang.parser;
  * take, never an argument, a method receiver, or anywhere else a value
  * is expected. The marker is therefore <em>not</em> a {@link Value}
  * kind; this line is its sole producer. Cross-line behaviour: a closed
- * leaf ({@link Openness#VERTICAL_COMPLETED}), so a void has no
- * children.</p>
+ * leaf ({@link Openness#VCOMPLETED}), so a void has no children.</p>
  *
  * @since 0.1
  */
@@ -81,7 +80,7 @@ final class LnVoid implements Line {
         }
         Comments.seal(globals, emit, this.span);
         final Level level = new Transition(stack, this.span).apply(
-            Kind.VOID, Openness.VERTICAL_COMPLETED, new Admission(suffix.named(), true)
+            Kind.VOID, Openness.VCOMPLETED, new Admission(suffix.named(), true)
         );
         if (slash >= 0 && !level.patom()) {
             throw new ParseError(

--- a/eo-parser/src/main/java/org/eolang/parser/Openness.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Openness.java
@@ -14,17 +14,16 @@ package org.eolang.parser;
  * <ul>
  * <li>{@link #OPEN} — may still receive deeper-indent children or a
  * same-indent {@code .method} continuation.</li>
- * <li>{@link #VERTICAL_COMPLETED} — child block has ended; a same-indent
- * {@code .method} may still wrap it, but no more vertical args may be
- * added.</li>
- * <li>{@link #HORIZONTAL_COMPLETED} — cannot be extended in any
- * direction. {@link Kind#horizontallyCompleted()} pins which kinds
- * start out in this state.</li>
+ * <li>{@link #VCOMPLETED} — vertically completed: the child block has
+ * ended; a same-indent {@code .method} may still wrap it, but no more
+ * vertical args may be added.</li>
+ * <li>{@link #HCOMPLETED} — horizontally completed: cannot be extended
+ * in any direction. {@link Kind#horizontallyCompleted()} pins which
+ * kinds start out in this state.</li>
  * </ul>
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.LongVariable")
 enum Openness {
 
     /**
@@ -33,12 +32,13 @@ enum Openness {
     OPEN,
 
     /**
-     * Child block has ended; same-indent {@code .method} may wrap.
+     * Vertically completed: child block has ended; same-indent
+     * {@code .method} may wrap.
      */
-    VERTICAL_COMPLETED,
+    VCOMPLETED,
 
     /**
-     * Closed in every direction.
+     * Horizontally completed: closed in every direction.
      */
-    HORIZONTAL_COMPLETED
+    HCOMPLETED
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -221,8 +221,7 @@ final class Stack {
      * on each as it is removed. After the pop sweep, if the new top has
      * indent {@code target} - 2 (a step occurred), its openness is
      * downgraded from {@link Openness#OPEN OPEN} to
-     * {@link Openness#VERTICAL_COMPLETED VERTICAL_COMPLETED} per
-     * R-5.2.2.
+     * {@link Openness#VCOMPLETED VCOMPLETED} per R-5.2.2.
      * @param target Target indent
      */
     void popDeeperThan(final int target) {
@@ -233,7 +232,7 @@ final class Stack {
             this.closer.onClose(last, true);
         }
         if (stepped && !this.levels.isEmpty() && this.top().openness() == Openness.OPEN) {
-            this.top().close(Openness.VERTICAL_COMPLETED);
+            this.top().close(Openness.VCOMPLETED);
         }
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -50,11 +50,11 @@ final class LevelTest {
         final Level level = new Level(
             0, 1, Kind.HEAD, Openness.OPEN, Kind.TOP_LEVEL, false
         );
-        level.close(Openness.VERTICAL_COMPLETED);
+        level.close(Openness.VCOMPLETED);
         MatcherAssert.assertThat(
             "after close(), openness must reflect the new state",
             level.openness(),
-            Matchers.equalTo(Openness.VERTICAL_COMPLETED)
+            Matchers.equalTo(Openness.VCOMPLETED)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnApplicationTest.java
@@ -251,9 +251,9 @@ final class LnApplicationTest {
         new LnApplication(new Span("foo a b > x", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "a happlication cannot receive deeper-indent children so it pushes HORIZONTAL_COMPLETED",
+            "a happlication cannot receive deeper-indent children so it pushes HCOMPLETED",
             stack.top().openness(),
-            Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
+            Matchers.equalTo(Openness.HCOMPLETED)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -92,9 +92,9 @@ final class LnMethodTest {
         new LnMethod(new Span(".bar 42", 2))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "VMETHOD_WITH_HARGS must be HORIZONTAL_COMPLETED so no further extension is allowed",
+            "VMETHOD_WITH_HARGS must be HCOMPLETED so no further extension is allowed",
             stack.top().openness(),
-            Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
+            Matchers.equalTo(Openness.HCOMPLETED)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -48,9 +48,9 @@ final class LnOnlyPhiTest {
         new LnOnlyPhi(new Span("right arg > [x] > left", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "an only-phi whose φ carries horizontal args cannot accept a body — must be HORIZONTAL_COMPLETED",
+            "an only-phi whose φ carries horizontal args cannot accept a body — must be HCOMPLETED",
             stack.top().openness(),
-            Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
+            Matchers.equalTo(Openness.HCOMPLETED)
         );
     }
 
@@ -224,9 +224,9 @@ final class LnOnlyPhiTest {
         new LnOnlyPhi(new Span("if. cond then else > [t] > pair", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "a reversed-dispatch φ carrying horizontal args cannot accept a body — must be HORIZONTAL_COMPLETED",
+            "a reversed-dispatch φ carrying horizontal args cannot accept a body — must be HCOMPLETED",
             stack.top().openness(),
-            Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
+            Matchers.equalTo(Openness.HCOMPLETED)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -59,9 +59,9 @@ final class LnReversedTest {
         new LnReversed(new Span("if. cond then > x", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "REVERSED_WITH_HARGS must be HORIZONTAL_COMPLETED — no deeper continuation allowed",
+            "REVERSED_WITH_HARGS must be HCOMPLETED — no deeper continuation allowed",
             stack.top().openness(),
-            Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
+            Matchers.equalTo(Openness.HCOMPLETED)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/OpennessTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/OpennessTest.java
@@ -35,8 +35,8 @@ final class OpennessTest {
     @Test
     void offersVerticalCompletedState() {
         MatcherAssert.assertThat(
-            "VERTICAL_COMPLETED must be one of the openness states",
-            Openness.valueOf("VERTICAL_COMPLETED"),
+            "VCOMPLETED must be one of the openness states",
+            Openness.valueOf("VCOMPLETED"),
             Matchers.notNullValue()
         );
     }
@@ -44,8 +44,8 @@ final class OpennessTest {
     @Test
     void offersHorizontalCompletedState() {
         MatcherAssert.assertThat(
-            "HORIZONTAL_COMPLETED must be one of the openness states",
-            Openness.valueOf("HORIZONTAL_COMPLETED"),
+            "HCOMPLETED must be one of the openness states",
+            Openness.valueOf("HCOMPLETED"),
             Matchers.notNullValue()
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -128,9 +128,9 @@ final class StackTest {
         stack.push(2, 2, Kind.HEAD, Openness.OPEN);
         stack.popDeeperThan(0);
         MatcherAssert.assertThat(
-            "after popping a deeper level, the surviving top must drop to VERTICAL_COMPLETED",
+            "after popping a deeper level, the surviving top must drop to VCOMPLETED",
             stack.top().openness(),
-            Matchers.equalTo(Openness.VERTICAL_COMPLETED)
+            Matchers.equalTo(Openness.VCOMPLETED)
         );
     }
 
@@ -138,13 +138,13 @@ final class StackTest {
     void leavesHorizontallyCompletedTopAlone() {
         final Stack stack = new Stack();
         final Level top = stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
-        top.close(Openness.HORIZONTAL_COMPLETED);
+        top.close(Openness.HCOMPLETED);
         stack.push(2, 2, Kind.HEAD, Openness.OPEN);
         stack.popDeeperThan(0);
         MatcherAssert.assertThat(
             "a horizontally-completed top must not be downgraded to vertical-completed",
             stack.top().openness(),
-            Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
+            Matchers.equalTo(Openness.HCOMPLETED)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
@@ -57,7 +57,7 @@ final class TransitionTest {
     void rejectsDeeperChildUnderHorizontallyCompletedParent() {
         final Stack stack = new Stack();
         new Transition(stack, new Span("zeta", 1))
-            .apply(Kind.HAPPLICATION, Openness.HORIZONTAL_COMPLETED, new Admission(null, false));
+            .apply(Kind.HAPPLICATION, Openness.HCOMPLETED, new Admission(null, false));
         Assertions.assertThrows(
             ParseError.class,
             () -> new Transition(stack, new Span("  eta", 2))
@@ -100,7 +100,7 @@ final class TransitionTest {
         MatcherAssert.assertThat(
             "applying at the same indent must replace the top level's kind in place",
             new Transition(stack, new Span("iota", 2))
-                .apply(Kind.HAPPLICATION, Openness.HORIZONTAL_COMPLETED, new Admission(null, false))
+                .apply(Kind.HAPPLICATION, Openness.HCOMPLETED, new Admission(null, false))
                 .kind(),
             Matchers.equalTo(Kind.HAPPLICATION)
         );
@@ -136,7 +136,7 @@ final class TransitionTest {
      */
     private Level happlicationChild(final Stack stack, final boolean permitted) {
         return new Transition(stack, new Span("  42", 2)).apply(
-            Kind.HAPPLICATION, Openness.HORIZONTAL_COMPLETED, new Admission(null, permitted)
+            Kind.HAPPLICATION, Openness.HCOMPLETED, new Admission(null, permitted)
         );
     }
 }


### PR DESCRIPTION
Closes #7113.

`Openness` carried `@SuppressWarnings("PMD.LongVariable")` purely because two constants were over the limit. Renaming them removes the need for the suppression:

* `VERTICAL_COMPLETED` → `VCOMPLETED`
* `HORIZONTAL_COMPLETED` → `HCOMPLETED`

The short forms keep the spec vocabulary of §1.6 (`vertical-completed` / `horizontal-completed`) and match the `V`/`H` prefix idiom already used by `Kind` (`HMETHOD`, `HAPPLICATION`, `VAPPLICATION`) and by the spec's `hargs`. Javadoc on the two constants and in the enum header now spells out "vertically completed" and "horizontally completed", so nothing is lost by the shorter identifiers; a few Javadoc lines were re-wrapped after the rename.

The rename is mechanical across all `Openness.*` usages in `eo-parser` main and test sources — no behaviour change.

Checks run locally:

* `mvn -pl eo-parser test -Dtest='OpennessTest,StackTest,LevelTest,TransitionTest,Ln*Test,KindTest'` — 219 tests, all green.
* `mvn -pl eo-parser -Pqulice com.qulice:qulice-maven-plugin:0.31.0:check` — 105 files against 1014 rules, BUILD SUCCESS, confirming PMD no longer flags the constants without the suppression.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FxF7njpffdiYqkfuR2UBVU)_