### PR TITLE
Give every registered .eo file a record in the LCOV report

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -39,6 +39,13 @@ import org.eolang.parser.EoSyntax;
  * own name (they all carry {@code @loc} with the {@code Φ} prefix of the
  * object they name, so the runtime hits still line up).</p>
  *
+ * <p>Every registered {@code .eo} file gets a record of its own, even one
+ * the manifest names no location in: a file of nothing but atom
+ * declarations and unit tests, like {@code bytes.eo}, has no dataizable
+ * body at all. Such a file used to be absent from the tracefile
+ * altogether, which left the report unable to tell it apart from a file
+ * that was never compiled (#7057).</p>
+ *
  * @since 0.75.0
  */
 @Mojo(
@@ -106,14 +113,16 @@ public final class MjCoverageReport extends MjSafe {
         try (TjsForeign tojos = this.tojos()) {
             for (final TjForeign tojo : tojos.withXmir()) {
                 final String source = tojo.source().toString();
+                final Map<Integer, Integer> lines = perfile.computeIfAbsent(
+                    source, key -> new LinkedHashMap<>(0)
+                );
                 final XML xmir = new EoSyntax(Files.readString(tojo.source())).parsed();
                 for (final String location : manifest.locations(xmir)) {
                     final int last = location.lastIndexOf(':');
                     final int line = Integer.parseInt(
                         location.substring(location.lastIndexOf(':', last - 1) + 1, last)
                     );
-                    perfile.computeIfAbsent(source, key -> new LinkedHashMap<>(0))
-                        .putIfAbsent(line, 0);
+                    lines.putIfAbsent(line, 0);
                     lineof.put(location, line);
                     fileof.put(location, source);
                 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LcovReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LcovReportTest.java
@@ -37,6 +37,38 @@ final class LcovReportTest {
     }
 
     @Test
+    void rendersAnEmptyRecordForAFileWithoutLines() {
+        final Map<String, Map<Integer, Integer>> files = new LinkedHashMap<>(1);
+        files.put("foo.eo", new LinkedHashMap<>(0));
+        final StringBuilder expected = new StringBuilder(32);
+        for (final String line : new String[] {
+            "SF:foo.eo", "LH:0", "LF:0", "end_of_record",
+        }) {
+            expected.append(line).append('\n');
+        }
+        MatcherAssert.assertThat(
+            "a file with no lines must still be rendered as a record of its own, but it wasnt",
+            new LcovReport(files).text(),
+            Matchers.equalTo(expected.toString())
+        );
+    }
+
+    @Test
+    void ignoresAFileWithoutLinesInThePercentage() {
+        final Map<Integer, Integer> lines = new LinkedHashMap<>(2);
+        lines.put(1, 1);
+        lines.put(2, 0);
+        final Map<String, Map<Integer, Integer>> files = new LinkedHashMap<>(2);
+        files.put("a.eo", lines);
+        files.put("b.eo", new LinkedHashMap<>(0));
+        MatcherAssert.assertThat(
+            "a file with nothing to instrument must not drag the percentage down, but it did",
+            new LcovReport(files).covered(),
+            Matchers.closeTo(50.0, 0.001)
+        );
+    }
+
+    @Test
     void computesTheCoveredPercentageAcrossFiles() {
         final Map<Integer, Integer> first = new LinkedHashMap<>(2);
         first.put(1, 1);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -74,6 +74,30 @@ final class MjCoverageReportTest {
     }
 
     @Test
+    void reportsAFileThatHasNothingToInstrument(@Mktmp final Path temp) throws Exception {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "[] > foo",
+                "  [] > bar /Q.bytes"
+            ),
+            "foo",
+            "foo.eo"
+        ).execute(MjParse.class);
+        final Path hits = temp.resolve("coverage.txt");
+        Files.writeString(hits, "");
+        final Path lcov = temp.resolve("coverage.info");
+        maven.with("coverageFile", hits.toFile())
+            .with("lcovFile", lcov.toFile())
+            .execute(MjCoverageReport.class);
+        MatcherAssert.assertThat(
+            "a file the manifest names no location in must still get a record of its own, so that the report knows the file exists, but it got none",
+            Files.readString(lcov),
+            Matchers.stringContainsInOrder("SF:", "foo.eo", "LH:0", "LF:0", "end_of_record")
+        );
+    }
+
+    @Test
     void doesNotAttributeMergedMembersToThePackageFile(@Mktmp final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp).withProgram(
             String.join(


### PR DESCRIPTION
The packages themselves came back with #7069: the Codecov report on master now lists `string`, `number`, `bytes`, `tuple` and the rest, 166 of the 171 `.eo` files under `eo-runtime/src/main/eo`.

The five that are still absent are `bytes.eo`, `dataized.eo`, `input.eo`, `output.eo` and `recovered.eo`. They have a different cause than the packages did. Each of them holds nothing but atom declarations and unit tests, so the coverage manifest names no location in them at all, and `MjCoverageReport` only ever created a `perfile` entry from inside the loop over those locations. No entry meant no `SF` block, and a file with no block in the tracefile is a file the report has no idea exists.

So the entry is now created once per registered source, before the locations are read. A file with nothing to instrument gets `LH:0`/`LF:0` and is listed as a file of zero countable lines, which is what it is. `LcovReport.covered()` walks the lines rather than the files, so an empty record contributes nothing to the percentage and the `eo.minCoverage` gate reads exactly as before.

One thing worth watching after this lands: Codecov may drop zero-line files when it ingests the tracefile, in which case the five will still not show in the UI even though the tracefile is now complete. The tracefile is the part this repository controls; if the UI still hides them, that is a conversation with Codecov's ingestion rather than another change here.

Closes #7057
