### PR TITLE
#7176: stop a one-byte chunk from triggering BYTES continuation merge

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -189,7 +189,7 @@ final class Eo implements Iterable<Directive> {
             }
             body.append(trimmed);
             idx = idx + 1;
-            if (!trimmed.endsWith("-")) {
+            if (!Eo.isBytesContinuation(trimmed)) {
                 break;
             }
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/one-byte-chunk-does-not-continue-bytes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/one-byte-chunk-does-not-continue-bytes.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7176: R-3.13.1 says a one-byte chunk is complete on its own line and cannot
+# continue a bytes literal, so the merge stops at `BE-` and the token that was
+# merged before it keeps a dangling continuation dash.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'dangling continuation dash')]
+input: |
+  foo > main
+    CA-FE-
+    BE-
+    BE-BE


### PR DESCRIPTION
`Eo.mergeBytesContinuation` decided whether to keep merging a chunk into the multi-line BYTES literal from `trimmed.endsWith("-")` alone, without re-applying the two-byte minimum that `isBytesContinuation` already enforces for the opening chunk.

```
[] > foo
  size. > @
    CA-FE-
    BE-
    BE-BE
```

merged all three lines into one five-byte literal, silently dropping a byte from what was written.

R-3.13.1 says a one-byte chunk is always complete on its own line and its trailing dash cannot trigger continuation. Reusing `isBytesContinuation` in the merge loop stops the merge after `BE-`, leaving `CA-FE-BE-` with a dangling continuation dash, which `Tokens.readPairs` already rejects (the error added for #6566), and `BE-BE` becomes its own line.

Fixes #7176
