### PR TITLE
Drop unused SAME_THREAD execution annotation from EoSyntaxTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -37,7 +37,6 @@ import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -49,9 +48,17 @@ import org.xml.sax.SAXParseException;
  * Test case for {@link EoSyntax}.
  * @since 0.1
  */
-@Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(LogProgress.class)
 final class EoSyntaxTest {
+
+    @Test
+    void runsWithoutSingleThreadRestriction() {
+        MatcherAssert.assertThat(
+            "class still carries an execution mode restriction",
+            EoSyntaxTest.class.isAnnotationPresent(Execution.class),
+            Matchers.is(false)
+        );
+    }
 
     @Test
     void parsesSimpleCode() throws Exception {


### PR DESCRIPTION
The class-level @Execution(ExecutionMode.SAME_THREAD) on EoSyntaxTest was added in 2e4fb89a58 alongside a test that mutated a shared log4j level and needed to avoid running concurrently with the rest of the class. That test, its setUp, tearDown and the field holding the prior level were removed in b033278f1f, but the annotation and its two imports were left behind.

Nothing in the class touches shared state any more, so the annotation just serializes the class onto one thread for no reason, which matters here because the four @ClasspathSource packs dominate its runtime.

This drops the annotation and the two now-unused imports, and adds a test asserting the class no longer carries an Execution annotation.

Closes #7105