### PR TITLE
#7077: file.touched can truncate a file created by another process

### DIFF
--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -1,6 +1,17 @@
 # Touches a file, creating it if it does not exist yet, and returning the same
 # file, unchanged, if it already does. It is a method of `file`, and `f` is the
 # file it is taken off.
+#
+# @todo #7077:60min Add a synchronization-based regression test that creates
+#  the target file between the exists() probe and the exclusive open below,
+#  so the race this fixes is actually exercised. A single-threaded EO `++>`
+#  test can't trigger it: `f.exists.if` always sees a consistent snapshot in
+#  one thread. It needs a JUnit test against the generated `EOtouched` class
+#  (see PhDefaultRaceTest.java for the com.yegor256.Together idiom this repo
+#  already uses for exactly this kind of interleaving), with one thread
+#  paused right after the exists() probe while another thread creates and
+#  writes to the file, then confirms the paused thread's touched() does not
+#  truncate it.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,32 +24,54 @@
   f.exists.if > @
     f
     if.
-      descriptor.eq -1
+      or.
+        descriptor.gte 0
+        errno.eq eexist
+      seq *
+        if.
+          descriptor.gte 0
+          code.
+            os.is-windows.if
+              win32 *1
+                "_close"
+                descriptor
+              posix *1
+                "close"
+                descriptor
+          0
+        f
       T
         "Cant touch the file '%s': %s".printf
-          * f.path created.output
-      seq *
-        code.
-          os.is-windows.if
-            win32 *1
-              "_close"
-              descriptor
-            posix *1
-              "close"
-              descriptor
-        f
-  called. > created
+          * f.path opened.output
+  opened.code > descriptor
+  os.is-windows.if > eexist
+    win32.eexist
+    posix.eexist
+  code. > errno
+    os.is-windows.if
+      win32
+        "_errno"
+        *
+      posix
+        "errno"
+        *
+  ^ > f
+  called. > opened
     os.is-windows.if
       win32 *1
-        "_creat"
+        "_open"
         f.path
+        plus.
+          win32.creat.plus win32.exclusive
+          win32.wronly
         win32.mode
       posix *1
-        "creat"
+        "open"
         f.path
+        plus.
+          posix.creat.plus posix.exclusive
+          posix.wronly
         posix.mode
-  created.code > descriptor
-  ^ > f
 
   ++> can-return-itself-after-touching
     temp.deleted.touched.path.eq temp.path > @


### PR DESCRIPTION
Addresses #7077.

`file.touched` checked `f.exists` and then called `creat`, which is equivalent to `open(O_CREAT|O_WRONLY|O_TRUNC)`. Those are two separate syscalls, so a file created by another process between the check and the `creat` call got silently truncated to zero bytes.

Switched to `open` with `O_CREAT | O_EXCL | O_WRONLY` (both `posix.eo` and `win32.eo` already define `creat`, `exclusive`, `wronly`, `mode` and `eexist` for exactly this). An exclusive create either succeeds (new file, no truncation flag involved) or fails with `EEXIST`, which `touched` now treats the same as "already there" instead of an error. Any other failure still raises through `T` as before.

Added a `@todo` puzzle for the concurrency regression test the issue asks for: it needs a JUnit test against the generated `EOtouched` class with real thread interleaving (this repo already has that idiom in `PhDefaultRaceTest.java` via `com.yegor256.Together`), since a single-threaded EO `++>` test can't trigger the race at all. Referencing the issue in prose rather than closing it, since the puzzle means this part isn't finished yet.

Verified the existing `can-touch-a-file`, `can-touch-a-file-twice` and `can-return-itself-after-touching` tests still pass by running the full `eo-runtime` test suite locally (2199 tests, 0 failures).
