### PR TITLE
Remove dead `java:S5164` suppression from `Dataized`

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -20,7 +20,6 @@ import java.util.Arrays;
  * @see <a href="https://arxiv.org/abs/2111.13384">Canonical explanation of the Dataization concept</a>
  * @since 0.1
  */
-@SuppressWarnings("java:S5164")
 public final class Dataized {
 
     /**


### PR DESCRIPTION
No refactoring turned out to be necessary here: the suppression is simply dead and can be deleted.

`java:S5164` is Sonar's *"ThreadLocal variables should be cleaned up when no longer used"*. `Dataized` has no `ThreadLocal` at all, so the class-level suppression silences nothing.

It is a leftover. Up to [0.42.0](https://github.com/objectionary/eo/blob/0.42.0/eo-runtime/src/main/java/org/eolang/Dataized.java) the class held two `ThreadLocal` fields used to track the dataization nesting depth for `FINE` logging:

```java
private static final ThreadLocal<Integer> LEVEL = ThreadLocal.withInitial(() -> 0);
private static final ThreadLocal<Integer> MAX_LEVEL =
    ThreadLocal.withInitial(() -> Integer.getInteger("max.dataization.log", 3));
```

Both carried `@todo #2251` notes about calling `ThreadLocal#remove()`, which is exactly what the suppression was for. The fields and the logging they served were later removed, and `take()` is now a one-liner delegating to `this.phi.delta()` — but the annotation stayed behind, where it now only sends readers hunting for a `ThreadLocal` that isn't there.

The runtime's one remaining `ThreadLocal` is `PhDefault.NESTING`, which keeps its own suppression placed narrowly on the field itself. That one is left untouched.

### Changes

- `eo-runtime/src/main/java/org/eolang/Dataized.java`: dropped `@SuppressWarnings("java:S5164")` from the class declaration. One line removed, nothing else.

### Verification

`@SuppressWarnings` has `SOURCE` retention, so removing an inapplicable one cannot change behaviour — no bytecode difference beyond the annotation itself, and no test could observe it. Confirmed the file still compiles clean:

```
javac -Xlint:all -sourcepath eo-runtime/src/main/java .../Dataized.java
```

No errors and no warnings, so nothing was relying on the suppression. Grepped the repo to confirm `S5164` appears nowhere else except `PhDefault`. The full Maven build was not run locally (the sandbox has no populated `~/.m2` and is offline), so CI is the real check for `qulice`.

---
_Generated by [Claude Code](https://claude.ai/code/session_0139rKYiuyxPyoPjd1FDPwPR)_