### PR TITLE
Give directory.walk's glob regex a real string receiver

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -139,16 +139,17 @@
             match.
               compile.
                 regex.
-                  Q.string chars.as-bytes
+                  string
+                    as-bytes.
+                      "".joined >>
+                        *
+                          "/^"
+                          translated 0 "" false false
+                          "$/"
                   T > [message] >>
                     "Can't parse '%s' as a glob pattern, %s".printf
                       * ^.glob message
               text
-      "".joined >> chars
-        *
-          "/^"
-          translated 0 "" false false
-          "$/"
     "".joined >> single
       *
         "[^"

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -139,15 +139,16 @@
             match.
               compile.
                 regex.
-                  "".joined >>!
-                    *
-                      "/^"
-                      translated 0 "" false false
-                      "$/"
-                T > [message] >>
-                  "Can't parse '%s' as a glob pattern, %s".printf
-                    * ^.glob message
+                  Q.string chars.as-bytes
+                  T > [message] >>
+                    "Can't parse '%s' as a glob pattern, %s".printf
+                      * ^.glob message
               text
+      "".joined >> chars
+        *
+          "/^"
+          translated 0 "" false false
+          "$/"
     "".joined >> single
       *
         "[^"

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -25,6 +25,13 @@
       | items.head items.tail
   ^ > text
 
+  matches. ++> can-apply-regex-to-a-joined-string
+    compiled.
+      regex.
+        "".joined
+          * "/[a-z]+/"
+    "hello"
+
   eq. ++> can-join-many-strings
     "hello-world-dear-friend"
     "-".joined
@@ -43,10 +50,3 @@
     "some"
     "-".joined
       * "some"
-
-  matches. ++> can-apply-regex-to-a-joined-string
-    compiled.
-      regex.
-        "".joined
-          * "/[a-z]+/"
-    "hello"

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -43,3 +43,10 @@
     "some"
     "-".joined
       * "some"
+
+  matches. ++> can-apply-regex-to-a-joined-string
+    compiled.
+      regex.
+        "".joined
+          * "/[a-z]+/"
+    "hello"


### PR DESCRIPTION
Every glob walk crashes because \`directory.eo\` calls \`.regex\` directly on a \`joined\` object rather than on a proper \`string\`. \`regex\` is a member the \`string\` package merges into \`Φ.string\`, and a \`joined\` instance doesn't carry that merged attribute on its own decoratee chain, so the lookup falls through to \`PhTerminator\` with "the attribute \"regex\" is not found in []".

This names the built pattern as \`chars\` and wraps it in \`Q.string\` before calling \`.regex\`, so the receiver is unambiguously the merged package object that actually declares \`regex\`.

\`string/joined.eo\` gets a regression test, \`can-apply-regex-to-a-joined-string\`, that reproduces the exact shape of the bug directly against \`joined\`, independent of the glob-translation logic.

Closes #7109