### PR TITLE
#7211: resolve a file-local handle's path in resolve-local-names.xsl

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -25,16 +25,6 @@ import org.cactoos.scalar.Unchecked;
  * into the root {@code Φ} (see {@code add-default-package.xsl}).</p>
  *
  * @since 0.60
- * @todo #7134:45min Resolve a file-local handle to its full path in
- *  {@code resolve-local-names.xsl}. That sheet knows the node a
- *  {@code >>} handle declares and the node that reads it, so it knows
- *  how many formations sit between them; today it rewrites only the
- *  name and leaves the {@code ρ} run to {@code build-fqns.xsl}, which
- *  is why that sheet still walks scopes for cactus names after it
- *  stopped doing so for every other name. Once the handle arrives
- *  with its path already built, the cactus exception in
- *  {@code build-fqns.xsl} goes away and no name is resolved across a
- *  scope the author did not write.
  */
 public final class Canonical implements UnaryOperator<XML> {
 

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -13,12 +13,14 @@
   lives in an enclosing scope instead is reported: this stage used
   to walk up and insert the '^.' hops itself, which made the same
   source text mean one thing here and another one level down, so
-  the hops are the author's to write now. The one exception is a
-  cactus name, which no author writes: it is what a '&gt;&gt;'
-  handle resolves to, and the handle is spelled bare wherever the
-  file reads it. Those objects which are skipped after this
-  transformation are not visible in the current scope. Maybe they
-  are global or just a mistake.
+  the hops are the author's to write now. A cactus name - what a
+  '&gt;&gt;' handle resolves to - never reaches this rule at all: it
+  arrives from "resolve-local-names.xsl" with its receiver, ξ or the
+  right number of '.ρ' hops, already built, the same way an explicit
+  "^.foo" a real author wrote does, so no name is resolved across a
+  scope the author did not write. Those objects which are skipped
+  after this transformation are not visible in the current scope.
+  Maybe they are global or just a mistake.
 
   We must skip objects that refer to
   "bytes", "string" or "number" if such objects are inside the
@@ -153,8 +155,8 @@
       </xsl:when>
       <xsl:when test="eo:abstract($parent)">
         <xsl:choose>
-          <!-- Found reference in the current scope, or a handle above -->
-          <xsl:when test="$parent/o[@name=$find] and ($rhos=0 or contains($find, $eo:cactoos))">
+          <!-- Found reference in the current scope -->
+          <xsl:when test="$parent/o[@name=$find] and $rhos=0">
             <xsl:apply-templates select="$self" mode="with-rho">
               <xsl:with-param name="rhos" select="$rhos"/>
               <xsl:with-param name="current">

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -119,26 +119,84 @@
     <xsl:sequence select="if (empty($receiver/@base)) then () else if ($receiver/@base='ξ' and empty($receiver/@method)) then $ref/ancestor::o[not(@base)][1] else if ($receiver/@base='ρ' and empty($receiver/@method)) then $ref/ancestor::o[not(@base)][2] else if ($receiver/@base='.ρ' and exists($receiver/@method)) then eo:scope($receiver)/ancestor::o[not(@base)][1] else if (empty($receiver/@method) and $owner/@name=$receiver/@base) then $owner else ()"/>
   </xsl:function>
   <!--
+  How many formations separate a bare, ancestor-search-captured reference
+  from the formation that owns the handle capturing it - the same "rhos"
+  count "build-fqns.xsl" computes for every other name, so the receiver
+  built below matches what that stage would have built itself, and it never
+  needs to walk scopes for a cactus name again (#7134).
+  -->
+  <xsl:function name="eo:hops" as="xs:integer">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:param name="owner" as="element()"/>
+    <xsl:sequence select="count($ref/ancestor::o[not(@base)]) - count($owner/ancestor-or-self::o[not(@base)])"/>
+  </xsl:function>
+  <!--
+  The receiver a captured bare reference dispatches through: "ξ" itself
+  when the handle lives in the reference's own formation, or that many
+  ".ρ" hops out otherwise - the exact shape "build-fqns.xsl"'s "with-rho"
+  builds from a "rhos" count, built here instead since this pass is the one
+  that knows the count.
+  -->
+  <xsl:function name="eo:receiver" as="element()">
+    <xsl:param name="hops" as="xs:integer"/>
+    <xsl:choose>
+      <xsl:when test="$hops le 0">
+        <o>
+          <xsl:attribute name="base" select="'ξ'"/>
+        </o>
+      </xsl:when>
+      <xsl:otherwise>
+        <o>
+          <xsl:attribute name="base" select="'.ρ'"/>
+          <xsl:sequence select="eo:receiver($hops - 1)"/>
+        </o>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <!--
   Matches every reference and rewrites the ones a handle captures. The
   captor is looked up once, into a variable, instead of once in the match
   pattern and again in the body: the search is the expensive part of this
   pass, and a pattern that calls it cannot share its answer with the
   template it selects, so every captured reference paid for it twice.
+
+  A reference captured through an explicit receiver ("^.foo" via
+  "eo:scope") keeps that receiver as the author wrote it, so only its
+  trailing name is rewritten; so does one captured in its own declaring
+  formation (zero hops), which "build-fqns.xsl" already resolves correctly
+  on its own, the same way it does for a bare public-attribute name found
+  in the current scope. Only a bare reference captured one or more
+  formations further out carries no receiver at all, so one is built here
+  from the hop count, with the handle's path arriving already resolved
+  instead of left for "build-fqns.xsl" to re-derive through its cactus
+  exception.
   -->
   <xsl:template match="o[@base]">
     <xsl:variable name="captor" as="element()?" select="eo:captor(.)"/>
-    <xsl:copy>
-      <xsl:choose>
-        <xsl:when test="exists($captor)">
+    <xsl:variable name="hops" as="xs:integer?" select="if (exists($captor) and empty(@method)) then eo:hops(., $captor/ancestor::o[not(@base)][1]) else ()"/>
+    <xsl:choose>
+      <xsl:when test="exists($hops) and $hops gt 0">
+        <xsl:copy>
+          <xsl:attribute name="base" select="concat('.', $captor/@name)"/>
+          <xsl:apply-templates select="@* except @base"/>
+          <xsl:sequence select="eo:receiver($hops)"/>
+          <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:when test="exists($captor)">
+        <xsl:copy>
           <xsl:attribute name="base" select="concat(if (exists(@method)) then '.' else '', $captor/@name)"/>
           <xsl:apply-templates select="@* except @base"/>
-        </xsl:when>
-        <xsl:otherwise>
+          <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
           <xsl:apply-templates select="@*"/>
-        </xsl:otherwise>
-      </xsl:choose>
-      <xsl:apply-templates select="node()"/>
-    </xsl:copy>
+          <xsl:apply-templates select="node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <xsl:template match="/object">
     <xsl:copy>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -4,6 +4,7 @@
 * SPDX-License-Identifier: MIT
 -->
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" exclude-result-prefixes="xs eo" id="resolve-local-names" version="2.0">
+  <xsl:import href="/org/eolang/parser/_specials.xsl"/>
   <!--
   The "&gt;&gt; foo" file-local handle (§3.10 / §9.2): the parser emits the
   anonymous object with its cactus @name plus a "@local='foo'" marker. A
@@ -173,11 +174,14 @@
   -->
   <xsl:template match="o[@base]">
     <xsl:variable name="captor" as="element()?" select="eo:captor(.)"/>
-    <xsl:variable name="hops" as="xs:integer?" select="if (exists($captor) and empty(@method)) then eo:hops(., $captor/ancestor::o[not(@base)][1]) else ()"/>
+    <xsl:variable name="name" as="xs:string" select="string(@base)"/>
+    <xsl:variable name="anonymous" as="element()?" select="if (exists($captor) or exists(@method) or not(contains($name, $eo:cactoos))) then () else ancestor::o[@name=$name][1]"/>
+    <xsl:variable name="holder" as="element()?" select="($captor, $anonymous)[1]"/>
+    <xsl:variable name="hops" as="xs:integer?" select="if (exists($holder) and empty(@method)) then eo:hops(., $holder/ancestor::o[not(@base)][1]) else ()"/>
     <xsl:choose>
       <xsl:when test="exists($hops) and $hops gt 0">
         <xsl:copy>
-          <xsl:attribute name="base" select="concat('.', $captor/@name)"/>
+          <xsl:attribute name="base" select="concat('.', $holder/@name)"/>
           <xsl:apply-templates select="@* except @base"/>
           <xsl:sequence select="eo:receiver($hops)"/>
           <xsl:apply-templates select="node()"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-sibling-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names-sibling-scope.yaml
@@ -9,7 +9,7 @@ asserts:
   # the file-local handle keeps its "@local" marker and gets a cactus name
   - //o[@local='blk' and @name]
   # only the handle's own body reference is rewritten to the cactus name
-  - /object[count(//o[@base=//o[@local='blk']/@name])=1]
+  - /object[count(//o[@base=concat('.', //o[@local='blk']/@name)])=1]
   # the sibling formation's own "> blk" reference is NOT hijacked by the handle
   - //o[@base='blk']
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/resolve-local-names.yaml
@@ -6,7 +6,8 @@ sheets:
   - /org/eolang/parser/parse/resolve-local-names.xsl
 asserts:
   - /object[not(errors)]
-  - /object[count(//o[@base='a🌵2-2'])=2]
+  - /object[count(//o[@base='.a🌵2-2'])=2]
+  - /object[count(//o[@base='.ρ']/o[@base='ξ'])=2]
   - //o[@name='a🌵2-2' and @local='fibo']
 input: |
   [] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/self-reference-in-a-nested-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/self-reference-in-a-nested-formation.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+input: |
+  +package snippets
+
+  [] > self-fibo
+    [n] >>
+      if. > @
+        n.lt 2
+        n
+        plus.
+          % (n.minus 1)
+          % (n.minus 2)
+    | 6 > num
+    stdout > @
+      "%d is the %dth number\n".printf
+        *
+          num
+          6


### PR DESCRIPTION
`build-fqns.xsl`'s FQN resolution stopped auto-inserting `^.` hops for ordinary names (an unresolved name in an enclosing scope is now reported, not silently walked to), except for one carve-out: a cactus name (what a `>>` handle resolves to) still walked scopes silently, since `resolve-local-names.xsl` only rewrote the captured reference's name and left the receiver path to `build-fqns.xsl`'s own scope walk.

`resolve-local-names.xsl` already knows exactly how many formations separate a captured bare reference from the formation that owns the handle (the same "ancestor formations" it walks to find the captor in the first place), so it can build that receiver itself: `ξ` when the handle lives in the reference's own formation, or the matching number of `.ρ` hops otherwise, the same shape `build-fqns.xsl`'s own `with-rho` builds from a hop count. With the path arriving already resolved, `build-fqns.xsl`'s cactus exception is now dead code and is removed; a cactus name goes through the ordinary FQN rule like everything else and is never resolved across a scope the author did not write.

A reference captured through an explicit receiver (`^.foo`) is unaffected, since the author already wrote the scope and `resolve-local-names.xsl` already left it alone there.

Verified against the whole `eo-runtime` corpus: a full `eo-parser` install followed by a full `eo-runtime` transpile and test run (2222 tests) against the patched parser, both green, on top of the full `eo-parser` suite (1798 tests).

Closes #7211
