### PR TITLE
#7101: text block body line starting with triple quotes misread as closer

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -338,9 +338,11 @@ final class Eo implements Iterable<Directive> {
     }
 
     private static boolean closesTextBlock(final Span span, final Globals globals) {
+        final String body = span.body();
         return !span.blank()
             && span.indent() == globals.textBlockOpenIndent()
-            && span.body().startsWith("\"\"\"");
+            && body.startsWith("\"\"\"")
+            && " .".indexOf(body.concat(" ").charAt(3)) >= 0;
     }
 
     private static Line classify(final Span span) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-body-line-with-triple-quotes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-body-line-with-triple-quotes.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7101: a body line that starts with triple quotes closes the block only when
+# nothing but a suffix follows them (R-3.11.3), so `"""hi` is content and the
+# block ends on the line after it.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object//o[@name='x']/o[@base='Φ.bytes']/o[text()='22-22-22-68-69']
+input: |
+  [] > main
+    """
+    """hi
+    """ > x


### PR DESCRIPTION
Fixes #7101.

`Eo.closesTextBlock` treated any line starting with `"""` at the opener's indent as the closer, even when the three quotes were immediately followed by ordinary text (`"""hello`). Per R-3.11.3 the closer is a `"""` on its own line, with only a legal suffix boundary (end of line, a space before a binding, or a `.` chain) allowed after it — anything else is body content.

Added that boundary check: the character right after the three quotes must be absent, a space, or a dot. Kept it to one compact boolean expression (using `body.concat(" ")` so the length-3 case doesn't need a separate branch) to stay under qulice's boolean-complexity and file-length limits, since `Eo.java` was already at the 1000-line ceiling.

Added `treatsATextBlockBodyLineStartingWithTripleQuotesAsContent`, confirmed to fail with the exact symptom from the issue (a "trailing garbage after expression" error) before the fix.
