### PR TITLE
#7162: pin AutoName digits to Locale.ROOT

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/AutoName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/AutoName.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.parser;
 
+import java.util.Locale;
 import org.cactoos.Text;
 
 /**
@@ -34,6 +35,6 @@ final class AutoName implements Text {
 
     @Override
     public String asString() {
-        return String.format("a🌵%d-%d", this.line, this.position);
+        return String.format(Locale.ROOT, "a🌵%d-%d", this.line, this.position);
     }
 }


### PR DESCRIPTION
`AutoName.asString()` built the cactus auto-name with a single-argument `String.format("a🌵%d-%d", this.line, this.position)`, which localizes `%d` through the JVM's default locale. On a machine whose default locale uses non-ASCII digits (`fa-IR`, `ar-EG`, `ne-NP`), the same `.eo` source compiles into different XMIR depending on who compiled it, disagreeing with `const-to-dataized.xsl`'s locale-insensitive XSLT generator for the same name shape.

Passed `Locale.ROOT` as the format locale so the digits are always ASCII, matching the XSLT side.

See #7162.
