### PR TITLE
#7174: emit method chain after text-block closer

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.parser;
 
+import java.util.List;
+
 /**
  * A triple-quoted text-block closer line — §3.11 of the spec.
  *
@@ -14,12 +16,14 @@ package org.eolang.parser;
  * line and any body lines are handled directly by {@link Eo#process}
  * (their pre-classification special path).</p>
  *
- * <p>On execution this line consumes the accumulated body, pushes a
- * {@link Kind#TEXT_BLOCK} level at the opener's indent, and emits the
- * resulting string literal as a {@code <o base='Φ.string'>} wrapper
- * with a UTF-8 hex {@code <o base='Φ.bytes'>} child carrying the joined
- * body. Method chains and arguments after the closing {@code """} are
- * deferred to a later iteration. *
+ * <p>On execution this line consumes the accumulated body and emits
+ * the resulting string literal as a {@code <o base='Φ.string'>}
+ * wrapper with a UTF-8 hex {@code <o base='Φ.bytes'>} child carrying
+ * the joined body. Per R-3.11.4 a {@code .method} chain after the
+ * closing {@code """} is allowed; when present it emits the way
+ * {@link ChainEmission} emits it for every other head — flat sibling
+ * {@code <o base='.<name>'>} links, with the line's outer binding and
+ * name suffix attaching to the last link.</p>
  *
  * @since 0.1
  */
@@ -49,7 +53,8 @@ final class LnTextBlock implements Line {
         }
         final Tokens tokens = new Tokens(body, this.span);
         tokens.seek(3);
-        tokens.readChain();
+        final List<MethodChain> chain = tokens.readChain();
+        final String outer = LnApplication.readOuterBinding(tokens);
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
@@ -73,18 +78,10 @@ final class LnTextBlock implements Line {
             throw error;
         }
         this.transition(stack, suffix);
-        emit.object(
-            suffix.attribute(this.span.line(), this.span.indent()),
-            "Φ.string",
-            this.span.line(), this.span.indent()
-        );
-        if (suffix.constant()) {
-            emit.constant();
+        this.emit(emit, suffix, chain, joined);
+        if (outer != null) {
+            emit.slot(Emissions.bindingTag(outer));
         }
-        Emissions.bytesCarrier(
-            emit, this.span.line(), this.span.indent(),
-            new Hex(joined).asString()
-        );
         globals.closeTextBlock();
         globals.clearBlanks();
         globals.markEmitted();
@@ -96,5 +93,41 @@ final class LnTextBlock implements Line {
             Openness.VCOMPLETED,
             new Admission(suffix.named(), suffix.test())
         );
+    }
+
+    private void emit(
+        final Emit emit, final Suffix suffix, final List<MethodChain> chain,
+        final byte[] joined
+    ) {
+        final String hex = new Hex(joined).asString();
+        if (chain.isEmpty()) {
+            emit.object(
+                suffix.attribute(this.span.line(), this.span.indent()),
+                "Φ.string", this.span.line(), this.span.indent()
+            );
+            if (suffix.constant()) {
+                emit.constant();
+            }
+            Emissions.bytesCarrier(emit, this.span.line(), this.span.indent(), hex);
+        } else {
+            emit.object(null, "Φ.string", this.span.line(), this.span.indent());
+            Emissions.bytesCarrier(emit, this.span.line(), this.span.indent(), hex);
+            emit.close();
+            for (int idx = 0; idx < chain.size() - 1; idx = idx + 1) {
+                final MethodChain link = chain.get(idx);
+                emit.object(null, ".".concat(link.name()), this.span.line(), link.dot());
+                emit.method(link.fragile());
+                emit.close();
+            }
+            final MethodChain last = chain.get(chain.size() - 1);
+            emit.object(
+                suffix.attribute(this.span.line(), this.span.indent()),
+                ".".concat(last.name()), this.span.line(), last.dot()
+            );
+            emit.method(last.fragile());
+            if (suffix.constant()) {
+                emit.constant();
+            }
+        }
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-chain-after-text-block-closer.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/method-chain-after-text-block-closer.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='main']/o[@name='txt' and @base='.as-bytes']/o[@base='Φ.string' and o/o[text()='68-69']]
+input: |
+  [] > main
+    """
+    hi
+    """.as-bytes > txt


### PR DESCRIPTION
`LnTextBlock.into` read the method chain after the closing `"""` with `tokens.readChain()` but discarded the result, so `""".as-bytes > txt` parsed into a bare `<o base='Φ.string'>` with the `.as-bytes` link silently gone.

Per R-3.11.4, a method chain after the closer is allowed, then the optional binding and suffix. This emits the chain the way `ChainEmission` emits it for every other head: the string object becomes the first sibling, each chain link is a flat `.method` sibling, and the outer binding/suffix attach to the last link. Also wires up the optional `:label`/`:N` binding via the same `LnApplication.readOuterBinding` helper already used by application lines, which previously fell through to `Suffix` and was reported as trailing garbage.

Fixes #7174
