### PR TITLE
Pin Hex's defensive copy of the constructor argument

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/HexTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/HexTest.java
@@ -67,4 +67,42 @@ final class HexTest {
             Matchers.equalTo("00-10-20")
         );
     }
+
+    @Test
+    void keepsOwnCopyOfConstructorArgument() {
+        final byte[] raw = {0x00, 0x10, 0x20};
+        final Hex hex = new Hex(raw);
+        raw[0] = (byte) 0xFF;
+        MatcherAssert.assertThat(
+            "mutating the caller's array after construction must not change the rendered bytes",
+            hex.asString(),
+            Matchers.equalTo("00-10-20")
+        );
+    }
+
+    @Test
+    void ignoresMutationOfSingleByteArrayAfterConstruction() {
+        final byte[] raw = {0x7A};
+        final Hex hex = new Hex(raw);
+        raw[0] = 0x00;
+        MatcherAssert.assertThat(
+            "mutating a single-byte array after construction must not change the rendered byte",
+            hex.asString(),
+            Matchers.equalTo("7A-")
+        );
+    }
+
+    @Test
+    void ignoresZeroingOfArrayAfterConstruction() {
+        final byte[] raw = {0x01, 0x02, 0x03, 0x04};
+        final Hex hex = new Hex(raw);
+        for (int idx = 0; idx < raw.length; idx = idx + 1) {
+            raw[idx] = 0x00;
+        }
+        MatcherAssert.assertThat(
+            "zeroing the caller's array after construction must not change the rendered bytes",
+            hex.asString(),
+            Matchers.equalTo("01-02-03-04")
+        );
+    }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/HexTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/HexTest.java
@@ -105,4 +105,16 @@ final class HexTest {
             Matchers.equalTo("01-02-03-04")
         );
     }
+
+    @Test
+    void keepsEarlierInstanceUnaffectedByReusingTheSameArray() {
+        final byte[] shared = {0x05, 0x06};
+        final Hex first = new Hex(shared);
+        shared[0] = 0x09;
+        MatcherAssert.assertThat(
+            "reusing the caller's array for a later Hex must not touch an earlier one",
+            first.asString(),
+            Matchers.equalTo("05-06")
+        );
+    }
 }


### PR DESCRIPTION
Closes #7172

All eight existing `HexTest` cases build their byte array inline as a constructor argument and keep no reference to it, so none of them exercise the defensive copy that `Hex(byte[])` takes with `raw.clone()`. Replacing that clone with a plain assignment would make `Hex` silently start sharing state with its caller, and the suite would stay green.

Adds three tests that hold the array in a local, construct the `Hex`, mutate the array afterward, and assert the rendered bytes are unaffected: a multi-byte case, the single-byte trailing-dash case, and a case that zeroes every byte of the array after construction.