### PR TITLE
#7169: assert the false half of Kind.pipeable and Kind.formation

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/KindTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/KindTest.java
@@ -6,7 +6,6 @@ package org.eolang.parser;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
@@ -29,11 +28,43 @@ final class KindTest {
         );
     }
 
-    @Test
-    void keepsIdentityObjectOutOfFormationSet() {
+    @ParameterizedTest
+    @EnumSource(
+        value = Kind.class,
+        names = {"BARE_FORMATION", "ONLY_PHI", "PIPE_APPLICATION", "IDENTITY_OBJECT"},
+        mode = EnumSource.Mode.EXCLUDE
+    )
+    void rejectsPipeAfterOtherKinds(final Kind kind) {
         MatcherAssert.assertThat(
-            "an identity object binds no body, so its children stay arguments rather than bindings",
-            Kind.IDENTITY_OBJECT.formation(),
+            "a pipe cannot attach to a kind that is neither formation-like nor a pipe",
+            kind.pipeable(),
+            Matchers.is(false)
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = Kind.class,
+        names = {"BARE_FORMATION", "ONLY_PHI"}
+    )
+    void marksFormationKinds(final Kind kind) {
+        MatcherAssert.assertThat(
+            "a formation kind must open a fresh naming scope",
+            kind.formation(),
+            Matchers.is(true)
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        value = Kind.class,
+        names = {"BARE_FORMATION", "ONLY_PHI"},
+        mode = EnumSource.Mode.EXCLUDE
+    )
+    void leavesOtherKindsOutOfFormations(final Kind kind) {
+        MatcherAssert.assertThat(
+            "a kind that opens no naming scope must not report itself as a formation",
+            kind.formation(),
             Matchers.is(false)
         );
     }


### PR DESCRIPTION
Closes #7169.

`Kind.pipeable()` and `Kind.formation()` had no test asserting `false`, so widening either body went unnoticed. Added the complementary parameterized cases (`EnumSource.Mode.EXCLUDE`, so kinds added later are covered automatically) plus the positive case for `formation()`. The single-kind `keepsIdentityObjectOutOfFormationSet` is subsumed by the new negative case, so it is gone.

Checked by mutation: `pipeable() -> return true` and `formation()` widened with `HEAD` produce 13 failures.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)