### PR TITLE
#7108: default value of includeSources via @Parameter

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -33,7 +33,6 @@ import org.cactoos.set.SetOf;
     defaultPhase = LifecyclePhase.GENERATE_SOURCES,
     threadSafe = true
 )
-@SuppressWarnings("PMD.ImmutableField")
 public final class MjRegister extends MjSafe {
 
     /**
@@ -49,14 +48,17 @@ public final class MjRegister extends MjSafe {
      *  properties since there is no way of passing it via command line.
      * @checkstyle MemberNameCheck (15 lines)
      */
-    @Parameter
+    @Parameter(defaultValue = "**.eo")
     private Set<String> includeSources;
 
     /**
      * List of exclusion GLOB filters for finding EO files
      * in the {@code <includeSources>} directory, which can be
      * pretty global (or even a root one).
-     * @checkstyle MemberNameCheck (7 lines)
+     * @implNote {@code defaultValue} attribute is omitted, because an empty
+     *  one is not rendered into the descriptor of the plugin by
+     *  the {@code maven-plugin-plugin}, thus this may stay {@code NULL}.
+     * @checkstyle MemberNameCheck (10 lines)
      */
     @Parameter
     private Set<String> excludeSources;
@@ -71,14 +73,6 @@ public final class MjRegister extends MjSafe {
         defaultValue = "true"
     )
     private boolean strictFileNames;
-
-    /**
-     * Ctor.
-     */
-    public MjRegister() {
-        this.includeSources = new SetOf<>("**.eo");
-        this.excludeSources = new SetOf<>();
-    }
 
     @Override
     public void exec() throws IOException {
@@ -100,15 +94,29 @@ public final class MjRegister extends MjSafe {
                 new Threaded<>(
                     new WkDefault(this.sourcesDir.toPath())
                         .includes(this.includeSources)
-                        .excludes(this.excludeSources),
+                        .excludes(this.excludes()),
                     file -> this.register(file, unplace, tojos)
                 ).total(),
                 this.sourcesDir,
                 this.foreign,
                 this.includeSources,
-                this.excludeSources
+                this.excludes()
             );
         }
+    }
+
+    /**
+     * Exclusion GLOB filters, as they were configured.
+     * @return Set of GLOB filters, never {@code NULL}
+     */
+    private Set<String> excludes() {
+        final Set<String> globs;
+        if (this.excludeSources == null) {
+            globs = new SetOf<>();
+        } else {
+            globs = this.excludeSources;
+        }
+        return globs;
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -27,6 +27,7 @@ import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.scalar.Synced;
+import org.cactoos.set.SetOf;
 import org.cactoos.text.TextOf;
 import org.cactoos.text.UncheckedText;
 
@@ -200,6 +201,7 @@ final class FakeMaven {
             this.params.putIfAbsent("attach", true);
             this.params.putIfAbsent("tests", true);
             this.params.putIfAbsent("strictFileNames", true);
+            this.params.putIfAbsent("includeSources", new SetOf<>("**.eo"));
         }
         final Moja<T> moja = new Moja<>(mojo);
         for (final Map.Entry<String, ?> entry : this.allowedParams(mojo).entrySet()) {


### PR DESCRIPTION
Closes #7108.

`MjRegister` no longer carries `@SuppressWarnings("PMD.ImmutableField")`. The suppression existed only because the constructor assigned the two private `@Parameter` fields; now the default of `<includeSources>` is expressed by Maven itself and the constructor is gone, so nothing assigns those fields inside the class and PMD stops asking for `final`:

```java
@Parameter(defaultValue = "**.eo")
private Set<String> includeSources;
```

Plexus converts a comma-separated `default-value` into a collection, and `maven-plugin-plugin` does render this one into the descriptor:

```xml
<includeSources implementation="java.util.Set" default-value="**.eo"/>
```

`<excludeSources>` can't be done the same way: `maven-plugin-plugin` only puts a parameter into the mojo's `<configuration>` when its `default-value` (or expression) is non-empty, so an empty default means no injection at all and a `NULL` field, which `Walk.excludes()` would choke on. The empty case therefore stays in the code, in a new `excludes()` method, and the field's Javadoc says why.

`FakeMaven` injects mojo parameters through `Moja` instead of reading the plugin descriptor, so it now provides `includeSources` among the defaults it already emulates (`strictFileNames`, `skipZeroVersions`, and so on).

How it was checked, besides `MjRegisterTest` and `MjCleanTest`: the plugin was installed locally and the `register` goal was run against a scratch project with two `.eo` files. Without any configuration it printed `Registered 1 EO sources ..., included [**.eo], excluded []`; with `<includeSources>**.eo</includeSources>` and `<excludeSources>**/bar.eo</excludeSources>` in the POM it printed `included [**.eo], excluded [**/bar.eo]` and registered one of the two files. `mvn -Pqulice verify` on `eo-maven-plugin` passes without the suppression.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Nr9MhViBkAYJ361KAKkpds)_