### PR TITLE
#7171: drop the unused Hex(String) constructor

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Hex.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Hex.java
@@ -5,7 +5,6 @@
 package org.eolang.parser;
 
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 
 /**
  * Hex encoder for numeric and string literals.
@@ -14,12 +13,10 @@ import java.nio.charset.StandardCharsets;
  * parsed literal values into the {@code BB-BB-…} byte-string form the
  * XMIR pipeline expects inside {@code <o base='Φ.bytes'>} elements.</p>
  *
- * <p>Three constructions are supported:</p>
+ * <p>Two constructions are supported:</p>
  *
  * <ul>
  * <li>From a {@code double} — produces 8-byte IEEE-754 big-endian.</li>
- * <li>From a UTF-8 string — produces the variable-length UTF-8 byte
- * sequence.</li>
  * <li>From a raw byte array — direct encoding.</li>
  * </ul>
  *
@@ -38,15 +35,6 @@ final class Hex {
      */
     Hex(final double value) {
         this(ByteBuffer.allocate(Double.BYTES).putDouble(value).array());
-    }
-
-    /**
-     * Ctor from a UTF-8 string. Produces the variable-length UTF-8 byte
-     * sequence.
-     * @param text The text
-     */
-    Hex(final String text) {
-        this(text.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/HexTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/HexTest.java
@@ -60,24 +60,6 @@ final class HexTest {
     }
 
     @Test
-    void encodesAsciiStringAsBytes() {
-        MatcherAssert.assertThat(
-            "an ASCII string must encode as its UTF-8 byte sequence",
-            new Hex("ABC").asString(),
-            Matchers.equalTo("41-42-43")
-        );
-    }
-
-    @Test
-    void encodesUtfString() {
-        MatcherAssert.assertThat(
-            "a non-ASCII string must encode as its multi-byte UTF-8 sequence",
-            new Hex("ä").asString(),
-            Matchers.equalTo("C3-A4")
-        );
-    }
-
-    @Test
     void preservesByteArrayContent() {
         MatcherAssert.assertThat(
             "passing raw bytes must round-trip them unchanged",


### PR DESCRIPTION
`Hex(String)` was never used. A repo-wide grep for `new Hex(` finds five construction sites and none of them pass a string: `LnTextBlock.java`, `Emissions.java` (three call sites), and `StHex.java` all hand in a `byte[]` or `double`. `Hex` is package-private, so `org.eolang.parser` is the entire search space.

The constructor also isn't equivalent to the path callers actually use: both `Emissions.string` and `LnTextBlock` decode escapes through `unescapeBytes` before encoding, while `Hex(String)` skipped that entirely and would encode raw `\uXXXX` text verbatim instead of the decoded UTF-8 R-9.7.4 requires — a trap for whoever reached for it based on the class docblock's "three constructions supported" list.

Dropped the constructor, the now-unused `StandardCharsets` import, the two `HexTest` cases that only existed to call it, and trimmed the docblock to the two real forms.

See #7171.
