### PR TITLE
#7107: reword the raw() helper's docblock to match what it actually parses

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -762,16 +762,16 @@ final class EoSyntaxTest {
     }
 
     /**
-     * Parse a single-line EO source with no post-XSL transform — the
-     * resulting XMIR shows the raw parser output, useful for asserting
-     * directly on the parser's emission shape.
-     * @param line One EO source line
+     * Parse EO source with no post-XSL transform — the resulting XMIR
+     * shows the raw parser output, useful for asserting directly on the
+     * parser's emission shape.
+     * @param source EO source
      * @return Raw XMIR
      * @throws Exception If parsing fails
      */
-    private static XML raw(final String line) throws Exception {
+    private static XML raw(final String source) throws Exception {
         return new EoSyntax(
-            new InputOf(line.concat(String.valueOf((char) 10))),
+            new InputOf(source.concat(String.valueOf((char) 10))),
             UnaryOperator.identity()
         ).parsed();
     }


### PR DESCRIPTION
The `raw` helper in `EoSyntaxTest` was documented as "Parse a single-line EO source with no post-XSL transform", its parameter named `line`, and the `@param` line said "One EO source line". Five callers (`rejectsOutOfRangeOctalEscape`, `rejectsLoneSurrogateUnicodeEscape`, `rejectsSignedUnicodeEscape`, `rejectsTruncatedUnicodeEscape`, `acceptsValidSurrogatePairEscape`) actually pass a whole two-line formation built with `String.join`, since testing those escapes needs a string literal inside a formation. The helper handles it fine; the docblock just described an input it never had.

Renamed the parameter to `source` and reworded the docblock to say it parses EO source with no post-XSL transform. No behavior change.

See #7107.
