### PR TITLE
#7175: track pipe and compact-tuple bindings for all-or-nothing rule

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -4,7 +4,9 @@
  */
 package org.eolang.parser;
 
+import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Cross-argument inline-binding validation — §6.6 of the spec.
@@ -22,6 +24,15 @@ import java.util.List;
  * @since 0.1
  */
 final class Bindings {
+
+    /**
+     * The parent kinds whose deeper children are application arguments,
+     * so the all-or-nothing rule of R-6.6.2 governs the group they form.
+     */
+    private static final Set<Kind> TRACKED = EnumSet.of(
+        Kind.HEAD, Kind.HMETHOD, Kind.VAPPLICATION, Kind.IDENTITY_OBJECT,
+        Kind.PIPE_APPLICATION, Kind.COMPACT_TUPLE
+    );
 
     /**
      * No instances.
@@ -120,8 +131,7 @@ final class Bindings {
     }
 
     private static boolean tracksBindings(final Kind kind) {
-        return kind == Kind.HEAD || kind == Kind.HMETHOD
-            || kind == Kind.VAPPLICATION || kind == Kind.IDENTITY_OBJECT;
+        return Bindings.TRACKED.contains(kind);
     }
 
     private static void rejectBinding(final String outer, final Span span) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-compact-tuple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-compact-tuple.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7175: the children of a compact tuple are application arguments (R-3.9.2),
+# so the all-or-nothing rule of R-6.6.2 governs them too.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'argument bindings must be all-or-nothing')]
+input: |
+  [] > main
+    sprintf *1 > r
+      1:a
+      2

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-pipe-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-pipe-group.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7175: R-3.14.6 says the all-or-nothing rule of §6.6 applies to the argument
+# group of a pipe, the same way it applies to the arguments of any other
+# application.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'argument bindings must be all-or-nothing')]
+input: |
+  [] > app
+    [x y] > add
+      x.plus y > @
+    | >>
+      "hello":foo
+      42


### PR DESCRIPTION
`Bindings.tracksBindings` listed `HEAD`, `HMETHOD`, `VAPPLICATION`, and `IDENTITY_OBJECT`, so `observeChild` never observed vertical children of a pipe group or a compact tuple, and the all-or-nothing rule (R-6.6.2) was never checked for them.

```
[] > app
  [x y] > add
    x.plus y > @
  | >>
    "hello":foo
    42
```

parsed without error even though one argument is bound and the other is not. A plain application head catches this exact mix.

R-3.14.6 says the all-or-nothing rule applies to a pipe's argument group explicitly, and R-3.9.2 says a compact tuple's children are application arguments too. Added `PIPE_APPLICATION` and `COMPACT_TUPLE` to `tracksBindings`.

Fixes #7175
