### PR TITLE
#7184: accept Long.MIN_VALUE in printf's %d long-range guard

### DIFF
--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -240,6 +240,12 @@
 
   42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-expose-valid-bytes
 
+  eq. ++> can-format-the-error-message-of-the-minimum-i64-when-converting-to-i32
+    "Can't convert i64 number -9223372036854775808 to i32 because it's out of i32 bounds"
+    as-i32.
+      i64 80-00-00-00-00-00-00-00
+      I
+
   eq. ++> can-keep-the-low-bits-of-a-large-product
     2147483647.as-i64.times 2147483647.as-i64
     i64 3F-FF-FF-FF-00-00-00-01

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -194,7 +194,7 @@
               gte.
                 number numeric
                 number limit
-              lte.
+              lt.
                 number numeric
                 times.
                   number limit
@@ -537,6 +537,11 @@
     "%d".printf
       * 9.99
 
+  eq. ++> can-write-the-negative-long-boundary-as-a-decimal
+    "-9223372036854775808"
+    "%d".printf
+      * -9.223372036854776e18
+
   printf. --> stops-on-a-bool-as-a-string
     "%s"
     * true
@@ -604,7 +609,3 @@
   printf. --> stops-on-formatting-nan-as-a-decimal
     "%d"
     * nan
-
-  printf. --> stops-on-the-negative-long-boundary-as-a-decimal
-    "%d"
-    * -9.223372036854776e18


### PR DESCRIPTION
`printf`'s `%d` guard rejects a value outside the long range `[-2^63, 2^63-1]`, but the negative side used `lte` against `-2^63`, rejecting the boundary itself even though `-9223372036854775808` is `Long.MIN_VALUE` and fits. This is a regression from the fix for #6572 (`de7b1f8f3b`), which changed the comparison from `lt` to `lte`.

Because of this, `i64.as-i32`'s own out-of-bounds message for the smallest `i64` died inside `printf`'s long-range complaint instead of naming the value: `80-00-00-00-00-00-00-00.as-i64.as-i32` never got to report "Can't convert i64 number -9223372036854775808 to i32 because it's out of i32 bounds". The rest of the library already treats this boundary as in range: `number/as-decimal.eo` special-cases and prints it, and `number/as-i64.eo` accepts it.

Changed the negative-side comparison back to `lt`. Flipped the `-->` test at the old boundary into a `++>` one asserting the printed digits, and added a test that `i64.as-i32` can now report its own error message for the minimum `i64`.

Fixes #7184
