### PR TITLE
#7075: path.dirname returns empty string for an empty path

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -36,19 +36,16 @@
     [] > dirname
       string > @
         if.
-          pth.size.eq 0
-          ^.trimmed >> pth!
+          len.eq -1
+          "."
           if.
-            len.eq -1
-            "."
-            if.
-              len.eq 0
-              ^.separator
-              as-bytes.
-                text.slice
-                  0
-                  text.last-index-of ^.separator >> len!
-      string pth > text
+            len.eq 0
+            ^.separator
+            as-bytes.
+              text.slice
+                0
+                text.last-index-of ^.separator >> len!
+      string ^.trimmed > text
     sys.drive uri > drive
     if. > driveless
       drive.size.eq 0
@@ -535,6 +532,11 @@
   eq. ++> can-return-the-current-dirname-of-a-relative-posix-file-ending-with-a-separator
     dirname.
       path.posix "foo/"
+    "."
+
+  eq. ++> can-return-the-current-dirname-of-an-empty-path
+    dirname.
+      path ""
     "."
 
   eq. ++> can-return-the-dirname-ignoring-repeated-trailing-separators


### PR DESCRIPTION
Fixes #7075.

`path.dirname` short-circuited an empty path to `trimmed` (empty again), so it returned `""` instead of falling through to the branch that already handles "no separator anywhere" and answers `"."`. `basename` has the same short-circuit and is correct there, since the basename of an empty path really is empty; `dirname` doesn't need it, `pth`/`text` becoming an empty string already lands on `last-index-of` returning `-1`.

Removed the short-circuit so an empty path falls through to the existing `len.eq -1` branch, matching POSIX `dirname(3)`, `node:path.dirname("")` and `java.io.File`, all of which answer `"."` for an empty path.

Added `can-return-the-current-dirname-of-an-empty-path`.
