### PR TITLE
Fill a declared receiver void on dispatch

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -448,9 +448,17 @@
   <!-- Void attribute -->
   <xsl:template match="void">
     <xsl:param name="name"/>
-    <xsl:text>new AtVoid("</xsl:text>
-    <xsl:value-of select="eo:literal($name)"/>
-    <xsl:text>")</xsl:text>
+    <xsl:choose>
+      <!-- A receiver is held by reference, so it survives a copy untouched -->
+      <xsl:when test="$name=$eo:rho">
+        <xsl:text>new AtRho()</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>new AtVoid("</xsl:text>
+        <xsl:value-of select="eo:literal($name)"/>
+        <xsl:text>")</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <!--
   Atom as attribute.

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/receiver-void-as-rho.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/receiver-void-as-rho.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/package.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - /object/class/java[contains(text(), 'this.add("ρ", new AtRho());')]
+  - /object/class/java[contains(text(), 'this.add("x", new AtVoid("x"));')]
+input: |
+  x > [^ x] > receiver

--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -60,7 +60,7 @@ final class AtRho implements Attribute {
 
     @Override
     public boolean vacant() {
-        return false;
+        return this.rho.get() == null;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -9,13 +9,17 @@ import java.util.Objects;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
- * Special attribute for \rho.
+ * The attribute that holds the receiver.
  *
- * <p>The attribute can be set only once, and it ignores all other puts.</p>
+ * <p>It behaves as a void in every respect but one. A void owns what
+ * fills it, so copying the object copies the value too; a receiver
+ * points the other way, at the object this one hangs off, and
+ * duplicating that on every copy would clone the whole chain above.
+ * So {@link #copy(Phi)} carries the reference over untouched.</p>
  *
  * @since 0.36.0
  */
-final class AtRho implements Attribute {
+public final class AtRho implements Attribute {
 
     /**
      * Rho.
@@ -25,7 +29,7 @@ final class AtRho implements Attribute {
     /**
      * Ctor.
      */
-    AtRho() {
+    public AtRho() {
         this(null);
     }
 
@@ -44,18 +48,29 @@ final class AtRho implements Attribute {
 
     @Override
     public Phi get() {
-        if (this.rho.get() == null) {
-            throw new ExUnset(
-                String.format("The \"%s\" attribute is not set", Phi.RHO)
+        final Phi phi = this.rho.get();
+        final Phi result;
+        if (phi == null) {
+            result = new PhTerminator(
+                String.format("the attribute \"%s\" is not set", Phi.RHO)
             );
+        } else {
+            result = phi;
         }
-        return this.rho.get();
+        return result;
     }
 
     @Override
     public void put(final Phi phi) {
         Objects.requireNonNull(phi, "Attribute value can't be null");
-        this.rho.compareAndSet(null, phi);
+        if (!this.rho.compareAndSet(null, phi)) {
+            throw new ExReadOnly(
+                String.format(
+                    "This void attribute \"%s\" is already set, can't reset",
+                    Phi.RHO
+                )
+            );
+        }
     }
 
     @Override
@@ -65,6 +80,12 @@ final class AtRho implements Attribute {
 
     @Override
     public String φTerm() {
-        return "^";
+        final String term;
+        if (this.rho.get() == null) {
+            term = "?";
+        } else {
+            term = "^";
+        }
+        return term;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -181,13 +181,7 @@ public class PhDefault implements Phi, Cloneable {
 
     @Override
     public boolean hasRho() {
-        boolean has = true;
-        try {
-            this.loaded().get(Phi.RHO).get();
-        } catch (final ExUnset exception) {
-            has = false;
-        }
-        return has;
+        return !this.loaded().get(Phi.RHO).vacant();
     }
 
     @Override
@@ -326,7 +320,11 @@ public class PhDefault implements Phi, Cloneable {
             if (PhDefault.SORTABLE.matcher(name).matches()) {
                 this.order.add(name);
             }
-            this.loaded().put(name, new AtWithRho(attr, this));
+            if (Phi.RHO.equals(name)) {
+                this.loaded().put(name, attr);
+            } else {
+                this.loaded().put(name, new AtWithRho(attr, this));
+            }
         } finally {
             this.lock.unlock();
         }

--- a/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
@@ -81,4 +81,24 @@ final class AtRhoTest {
             Matchers.containsString("can't be null")
         );
     }
+
+    @Test
+    void reportsItselfVacantWhileUnset() {
+        MatcherAssert.assertThat(
+            "an unset rho attribute must report itself vacant, but it didnt",
+            new AtRho().vacant(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void stopsBeingVacantOnceBound() {
+        final AtRho attr = new AtRho();
+        attr.put(new PhDefault());
+        MatcherAssert.assertThat(
+            "a bound rho attribute must stop reporting itself vacant, but it didnt",
+            attr.vacant(),
+            Matchers.is(false)
+        );
+    }
 }

--- a/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
@@ -16,20 +16,31 @@ import org.junit.jupiter.api.Test;
 final class AtRhoTest {
 
     @Test
-    void printsCaretAsTerm() {
+    void printsQuestionMarkAsTermWhileUnset() {
         MatcherAssert.assertThat(
-            "AtRho must render as caret in φ-term, but it didnt",
+            "an unset rho must render as a question mark in φ-term, but it didnt",
             new AtRho().φTerm(),
+            Matchers.equalTo("?")
+        );
+    }
+
+    @Test
+    void printsCaretAsTermOnceBound() {
+        final Attribute rho = new AtRho();
+        rho.put(new PhDefault());
+        MatcherAssert.assertThat(
+            "a bound rho must render as a caret in φ-term, but it didnt",
+            rho.φTerm(),
             Matchers.equalTo("^")
         );
     }
 
     @Test
-    void throwsOnEmptyRho() {
-        Assertions.assertThrows(
-            ExUnset.class,
-            new AtRho()::get,
-            "AtRho must throw an exception if attribute is not set"
+    void terminatesOnEmptyRho() {
+        MatcherAssert.assertThat(
+            "reading an unset rho must give a termination, but it didnt",
+            new AtRho().get(),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 
@@ -58,15 +69,13 @@ final class AtRhoTest {
     }
 
     @Test
-    void doesNotResetObject() {
+    void rejectsSecondPut() {
         final Attribute rho = new AtRho();
-        final Phi obj = new PhDefault();
-        rho.put(obj);
         rho.put(new PhDefault());
-        MatcherAssert.assertThat(
-            "AtRho must not change state after put()",
-            rho.get(),
-            Matchers.equalTo(obj)
+        Assertions.assertThrows(
+            ExReadOnly.class,
+            () -> rho.put(new PhDefault()),
+            "a rho that is already bound must reject a second put"
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -95,10 +95,10 @@ final class PhDefaultTest {
 
     @Test
     void doesNotHaveRhoWhenFormed() {
-        Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new PhSafe(PhDefaultTest.Int.made()).take(Phi.RHO),
-            String.format("Object should not have %s attribute when it's just formed", Phi.RHO)
+        MatcherAssert.assertThat(
+            String.format("a just-formed object must terminate on %s, but it didnt", Phi.RHO),
+            PhDefaultTest.Int.made().take(Phi.RHO),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 
@@ -112,10 +112,10 @@ final class PhDefaultTest {
 
     @Test
     void doesNotHaveRhoAfterCopying() {
-        Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new PhSafe(PhDefaultTest.Int.made().copy()).take(Phi.RHO),
-            String.format("Object should not give %s attribute after copying", Phi.RHO)
+        MatcherAssert.assertThat(
+            String.format("a copied object must terminate on %s, but it didnt", Phi.RHO),
+            PhDefaultTest.Int.made().copy().take(Phi.RHO),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -646,6 +646,26 @@ final class PhDefaultTest {
         }
     }
 
+    @Test
+    void bindsTheHostIntoADeclaredReceiverVoid() {
+        final Phi host = new PhDefault(
+            new Attrs(
+                new Attr(
+                    "kid",
+                    new AtComposite(
+                        new PhDefault(),
+                        rho -> new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO))))
+                    )
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            "dispatching off a host must fill the declared ρ void of the taken object, but it didnt",
+            host.take("kid").take(Phi.RHO),
+            Matchers.is(host)
+        );
+    }
+
     private void joinsThreads(final Thread... threads) {
         for (final Thread thread : threads) {
             try {


### PR DESCRIPTION
Since #7134 an object may declare its receiver as an ordinary void, and `[^ x] > foo` transpiles to `this.add("ρ", new AtVoid("ρ"))`. Nothing filled it. `hasRho()` decided the question by reading the attribute and catching `ExUnset`, which only `AtRho` throws — an empty `AtVoid` returns a `PhTerminator` instead, so an unset receiver reported itself as set, and `AtWithRho.get()` binds the host only when it reports otherwise.

Asking the attribute whether it is vacant answers for both kinds:

```java
public boolean hasRho() {
    return !this.loaded().get(Phi.RHO).vacant();
}
```

`AtRho.vacant()` now reports whether its reference is still null rather than a flat `false`. That flat answer was only ever consulted by `PhDefault.vacancy`, which walks `order`, and `ρ` never enters `order` because it does not match `SORTABLE` — so positional filling is untouched, and the receiver is still found by name alone.

One more thing had to change. `add` wraps every attribute in `AtWithRho`, which stamps a rho onto whatever it hands back; `defaults()` installs the implicit `AtRho` unwrapped. A declared receiver went through `add`, so reading it returned a stamped copy of the host instead of the host. `add` now leaves `ρ` unwrapped, as `defaults()` always did.
