### PR TITLE
#7102: recover directory.deleted from a concurrently removed root

### DIFF
--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -1,5 +1,12 @@
 # Recursively deletes a directory and all of its contents. It is a method of
 # `directory`, and `d` is the directory it is taken off.
+#
+# @todo #7102:60min Add a genuine concurrency regression test for the race
+#  this object recovers from: another process removing `d` after the initial
+#  `exists` check but before `cleared` finishes walking it. A single-threaded
+#  EO test cannot trigger that interleaving; it needs a JUnit test against the
+#  generated `EOdirectory$EOdeleted` class, racing two threads with something
+#  like `com.yegor256.Together`, the way `PhDefaultRaceTest.java` does.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -11,15 +18,20 @@
 [] > deleted
   d.exists.if > @
     seq *
-      if. > [tup] >> r
-        tup.length.eq 0
-        true
-        seq *
-          tup.head.deleted
-          ^.r tup.tail
-      | (d.walk "**").at.^
+      recovered
+        cleared
+        d.exists.not.if true cleared
       d
     d
+  seq * > cleared
+    if. > [tup] >> r
+      tup.length.eq 0
+      true
+      seq *
+        tup.head.deleted
+        ^.r tup.tail
+    | (d.walk "**").at.^
+    true
   ^ > d
 
   ++> can-delete-a-directory-with-a-file-and-a-directory


### PR DESCRIPTION
`directory.deleted` was not idempotent under concurrent deletion: it checked `d.exists` once, then unconditionally walked the directory with `d.walk "**"`. If another process removed `d` between the check and the walk, `Files.list` threw on the missing path even though the end state (directory gone) was already the desired outcome.

The walk-and-delete step now runs inside `recovered`. If it terminates and `d` no longer exists, that is treated as success, matching the existing behavior when `d` is absent at entry. If `d` still exists, the walk is retried once so a real failure (permissions, I/O error) surfaces with its own message instead of being silently swallowed.

The recursive walker was extracted into a shared `cleared` attribute so it is defined once instead of being duplicated by the canonical formatter across both `recovered` branches.

See #7102 for the reproduction steps. A `@todo` puzzle documents that a genuine concurrency regression test (racing two threads against the generated `EOdirectory$EOdeleted` class) is still needed, since a single-threaded EO test cannot trigger the actual race.
