### PR TITLE
#7181: make Filled.instead deterministic regardless of HashMap order

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -71,16 +71,24 @@ final class Filled {
      *  no caller says what the void holds
      */
     String instead(final String answer, final String bearer) {
-        String found = answer;
-        for (final Map.Entry<String, String> holds : this.fillings(bearer).entrySet()) {
-            final String hollow = holds.getKey();
-            if (answer.equals(hollow)) {
-                found = holds.getValue();
-                break;
+        final Map<String, String> fillings = this.fillings(bearer);
+        final String found;
+        if (fillings.containsKey(answer)) {
+            found = fillings.get(answer);
+        } else {
+            String longest = "";
+            for (final String hollow : fillings.keySet()) {
+                if (answer.startsWith(hollow.concat("."))
+                    && hollow.length() > longest.length()) {
+                    longest = hollow;
+                }
             }
-            if (answer.startsWith(hollow.concat("."))) {
-                found = this.asked(holds.getValue(), answer.substring(hollow.length() + 1), answer);
-                break;
+            if (longest.isEmpty()) {
+                found = answer;
+            } else {
+                found = this.asked(
+                    fillings.get(longest), answer.substring(longest.length() + 1), answer
+                );
             }
         }
         return found;

--- a/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Filled}.
+ * @since 0.69.0
+ */
+final class FilledTest {
+
+    @Test
+    void prefersAnExactMatchOverAPrefixMatch() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put(
+            "form",
+            List.of(
+                Map.of("void", "true", "type", "Φ.node.x"),
+                Map.of("void", "true", "type", "Φ.node")
+            )
+        );
+        MatcherAssert.assertThat(
+            "an exact fill of the whole answer must win over a fill of one of its prefixes",
+            new Filled(
+                Map.of("app", List.of("value-x", "value-foo")),
+                Map.of("app", "form"),
+                new Provided(
+                    rows, Collections.emptyMap(),
+                    Collections.emptyList(), Collections.emptyMap()
+                )
+            ).instead("Φ.node.x", "app"),
+            Matchers.equalTo("value-x")
+        );
+    }
+
+    @Test
+    void prefersTheLongestOfTwoMatchingPrefixes() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put(
+            "form",
+            List.of(
+                Map.of("void", "true", "type", "Φ.node"),
+                Map.of("void", "true", "type", "Φ.node.x")
+            )
+        );
+        rows.put("long-fill", List.of(Map.of("name", "y", "type", "Φ.result")));
+        MatcherAssert.assertThat(
+            "the more specific (longer) filled prefix must win, not whichever the map yields first",
+            new Filled(
+                Map.of("app", List.of("short-fill", "long-fill")),
+                Map.of("app", "form"),
+                new Provided(
+                    rows, Collections.emptyMap(),
+                    Collections.emptyList(), Collections.emptyMap()
+                )
+            ).instead("Φ.node.x.y", "app"),
+            Matchers.equalTo("Φ.result")
+        );
+    }
+}


### PR DESCRIPTION
`Filled.instead` walked `fillings(bearer).entrySet()`, a `HashMap`, and took the first entry that matched the answer, either exactly or as a prefix. Iteration order is unspecified, so when the answer has both an exact fill and a prefix fill, or two prefix fills of different depth, the winner depended on hash bucket order instead of the actual rule: an exact match should always win, and among prefixes the longest (most specific) one should win.

Rewrote `instead` to look up the exact key first, and otherwise scan for the longest matching prefix explicitly, so the choice no longer depends on map iteration order.

Fixes #7181
