### PR TITLE
style(runtime): copy the entries Attrs is given, drop the PMD suppression

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Attrs.java
+++ b/eo-runtime/src/main/java/org/eolang/Attrs.java
@@ -19,15 +19,17 @@ import java.util.Set;
  * {@link AbstractMap.SimpleEntry} (a constructor invocation, not a method
  * call) being acceptable as a {@code Map.Entry} factory.</p>
  *
- * <p>The underlying {@link LinkedHashMap} is built lazily on first access so the
- * constructor itself remains free of method calls.</p>
+ * <p>The underlying {@link LinkedHashMap} is built lazily on first access, so
+ * the constructor does nothing but copy the entries it was given. The copy is
+ * what keeps the map immune to a caller that mutates its own array after
+ * handing it over.</p>
  *
  * @since 0.59
  */
 public final class Attrs extends AbstractMap<String, Attribute> {
 
     /**
-     * Initial entries supplied via constructor.
+     * Initial entries supplied via constructor, our own copy of them.
      */
     private final Map.Entry<String, Attribute>[] entries;
 
@@ -41,10 +43,9 @@ public final class Attrs extends AbstractMap<String, Attribute> {
      * @param initial Entries to populate the map with
      */
     @SafeVarargs
-    @SuppressWarnings("PMD.ArrayIsStoredDirectly")
     public Attrs(final Map.Entry<String, Attribute>... initial) {
         super();
-        this.entries = initial;
+        this.entries = initial.clone();
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/AttrsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AttrsTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Attrs}.
+ * @since 0.59
+ */
+final class AttrsTest {
+
+    @Test
+    void keepsTheOrderOfTheEntriesItWasGiven() {
+        MatcherAssert.assertThat(
+            "the attributes must come out in the order they were given, but they didnt",
+            new Attrs(
+                new Attr("x", new AtVoid("x")),
+                new Attr("y", new AtVoid("y"))
+            ).keySet(),
+            Matchers.contains("x", "y")
+        );
+    }
+
+    @Test
+    void ignoresLaterChangesToTheArrayItWasGiven() {
+        final Attr[] given = {new Attr("x", new AtVoid("x"))};
+        final Attrs attrs = new Attrs(given);
+        given[0] = new Attr("y", new AtVoid("y"));
+        MatcherAssert.assertThat(
+            "a change to the array must not reach the attributes, but it did",
+            attrs.keySet(),
+            Matchers.contains("x")
+        );
+    }
+
+    @Test
+    void countsTheEntriesWithoutReadingThemAll() {
+        MatcherAssert.assertThat(
+            "the size must count every entry given, but it didnt",
+            new Attrs(
+                new Attr("x", new AtVoid("x")),
+                new Attr("y", new AtVoid("y"))
+            ).size(),
+            Matchers.equalTo(2)
+        );
+    }
+}


### PR DESCRIPTION
`Attrs` carried `@SuppressWarnings("PMD.ArrayIsStoredDirectly")` on its constructor, which silenced the warning instead of answering it: the varargs array was kept as-is, so a caller holding a reference to that array could still change the map's contents after handing it over.

The constructor now clones the array — the same idiom `BytesRaw`, `Quoted` and `Hex` already use — so the suppression is gone and the entries genuinely belong to the map. The clone is shallow and the class stays lazy: the `LinkedHashMap` is still built on first access, and the constructor still does nothing but one field assignment.

`AttrsTest` pins the three things the class promises: it keeps the order it was given, it counts every entry, and a later change to the caller's array does not reach it.

Verified locally by compiling `Attrs` and the new test (`javac -Xlint:all`, no warnings) and running `AttrsTest` on the JUnit 5 console launcher — 3 tests, all green. A full `mvn -Pqulice` run was not possible here (empty local repository, whole-reactor build), so CI is the check on the rest.

---
_Generated by [Claude Code](https://claude.ai/code/session_017LNNd2LLuejpyB25rYy8R1)_