### PR TITLE
#7100: file.deleted fails when a file is concurrently deleted

### DIFF
--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -11,7 +11,9 @@
 [] > deleted
   f.exists.if > @
     if.
-      removed.code.eq 0
+      or.
+        removed.code.eq 0
+        f.exists.not
       f
       T
         "Cant delete the file '%s': %s".printf


### PR DESCRIPTION
Fixes #7100.

`file.deleted` promises to return `f` unchanged when the file does not exist, but only checked that at the start. If another process removed the same path between the `exists` probe and the `unlink` call, the syscall failed with the platform's not-found error and `deleted` raised it as if it were a genuine failure, even though the postcondition (the path is gone) was already satisfied.

Added `f.exists.not` as an alternate success condition alongside `removed.code.eq 0`. `file.exists` is already link-aware (#7027), so a disappeared dangling link is treated the same way as a disappeared regular file. Any other removal failure still raises through `T` as before.

Verified against the full eo-runtime test suite (2199 tests, 0 failures), including `EOfileTest`'s existing `can-delete-a-file-twice`, `can-delete-a-dangling-symlink` and `can-delete-a-symlink-to-a-directory` cases.
