### PR TITLE
#7167: drop dead horizontallyCompleted() and its stale R-6.1.1 claim

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Kind.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Kind.java
@@ -17,9 +17,8 @@ package org.eolang.parser;
  * <p>The three kinds in the horizontally-completed set
  * ({@link #HAPPLICATION}, {@link #REVERSED_HARGS}, {@link #VMETHOD_HARGS})
  * never receive deeper children and cannot be wrapped by a same-indent
- * {@code .method}. {@link #horizontallyCompleted()} is the single source
- * of truth for that set; R-5.2.3 and R-6.1.1 read it. An
- * {@link #ONLY_PHI} with a bare (zero-hargs) φ is instead
+ * {@code .method}. {@link Openness} is the single source of truth for
+ * that set. An {@link #ONLY_PHI} with a bare (zero-hargs) φ is instead
  * {@link Openness#OPEN}: its φ accepts deeper-indent vertical
  * arguments (§4.5).</p>
  *
@@ -124,21 +123,6 @@ enum Kind {
      * {@link #HEAD}.
      */
     IDENTITY_OBJECT;
-
-    /**
-     * Whether this kind is in the horizontally-completed set.
-     *
-     * <p>Members of this set cannot be extended by deeper-indent children
-     * nor wrapped by a same-indent {@code .method}. Single source of truth
-     * for R-5.2.3 and R-6.1.1.</p>
-     *
-     * @return True iff this kind is horizontally completed
-     */
-    boolean horizontallyCompleted() {
-        return this == HAPPLICATION
-            || this == REVERSED_HARGS
-            || this == VMETHOD_HARGS;
-    }
 
     /**
      * Whether this kind opens a formation — a fresh naming scope whose

--- a/eo-parser/src/main/java/org/eolang/parser/Openness.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Openness.java
@@ -18,8 +18,7 @@ package org.eolang.parser;
  * ended; a same-indent {@code .method} may still wrap it, but no more
  * vertical args may be added.</li>
  * <li>{@link #HCOMPLETED} — horizontally completed: cannot be extended
- * in any direction. {@link Kind#horizontallyCompleted()} pins which
- * kinds start out in this state.</li>
+ * in any direction.</li>
  * </ul>
  *
  * @since 0.1

--- a/eo-parser/src/test/java/org/eolang/parser/KindTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/KindTest.java
@@ -19,40 +19,6 @@ final class KindTest {
     @ParameterizedTest
     @EnumSource(
         value = Kind.class,
-        names = {
-            "HAPPLICATION",
-            "REVERSED_HARGS",
-            "VMETHOD_HARGS"
-        }
-    )
-    void marksHorizontallyCompletedKinds(final Kind kind) {
-        MatcherAssert.assertThat(
-            "Appendix A's horizontally-completed set must report true",
-            kind.horizontallyCompleted(),
-            Matchers.is(true)
-        );
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = Kind.class,
-        names = {
-            "TOP_LEVEL", "HEAD", "HMETHOD", "BARE_FORMATION", "BARE_REVERSED",
-            "COMPACT_TUPLE", "ONLY_PHI", "VAPPLICATION", "VMETHOD",
-            "TEXT_BLOCK", "IDENTITY_OBJECT"
-        }
-    )
-    void leavesOtherKindsOutOfHorizontallyCompletedSet(final Kind kind) {
-        MatcherAssert.assertThat(
-            "kinds outside Appendix A's horizontally-completed set must report false",
-            kind.horizontallyCompleted(),
-            Matchers.is(false)
-        );
-    }
-
-    @ParameterizedTest
-    @EnumSource(
-        value = Kind.class,
         names = {"BARE_FORMATION", "ONLY_PHI", "PIPE_APPLICATION", "IDENTITY_OBJECT"}
     )
     void acceptsPipeAfterFormationLikeKinds(final Kind kind) {


### PR DESCRIPTION
`Kind.horizontallyCompleted()` was never called by production code. A repo-wide grep finds it in three places only: its own definition, a javadoc sentence in `Openness.java`, and two assertions in `KindTest.java`.

Its own docblock claimed it is "the single source of truth for that set; R-5.2.3 and R-6.1.1 read it". Neither is true. R-5.2.3(b) is enforced in `LnMethod.precheck`, which reads `Openness.HCOMPLETED` off the stack top directly and never calls this method. The string `R-6.1.1` does not appear anywhere else in the sources.

The two sources also disagreed about the set itself: `LnOnlyPhi.transition` pushes `ONLY_PHI` with `Openness.HCOMPLETED` whenever the phi carries horizontal args, matching the constant's own docblock, but `horizontallyCompleted()` reported `ONLY_PHI` as false unconditionally.

Dropped the method and the two `KindTest` cases that only existed to call it, and corrected the docblock paragraphs in `Kind.java` and `Openness.java` to point at `Openness` as the actual authority instead of the dead method.

See #7167.
