### PR TITLE
test(#7098): create the target of a dangling symlink

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -371,6 +371,21 @@
     mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
     d.resolved "ссылка" > link
 
+  ++> can-create-the-target-of-a-dangling-symlink-on-writing
+    os.is-windows.or > @
+      seq *
+        target.as-file.exists
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.open
+          "w"
+          f.write "created" > [f]
+    target.resolved "dangling-link" > link
+    mktemp.tmpfile.deleted.as-path > target
+
   not. ++> can-tell-that-an-absent-file-does-not-exist
     exists.
       file "absent.txt"

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -240,6 +240,21 @@
           n.minus 1
     mktemp.tmpfile > tmp
 
+  ++> can-create-the-target-of-a-dangling-symlink-on-writing
+    os.is-windows.or > @
+      seq *
+        target.as-file.exists
+        code.
+          posix *1
+            "symlink"
+            target
+            link
+        link.as-file.open
+          "w"
+          f.write "created" > [f]
+    target.resolved "dangling-link" > link
+    mktemp.tmpfile.deleted.as-path > target
+
   eq. ++> can-keep-the-size-of-a-file-opened-for-appending
     size.
       open.
@@ -370,21 +385,6 @@
         link.as-file.is-symlink false
     mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
     d.resolved "ссылка" > link
-
-  ++> can-create-the-target-of-a-dangling-symlink-on-writing
-    os.is-windows.or > @
-      seq *
-        target.as-file.exists
-        code.
-          posix *1
-            "symlink"
-            target
-            link
-        link.as-file.open
-          "w"
-          f.write "created" > [f]
-    target.resolved "dangling-link" > link
-    mktemp.tmpfile.deleted.as-path > target
 
   not. ++> can-tell-that-an-absent-file-does-not-exist
     exists.


### PR DESCRIPTION
Fixes #7098

This regression test opens a dangling symbolic link for writing and asserts that the target file is created, which is what O_CREAT does on POSIX. The result of this test on CI will tell whether the bug is still reproducible.