### PR TITLE
fix(#7106): give EoSyntaxTest failures a claim about what broke, not a document dump

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -241,7 +241,7 @@ final class EoSyntaxTest {
     @Test
     void parsesCanonicalEoProgram() throws Exception {
         MatcherAssert.assertThat(
-            "We expect that all of the bytes contain a formation with data",
+            "a formation came out with empty bytes",
             new EoSyntax(
                 new TextOf(
                     new ResourceOf("org/eolang/parser/canonical.eo")
@@ -340,7 +340,7 @@ final class EoSyntaxTest {
     )
     void storesAsBytes(final String code) throws IOException {
         MatcherAssert.assertThat(
-            "We data is parsed successfully as bytes",
+            "data was not stored as bytes",
             new EoSyntax(new InputOf(code)).parsed(),
             XhtmlMatchers.hasXPaths(
                 "/object[count(o)=1]",
@@ -355,7 +355,10 @@ final class EoSyntaxTest {
         final Xtory story = EoSyntaxTest.typo(yaml);
         final Xnav after = new Xnav(story.after().inner());
         MatcherAssert.assertThat(
-            after.toString(),
+            String.format(
+                "no error was reported on line %s of %s",
+                story.map().get("line"), yaml
+            ),
             after.path("/object/errors/error/@line").map(line -> line.text().get())
                 .collect(Collectors.toList()),
             Matchers.hasItem(story.map().get("line").toString())
@@ -396,7 +399,7 @@ final class EoSyntaxTest {
         );
         Assumptions.assumeTrue(story.map().get("skip") == null);
         MatcherAssert.assertThat(
-            "passed without exceptions",
+            String.format("pack XPaths do not match the parsed XMIR in %s", yaml),
             story,
             new XtoryMatcher()
         );
@@ -406,7 +409,7 @@ final class EoSyntaxTest {
     @ClasspathSource(value = "org/eolang/parser/eo-syntax/", glob = "**.yaml")
     void validatesEoSyntax(final String yaml) {
         MatcherAssert.assertThat(
-            "passed without exceptions",
+            String.format("pack XPaths do not match the parsed XMIR in %s", yaml),
             new XtSticky(
                 new XtYaml(
                     yaml,

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -353,13 +353,13 @@ final class EoSyntaxTest {
     @ClasspathSource(value = "org/eolang/parser/eo-typos/", glob = "**.yaml")
     void checksTypoPacks(final String yaml) {
         final Xtory story = EoSyntaxTest.typo(yaml);
-        final Xnav after = new Xnav(story.after().inner());
         MatcherAssert.assertThat(
             String.format(
                 "no error was reported on line %s of %s",
                 story.map().get("line"), yaml
             ),
-            after.path("/object/errors/error/@line").map(line -> line.text().get())
+            new Xnav(story.after().inner())
+                .path("/object/errors/error/@line").map(line -> line.text().get())
                 .collect(Collectors.toList()),
             Matchers.hasItem(story.map().get("line").toString())
         );


### PR DESCRIPTION
Four assertion messages in EoSyntaxTest.java left the reader with a diff and nothing else.

`checksTypoPacks` used `after.toString()` as its message, dumping the whole parsed XMIR document instead of saying what should have been true. It now names the expected error line and the pack, so a failure reads as a claim: no error was reported on that line.

`parsesCanonicalEoProgram` and `storesAsBytes` phrased their messages as expectations ("We expect...", "We data is...") rather than as statements of what broke. They now read as negative claims about the outcome: a formation came out with empty bytes, or the data was not stored as bytes.

`checksEoPacks` and `validatesEoSyntax` both said "passed without exceptions", though neither assertion is about exceptions — both check that the pack's declared XPaths match the parsed XMIR. The message now says that directly, naming the pack.

Closes #7106