### PR TITLE
#7178: format the invalid-limit message with %f in nsplit

### DIFF
--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -24,7 +24,7 @@
       if.
         size.eq 0
         "The delimiter must not be empty"
-        "Invalid limit %d for nsplit, must be at least 1".printf
+        "Invalid limit %f for nsplit, must be at least 1".printf
           * limit
     if.
       1.eq limit
@@ -78,6 +78,13 @@
         0
   text.as-bytes >> bts!
   ^ > text
+
+  eq. ++> can-format-the-error-message-of-a-fractional-limit
+    "Invalid limit 1.500000 for nsplit, must be at least 1"
+    "a-b-c".nsplit
+      "-"
+      1.5
+      I
 
   eq. ++> can-nsplit-an-empty-text-into-one-empty-string
     "".nsplit


### PR DESCRIPTION
`string.nsplit` rejects an invalid limit and formats the message with `%d`, which truncates toward zero. `"a-b-c".nsplit "-" 1.5 I` reported `Invalid limit 1 for nsplit, must be at least 1`, naming `1` as the reason even though `1` is a perfectly good limit; the real (fractional) value never showed up. With a non-finite limit `%d` cannot even build the message at all, so `nan` or `pinf` died inside the error instead of producing it.

Switched to `%f`, the way every sibling guard in the package already does (`slice.eo`, `truncated.eo`, `repeated.eo`, `padded-left.eo`, `padded-right.eo`, `padded-zeros.eo`, `at.eo`). Added `can-format-the-error-message-of-a-fractional-limit`, since nothing dataized the message before.

Fixes #7178
