### PR TITLE
#7080: directory.made fails with EEXIST on a concurrently created directory

### DIFF
--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -3,6 +3,14 @@
 # path already exists, it must already be a directory: if a regular file (or
 # any non-directory entry) occupies the path, the computation terminates
 # instead of returning that entry decorated as a directory.
+#
+# @todo #7080:60min Add a synchronization-based regression test that creates
+#  the target directory between the exists() probe and mkdir below, so the
+#  race this fixes is actually exercised. A single-threaded EO `++>` test
+#  can't trigger it, same reasoning as the `@todo` in file/touched.eo: it
+#  needs a JUnit test against the generated `EOmade` class with real thread
+#  interleaving (see PhDefaultRaceTest.java for the com.yegor256.Together
+#  idiom this repo already uses for exactly this kind of interleaving).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -23,23 +31,36 @@
         directory
           file d.as-path.dirname
       if.
-        created.code.eq 0
+        or.
+          created.code.eq 0
+          and.
+            errno.eq eexist
+            d.is-directory
         d
         T
           "Cant make the directory '%s': %s".printf
-            *
-              d.path
-              output.
-                called. >> created
-                  os.is-windows.if
-                    win32 *1
-                      "_mkdir"
-                      d.path
-                    posix *1
-                      "mkdir"
-                      d.path
-                      posix.permissions
+            * d.path created.output
+  called. > created
+    os.is-windows.if
+      win32 *1
+        "_mkdir"
+        d.path
+      posix *1
+        "mkdir"
+        d.path
+        posix.permissions
   ^ > d
+  os.is-windows.if > eexist
+    win32.eexist
+    posix.eexist
+  code. > errno
+    os.is-windows.if
+      win32
+        "_errno"
+        *
+      posix
+        "errno"
+        *
 
   ++> can-make-a-new-directory
     dir.exists.and dir.is-directory > @


### PR DESCRIPTION
Addresses #7080.

`directory.made` checked `d.exists` and then called `mkdir`, two separate syscalls. A directory created by another process between the two made `mkdir` return `EEXIST`, which `made` treated as an unrecoverable error even though the postcondition (the path is a directory) was already satisfied.

`made` now treats a failed `mkdir` as success when the failure is `EEXIST` and the path is in fact a directory, using the same `errno`/`eexist` idiom `file.touched` (#7077) already uses for the same class of race. Any other failure, or a non-directory entry occupying the path, still raises through `T` as before.

Added the same kind of `@todo` puzzle as #7077 for the concurrency regression test the issue asks for, since a single-threaded EO `++>` test can't trigger the race either. Referencing the issue in prose rather than closing it.

Verified format and lint are clean (`eo:format`/`eo:lint`, no complaints). I could not confirm the full eo-runtime test suite's `EOdirectoryTest` for this specific change: I found that `mvn -pl eo-runtime test -Deo.transpileTests=false` currently generates and runs only 471 of the module's tests instead of the ~2200 I saw a few commits earlier on this same branch line, and `EOdirectoryTest` is one of the missing ones. I confirmed this gap exists identically with `made.eo` reverted to its unmodified master state, so it's unrelated to this change; happy to file it separately if useful.
