### PR TITLE
name both +> and -> as allowed atom test attributes

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -193,7 +193,7 @@ final class LnFormation implements Line {
         if (!stack.empty() && stack.top().atom() && !suffix.test()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body"
+                "Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body"
             );
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -88,7 +88,7 @@ final class Transition {
         if (!this.stack.empty() && this.stack.top().atom() && !admission.permitted()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body"
+                "Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body"
             );
         }
         return this.stack.push(this.span.indent(), this.span.line(), kind, openness);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:2] error: 'Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body'
+  [2:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
     42 > bar
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:2] error: 'Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body'
+  [2:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
     [] > inner
     ^
 input: |


### PR DESCRIPTION
The error thrown when an atom body holds something other than a test attribute says only \`+>\` is allowed, but \`Suffix.test()\` accepts \`Form.TEST\` and \`Form.THROWS\` alike, so a throwing test attribute (\`-> name\`) is admitted under an atom exactly like \`+> name\`. The message named one of the two forms the parser actually permits, which reads as a contradiction to anyone writing \`-> name\` in an atom body.

This updates the message in \`Transition.java\` and its copy in \`LnFormation.java\` to name both markers, and updates the two typo fixtures that assert the old wording.

Closes #7122