### PR TITLE
#7112: check the xmir.xsd system property before the built-in path guesses

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/DrProgram.java
+++ b/eo-parser/src/main/java/org/eolang/parser/DrProgram.java
@@ -80,11 +80,11 @@ final class DrProgram implements Iterable<Directive> {
             Manifests.read("EO-Version")
         );
         final String[] opts = {
+            System.getProperty("xmir.xsd", ""),
             "XMIR.xsd",
             "src/main/resources/XMIR.xsd",
             "eo-parser/src/main/resources/XMIR.xsd",
             "../eo-parser/src/main/resources/XMIR.xsd",
-            System.getProperty("xmir.xsd", ""),
         };
         for (final String opt : opts) {
             if (opt.isEmpty()) {


### PR DESCRIPTION
`DrProgram.schema()`'s candidate list put `System.getProperty("xmir.xsd", "")` last, after four relative path guesses. The loop breaks on the first candidate that exists, so the property was only consulted once all four guesses missed. The one place that sets it, `eo-runtime/pom.xml`'s `snippet-test` failsafe execution, runs with a working directory where one of the guesses already resolves to the same file, so the explicit setting was silently stepped over every run.

Moved the property to the front of the array, since an explicit override is the most specific answer available and should win over guesses made because nobody told the code where the file is.

No new test: the module runs its JUnit5 tests with `junit.jupiter.execution.parallel.mode.default = concurrent` (configured in the root `pom.xml`'s surefire profile), and this method reads a JVM-wide `System` property that is also read, transitively, by most of the suite (anything building `DrProgram` or calling `EoSyntax.parsed()`). A test that mutates `xmir.xsd` for the duration of one method can't be isolated from unrelated tests running concurrently on other threads at the same moment, so it would risk flaking the rest of the module rather than verifying anything reliably. The existing `DrProgramTest` already asserts that a valid, existing schema file is always chosen.

See #7112.
