### PR TITLE
#7131: add explicit ctor to MjRegister

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -74,6 +74,13 @@ public final class MjRegister extends MjSafe {
     )
     private boolean strictFileNames;
 
+    /**
+     * Ctor.
+     */
+    public MjRegister() {
+        // nothing
+    }
+
     @Override
     public void exec() throws IOException {
         if (this.sourcesDir == null) {


### PR DESCRIPTION
Closes #7131.

The `site` job has been red on master since the workflow landed. `maven-javadoc-plugin` fails the report on warnings, and `MjRegister` is the one public mojo that never declared a constructor, so javadoc complains about the synthesized one: "use of default constructor, which does not provide a comment". Nothing else in the reactor warns, so this single line is what stops `mvn clean site -Psite` from finishing.

It now has the same commented no-arg constructor every sibling mojo carries, placed after the fields like in `MjResolve`.

@yegor256 please take a look.
