### PR TITLE
refactor(runtime): use ReentrantLock in AtOnce instead of synchronized

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -5,6 +5,8 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * Attribute that retrieves object only once.
@@ -26,12 +28,18 @@ public final class AtOnce implements Attribute {
     private final AtomicReference<Phi> cached;
 
     /**
+     * Lock guarding the first retrieval of the origin attribute.
+     */
+    private final Lock lock;
+
+    /**
      * Ctor.
      * @param attr Origin attribute
      */
     public AtOnce(final Attribute attr) {
         this.origin = attr;
         this.cached = new AtomicReference<>(null);
+        this.lock = new ReentrantLock();
     }
 
     @Override
@@ -40,19 +48,18 @@ public final class AtOnce implements Attribute {
     }
 
     @Override
-    @SuppressWarnings({"PMD.AvoidSynchronizedStatement", "PMD.DoubleCheckedLocking"})
     public Phi get() {
-        Phi result = this.cached.get();
-        if (result == null) {
-            synchronized (this.cached) {
-                result = this.cached.get();
-                if (result == null) {
-                    result = this.origin.get();
-                    this.cached.set(result);
+        if (this.cached.get() == null) {
+            this.lock.lock();
+            try {
+                if (this.cached.get() == null) {
+                    this.cached.set(this.origin.get());
                 }
+            } finally {
+                this.lock.unlock();
             }
         }
-        return result;
+        return this.cached.get();
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/AtOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtOnceTest.java
@@ -5,6 +5,7 @@
 package org.eolang;
 
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -50,6 +51,26 @@ final class AtOnceTest {
         attr.get();
         MatcherAssert.assertThat(
             "AtOnce must execute nested attribute only once",
+            count.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void cachesAttributeInParallelThreads() {
+        final AtomicInteger count = new AtomicInteger();
+        final Attribute attr = new AtOnce(
+            new AtComposite(
+                new PhDefault(),
+                phi -> {
+                    count.incrementAndGet();
+                    return phi;
+                }
+            )
+        );
+        IntStream.range(0, 100).parallel().forEach(idx -> attr.get());
+        MatcherAssert.assertThat(
+            "AtOnce must execute nested attribute only once, even in parallel threads",
             count.get(),
             Matchers.equalTo(1)
         );


### PR DESCRIPTION
`AtOnce.get()` guarded its lazy initialization with a `synchronized`
block and double-checked locking, which forced this suppression:

```java
@SuppressWarnings({"PMD.AvoidSynchronizedStatement", "PMD.DoubleCheckedLocking"})
```

Now the first retrieval of the origin attribute is guarded by a
`ReentrantLock` field, exactly the way `PhOnce.loaded()` already does it
in the same package, so the suppression is gone.

Behavior is unchanged: the origin attribute is still retrieved at most
once, the lock is still reentrant (so nested `get()` calls on the same
thread behave as before), and it is released in a `finally` block.

Also added `AtOnceTest.cachesAttributeInParallelThreads()`, which hits a
single `AtOnce` from 100 parallel stream tasks and asserts the nested
attribute was executed exactly once.

Verified by compiling `AtOnce` and its dependencies with `javac` and
running the four existing `AtOnceTest` scenarios plus the new parallel
one directly — all pass. The full Maven reactor build was not run here
(`eo-runtime` needs `eo-maven-plugin:1.0-SNAPSHOT` built first), so CI
is the authority on the complete suite and on qulice.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHjiwu2YYUidZr8QQZWyVj)_