### PR TITLE
#7183: normalize a carried mantissa by magnitude, not one signed literal

### DIFF
--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -22,9 +22,11 @@
         "-infinity".as-bytes
         "infinity".as-bytes
     if.
-      mantissa.eq "10.000000".as-bytes
+      or.
+        mantissa.eq "10.000000".as-bytes
+        carried
       concat.
-        "1.000000".as-bytes.concat "e".as-bytes
+        normalized.concat "e".as-bytes
         as-decimal.
           plus.
             number exponent
@@ -33,6 +35,7 @@
         mantissa.concat "e".as-bytes
         as-decimal.
           number exponent
+  mantissa.eq "-10.000000".as-bytes > carried!
   rec-exponent > exponent!
     n.abs
     0
@@ -42,6 +45,9 @@
         number exponent
     6
   ^ > n
+  carried.if > normalized!
+    "-1.000000".as-bytes
+    "1.000000".as-bytes
   if. > [m count] >> rec-exponent
     m.lt 10
     count
@@ -57,6 +63,14 @@
   eq. ++> can-carry-a-rounded-mantissa-past-the-long-range
     "1.000000e20"
     string 9.9999996e19.as-scientific
+
+  eq. ++> can-carry-a-rounded-negative-mantissa-into-the-next-power-of-ten
+    "-1.000000e1"
+    string -9.9999996.as-scientific
+
+  eq. ++> can-carry-a-rounded-negative-mantissa-past-the-long-range
+    "-1.000000e20"
+    string -9.9999996e19.as-scientific
 
   eq. ++> can-name-a-magnitude-past-the-long-range
     "1.000000e19"


### PR DESCRIPTION
`number.as-scientific` normalizes a mantissa that rounding carried up to ten by comparing it against a single literal, `"10.000000"`. `exponent` comes from `n.abs` and carries no sign, but `mantissa` is `as-fixed` of `n.div (10.power exponent)`, which keeps the sign. For a negative number the carried mantissa is `"-10.000000"`, the literal never matches, and the value prints unnormalized: `-9.9999996.as-scientific` gave `-10.000000e0` instead of `-1.000000e1`.

#6734 fixed this for positive numbers with the one-sided comparison; the negative half was never covered, and both existing carry tests use positive input.

Checks the magnitude (both `"10.000000"` and `"-10.000000"`) and picks the correctly-signed normalized mantissa (`"1.000000"` or `"-1.000000"`), so the sign survives the carry. Added the negative counterparts of the two existing carry tests.

Fixes #7183
