### PR TITLE
#7122: name both test attribute markers in the atom-body error message

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -193,7 +193,7 @@ final class LnFormation implements Line {
         if (!stack.empty() && stack.top().atom() && !suffix.test()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body"
+                "Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body"
             );
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -88,7 +88,7 @@ final class Transition {
         if (!this.stack.empty() && this.stack.top().atom() && !admission.permitted()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body"
+                "Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body"
             );
         }
         return this.stack.push(this.span.indent(), this.span.line(), kind, openness);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:2] error: 'Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body'
+  [2:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
     42 > bar
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:2] error: 'Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body'
+  [2:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
     [] > inner
     ^
 input: |


### PR DESCRIPTION
The atom-body error message read "Atom cannot contain inner objects; only `+>` test attributes are allowed in an atom body", but the admission flag every call site builds from `Suffix.test()` returns true for both `Form.TEST` (`+>`) and `Form.THROWS` (`->`), so a throwing test attribute is accepted in an atom body exactly like a plain one. The message only named one of the two forms the parser actually permits.

Reworded to "only `+>` and `->` test attributes are allowed in an atom body" in both copies of the check (`Transition.java` and `LnFormation.java`), and in the two existing typo fixtures that assert the old wording (`not-empty-atoms.yaml`, `not-empty-atoms-application.yaml`).

See #7122.
