### PR TITLE
#7063: key the Catalogs cache on path and format together

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
@@ -58,10 +58,16 @@ final class Catalogs {
     private final Map<Path, Tojos> all;
 
     /**
+     * The format each cached path was first built with.
+     */
+    private final Map<Path, String> formats;
+
+    /**
      * Ctor.
      */
     private Catalogs() {
         this.all = new ConcurrentHashMap<>(0);
+        this.formats = new ConcurrentHashMap<>(0);
     }
 
     /**
@@ -70,9 +76,7 @@ final class Catalogs {
      * @return The Tojos
      */
     Tojos make(final Path file) {
-        return this.all.computeIfAbsent(
-            file.toAbsolutePath(), f -> Catalogs.build(f, "csv")
-        );
+        return this.make(file, "csv");
     }
 
     /**
@@ -80,18 +84,19 @@ final class Catalogs {
      * @param file The file
      * @param fmt The format
      * @return The Tojos
-     * @todo #7023:30min This caches on the absolute path alone, so if two
-     *  callers ask for the same path with a different format, the second
-     *  format is silently dropped and the first caller's mono keeps
-     *  serving both. Key the cache on path and format together, or throw
-     *  when a path is requested again with a format that disagrees with
-     *  the one it was first built with. See
-     *  https://github.com/objectionary/eo/issues/7023.
      */
     Tojos make(final Path file, final String fmt) {
-        return this.all.computeIfAbsent(
-            file.toAbsolutePath(), f -> Catalogs.build(f, fmt)
-        );
+        final Path abs = file.toAbsolutePath();
+        final String before = this.formats.putIfAbsent(abs, fmt);
+        if (before != null && !before.equals(fmt)) {
+            throw new IllegalStateException(
+                String.format(
+                    "The file '%s' was already cached with format '%s', can't reuse it with format '%s'",
+                    abs, before, fmt
+                )
+            );
+        }
+        return this.all.computeIfAbsent(abs, f -> Catalogs.build(f, fmt));
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjsPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjsPlaced.java
@@ -32,7 +32,7 @@ final class TjsPlaced implements Closeable {
      * @param file Path to the tojos file
      */
     TjsPlaced(final Path file) {
-        this(Catalogs.INSTANCE.make(file));
+        this(Catalogs.INSTANCE.make(file, "json"));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsTest.java
@@ -13,7 +13,9 @@ import java.nio.file.Path;
 import java.util.UUID;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -43,6 +45,29 @@ final class CatalogsTest {
                 }
             ),
             Matchers.not(Matchers.hasItem(false))
+        );
+    }
+
+    @Test
+    void reusesTheSameFormatForTheSamePath(@Mktmp final Path tmp) {
+        final Path file = tmp.resolve("foreign");
+        Assertions.assertDoesNotThrow(
+            () -> {
+                Catalogs.INSTANCE.make(file, "csv");
+                Catalogs.INSTANCE.make(file, "csv");
+            },
+            "Asking for the same path with the same format twice must not fail"
+        );
+    }
+
+    @Test
+    void rejectsADisagreeingFormatForAnAlreadyCachedPath(@Mktmp final Path tmp) {
+        final Path file = tmp.resolve("foreign");
+        Catalogs.INSTANCE.make(file, "csv");
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> Catalogs.INSTANCE.make(file, "json"),
+            "Asking for the same path with a different format must fail loudly"
         );
     }
 }


### PR DESCRIPTION
Closes #7063.

Resolves the puzzle `7023-fbecf3d2`: `Catalogs.make(Path, String)` cached on the absolute path alone, so a second caller asking for the same path with a different format silently got the first caller's mono instead of its own.

Added a second map tracking the format each path was first cached with. A repeat call with the same format is a no-op as before; a repeat call with a different format now throws `IllegalStateException` naming both formats, instead of silently serving the wrong one.

Added two tests: same-path-same-format still succeeds, same-path-different-format throws.
