### PR TITLE
#7073: uri splits authority at first @, leaking userinfo into host

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -73,7 +73,7 @@
         has-userinfo.if >> host-port-bytes!
           authority.slice
             plus.
-              authority.index-of "@" >> userinfo-at-idx
+              authority.last-index-of "@" >> userinfo-at-idx
               1
             authority.length.minus
               number
@@ -184,6 +184,11 @@
       uri "http://user:pass@host:80/some/path"
     "host"
 
+  eq. ++> can-parse-a-host-past-an-at-sign-inside-userinfo
+    host.
+      uri "http://a@b@host/p"
+    "host"
+
   eq. ++> can-parse-a-path-alongside-a-userinfo-authority
     path.
       uri "http://user:pass@host:80/some/path"
@@ -213,6 +218,11 @@
     scheme.
       uri "HTTP://host/path"
     "HTTP"
+
+  eq. ++> can-parse-a-userinfo-holding-an-at-sign
+    userinfo.
+      uri "http://a@b@host/p"
+    "a@b"
 
   eq. ++> can-parse-a-userinfo-without-a-password
     userinfo.


### PR DESCRIPTION
Fixes #7073.

`uri`'s `host-port` binding split the authority at the first `@`, so when the userinfo itself contains an `@` the leftover part landed in the host, producing a host string that still carries an `@` and cannot resolve as a host.

RFC 3986 forbids `@` in `reg-name` but allows it in `userinfo` (via pct-encoded, though callers sometimes write it literally), so whatever sits before the last `@` is the userinfo, which is also what curl and the WHATWG URL parser do.

One-token fix: `authority.index-of "@"` to `authority.last-index-of "@"`. `userinfo` reuses the same binding, so it needed no separate change.

Added `can-parse-a-host-past-an-at-sign-inside-userinfo` and `can-parse-a-userinfo-holding-an-at-sign`.
