### PR TITLE
#7076: trailing space breaks a multi-line BYTES literal

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -212,16 +212,17 @@ final class Eo implements Iterable<Directive> {
         final Globals globals, final Emit emit, final Recovery recovery
     ) {
         final Span head = spans.get(start);
-        final StringBuilder body = new StringBuilder(head.body());
+        final StringBuilder body = new StringBuilder(head.body().stripTrailing());
         int idx = start + 1;
         while (idx < spans.size()) {
             final Span next = spans.get(idx);
-            if (next.indent() < head.indent() || !Eo.isBytesOnly(next.body())) {
+            final String trimmed = next.body().stripTrailing();
+            if (next.indent() < head.indent() || !Eo.isBytesOnly(trimmed)) {
                 break;
             }
-            body.append(next.body());
+            body.append(trimmed);
             idx = idx + 1;
-            if (!next.body().endsWith("-")) {
+            if (!trimmed.endsWith("-")) {
                 break;
             }
         }
@@ -246,9 +247,8 @@ final class Eo implements Iterable<Directive> {
      * @return True if a BYTES continuation starts here
      */
     private static boolean isBytesContinuation(final String body) {
-        return body.length() >= 6
-            && body.endsWith("-")
-            && Eo.isBytesOnly(body);
+        final String trimmed = body.stripTrailing();
+        return trimmed.length() >= 6 && trimmed.endsWith("-") && Eo.isBytesOnly(trimmed);
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -914,6 +914,17 @@ final class EoTest {
     }
 
     @Test
+    void mergesMultiLineBytesWithATrailingSpaceOnEitherChunk() {
+        MatcherAssert.assertThat(
+            "a trailing space on either chunk must not break a BYTES continuation",
+            EoTest.render("foo > main", "  CA-FE- ", "  BE-BE "),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='main']/o[@base='Φ.bytes']/o[text()='CA-FE-BE-BE']"
+            )
+        );
+    }
+
+    @Test
     void leavesSingleLineBytesAlone() {
         MatcherAssert.assertThat(
             "a single-line BYTES literal without trailing dash must NOT consume the next line",


### PR DESCRIPTION
Fixes #7076.

A trailing space on either chunk of a multi-line BYTES literal broke the continuation. `isBytesContinuation` and `mergeBytesContinuation` in `Eo.java` compared the raw line body (trailing whitespace intact) against `endsWith("-")` and `isBytesOnly`, so a space after the dash on the opening chunk stopped it from being recognised as a continuation at all, and a space after the closing chunk broke the merge the same way. The resulting error also named the wrong thing: "dangling continuation dash" pointing at a character nobody typed.

Every other line shape already tolerates a trailing space (formation head, meta, string literal), so the fix strips it before the BYTES-specific checks in both places, matching that behavior instead of special-casing this one shape.

Added `mergesMultiLineBytesWithATrailingSpaceOnEitherChunk`, covering a trailing space on both the opening and the closing chunk in one assertion (kept the file under the 1000-line checkstyle limit).
