### PR TITLE
#7079: range.naturals recurses indefinitely past 2^53

### DIFF
--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -15,7 +15,11 @@
 
 [] > naturals
   if. > @
-    r.start.is-integer.and r.end.is-integer
+    and.
+      r.start.is-integer.and r.end.is-integer
+      and.
+        r.start.abs.lt safe
+        r.end.abs.lt safe
     range
       [] >>
         build ^.r.start > @
@@ -25,9 +29,10 @@
             1.plus @
       r.end
     T
-      "Range bounds must be integers, but were %f and %f".printf
+      "Range bounds must be integers within the safe unit-step range (|x| < 2^53), but were %f and %f".printf
         * r.start r.end
   ^ > r
+  2.power 53 > safe
 
   eq. ++> can-build-a-range-of-negatives
     naturals.
@@ -70,3 +75,13 @@
     range
       1
       3.5
+
+  naturals. --> rejects-a-lower-bound-at-the-precision-boundary
+    range
+      9007199254740992
+      9007199254740994
+
+  naturals. --> rejects-a-negative-lower-bound-at-the-precision-boundary
+    range
+      -9007199254740992
+      0


### PR DESCRIPTION
Fixes #7079.

`range.naturals` only validated that both bounds were integers, but its successor is a plain `1.plus`. At `2^53` and beyond, adding one to a `number` produces the same value in binary64, so an ascending range starting at or past that boundary never advances and recurses indefinitely.

Rejected bounds whose absolute value reaches `2^53`, the safe unit-step precision limit, alongside the existing integer check, with the same `cant-print`-style `T` fallback the fractional-bound rejection already uses.

Added `rejects-a-lower-bound-at-the-precision-boundary` and `rejects-a-negative-lower-bound-at-the-precision-boundary`, both confirmed to fail before the fix (infinite recursion) and pass after.
