### PR TITLE
#7177: return one empty string for an empty text in nsplit

### DIFF
--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -27,60 +27,63 @@
         "Invalid limit %d for nsplit, must be at least 1".printf
           * limit
     if.
-      text.size.eq 0
-      *
-      if.
-        1.eq limit
-        * text
-        [accum start current count] >> rec-nsplit
-          if. > @
-            ^.text.size.eq current
-            appended
+      1.eq limit
+      * text
+      [accum start current count] >> rec-nsplit
+        if. > @
+          ^.text.size.eq current
+          appended
+          if.
+            or.
+              size.eq 0
+              gt.
+                current.plus size
+                ^.text.size
+            ^.rec-nsplit
+              accum
+              start
+              as-number.
+                current.plus 1
+              count
             if.
-              or.
-                size.eq 0
-                gt.
+              and.
+                ^.delimiter.eq
+                  bts.slice current size
+                lt.
+                  number count
+                  minus. (number ^.limit) 1
+              ^.rec-nsplit
+                appended
+                as-number.
                   current.plus size
-                  ^.text.size
+                as-number.
+                  current.plus size
+                as-number.
+                  count.plus 1
               ^.rec-nsplit
                 accum
                 start
                 as-number.
                   current.plus 1
                 count
-              if.
-                and.
-                  ^.delimiter.eq
-                    bts.slice current size
-                  lt.
-                    number count
-                    minus. (number ^.limit) 1
-                ^.rec-nsplit
-                  appended
-                  as-number.
-                    current.plus size
-                  as-number.
-                    current.plus size
-                  as-number.
-                    count.plus 1
-                ^.rec-nsplit
-                  accum
-                  start
-                  as-number.
-                    current.plus 1
-                  count
-          accum.with > appended
-            string
-              bts.slice
-                start
-                current.minus start
-        |
-          *
-          0
-          0
-          0
+        accum.with > appended
+          string
+            bts.slice
+              start
+              current.minus start
+      |
+        *
+        0
+        0
+        0
   text.as-bytes >> bts!
   ^ > text
+
+  eq. ++> can-nsplit-an-empty-text-into-one-empty-string
+    "".nsplit
+      "-"
+      3
+    * ""
 
   eq. ++> can-recover-from-a-fractional-limit
     "recovered"


### PR DESCRIPTION
`string.nsplit` short-circuited an empty text into an empty tuple before checking the limit, so `"".nsplit "-" 3` returned a tuple of length 0. Its sibling `string.split` returns `* ""`, a one-element tuple, for the same input (fixed in #6597), and `nsplit`'s own docblock says it behaves the same way `split` does.

Removed the empty-text special case. With it gone, `1.eq limit` and the `rec-nsplit` recursion already produce the right one-element result for an empty text on their own: the base case (`^.text.size.eq current`) is true from the first call, so it returns the accumulator with one empty string appended, matching `split`.

Added `can-nsplit-an-empty-text-into-one-empty-string`, mirroring `split.eo`'s existing `can-split-an-empty-text-into-one-empty-string`.

Fixes #7177
