### PR TITLE
#7220: ask the attribute whether it is vacant in hasRho

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -60,7 +60,7 @@ final class AtRho implements Attribute {
 
     @Override
     public boolean vacant() {
-        return false;
+        return this.rho.get() == null;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -181,13 +181,7 @@ public class PhDefault implements Phi, Cloneable {
 
     @Override
     public boolean hasRho() {
-        boolean has = true;
-        try {
-            this.loaded().get(Phi.RHO).get();
-        } catch (final ExUnset exception) {
-            has = false;
-        }
-        return has;
+        return !this.loaded().get(Phi.RHO).vacant();
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -120,6 +120,27 @@ final class PhDefaultTest {
     }
 
     @Test
+    void doesNotHaveRhoWhenItIsDeclaredAsVoid() {
+        MatcherAssert.assertThat(
+            String.format("Object with %s declared as void must not report it as set", Phi.RHO),
+            new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO)))).hasRho(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void bindsHostToRhoDeclaredAsVoid() {
+        final Phi host = new PhDefault(new Attrs(new Attr("x", new AtVoid("x"))));
+        host.put(Phi.RHO, Phi.Φ);
+        host.put("x", new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO)))));
+        MatcherAssert.assertThat(
+            String.format("Dispatch must bind the host to %s declared as void", Phi.RHO),
+            host.take("x").take(Phi.RHO),
+            Matchers.equalTo(host)
+        );
+    }
+
+    @Test
     void copiesKid() {
         final Phi phi = PhDefaultTest.Int.made();
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #7220.

`PhDefault.hasRho()` decided by catching `ExUnset`, which only `AtRho` throws. Since #7134 an object may declare `ρ` as an ordinary void, and an empty `AtVoid` returns a `PhTerminator` instead of throwing, so `hasRho()` answered `true` for a receiver that was never set and `AtWithRho.get()` never bound the host.

Now `hasRho()` asks the attribute `vacant()`, and `AtRho.vacant()` reports whether its reference is still null. `ρ` never enters `order` (it does not match `SORTABLE`), so `PhDefault.vacancy` and positional filling are untouched.

Two regression tests in `PhDefaultTest`.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ee3mimX7pKKvsugzi18cSM