### PR TITLE
Check the xmir.xsd property before the relative XSD guesses

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/DrProgram.java
+++ b/eo-parser/src/main/java/org/eolang/parser/DrProgram.java
@@ -80,11 +80,11 @@ final class DrProgram implements Iterable<Directive> {
             Manifests.read("EO-Version")
         );
         final String[] opts = {
+            System.getProperty("xmir.xsd", ""),
             "XMIR.xsd",
             "src/main/resources/XMIR.xsd",
             "eo-parser/src/main/resources/XMIR.xsd",
             "../eo-parser/src/main/resources/XMIR.xsd",
-            System.getProperty("xmir.xsd", ""),
         };
         for (final String opt : opts) {
             if (opt.isEmpty()) {

--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -121,6 +121,21 @@ final class DrProgramTest {
     }
 
     @Test
+    void ignoresEmptyXmirXsdProperty() throws Exception {
+        System.setProperty("xmir.xsd", "");
+        try {
+            MatcherAssert.assertThat(
+                "schema location falls back to a guess when the xmir.xsd property is empty",
+                new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner())
+                    .element("object").attribute("xsi:noNamespaceSchemaLocation").text().get(),
+                Matchers.not(Matchers.emptyString())
+            );
+        } finally {
+            System.clearProperty("xmir.xsd");
+        }
+    }
+
+    @Test
     void validatesAgainstSchema() {
         Assertions.assertDoesNotThrow(
             new StrictXML(

--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -105,6 +105,22 @@ final class DrProgramTest {
     }
 
     @Test
+    void ignoresMissingXmirXsdProperty() throws Exception {
+        final Path missing = Paths.get("does-not-exist-1234567890.xsd").toAbsolutePath();
+        System.setProperty("xmir.xsd", missing.toString());
+        try {
+            MatcherAssert.assertThat(
+                "schema location falls back to a guess when the xmir.xsd property does not exist",
+                new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner())
+                    .element("object").attribute("xsi:noNamespaceSchemaLocation").text().get(),
+                Matchers.not(Matchers.equalTo(missing.toUri().toString()))
+            );
+        } finally {
+            System.clearProperty("xmir.xsd");
+        }
+    }
+
+    @Test
     void validatesAgainstSchema() {
         Assertions.assertDoesNotThrow(
             new StrictXML(

--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -9,6 +9,9 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.StrictXML;
 import com.jcabi.xml.XMLDocument;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -81,6 +84,24 @@ final class DrProgramTest {
                 .attribute("xsi:noNamespaceSchemaLocation").text().get(),
             Matchers.not(Matchers.startsWith("file:////"))
         );
+    }
+
+    @Test
+    void honorsExplicitXmirXsdProperty() throws Exception {
+        final Path file = Files.createTempFile("xmir", ".xsd");
+        Files.write(file, "<xsd/>".getBytes(StandardCharsets.UTF_8));
+        System.setProperty("xmir.xsd", file.toString());
+        try {
+            MatcherAssert.assertThat(
+                "explicit xmir.xsd property overrides the relative guesses",
+                new Xnav(new XMLDocument(new Xembler(new DrProgram()).xml()).inner())
+                    .element("object").attribute("xsi:noNamespaceSchemaLocation").text().get(),
+                Matchers.equalTo(file.toUri().toString())
+            );
+        } finally {
+            System.clearProperty("xmir.xsd");
+            Files.delete(file);
+        }
     }
 
     @Test


### PR DESCRIPTION
Closes #7112

DrProgram.schema() picked the XSD location by trying four relative-path guesses first and only fell back to the `xmir.xsd` system property when all four missed. In eo-runtime's snippet-test execution the fourth guess happens to resolve, so the explicit property was silently ignored — it just went unnoticed because the guess pointed at the same file.

The property is now the first candidate, since an explicit override is more specific than any guess. The guesses still run afterward for the case where nothing was set.

Added a test that points `xmir.xsd` at a file the relative guesses would not find, confirming the schema location resolves to that file rather than to `src/main/resources/XMIR.xsd`.