### PR TITLE
#7105: drop stale SAME_THREAD execution annotation from EoSyntaxTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -36,8 +36,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.parallel.Execution;
-import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -49,7 +47,6 @@ import org.xml.sax.SAXParseException;
  * Test case for {@link EoSyntax}.
  * @since 0.1
  */
-@Execution(ExecutionMode.SAME_THREAD)
 @ExtendWith(LogProgress.class)
 final class EoSyntaxTest {
 


### PR DESCRIPTION
`@Execution(ExecutionMode.SAME_THREAD)` on `EoSyntaxTest` came in with the class's `parsesSimpleCodeWithDebugMode` test, which mutated a shared log4j level in `setUp`/`tearDown` and needed the whole class serialized onto one thread because of it. That test, its `setUp`, `tearDown` and the field holding the saved level were all removed later, but the annotation stayed.

Nothing left in the class touches shared state: it has no fields, and the helper methods are pure. The annotation just forces the class onto a single thread for no reason, which matters here because the four `@ClasspathSource`-driven test packs are several hundred yaml files between them.

Dropped the annotation and its two now-unused imports (`Execution`, `ExecutionMode`).

See #7105 for the history.
