### PR TITLE
Check EoSyntax transform for null at each constructor

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -82,7 +82,7 @@ public final class EoSyntax implements Syntax {
      * @param transform Transform XMIR after parsing train
      */
     EoSyntax(final Input ipt, final Train<Shift> transform) {
-        this(ipt, new Xsline(transform)::pass);
+        this(ipt, new Xsline(Objects.requireNonNull(transform, "transform"))::pass);
     }
 
     /**
@@ -92,13 +92,13 @@ public final class EoSyntax implements Syntax {
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
         this.input = ipt;
-        this.transform = transform;
+        this.transform = Objects.requireNonNull(transform, "transform");
     }
 
     @Override
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return Objects.requireNonNull(this.transform, "transform").apply(
+        return this.transform.apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -96,9 +96,6 @@ public final class EoSyntax implements Syntax {
      * @param transform Transform XMIR after parsing function
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
-        if (transform == null) {
-            throw new NullPointerException("EoSyntax transform can't be null");
-        }
         this.input = ipt;
         this.transform = transform;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -98,7 +98,7 @@ public final class EoSyntax implements Syntax {
     @Override
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return this.transform.apply(
+        return Objects.requireNonNull(this.transform, "transform").apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -82,7 +82,12 @@ public final class EoSyntax implements Syntax {
      * @param transform Transform XMIR after parsing train
      */
     EoSyntax(final Input ipt, final Train<Shift> transform) {
-        this(ipt, new Xsline(Objects.requireNonNull(transform, "transform"))::pass);
+        this(
+            ipt,
+            new Xsline(
+                Objects.requireNonNull(transform, "EoSyntax train can't be null")
+            )::pass
+        );
     }
 
     /**
@@ -101,7 +106,7 @@ public final class EoSyntax implements Syntax {
     @Override
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return this.transform.apply(
+        return Objects.requireNonNull(this.transform, "EoSyntax has no transform").apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -91,14 +91,17 @@ public final class EoSyntax implements Syntax {
      * @param transform Transform XMIR after parsing function
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
+        if (transform == null) {
+            throw new NullPointerException("EoSyntax transform can't be null");
+        }
         this.input = ipt;
-        this.transform = Objects.requireNonNull(transform, "transform");
+        this.transform = transform;
     }
 
     @Override
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return Objects.requireNonNull(this.transform, "transform").apply(
+        return this.transform.apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -9,7 +9,9 @@ import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.TrDefault;
+import com.yegor256.xsline.Train;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -80,6 +82,26 @@ final class EoSyntaxTest {
             NullPointerException.class,
             () -> new EoSyntax(new InputOf(""), (UnaryOperator<XML>) null).parsed(),
             "EoSyntax must reject a null transform, but it didn't"
+        );
+    }
+
+    @Test
+    void rejectsANullTrain() {
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new EoSyntax(new InputOf(""), (Train<Shift>) null).parsed(),
+            "EoSyntax must reject a null train, but it didn't"
+        );
+    }
+
+    @Test
+    void acceptsANonNullTrain() throws Exception {
+        MatcherAssert.assertThat(
+            "EoSyntax must parse code with a non-null train, but it didn't",
+            XhtmlMatchers.xhtml(
+                new EoSyntax("[] > foo", new TrDefault<Shift>()).parsed().toString()
+            ),
+            XhtmlMatchers.hasXPath("/object/o[@name='foo']")
         );
     }
 


### PR DESCRIPTION
The null guard in `EoSyntax.parsed()` only ever saw what the `UnaryOperator<XML>` constructor assigned, and the package-private `Train<Shift>` constructor wraps its argument into a method reference bound to an `Xsline`. A method reference on an `Xsline` built from a null train is itself non-null, so `new EoSyntax(input, (Train<Shift>) null)` sailed past the guard and blew up several frames deep inside `Xsline` with a message-less `NullPointerException`.

This checks the train where it arrives: the `Train<Shift>` constructor now validates before wrapping it into `new Xsline(...)::pass`, so the failure names the object and the argument at construction time instead of during parsing. The `UnaryOperator<XML>` path keeps its check in `parsed()`, since qulice's `ConstructorsCodeFreeCheck` forbids a method call in the primary constructor and PMD's `AvoidThrowingNullPointerException` forbids the `if`-throw that would replace it; its message now names the object too.

Added `rejectsANullTrain` to cover the path that previously slipped through, and `acceptsANonNullTrain` to cover the corresponding valid case.

Closes #7104
