### PR TITLE
#7185: name the out-of-range number with %s and as-scientific in as-i64

### DIFF
--- a/eo-runtime/src/main/eo/number/as-i64.eo
+++ b/eo-runtime/src/main/eo/number/as-i64.eo
@@ -36,8 +36,8 @@
                   00-10-00-00-00-00-00-00
                 00-10-00-00-00-00-00-00
     cant-convert
-      "Can't convert number %f to i64 because it's out of i64 bounds".printf
-        * n
+      "Can't convert number %s to i64 because it's out of i64 bounds".printf
+        * string n.as-scientific
     if.
       exp.lt 1023
       00-00-00-00-00-00-00-00.as-i64
@@ -72,6 +72,10 @@
     80-00-00-00-00-00-00-00
 
   42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-convert-the-origin-number
+
+  eq. ++> can-format-the-error-message-of-an-out-of-range-number
+    "Can't convert number 1.000000e30 to i64 because it's out of i64 bounds"
+    1.0e30.as-i64 I
 
   eq. ++> can-recover-from-an-out-of-range-number
     "recovered"


### PR DESCRIPTION
`number.as-i64` names the number it cannot convert with `%f`, which goes through `as-fixed` and `as-decimal`. `as-decimal` itself terminates for exactly the magnitudes this branch is reached for (`2^63` or larger, or non-finite), so the message destroyed itself instead of arriving: `1.0e300.as-i64` (unbound `cant-convert`) died inside `as-decimal`'s own complaint instead of reporting "Can't convert number ... to i64 because it's out of i64 bounds".

This is the same pathology #6359 fixed for `printf`'s own `%d` guard (`786846af07`, replacing `%f` with `%s` plus `as-scientific`), left uncorrected at this call site. Switched to `%s` with `n.as-scientific`, and added `can-format-the-error-message-of-an-out-of-range-number`, since the existing tests only bind a fallback or assert that it stops, so the message was never actually dataized.

Fixes #7185
