### PR TITLE
#7074: as-fixed aborts instead of recovering on a non-finite number

### DIFF
--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -18,12 +18,15 @@
 
 [places cant-print] > as-fixed
   if. > @
-    or.
-      0.gt places
-      places.is-integer.not
+    n.is-finite.not.or
+      or.
+        0.gt places
+        places.is-integer.not
     cant-print
-      "Can't write a fixed-point decimal with %f fraction places".printf
-        * places
+      n.is-finite.not.if
+        "Can't write a non-finite number as a fixed-point decimal"
+        "Can't write a fixed-point decimal with %f fraction places".printf
+          * places
     if.
       n.as-bytes.eq 80-00-00-00-00-00-00-00
       "-".as-bytes.concat
@@ -138,6 +141,18 @@
     "-0.00"
     string
       0.neg.as-fixed 2
+
+  eq. ++> can-recover-from-a-non-finite-number
+    "recovered"
+    nan.as-fixed
+      2
+      "recovered" > [message]
+
+  eq. ++> can-recover-from-an-infinite-number
+    "recovered"
+    pinf.as-fixed
+      2
+      "recovered" > [message]
 
   eq. ++> can-recover-from-infinite-places
     "recovered"


### PR DESCRIPTION
Fixes #7074.

`as-fixed`'s `cant-print` guard only checked `places`. A non-finite `n` walked straight past it into `unit.as-decimal`, which aborts by design (#5973), so the caller got a raw 15-frame `ExFailure` instead of the fallback that was passed in. `string.printf`'s `%f` conversion inherits this: `"%f".printf * nan` fails instead of honouring the fallback it already sets up.

Extended the guard to also check `n.is-finite`, with its own message distinguishing a non-finite receiver from bad `places`. The `%f` conversion in `printf.eo` needed no change, since it already passes a fallback to `as-fixed` and just wasn't reaching it before.

Added `can-recover-from-a-non-finite-number` and `can-recover-from-an-infinite-number`.
