### PR TITLE
#7186: take the reciprocal of the base before exponentiating for negative exponents

### DIFF
--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -42,20 +42,19 @@
               expo.is-integer.if
                 if.
                   expo.lt 0
-                  1.div
-                    [b n] >> ipow
-                      if. > @
-                        n.eq 0
-                        1
-                        if.
-                          is-integer. (n.div 2)
-                          times.
-                            number half
-                            number half
-                          b.times
-                            ^.ipow b (n.minus 1)
-                      ^.ipow b (n.div 2) > half!
-                    | base expo.abs
+                  [b n] >> ipow
+                    if. > @
+                      n.eq 0
+                      1
+                      if.
+                        is-integer. (n.div 2)
+                        times.
+                          number half
+                          number half
+                        b.times
+                          ^.ipow b (n.minus 1)
+                    ^.ipow b (n.div 2) > half!
+                  | (1.div base) expo.abs
                   ipow base expo.abs
                 if.
                   base.gt 0
@@ -112,6 +111,10 @@
                 nan
                 pinf
   ^ > num
+
+  gt. ++> can-avoid-underflow-for-a-negative-exponent-that-overflows-positive
+    10.power -315
+    0
 
   eq. ++> can-be-called-as-a-method-on-a-number
     2.power 4


### PR DESCRIPTION
`number.power` computed a negative integer exponent as the reciprocal of the positive power: `1.div (ipow base expo.abs)`. `ipow base expo.abs` is evaluated first, in double precision, so when `base^|expo|` passes `Double.MAX_VALUE` it becomes infinity, and `1.div infinity` is zero, even where the true answer is a representable subnormal. `10.power -315` gave `0` instead of `1.0e-315`, matching `Math.pow(10, -315)`.

Took the reciprocal of the base first instead: `ipow (1.div base) expo.abs`. Repeated squaring toward zero has much more room before hitting the underflow floor (subnormals down to ~4.9e-324) than squaring toward infinity does before overflow (~1.8e308), so this avoids the intermediate overflow for the range the docblock already promises (IEEE rules matching `Math.pow`).

Fixes #7186
