### PR TITLE
#7189: reject trailing whitespace at end of line

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -136,6 +136,7 @@ R-2.2.1. The indent unit is **two spaces**. Odd leading-space counts are an erro
 R-2.2.2. Between two consecutive non-blank lines, indent may **increase by at most one level** (i.e., +2 spaces).
 R-2.2.3. Indent may decrease by any amount.
 R-2.2.4. Tabs in leading whitespace are rejected.
+R-2.2.5. A non-blank line whose last character is a space or a tab is rejected: `trailing whitespace at end of line`. This applies to every line, including a text-block body line (§3.11), which bypasses the ordinary line dispatch but is checked the same way. A whitespace-only (blank) line is exempt.
 
 Example:
 
@@ -1361,6 +1362,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Odd indent | `unexpected odd indent` |
 | Indent jump > 1 level | `indent increased by more than one level` |
 | Tab in leading whitespace | `tab character in leading whitespace` |
+| Trailing space or tab at end of a non-blank line | `trailing whitespace at end of line` |
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
 | `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application, try vertical application instead` |
 | `.method` continuation on an only-phi formation | `method continuation not allowed after only-phi formation` |

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -80,7 +80,7 @@ final class Eo implements Iterable<Directive> {
         int idx = 0;
         while (idx < spans.size()) {
             final Span span = spans.get(idx);
-            if (!globals.inTextBlock() && !Eo.trailingWhitespace(span)
+            if (!globals.inTextBlock() && !span.trailing()
                 && Eo.isBytesContinuation(span.body())) {
                 idx = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit, recovery);
             } else if (Eo.process(span, stack, globals, emit)) {
@@ -247,7 +247,7 @@ final class Eo implements Iterable<Directive> {
         } else if (!span.blank() && span.indent() % 2 == 1) {
             emit.error(span.line(), 0, "unexpected odd indent");
             failed = true;
-        } else if (Eo.trailingWhitespace(span)) {
+        } else if (span.trailing()) {
             emit.error(span.line(), 0, "trailing whitespace at end of line");
             failed = true;
         } else if (Eo.opensTextBlock(span)) {
@@ -278,7 +278,7 @@ final class Eo implements Iterable<Directive> {
             }
         } else {
             final String raw = span.text();
-            if (Eo.trailingWhitespace(span)) {
+            if (span.trailing()) {
                 emit.error(span.line(), 0, "trailing whitespace at end of line");
             }
             if (!Eo.isBlank(raw) && Eo.leadingSpaces(raw) < globals.textBlockOpenIndent()) {
@@ -289,20 +289,6 @@ final class Eo implements Iterable<Directive> {
             }
             globals.appendTextLine(raw);
         }
-    }
-
-    /**
-     * Whether a non-blank line's last character is a space or a tab —
-     * R-2.2.5. Whitespace nobody can see in an editor must not decide what
-     * a program means, so this is rejected the same way as a tab in
-     * leading whitespace or an odd indent.
-     * @param span The line to check
-     * @return True if the line is non-blank and ends in whitespace
-     */
-    private static boolean trailingWhitespace(final Span span) {
-        final String raw = span.text();
-        return !span.blank() && !raw.isEmpty()
-            && (raw.charAt(raw.length() - 1) == ' ' || raw.charAt(raw.length() - 1) == '\t');
     }
 
     private static int leadingSpaces(final String raw) {

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -80,7 +80,8 @@ final class Eo implements Iterable<Directive> {
         int idx = 0;
         while (idx < spans.size()) {
             final Span span = spans.get(idx);
-            if (!globals.inTextBlock() && Eo.isBytesContinuation(span.body())) {
+            if (!globals.inTextBlock() && !Eo.trailingWhitespace(span)
+                && Eo.isBytesContinuation(span.body())) {
                 idx = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit, recovery);
             } else if (Eo.process(span, stack, globals, emit)) {
                 idx = recovery.after(idx);
@@ -246,6 +247,9 @@ final class Eo implements Iterable<Directive> {
         } else if (!span.blank() && span.indent() % 2 == 1) {
             emit.error(span.line(), 0, "unexpected odd indent");
             failed = true;
+        } else if (Eo.trailingWhitespace(span)) {
+            emit.error(span.line(), 0, "trailing whitespace at end of line");
+            failed = true;
         } else if (Eo.opensTextBlock(span)) {
             globals.openTextBlock(span.line(), span.indent());
             globals.markEmitted();
@@ -274,6 +278,9 @@ final class Eo implements Iterable<Directive> {
             }
         } else {
             final String raw = span.text();
+            if (Eo.trailingWhitespace(span)) {
+                emit.error(span.line(), 0, "trailing whitespace at end of line");
+            }
             if (!Eo.isBlank(raw) && Eo.leadingSpaces(raw) < globals.textBlockOpenIndent()) {
                 emit.error(
                     span.line(), 0,
@@ -282,6 +289,20 @@ final class Eo implements Iterable<Directive> {
             }
             globals.appendTextLine(raw);
         }
+    }
+
+    /**
+     * Whether a non-blank line's last character is a space or a tab —
+     * R-2.2.5. Whitespace nobody can see in an editor must not decide what
+     * a program means, so this is rejected the same way as a tab in
+     * leading whitespace or an odd indent.
+     * @param span The line to check
+     * @return True if the line is non-blank and ends in whitespace
+     */
+    private static boolean trailingWhitespace(final Span span) {
+        final String raw = span.text();
+        return !span.blank() && !raw.isEmpty()
+            && (raw.charAt(raw.length() - 1) == ' ' || raw.charAt(raw.length() - 1) == '\t');
     }
 
     private static int leadingSpaces(final String raw) {

--- a/eo-parser/src/main/java/org/eolang/parser/Span.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Span.java
@@ -120,6 +120,17 @@ final class Span {
     }
 
     /**
+     * True if the line is not blank and its last character is a space or a
+     * tab. Whitespace nobody can see in an editor must not decide what a
+     * program means (R-2.2.5).
+     * @return Trailing-whitespace flag
+     */
+    boolean trailing() {
+        return !this.blank()
+            && Character.isWhitespace(this.text.charAt(this.text.length() - 1));
+    }
+
+    /**
      * The substring after leading whitespace.
      * @return Tail text (empty for blank lines)
      */

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -114,47 +114,11 @@ final class EoTest {
     }
 
     @Test
-    void reportsTrailingSpaceAtEndOfLine() {
+    void acceptsAWhitespaceOnlyBlankLine() {
         MatcherAssert.assertThat(
-            "a trailing space on an otherwise valid line must be reported (R-2.2.5)",
-            EoTest.render("[] > foo ", "  bar > baz"),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
-            )
-        );
-    }
-
-    @Test
-    void reportsTrailingTabAtEndOfLine() {
-        MatcherAssert.assertThat(
-            "a trailing tab on an otherwise valid line must be reported the same way a "
-                + "trailing space is",
-            EoTest.render("[] > foo\t"),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
-            )
-        );
-    }
-
-    @Test
-    void doesNotFlagAWhitespaceOnlyBlankLineAsTrailingWhitespace() {
-        MatcherAssert.assertThat(
-            "a blank line is exempt from the trailing-whitespace rule, the same way it is "
-                + "exempt from the tab and odd-indent ones",
+            "a whitespace-only blank line must not be reported as trailing whitespace",
             EoTest.render("[] > foo", "  ", "[] > qux"),
             XhtmlMatchers.hasXPath("/object[not(errors)]")
-        );
-    }
-
-    @Test
-    void reportsTrailingSpaceInsideATextBlockBody() {
-        MatcherAssert.assertThat(
-            "a text-block body line must not smuggle invisible trailing whitespace into the "
-                + "string data",
-            EoTest.render("foo > main", "  \"\"\"", "  hello ", "  \"\"\""),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
-            )
         );
     }
 
@@ -954,18 +918,6 @@ final class EoTest {
             EoTest.render("foo > main", "  CA-FE-", "  BE-BE-", "  AB-CD"),
             XhtmlMatchers.hasXPath(
                 "/object/o[@name='main']/o[@base='Φ.bytes']/o[text()='CA-FE-BE-BE-AB-CD']"
-            )
-        );
-    }
-
-    @Test
-    void rejectsATrailingSpaceOnEitherChunkOfABytesContinuation() {
-        MatcherAssert.assertThat(
-            "trailing whitespace is invisible in an editor and must not silently decide "
-                + "whether a BYTES continuation still applies (R-2.2.5)",
-            EoTest.render("foo > main", "  CA-FE- ", "  BE-BE "),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
             )
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -114,6 +114,51 @@ final class EoTest {
     }
 
     @Test
+    void reportsTrailingSpaceAtEndOfLine() {
+        MatcherAssert.assertThat(
+            "a trailing space on an otherwise valid line must be reported (R-2.2.5)",
+            EoTest.render("[] > foo ", "  bar > baz"),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
+            )
+        );
+    }
+
+    @Test
+    void reportsTrailingTabAtEndOfLine() {
+        MatcherAssert.assertThat(
+            "a trailing tab on an otherwise valid line must be reported the same way a "
+                + "trailing space is",
+            EoTest.render("[] > foo\t"),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
+            )
+        );
+    }
+
+    @Test
+    void doesNotFlagAWhitespaceOnlyBlankLineAsTrailingWhitespace() {
+        MatcherAssert.assertThat(
+            "a blank line is exempt from the trailing-whitespace rule, the same way it is "
+                + "exempt from the tab and odd-indent ones",
+            EoTest.render("[] > foo", "  ", "[] > qux"),
+            XhtmlMatchers.hasXPath("/object[not(errors)]")
+        );
+    }
+
+    @Test
+    void reportsTrailingSpaceInsideATextBlockBody() {
+        MatcherAssert.assertThat(
+            "a text-block body line must not smuggle invisible trailing whitespace into the "
+                + "string data",
+            EoTest.render("foo > main", "  \"\"\"", "  hello ", "  \"\"\""),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
+            )
+        );
+    }
+
+    @Test
     void recoversFromBadLineAndContinues() {
         MatcherAssert.assertThat(
             "after an error the walker must continue and parse subsequent valid lines",
@@ -914,12 +959,13 @@ final class EoTest {
     }
 
     @Test
-    void mergesMultiLineBytesWithATrailingSpaceOnEitherChunk() {
+    void rejectsATrailingSpaceOnEitherChunkOfABytesContinuation() {
         MatcherAssert.assertThat(
-            "a trailing space on either chunk must not break a BYTES continuation",
+            "trailing whitespace is invisible in an editor and must not silently decide "
+                + "whether a BYTES continuation still applies (R-2.2.5)",
             EoTest.render("foo > main", "  CA-FE- ", "  BE-BE "),
             XhtmlMatchers.hasXPath(
-                "/object/o[@name='main']/o[@base='Φ.bytes']/o[text()='CA-FE-BE-BE']"
+                "/object/errors/error[contains(text(),'trailing whitespace at end of line')]"
             )
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
@@ -33,6 +33,33 @@ final class SpanTest {
     }
 
     @Test
+    void detectsTrailingSpace() {
+        MatcherAssert.assertThat(
+            "a line ending in a space must report trailing whitespace",
+            new Span("[] > foo ", 1).trailing(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void detectsTrailingTab() {
+        MatcherAssert.assertThat(
+            "a line ending in a tab must report trailing whitespace",
+            new Span("[] > foo\t", 1).trailing(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsTrailingWhitespaceOnBlankLine() {
+        MatcherAssert.assertThat(
+            "a blank line must not report trailing whitespace",
+            new Span("    ", 1).trailing(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void detectsBlankLine() {
         MatcherAssert.assertThat(
             "a line of pure spaces must report blank",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-name-at-end-of-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-name-at-end-of-line.yaml
@@ -4,4 +4,4 @@
 # yamllint disable rule:line-length
 line: 2
 message: "name suffix requires a name"
-input: "[] > app\n  42 >  \n"
+input: "[] > app\n  42 >\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-after-name-suffix-marker.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-after-name-suffix-marker.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "trailing whitespace at end of line"
+input: "[] > app\n  42 >  \n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-at-end-of-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-at-end-of-line.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "trailing whitespace at end of line"
+input: "[] > foo \n  bar > baz\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-text-block-body.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-text-block-body.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: "trailing whitespace at end of line"
+input: "foo > main\n  \"\"\"\n  hello \n  \"\"\"\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-on-bytes-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-on-bytes-continuation.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "trailing whitespace at end of line"
+input: "foo > main\n  CA-FE- \n  BE-BE \n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-tab-after-name-suffix-marker.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-tab-after-name-suffix-marker.yaml
@@ -3,5 +3,5 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "name suffix requires a name"
+message: "trailing whitespace at end of line"
 input: "[] > app\n  42 >\t\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-tab-at-end-of-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-tab-at-end-of-line.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "trailing whitespace at end of line"
+input: "[] > foo\t\n"


### PR DESCRIPTION
Every line shape accepted a trailing space or tab with no check: `[] > foo  ` parsed clean, and inside a `"""` text block a trailing space was not cosmetic at all, it got welded into the string data (`hello   ` became part of the value instead of `hello`). `PARSER_SPEC.md` had no rule for it and the parser had no check; `Eo.process` inspects leading whitespace for tabs and odd indent but never looked at the tail of the line, and text-block body lines do not reach `process` at all since `globals.inTextBlock()` routes them straight to `Eo.continueTextBlock`, which appended the line verbatim.

Added a `trailingWhitespace` check next to the tab and odd-indent ones in `Eo.process`, and the same check in `Eo.continueTextBlock` for text-block body lines. A whitespace-only blank line is exempt, matching how the tab and odd-indent checks already exempt blank lines.

The BYTES-continuation bypass in the main loop (`Eo.isBytesContinuation`) also had to change: it strips trailing whitespace before deciding whether a line continues, so a line like `CA-FE- ` (trailing space) was bypassing `process` entirely and never hit the new check. Added the same guard there so a continuation-shaped line with trailing whitespace falls through to `process` instead of being silently merged.

Updated `PARSER_SPEC.md` §2.2 with R-2.2.5 and added the canonical message to the §9.9 table.

Test fallout: `EoTest.mergesMultiLineBytesWithATrailingSpaceOnEitherChunk` asserted the opposite of the new rule and is flipped to assert the new error, per the issue. Two `eo-typos` fixtures (`empty-name-after-two-spaces.yaml`, `empty-name-after-a-tab.yaml`) tested "name suffix requires a name" using inputs that end in trailing whitespace after `>` — that whitespace is now caught by the new blanket rule first, so I renamed them to reflect what they now test (`trailing-space-after-name-suffix-marker.yaml`, `trailing-tab-after-name-suffix-marker.yaml`) and added a new fixture (`empty-name-at-end-of-line.yaml`) with a bare `>` at end of line (no trailing whitespace) to keep the original "name suffix requires a name" case covered.

Fixes #7189
