### PR TITLE
#7106: replace uninformative assertion messages in EoSyntaxTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -241,7 +241,7 @@ final class EoSyntaxTest {
     @Test
     void parsesCanonicalEoProgram() throws Exception {
         MatcherAssert.assertThat(
-            "We expect that all of the bytes contain a formation with data",
+            "no formation should come out with empty bytes",
             new EoSyntax(
                 new TextOf(
                     new ResourceOf("org/eolang/parser/canonical.eo")
@@ -340,7 +340,7 @@ final class EoSyntaxTest {
     )
     void storesAsBytes(final String code) throws IOException {
         MatcherAssert.assertThat(
-            "We data is parsed successfully as bytes",
+            "data must be parsed as a single bytes formation",
             new EoSyntax(new InputOf(code)).parsed(),
             XhtmlMatchers.hasXPaths(
                 "/object[count(o)=1]",
@@ -355,7 +355,7 @@ final class EoSyntaxTest {
         final Xtory story = EoSyntaxTest.typo(yaml);
         final Xnav after = new Xnav(story.after().inner());
         MatcherAssert.assertThat(
-            after.toString(),
+            "no error was reported on the line the pack names",
             after.path("/object/errors/error/@line").map(line -> line.text().get())
                 .collect(Collectors.toList()),
             Matchers.hasItem(story.map().get("line").toString())
@@ -396,7 +396,7 @@ final class EoSyntaxTest {
         );
         Assumptions.assumeTrue(story.map().get("skip") == null);
         MatcherAssert.assertThat(
-            "passed without exceptions",
+            "the pack XPaths must match the parsed XMIR",
             story,
             new XtoryMatcher()
         );
@@ -406,7 +406,7 @@ final class EoSyntaxTest {
     @ClasspathSource(value = "org/eolang/parser/eo-syntax/", glob = "**.yaml")
     void validatesEoSyntax(final String yaml) {
         MatcherAssert.assertThat(
-            "passed without exceptions",
+            "the pack XPaths must match the parsed XMIR",
             new XtSticky(
                 new XtYaml(
                     yaml,


### PR DESCRIPTION
Four assertion messages in `EoSyntaxTest` did not describe what the assertion actually checks, so a failure left only a diff to work from.

- `checksTypoPacks` used `after.toString()` (the whole parsed XMIR document) as the message, replaced with a description of the actual claim: no error was reported on the line the pack names.
- `parsesCanonicalEoProgram` said "We expect that all of the bytes contain a formation with data", which described the opposite of what the matcher checks (it denies the presence of any `Φ.bytes` without children). Replaced with "no formation should come out with empty bytes".
- `storesAsBytes` said "We data is parsed successfully as bytes", not a sentence and phrased as an expectation. Replaced with "data must be parsed as a single bytes formation".
- `checksEoPacks` and `validatesEoSyntax` both said "passed without exceptions", though neither assertion is about exceptions; both hand an `Xtory` to an `XtoryMatcher`, which checks the pack's declared XPaths. Replaced with "the pack XPaths must match the parsed XMIR".

See #7106.
