### PR TITLE
#7164: drop the unread end index from Value

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -140,7 +140,7 @@ final class LnReversed implements Line {
             final int start = tokens.cursor();
             final String mapped = LnReversed.rootSymbol(tokens.current());
             tokens.seek(start + 1);
-            value = new Value(Value.Kind.IDENTIFIER, mapped, start, start + 1);
+            value = new Value(Value.Kind.IDENTIFIER, mapped, start);
         } else {
             value = tokens.readName();
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -146,7 +146,7 @@ final class Tokens {
         }
         return new Value(
             Value.Kind.BYTES, raw,
-            this.span.indent() + start, this.cursor
+            this.span.indent() + start
         );
     }
 
@@ -178,7 +178,7 @@ final class Tokens {
         }
         return new Value(
             Value.Kind.GROUP, this.body.substring(start, this.cursor),
-            this.span.indent() + start, this.cursor
+            this.span.indent() + start
         );
     }
 
@@ -216,7 +216,7 @@ final class Tokens {
         this.cursor = idx;
         return new Value(
             Value.Kind.IDENTIFIER, raw,
-            this.span.indent() + start, idx
+            this.span.indent() + start
         );
     }
 
@@ -242,7 +242,7 @@ final class Tokens {
                 this.readFloatTail(start);
                 value = new Value(
                     Value.Kind.FLOAT, this.body.substring(start, this.cursor),
-                    this.span.indent() + start, this.cursor
+                    this.span.indent() + start
                 );
             } else {
                 value = integer;
@@ -284,7 +284,7 @@ final class Tokens {
         this.cursor = idx;
         return new Value(
             Value.Kind.INTEGER, this.body.substring(start, idx),
-            this.span.indent() + start, idx
+            this.span.indent() + start
         );
     }
 
@@ -317,7 +317,7 @@ final class Tokens {
         }
         return new Value(
             Value.Kind.HEX, this.body.substring(start, this.cursor),
-            this.span.indent() + start, this.cursor
+            this.span.indent() + start
         );
     }
 
@@ -349,7 +349,7 @@ final class Tokens {
         this.cursor = this.cursor + 1;
         return new Value(
             Value.Kind.ROOT, String.valueOf(this.body.charAt(start)),
-            this.span.indent() + start, this.cursor
+            this.span.indent() + start
         );
     }
 
@@ -389,7 +389,7 @@ final class Tokens {
                 this.cursor = this.cursor + 1;
                 return new Value(
                     Value.Kind.STRING, this.body.substring(start, this.cursor),
-                    this.span.indent() + start, this.cursor
+                    this.span.indent() + start
                 );
             } else {
                 this.cursor = this.cursor + 1;
@@ -463,7 +463,7 @@ final class Tokens {
             }
             value = new Value(
                 Value.Kind.IDENTIFIER, mapped,
-                this.span.indent() + this.cursor, this.cursor + 1
+                this.span.indent() + this.cursor
             );
             this.cursor = this.cursor + 1;
         } else {
@@ -713,7 +713,7 @@ final class Tokens {
         } else {
             cnst = false;
         }
-        return new Value(bare.kind(), bare.raw(), bare.pos(), this.cursor, tie, tail, cnst);
+        return new Value(bare.kind(), bare.raw(), bare.pos(), tie, tail, cnst);
     }
 
     private void readFloatTail(final int start) {
@@ -782,7 +782,7 @@ final class Tokens {
     private Value reserved(final Value.Kind kind, final String raw) {
         this.cursor = this.cursor + 1;
         return new Value(
-            kind, raw, this.span.indent() + this.cursor - 1, this.cursor
+            kind, raw, this.span.indent() + this.cursor - 1
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -46,11 +46,6 @@ final class Value {
     private final int pos;
 
     /**
-     * Index in the line body immediately past this value.
-     */
-    private final int end;
-
-    /**
      * Inline binding label (R-3.12) — {@code null} when no
      * {@code :label} or {@code :N} follows the value. Numeric bindings
      * are stored as their digit string; the emitter prefixes
@@ -79,10 +74,9 @@ final class Value {
      * @param tag Kind
      * @param text Raw text
      * @param column Start column
-     * @param after Index past the value
      */
-    Value(final Kind tag, final String text, final int column, final int after) {
-        this(tag, text, column, after, null, Value.NO_CHAIN, false);
+    Value(final Kind tag, final String text, final int column) {
+        this(tag, text, column, null, Value.NO_CHAIN, false);
     }
 
     /**
@@ -90,13 +84,12 @@ final class Value {
      * @param tag Kind
      * @param text Raw text
      * @param column Start column
-     * @param after Index past the value
      * @param tie Optional inline-binding label or N
      */
     Value(
-        final Kind tag, final String text, final int column, final int after, final String tie
+        final Kind tag, final String text, final int column, final String tie
     ) {
-        this(tag, text, column, after, tie, Value.NO_CHAIN, false);
+        this(tag, text, column, tie, Value.NO_CHAIN, false);
     }
 
     /**
@@ -104,19 +97,17 @@ final class Value {
      * @param tag Kind
      * @param text Raw text
      * @param column Start column
-     * @param after Index past the value
      * @param tie Optional inline-binding label or N
      * @param links Method-dispatch chain on this value (empty for a bare value)
      * @param cnst Whether a trailing {@code !} const marker is present
      */
     Value(
-        final Kind tag, final String text, final int column, final int after,
+        final Kind tag, final String text, final int column,
         final String tie, final List<MethodChain> links, final boolean cnst
     ) {
         this.kind = tag;
         this.raw = text;
         this.pos = column;
-        this.end = after;
         this.binding = tie;
         this.chain = links;
         this.constant = cnst;
@@ -144,14 +135,6 @@ final class Value {
      */
     int pos() {
         return this.pos;
-    }
-
-    /**
-     * Index past this value in the body.
-     * @return End index
-     */
-    int end() {
-        return this.end;
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
@@ -32,7 +32,7 @@ final class BindingsTest {
     void acceptsSingleArg() {
         Assertions.assertDoesNotThrow(
             () -> Bindings.checkAllOrNothing(
-                Collections.singletonList(new Value(Value.Kind.IDENTIFIER, "a", 4, 5)),
+                Collections.singletonList(new Value(Value.Kind.IDENTIFIER, "a", 4)),
                 new Span("foo a", 1)
             ),
             "a single arg was rejected by the all-or-nothing rule"
@@ -44,9 +44,9 @@ final class BindingsTest {
         Assertions.assertDoesNotThrow(
             () -> Bindings.checkAllOrNothing(
                 Arrays.asList(
-                    new Value(Value.Kind.IDENTIFIER, "a", 4, 5),
-                    new Value(Value.Kind.IDENTIFIER, "b", 6, 7),
-                    new Value(Value.Kind.IDENTIFIER, "c", 8, 9)
+                    new Value(Value.Kind.IDENTIFIER, "a", 4),
+                    new Value(Value.Kind.IDENTIFIER, "b", 6),
+                    new Value(Value.Kind.IDENTIFIER, "c", 8)
                 ),
                 new Span("foo a b c", 1)
             ),
@@ -59,8 +59,8 @@ final class BindingsTest {
         Assertions.assertDoesNotThrow(
             () -> Bindings.checkAllOrNothing(
                 Arrays.asList(
-                    new Value(Value.Kind.IDENTIFIER, "a", 4, 5, "x"),
-                    new Value(Value.Kind.IDENTIFIER, "b", 8, 9, "y")
+                    new Value(Value.Kind.IDENTIFIER, "a", 4, "x"),
+                    new Value(Value.Kind.IDENTIFIER, "b", 8, "y")
                 ),
                 new Span("foo a:x b:y", 1)
             ),
@@ -75,8 +75,8 @@ final class BindingsTest {
         Assertions.assertDoesNotThrow(
             () -> Bindings.checkAllOrNothing(
                 Arrays.asList(
-                    new Value(Value.Kind.IDENTIFIER, "a", 4, 5, Integer.toString(slot)),
-                    new Value(Value.Kind.IDENTIFIER, "b", 6, 7, Integer.toString(slot))
+                    new Value(Value.Kind.IDENTIFIER, "a", 4, Integer.toString(slot)),
+                    new Value(Value.Kind.IDENTIFIER, "b", 6, Integer.toString(slot))
                 ),
                 new Span(String.format("foo a:%1$d b:%1$d", slot), 1)
             ),
@@ -89,8 +89,8 @@ final class BindingsTest {
         Assertions.assertDoesNotThrow(
             () -> Bindings.checkAllOrNothing(
                 Arrays.asList(
-                    new Value(Value.Kind.IDENTIFIER, "a", 4, 5, ""),
-                    new Value(Value.Kind.IDENTIFIER, "b", 6, 7, "")
+                    new Value(Value.Kind.IDENTIFIER, "a", 4, ""),
+                    new Value(Value.Kind.IDENTIFIER, "b", 6, "")
                 ),
                 new Span("foo a: b:", 1)
             ),
@@ -106,8 +106,8 @@ final class BindingsTest {
                 ParseError.class,
                 () -> Bindings.checkAllOrNothing(
                     Arrays.asList(
-                        new Value(Value.Kind.IDENTIFIER, "a", 4, 5, ""),
-                        new Value(Value.Kind.IDENTIFIER, "b", 6, 7)
+                        new Value(Value.Kind.IDENTIFIER, "a", 4, ""),
+                        new Value(Value.Kind.IDENTIFIER, "b", 6)
                     ),
                     new Span("foo a: b", 1)
                 )
@@ -124,8 +124,8 @@ final class BindingsTest {
                 ParseError.class,
                 () -> Bindings.checkAllOrNothing(
                     Arrays.asList(
-                        new Value(Value.Kind.IDENTIFIER, "a", 4, 5, "x"),
-                        new Value(Value.Kind.IDENTIFIER, "b", 8, 9)
+                        new Value(Value.Kind.IDENTIFIER, "a", 4, "x"),
+                        new Value(Value.Kind.IDENTIFIER, "b", 8)
                     ),
                     new Span("foo a:x b", 1)
                 ),
@@ -141,8 +141,8 @@ final class BindingsTest {
             ParseError.class,
             () -> Bindings.checkAllOrNothing(
                 Arrays.asList(
-                    new Value(Value.Kind.IDENTIFIER, "a", 4, 5),
-                    new Value(Value.Kind.IDENTIFIER, "b", 6, 7, "y")
+                    new Value(Value.Kind.IDENTIFIER, "a", 4),
+                    new Value(Value.Kind.IDENTIFIER, "b", 6, "y")
                 ),
                 new Span("foo a b:y", 1)
             ),
@@ -158,9 +158,9 @@ final class BindingsTest {
                 ParseError.class,
                 () -> Bindings.checkAllOrNothing(
                     Arrays.asList(
-                        new Value(Value.Kind.IDENTIFIER, "a", 4, 5),
-                        new Value(Value.Kind.IDENTIFIER, "b", 6, 7),
-                        new Value(Value.Kind.IDENTIFIER, "c", 8, 9, "z")
+                        new Value(Value.Kind.IDENTIFIER, "a", 4),
+                        new Value(Value.Kind.IDENTIFIER, "b", 6),
+                        new Value(Value.Kind.IDENTIFIER, "c", 8, "z")
                     ),
                     new Span("foo a b c:z", 1)
                 ),
@@ -174,7 +174,7 @@ final class BindingsTest {
     void acceptsReceiverWithoutBinding() {
         Assertions.assertDoesNotThrow(
             () -> Bindings.checkReceiver(
-                new Value(Value.Kind.IDENTIFIER, "cond", 4, 8),
+                new Value(Value.Kind.IDENTIFIER, "cond", 4),
                 new Span("if. cond then else", 1)
             ),
             "a bare receiver was rejected"
@@ -186,7 +186,7 @@ final class BindingsTest {
         Assertions.assertThrows(
             ParseError.class,
             () -> Bindings.checkReceiver(
-                new Value(Value.Kind.IDENTIFIER, "cond", 4, 8, "x"),
+                new Value(Value.Kind.IDENTIFIER, "cond", 4, "x"),
                 new Span("if. cond:x then else", 1)
             ),
             "a receiver carrying a binding was accepted"

--- a/eo-parser/src/test/java/org/eolang/parser/ChainEmissionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ChainEmissionTest.java
@@ -25,7 +25,7 @@ final class ChainEmissionTest {
         new ChainEmission(
             emit,
             new Span("bar > foo", 1),
-            new Value(Value.Kind.IDENTIFIER, "bar", 6, 9),
+            new Value(Value.Kind.IDENTIFIER, "bar", 6),
             Collections.emptyList(),
             new Suffix("> foo", new Span("bar > foo", 1), 4)
         ).run();
@@ -48,7 +48,7 @@ final class ChainEmissionTest {
         new ChainEmission(
             emit,
             new Span("foo.bar > wrap", 1),
-            new Value(Value.Kind.IDENTIFIER, "foo", 0, 3),
+            new Value(Value.Kind.IDENTIFIER, "foo", 0),
             Collections.singletonList(new MethodChain("bar", 3, false)),
             new Suffix("> wrap", new Span("foo.bar > wrap", 1), 8)
         ).run();
@@ -72,7 +72,7 @@ final class ChainEmissionTest {
         new ChainEmission(
             emit,
             new Span("bar > foo!", 1),
-            new Value(Value.Kind.IDENTIFIER, "bar", 0, 3),
+            new Value(Value.Kind.IDENTIFIER, "bar", 0),
             Collections.emptyList(),
             new Suffix("> foo!", new Span("bar > foo!", 1), 4)
         ).run();
@@ -94,7 +94,7 @@ final class ChainEmissionTest {
         new ChainEmission(
             emit,
             new Span("foo.bar.baz > q", 1),
-            new Value(Value.Kind.IDENTIFIER, "foo", 0, 3),
+            new Value(Value.Kind.IDENTIFIER, "foo", 0),
             Arrays.asList(
                 new MethodChain("bar", 3, false),
                 new MethodChain("baz", 7, false)

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -16,16 +16,6 @@ import org.junit.jupiter.api.Test;
 final class TokensTest {
 
     @Test
-    void readsIdentifierAndAdvancesCursor() {
-        final Tokens tokens = new Tokens("foo", new Span("foo", 1));
-        MatcherAssert.assertThat(
-            "readName must return the parsed identifier and leave the cursor at end()",
-            tokens.readName().end(),
-            Matchers.equalTo(tokens.cursor())
-        );
-    }
-
-    @Test
     void readsIdentifierWithHyphen() {
         MatcherAssert.assertThat(
             "an identifier with a hyphen must be read as one NAME token per §2.3",

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -18,7 +18,7 @@ final class ValueTest {
     void retainsKindFromCtor() {
         MatcherAssert.assertThat(
             "kind() must round-trip the ctor tag so the emitter dispatches correctly",
-            new Value(Value.Kind.INTEGER, "42", 0, 2).kind(),
+            new Value(Value.Kind.INTEGER, "42", 0).kind(),
             Matchers.equalTo(Value.Kind.INTEGER)
         );
     }
@@ -27,7 +27,7 @@ final class ValueTest {
     void retainsRawTextFromCtor() {
         MatcherAssert.assertThat(
             "raw() must round-trip the source text untouched",
-            new Value(Value.Kind.IDENTIFIER, "foo-bar", 4, 11).raw(),
+            new Value(Value.Kind.IDENTIFIER, "foo-bar", 4).raw(),
             Matchers.equalTo("foo-bar")
         );
     }
@@ -36,17 +36,8 @@ final class ValueTest {
     void retainsPositionFromCtor() {
         MatcherAssert.assertThat(
             "pos() must round-trip the source column for emitter @pos",
-            new Value(Value.Kind.STAR, "*", 7, 8).pos(),
+            new Value(Value.Kind.STAR, "*", 7).pos(),
             Matchers.equalTo(7)
-        );
-    }
-
-    @Test
-    void retainsEndIndexFromCtor() {
-        MatcherAssert.assertThat(
-            "end() must round-trip the cursor advance position",
-            new Value(Value.Kind.IDENTIFIER, "foo", 0, 3).end(),
-            Matchers.equalTo(3)
         );
     }
 
@@ -63,7 +54,7 @@ final class ValueTest {
     void retainsBytesKind() {
         MatcherAssert.assertThat(
             "BYTES must be one of the recognised value kinds",
-            new Value(Value.Kind.BYTES, "CA-FE", 0, 5).kind(),
+            new Value(Value.Kind.BYTES, "CA-FE", 0).kind(),
             Matchers.equalTo(Value.Kind.BYTES)
         );
     }
@@ -72,7 +63,7 @@ final class ValueTest {
     void retainsHexKind() {
         MatcherAssert.assertThat(
             "HEX must be one of the recognised value kinds for `0xFF` literals",
-            new Value(Value.Kind.HEX, "0xFF", 0, 4).kind(),
+            new Value(Value.Kind.HEX, "0xFF", 0).kind(),
             Matchers.equalTo(Value.Kind.HEX)
         );
     }
@@ -81,7 +72,7 @@ final class ValueTest {
     void retainsBindingFromCtor() {
         MatcherAssert.assertThat(
             "binding() must round-trip the inline-binding tag from the ctor",
-            new Value(Value.Kind.IDENTIFIER, "a", 0, 1, "y").binding(),
+            new Value(Value.Kind.IDENTIFIER, "a", 0, "y").binding(),
             Matchers.equalTo("y")
         );
     }
@@ -90,7 +81,7 @@ final class ValueTest {
     void returnsNullBindingWhenAbsent() {
         MatcherAssert.assertThat(
             "binding() must return null when no inline binding was supplied",
-            new Value(Value.Kind.IDENTIFIER, "a", 0, 1).binding(),
+            new Value(Value.Kind.IDENTIFIER, "a", 0).binding(),
             Matchers.nullValue()
         );
     }
@@ -99,7 +90,7 @@ final class ValueTest {
     void retainsGroupKind() {
         MatcherAssert.assertThat(
             "GROUP must be one of the recognised value kinds for paren-bracketed expressions",
-            new Value(Value.Kind.GROUP, "(foo)", 0, 5).kind(),
+            new Value(Value.Kind.GROUP, "(foo)", 0).kind(),
             Matchers.equalTo(Value.Kind.GROUP)
         );
     }
@@ -108,7 +99,7 @@ final class ValueTest {
     void retainsFloatKind() {
         MatcherAssert.assertThat(
             "FLOAT must be one of the recognised value kinds",
-            new Value(Value.Kind.FLOAT, "3.14", 0, 4).kind(),
+            new Value(Value.Kind.FLOAT, "3.14", 0).kind(),
             Matchers.equalTo(Value.Kind.FLOAT)
         );
     }
@@ -117,7 +108,7 @@ final class ValueTest {
     void retainsStringKind() {
         MatcherAssert.assertThat(
             "STRING must be one of the recognised value kinds",
-            new Value(Value.Kind.STRING, "\"hi\"", 0, 4).kind(),
+            new Value(Value.Kind.STRING, "\"hi\"", 0).kind(),
             Matchers.equalTo(Value.Kind.STRING)
         );
     }
@@ -126,7 +117,7 @@ final class ValueTest {
     void retainsRootKind() {
         MatcherAssert.assertThat(
             "ROOT must be one of the recognised value kinds for Q/@/^/$",
-            new Value(Value.Kind.ROOT, "Q", 0, 1).kind(),
+            new Value(Value.Kind.ROOT, "Q", 0).kind(),
             Matchers.equalTo(Value.Kind.ROOT)
         );
     }
@@ -135,7 +126,7 @@ final class ValueTest {
     void retainsTermKind() {
         MatcherAssert.assertThat(
             "TERM must be one of the recognised value kinds for the bottom term T",
-            new Value(Value.Kind.TERM, "T", 0, 1).kind(),
+            new Value(Value.Kind.TERM, "T", 0).kind(),
             Matchers.equalTo(Value.Kind.TERM)
         );
     }
@@ -144,7 +135,7 @@ final class ValueTest {
     void retainsIdentityKind() {
         MatcherAssert.assertThat(
             "IDENTITY must be one of the recognised value kinds for the identity object I",
-            new Value(Value.Kind.IDENTITY, "I", 0, 1).kind(),
+            new Value(Value.Kind.IDENTITY, "I", 0).kind(),
             Matchers.equalTo(Value.Kind.IDENTITY)
         );
     }


### PR DESCRIPTION
`Value.end` (the index in the line body immediately past a value) was never read by production code. Its only two call sites were `ValueTest#retainsEndIndexFromCtor` and `TokensTest#readsIdentifierAndAdvancesCursor`, both of which existed only to keep the accessor exercised. Every constructor site across `Tokens.java` (nine of them) and `LnReversed.java` still had to compute and carry the value, and it lived in a different coordinate system than `pos` (a body index versus a line-absolute column) for nothing anyone consumed.

Same defect #6954 reported for `MethodChain.end`, fixed there by deleting the attribute.

Dropped the `end` field, the `end()` query, and the corresponding constructor parameter (all three overloads), updated every construction site in `Tokens.java` and `LnReversed.java` to the shorter signature, and removed the two tests that only existed to hold the field in place. Also updated `BindingsTest.java` and `ChainEmissionTest.java`, which construct `Value` instances directly and passed the now-removed argument.

See #7164.
