### PR TITLE
#7131: add explicit ctor to MjRegister, fixes site job

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -41,6 +41,13 @@ public final class MjRegister extends MjSafe {
     private static final Pattern PATTERN = Pattern.compile("^[a-zA-Z0-9\\-]+\\.eo$");
 
     /**
+     * Ctor.
+     */
+    public MjRegister() {
+        // nothing
+    }
+
+    /**
      * List of inclusion GLOB filters for finding EO files
      * in the {@code <includeSources>} directory, which can be
      * pretty global (or even a root one).


### PR DESCRIPTION
Fixes #7131.

`MjRegister` had no explicit constructor, so `maven-javadoc-plugin` flagged the synthesized default one as "use of default constructor, which does not provide a comment", which fails the `site` job's javadoc report and blocks CI on master right now.

Added the same explicit, commented no-arg constructor every sibling mojo (`MjResolve`, `MjCompile`, `MjParse`, etc.) already has. Verified the javadoc warning is gone by running the `javadoc:javadoc` goal directly.
