### PR TITLE
#7179: resume after an escaped %% at end, not index+2

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -140,11 +140,21 @@
           * ^.format
       if.
         25-.eq conv
-        walk
-          as-number.
-            index.plus 2
-          auto
-          acc.concat 25-
+        if.
+          eq.
+            number end
+            as-number.
+              index.plus 1
+          walk
+            as-number.
+              plus.
+                number end
+                1
+            auto
+            acc.concat 25-
+          T
+            "The escaped %% conversion does not take flags, width or precision".printf
+              * ^.format
         walk
           as-number.
             plus.
@@ -549,6 +559,10 @@
     "%,x"
     * 5
 
+  printf. --> stops-on-a-flag-before-an-escaped-percent
+    "%-%s"
+    * "x"
+
   printf. --> stops-on-a-hash-flag-with-s
     "%#s"
     * "Jeff"
@@ -572,6 +586,10 @@
   printf. --> stops-on-a-precision-with-d
     "%.2d"
     * 5
+
+  printf. --> stops-on-a-width-before-an-escaped-percent
+    "%5%s"
+    * "x"
 
   printf. --> stops-on-a-zero-flag-with-x
     "%0x"


### PR DESCRIPTION
The `%%` branch of `printf`'s `spec` resumed two bytes after the percent sign (`index.plus 2`) instead of one byte after the conversion (`end.plus 1`, the way the ordinary branch right below it does). The two only agree when no flags, width or precision were consumed, so a specifier carrying any of those before the second `%` both lost them and re-read a byte:

```
"%-%s".printf * "x"
```

returned `"%x"` instead of formatting `x` left-justified, because the walk consumed `-` as a flag, saw `%` as the conversion, then restarted at the very byte it just consumed.

`%%` does not take flags, width or precision, the same way Java's `Formatter` rejects it (`UnknownFormatConversionException` for `"%-%s"`). Added a check that `%%` is bare (`end` is exactly `index + 1`) before treating it as an escape; a `%%` carrying anything else is rejected, matching how the file already rejects `%,s`, `%0x` and `%.2d`.

Fixes #7179
