### PR TITLE
#7104: check transform for null at construction, not on every parsed() call

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -96,6 +96,7 @@ public final class EoSyntax implements Syntax {
     }
 
     @Override
+    @SuppressWarnings("java:S2259")
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
         return this.transform.apply(

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -82,7 +82,7 @@ public final class EoSyntax implements Syntax {
      * @param transform Transform XMIR after parsing train
      */
     EoSyntax(final Input ipt, final Train<Shift> transform) {
-        this(ipt, new Xsline(transform)::pass);
+        this(ipt, new Xsline(Objects.requireNonNull(transform, "transform"))::pass);
     }
 
     /**
@@ -92,13 +92,13 @@ public final class EoSyntax implements Syntax {
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
         this.input = ipt;
-        this.transform = transform;
+        this.transform = Objects.requireNonNull(transform, "transform");
     }
 
     @Override
     public XML parsed() throws IOException {
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return Objects.requireNonNull(this.transform, "transform").apply(
+        return this.transform.apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -9,6 +9,8 @@ import com.jcabi.log.Logger;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.Train;
 import com.yegor256.xsline.TrDefault;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -80,6 +82,15 @@ final class EoSyntaxTest {
             NullPointerException.class,
             () -> new EoSyntax(new InputOf(""), (UnaryOperator<XML>) null).parsed(),
             "EoSyntax must reject a null transform, but it didn't"
+        );
+    }
+
+    @Test
+    void rejectsANullTrain() {
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new EoSyntax(new InputOf(""), (Train<Shift>) null).parsed(),
+            "EoSyntax must reject a null train, but it didn't"
         );
     }
 


### PR DESCRIPTION
The guard in `EoSyntax.parsed()` was `Objects.requireNonNull(this.transform, "transform")`, but by the time `parsed()` runs, `this.transform` is always a non-null `UnaryOperator`, even when the caller passed a null `Train<Shift>`. The package-private `EoSyntax(Input, Train<Shift>)` constructor wraps its argument as `new Xsline(transform)::pass` before assigning the field, and a method reference bound to an `Xsline` holding a null train is itself a non-null `UnaryOperator`. `Xsline` does not check its argument either, so the null only surfaces several frames deep inside `Xsline.pass`, as a message-less `NullPointerException`.

Moved the null check to where each constructor receives its argument instead of to `parsed()`:
- the public `EoSyntax(Input, UnaryOperator<XML>)` constructor now null-checks before assigning the field
- the package-private `EoSyntax(Input, Train<Shift>)` constructor now null-checks before wrapping the train into `new Xsline(...)::pass`

`parsed()` no longer re-checks `this.transform` on every call, since it is now guaranteed non-null once the object is constructed.

Added `rejectsANullTrain`, exercising the `Train<Shift>` constructor the existing `rejectsANullTransform` test didn't cover.

See #7104 for the original analysis.
