### PR TITLE
#7118: shorten Kind constants to drop PMD.LongVariable

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -914,7 +914,7 @@ final class Eo implements Iterable<Directive> {
         if (level.kind() == Kind.COMPACT_TUPLE || level.star()) {
             Eo.closeCompactTuple(level, emit);
         }
-        if (level.kind() == Kind.ONLY_PHI_FORMATION
+        if (level.kind() == Kind.ONLY_PHI
             && level.openness() != Openness.HORIZONTAL_COMPLETED) {
             emit.close();
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Kind.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Kind.java
@@ -15,13 +15,13 @@ package org.eolang.parser;
  * {@link Openness} states; the kind name itself never regresses.</p>
  *
  * <p>The three kinds in the horizontally-completed set
- * ({@link #HAPPLICATION}, {@link #REVERSED_WITH_HARGS},
- * {@link #VMETHOD_WITH_HARGS}) never receive deeper children and cannot
- * be wrapped by a same-indent {@code .method}.
- * {@link #horizontallyCompleted()} is the single source of truth for
- * that set; R-5.2.3 and R-6.1.1 read it. An {@link #ONLY_PHI_FORMATION}
- * with a bare (zero-hargs) φ is instead {@link Openness#OPEN}: its φ
- * accepts deeper-indent vertical arguments (§4.5).</p>
+ * ({@link #HAPPLICATION}, {@link #REVERSED_HARGS}, {@link #VMETHOD_HARGS})
+ * never receive deeper children and cannot be wrapped by a same-indent
+ * {@code .method}. {@link #horizontallyCompleted()} is the single source
+ * of truth for that set; R-5.2.3 and R-6.1.1 read it. An
+ * {@link #ONLY_PHI} with a bare (zero-hargs) φ is instead
+ * {@link Openness#OPEN}: its φ accepts deeper-indent vertical
+ * arguments (§4.5).</p>
  *
  * <p>The {@link #TOP_LEVEL} sentinel is not a real expression kind — it is
  * the {@code parent_kind} for entries pushed at indent 0 (R-5.2.11), used
@@ -30,7 +30,6 @@ package org.eolang.parser;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.LongVariable")
 enum Kind {
 
     /**
@@ -68,7 +67,7 @@ enum Kind {
      * Reversed dispatch with horizontal args: {@code name. arg1 arg2}.
      * Horizontally completed.
      */
-    REVERSED_WITH_HARGS,
+    REVERSED_HARGS,
 
     /**
      * Compact tuple {@code head *N}.
@@ -80,7 +79,7 @@ enum Kind {
      * completed when the φ (its {@code expr}) carries horizontal args;
      * otherwise open, so its φ accepts deeper-indent vertical arguments.
      */
-    ONLY_PHI_FORMATION,
+    ONLY_PHI,
 
     /**
      * Multi-line vertical application: head + deeper-indent argument block.
@@ -97,7 +96,7 @@ enum Kind {
      * Vertical method chain whose last link carries horizontal args.
      * Horizontally completed.
      */
-    VMETHOD_WITH_HARGS,
+    VMETHOD_HARGS,
 
     /**
      * Pipe application {@code | args} — applies arguments to the
@@ -137,8 +136,8 @@ enum Kind {
      */
     boolean horizontallyCompleted() {
         return this == HAPPLICATION
-            || this == REVERSED_WITH_HARGS
-            || this == VMETHOD_WITH_HARGS;
+            || this == REVERSED_HARGS
+            || this == VMETHOD_HARGS;
     }
 
     /**
@@ -154,7 +153,7 @@ enum Kind {
      * @return True iff this kind is a formation
      */
     boolean formation() {
-        return this == BARE_FORMATION || this == ONLY_PHI_FORMATION;
+        return this == BARE_FORMATION || this == ONLY_PHI;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -113,7 +113,7 @@ final class Level {
     private boolean tupled;
 
     /**
-     * For a {@link Kind#ONLY_PHI_FORMATION} whose φ is a compact tuple
+     * For a {@link Kind#ONLY_PHI} whose φ is a compact tuple
      * ({@code seq * > [m]}, R-3.9.1 + R-3.10.6): true so the φ absorbs
      * deeper-indent lines into a {@code Φ.tuple} wrapper like a
      * {@link Kind#COMPACT_TUPLE} head, reusing {@link #count} /
@@ -237,14 +237,14 @@ final class Level {
     /**
      * The name a child of this entry should use for its governing
      * only-phi formation: this entry's own name when it is the
-     * {@link Kind#ONLY_PHI_FORMATION}, otherwise the name propagated
+     * {@link Kind#ONLY_PHI}, otherwise the name propagated
      * onto it (see {@link #argues(String)}). Never {@code null} — an
      * anonymous formation propagates as the empty string.
      * @return Governing formation name (possibly empty)
      */
     String governingFormation() {
         final String owner;
-        if (this.kind == Kind.ONLY_PHI_FORMATION) {
+        if (this.kind == Kind.ONLY_PHI) {
             owner = this.label;
         } else {
             owner = this.formation;
@@ -315,7 +315,7 @@ final class Level {
      * @return True if a child of this entry is an only-phi argument
      */
     boolean argumentative() {
-        return this.kind == Kind.ONLY_PHI_FORMATION
+        return this.kind == Kind.ONLY_PHI
             || this.formation != null && !this.kind.formation();
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -18,7 +18,7 @@ import java.util.List;
  * <li>{@link Kind#VMETHOD} when this {@code .method} has 0 horizontal
  * args — the chain stays open for further {@code .method} continuations
  * or deeper-indent vapplication children.</li>
- * <li>{@link Kind#VMETHOD_WITH_HARGS} when this {@code .method}
+ * <li>{@link Kind#VMETHOD_HARGS} when this {@code .method}
  * carries one or more horizontal args — the chain becomes
  * {@link Openness#HORIZONTAL_COMPLETED}.</li>
  * </ul>
@@ -108,7 +108,7 @@ final class LnMethod implements Line {
             kind = Kind.VMETHOD;
             openness = Openness.OPEN;
         } else {
-            kind = Kind.VMETHOD_WITH_HARGS;
+            kind = Kind.VMETHOD_HARGS;
             openness = Openness.HORIZONTAL_COMPLETED;
         }
         top.become(kind);
@@ -139,7 +139,7 @@ final class LnMethod implements Line {
                 "method continuation not allowed after horizontal application, try vertical application instead"
             );
         }
-        if (stack.top().kind() == Kind.ONLY_PHI_FORMATION) {
+        if (stack.top().kind() == Kind.ONLY_PHI) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "method continuation not allowed after only-phi formation"

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -32,7 +32,7 @@ import java.util.List;
  * {@code >>}).</li>
  * </ul>
  *
- * <p>Outer kind: {@link Kind#ONLY_PHI_FORMATION}. Openness depends on
+ * <p>Outer kind: {@link Kind#ONLY_PHI}. Openness depends on
  * the φ (the LHS): with zero horizontal args the φ is
  * {@link Openness#OPEN}, so deeper-indent lines attach to it as
  * vertical application arguments (§4.5) — {@code foo > [x] > bar} with
@@ -284,7 +284,7 @@ final class LnOnlyPhi implements Line {
             openness = Openness.HORIZONTAL_COMPLETED;
         }
         return new Transition(stack, this.span).apply(
-            Kind.ONLY_PHI_FORMATION, openness, new Admission(suffix.named(), suffix.test())
+            Kind.ONLY_PHI, openness, new Admission(suffix.named(), suffix.test())
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -16,7 +16,7 @@ import java.util.List;
  * predecessor is formed, then the pipe supplies its arguments.</p>
  *
  * <p>The predecessor (stack top at the pipe's indent) must be a formation
- * ({@link Kind#BARE_FORMATION} / {@link Kind#ONLY_PHI_FORMATION}) or
+ * ({@link Kind#BARE_FORMATION} / {@link Kind#ONLY_PHI}) or
  * another {@link Kind#PIPE_APPLICATION}, and must be named — a pipe refers
  * to it by name, so an unnamed formation is not a valid target (R-3.14.2).
  * A pipe after a {@code .method} dispatch is rejected (R-3.14.4): the

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -20,7 +20,7 @@ import java.util.List;
  * <ul>
  * <li><strong>Horizontal</strong> ({@code name. arg1 arg2}) —
  * {@code arg1} is the receiver, {@code arg2…} are method args. Outer
- * kind {@link Kind#REVERSED_WITH_HARGS},
+ * kind {@link Kind.REVERSED_HARGS},
  * {@link Openness#HORIZONTAL_COMPLETED}. No deeper-indent
  * children.</li>
  * <li><strong>Vertical</strong> ({@code name.} with no hargs) — the
@@ -92,7 +92,7 @@ final class LnReversed implements Line {
             kind = Kind.BARE_REVERSED;
             openness = Openness.OPEN;
         } else {
-            kind = Kind.REVERSED_WITH_HARGS;
+            kind = Kind.REVERSED_HARGS;
             openness = Openness.HORIZONTAL_COMPLETED;
         }
         this.transition(stack, suffix, kind, openness);

--- a/eo-parser/src/test/java/org/eolang/parser/KindTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/KindTest.java
@@ -21,8 +21,8 @@ final class KindTest {
         value = Kind.class,
         names = {
             "HAPPLICATION",
-            "REVERSED_WITH_HARGS",
-            "VMETHOD_WITH_HARGS"
+            "REVERSED_HARGS",
+            "VMETHOD_HARGS"
         }
     )
     void marksHorizontallyCompletedKinds(final Kind kind) {
@@ -38,7 +38,7 @@ final class KindTest {
         value = Kind.class,
         names = {
             "TOP_LEVEL", "HEAD", "HMETHOD", "BARE_FORMATION", "BARE_REVERSED",
-            "COMPACT_TUPLE", "ONLY_PHI_FORMATION", "VAPPLICATION", "VMETHOD",
+            "COMPACT_TUPLE", "ONLY_PHI", "VAPPLICATION", "VMETHOD",
             "TEXT_BLOCK", "IDENTITY_OBJECT"
         }
     )
@@ -53,7 +53,7 @@ final class KindTest {
     @ParameterizedTest
     @EnumSource(
         value = Kind.class,
-        names = {"BARE_FORMATION", "ONLY_PHI_FORMATION", "PIPE_APPLICATION", "IDENTITY_OBJECT"}
+        names = {"BARE_FORMATION", "ONLY_PHI", "PIPE_APPLICATION", "IDENTITY_OBJECT"}
     )
     void acceptsPipeAfterFormationLikeKinds(final Kind kind) {
         MatcherAssert.assertThat(

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -78,9 +78,9 @@ final class LnMethodTest {
         new LnMethod(new Span(".bar 42", 2))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "a .method continuation with horizontal args must promote the kind to VMETHOD_WITH_HARGS",
+            "a .method continuation with horizontal args must promote the kind to VMETHOD_HARGS",
             stack.top().kind(),
-            Matchers.equalTo(Kind.VMETHOD_WITH_HARGS)
+            Matchers.equalTo(Kind.VMETHOD_HARGS)
         );
     }
 
@@ -92,7 +92,7 @@ final class LnMethodTest {
         new LnMethod(new Span(".bar 42", 2))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "VMETHOD_WITH_HARGS must be HORIZONTAL_COMPLETED so no further extension is allowed",
+            "VMETHOD_HARGS must be HORIZONTAL_COMPLETED so no further extension is allowed",
             stack.top().openness(),
             Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
         );

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -24,9 +24,9 @@ final class LnOnlyPhiTest {
         new LnOnlyPhi(new Span("right > [x] > left", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "an only-phi line must push ONLY_PHI_FORMATION",
+            "an only-phi line must push ONLY_PHI",
             stack.top().kind(),
-            Matchers.equalTo(Kind.ONLY_PHI_FORMATION)
+            Matchers.equalTo(Kind.ONLY_PHI)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -47,9 +47,9 @@ final class LnReversedTest {
         new LnReversed(new Span("if. cond then else > x", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "a `name. arg1 arg2…` must push REVERSED_WITH_HARGS",
+            "a `name. arg1 arg2…` must push REVERSED_HARGS",
             stack.top().kind(),
-            Matchers.equalTo(Kind.REVERSED_WITH_HARGS)
+            Matchers.equalTo(Kind.REVERSED_HARGS)
         );
     }
 
@@ -59,7 +59,7 @@ final class LnReversedTest {
         new LnReversed(new Span("if. cond then > x", 1))
             .into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "REVERSED_WITH_HARGS must be HORIZONTAL_COMPLETED — no deeper continuation allowed",
+            "REVERSED_HARGS must be HORIZONTAL_COMPLETED — no deeper continuation allowed",
             stack.top().openness(),
             Matchers.equalTo(Openness.HORIZONTAL_COMPLETED)
         );


### PR DESCRIPTION
Closes #7118.

`Kind` carried a class-level `@SuppressWarnings("PMD.LongVariable")` that existed only for three enum constants over PMD's 17-character limit. This renames them and deletes the suppression:

| before | after |
| --- | --- |
| `REVERSED_WITH_HARGS` (19) | `REVERSED_HARGS` (14) |
| `VMETHOD_WITH_HARGS` (18) | `VMETHOD_HARGS` (13) |
| `ONLY_PHI_FORMATION` (18) | `ONLY_PHI` (8) |

The `WITH_` infix said nothing the `HARGS` suffix does not already say, and "only-phi" is how both the spec and the `LnOnlyPhi` line-handler name that kind. The Javadoc on each constant still spells out "Horizontally completed" and "Only-phi formation" in prose, so the shorter names lose nothing. The longest remaining constant is `PIPE_APPLICATION` (16), comfortably under the threshold.

The rename is mechanical and covers every usage: `Kind`, `Eo`, `Level`, `LnMethod`, `LnOnlyPhi`, `LnPipe`, `LnReversed` and the four affected test classes. One Javadoc paragraph in `Kind` is reflowed because the shorter names changed the line breaks.

Verification:

* `mvn -pl eo-parser -Pqulice verify` — BUILD SUCCESS, 1779 tests, 0 failures.
* I checked the suppression was live rather than stale: with it removed and `REVERSED_WITH_HARGS` restored, qulice reports `PMD: .../Kind.java[70-70]: Avoid excessively long variable names like REVERSED_WITH_HARGS (LongVariable)`.

No overlap with #7114, which shortens the `Openness` constants — `Kind` only links `Openness#OPEN`, whose name is unchanged.


---
_Generated by [Claude Code](https://claude.ai/code/session_01SPG1fozWwJLs96pcPfRWzR)_