### PR TITLE
#7078: bytes.as-input.read doesn't validate a non-integer size

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -31,10 +31,16 @@
 [] > as-input
   ^ > b
   [size] > read
-    @. > @
-      read.
-        input-block ^.b --
-        size
+    if. > @
+      size.is-finite.not.or
+        size.is-integer.not.or
+          0.gt size
+      T
+        "Can't read a non-integer, non-finite, or negative byte count"
+      @.
+        read.
+          input-block ^.b --
+          size
     [data buffer] > input-block
       buffer > @
       [size] > read
@@ -70,3 +76,11 @@
     01-02-03-04-05-06-07-08-F5-F6.as-input.read 4 > i1
     i1.read 4 > i2
     i2.read 4 > i3
+
+  01-02-03.as-input.read 3.5 --> stops-on-a-fractional-byte-count-above-available
+
+  01-02-03.as-input.read 0.5 --> stops-on-a-fractional-byte-count-below-available
+
+  01-02-03.as-input.read nan --> stops-on-a-nan-byte-count
+
+  01-02-03.as-input.read pinf --> stops-on-an-infinite-byte-count


### PR DESCRIPTION
Fixes #7078.

`bytes.as-input.read` never validated its `size` argument before comparing it against `available`. A fractional, `nan`, or infinite `size` larger than what remained fell through to the `available` branch, which silently returned all remaining bytes as if the request had been valid. Only `bytes.slice` validated the eventual computed size, so whether an invalid request failed depended on how much data happened to be left, not on the argument itself.

Added the same guard `number/as-decimal.eo` already uses for this shape of check: a finite, integer, non-negative requirement at the public `read` entry point, failing with `T` before anything is compared or consumed.

Added four regression tests: `nan`, `pinf`, and fractional counts both above and below the available byte count, all now failing consistently.
