### PR TITLE
Fix raw helper docblock and param name in EoSyntaxTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -762,16 +762,16 @@ final class EoSyntaxTest {
     }
 
     /**
-     * Parse a single-line EO source with no post-XSL transform — the
-     * resulting XMIR shows the raw parser output, useful for asserting
-     * directly on the parser's emission shape.
-     * @param line One EO source line
+     * Parse EO source with no post-XSL transform — the resulting XMIR
+     * shows the raw parser output, useful for asserting directly on the
+     * parser's emission shape.
+     * @param source EO source
      * @return Raw XMIR
      * @throws Exception If parsing fails
      */
-    private static XML raw(final String line) throws Exception {
+    private static XML raw(final String source) throws Exception {
         return new EoSyntax(
-            new InputOf(line.concat(String.valueOf((char) 10))),
+            new InputOf(source.concat(String.valueOf((char) 10))),
             UnaryOperator.identity()
         ).parsed();
     }


### PR DESCRIPTION
The \`raw\` helper in \`EoSyntaxTest\` is documented as parsing a single-line EO source, and its parameter was named \`line\`, but the body just appends a newline and hands the whole input to \`EoSyntax\`. Five callers already pass it multi-line programs built with \`String.join\`, since testing string-literal escapes needs a two-line formation.

This renames the parameter to \`source\` and rewords the docblock to describe what the helper actually does — parse EO source with no post-XSL transform. No behavior changes.

Closes #7107