### PR TITLE
Fix/7187 correct while docblock

### DIFF
--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -12,13 +12,14 @@
 # ```
 # seq > last
 #   *
+#     dataized "Iteration 0\n"
 #     dataized "Iteration 1\n"
 #     dataized "Iteration 2\n"
 #     dataized "Iteration 3\n"
 #     dataized "Iteration 4\n"
 # ```
 #
-# Only the first three strings are dataized for side effects while the last one
+# Only the first four strings are dataized for side effects while the last one
 # is returned as the result value assigned to the `last` object.
 # The `while` loop example produces identical behavior.
 


### PR DESCRIPTION

Fix the `while` loop documentation to match its zero-based iteration behavior.

The example previously documented iterations from `1` to `4`, while the implementation actually runs from `0` to `4`. This updates the example and the side-effect count accordingly.
