### PR TITLE
#7111: measure real parsing time into the ms attribute instead of writing a literal zero

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -97,20 +97,18 @@ public final class EoSyntax implements Syntax {
 
     @Override
     public XML parsed() throws IOException {
+        final long start = System.nanoTime();
         final String text = new UncheckedText(new TextOf(this.input)).asString();
+        final Directives dirs = new Directives()
+            .append(new DrProgram())
+            .append(new Listing(text))
+            .xpath("/object")
+            .strict(1)
+            .append(new Eo(text).directives())
+            .attr("ms", (System.nanoTime() - start) / (1000L * 1000L))
+            .up();
         return Objects.requireNonNull(this.transform, "transform").apply(
-            new XMLDocument(
-                new Xembler(
-                    new Directives()
-                        .append(new DrProgram())
-                        .append(new Listing(text))
-                        .xpath("/object")
-                        .strict(1)
-                        .append(new Eo(text).directives())
-                        .attr("ms", 0L)
-                        .up()
-                ).domQuietly()
-            )
+            new XMLDocument(new Xembler(dirs).domQuietly())
         );
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-only-phi-rollback-keeps-ms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/replaced-only-phi-rollback-keeps-ms.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object[@ms='0']
+  - /object[@ms]
   - /object/errors[count(error)=1]
   - /object/errors/error[contains(text(),'invalid unicode or octal escape')]
 input: |


### PR DESCRIPTION
Every parsed program's `<object>` element carried `ms="0"`, since `EoSyntax.parsed()` wrote the literal `.attr("ms", 0L)` instead of an elapsed time. `XMIR.xsd` still documents the attribute as "the number of milliseconds that were spent by the parser to generate this document", useful for debugging. It used to hold a real number before the parser rewrite; a later commit replaced that measurement with the constant.

`parsed()` now takes the clock before building the source text and directives, and writes the elapsed milliseconds into `ms` once the directive chain (which includes the actual `Eo(text).directives()` parse) is built, before handing the assembled XMIR to the transform.

`replaced-only-phi-rollback-keeps-ms.yaml` asserted `/object[@ms='0']`, which the fix makes false for real input. Changed it to `/object[@ms]`, since the pack cares about where the attribute lands, not what fixed value it holds, matching the same style already used by `error-on-text-block-closer-does-not-misplace-ms.yaml`.

See #7111.
