### PR TITLE
Bind msvcrt path functions to their wide twins

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -35,8 +36,8 @@ public final class AccessFuncCall implements Syscall {
         result.put(
             0,
             new Data.ToPhi(
-                Msvcrt.INSTANCE._access(
-                    new Dataized(params[0]).asString(),
+                Msvcrt.INSTANCE._waccess(
+                    new WString(new Dataized(params[0]).asString()),
                     new Dataized(params[1]).asNumber().intValue()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,8 +32,8 @@ public final class CreatFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._creat(
-            new Dataized(params[0]).asString(),
+        final int code = Msvcrt.INSTANCE._wcreat(
+            new WString(new Dataized(params[0]).asString()),
             new Dataized(params[1]).asNumber().intValue()
         );
         result.put(0, new Data.ToPhi(code));

--- a/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,7 +32,7 @@ public final class MkdirFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._mkdir(new Dataized(params[0]).asString());
+        final int code = Msvcrt.INSTANCE._wmkdir(new WString(new Dataized(params[0]).asString()));
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/win32/Msvcrt.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Msvcrt.java
@@ -8,16 +8,19 @@ import com.sun.jna.Library;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
+import com.sun.jna.WString;
 
 /**
  * The Microsoft C runtime (msvcrt), exposing the POSIX-compatible file functions.
  *
- * <p>The methods are named after the real msvcrt exports, so most carry a
- * leading underscore ({@code _open}, {@code _read}, {@code _stat64}); the ISO C
- * {@code rename} is the one without. They return small integer file descriptors,
- * exactly like libc on posix, which is why the win32 file objects can thread
- * them through EO the same way the posix ones do. Binding the real names keeps
- * the EO side honest and the backend free of any name mapping.</p>
+ * <p>The methods are named after the real msvcrt exports, so most carry a leading
+ * underscore ({@code _wopen}, {@code _read}, {@code _wstat64}); the ISO C
+ * {@code getenv} and {@code strerror} are the ones without. They return small
+ * integer file descriptors, exactly like libc on posix, which is why the win32
+ * file objects can thread them through EO the same way the posix ones do. Every
+ * function taking a path binds the wide twin and takes a {@link WString}, so a
+ * name leaving the active code page still reaches the CRT as it was written,
+ * while EO goes on asking for the narrow name it shares with posix.</p>
  *
  * @since 0.74.0
  */
@@ -58,7 +61,7 @@ public interface Msvcrt extends Library {
     /**
      * Opens a file and returns a file descriptor.
      *
-     * <p>The native {@code _open} is variadic, so {@code mode} is a trailing
+     * <p>The native {@code _wopen} is variadic, so {@code mode} is a trailing
      * varargs, making JNA use the variadic calling convention.</p>
      *
      * @param path Path to the file
@@ -66,7 +69,7 @@ public interface Msvcrt extends Library {
      * @param mode Permission bits used when the flags request file creation
      * @return File descriptor, or -1 on error
      */
-    int _open(String path, int flags, Object... mode);
+    int _wopen(WString path, int flags, Object... mode);
 
     /**
      * Reads bytes from a file descriptor into the buffer.
@@ -99,7 +102,7 @@ public interface Msvcrt extends Library {
      * @param mode Accessibility check to perform (0 tests for existence)
      * @return Zero when the check succeeds, -1 on error
      */
-    int _access(String path, int mode);
+    int _waccess(WString path, int mode);
 
     /**
      * Gets a file's status by path, filling a {@code struct _stat64} whose
@@ -108,21 +111,21 @@ public interface Msvcrt extends Library {
      * @param statbuf Structure to fill with the file's metadata
      * @return Zero on success, -1 on error
      */
-    int _stat64(String path, Structure statbuf);
+    int _wstat64(WString path, Structure statbuf);
 
     /**
      * Deletes a file.
      * @param path Path to the file
      * @return Zero on success, -1 on error
      */
-    int _unlink(String path);
+    int _wunlink(WString path);
 
     /**
      * Removes an empty directory.
      * @param path Path to the directory
      * @return Zero on success, -1 on error
      */
-    int _rmdir(String path);
+    int _wrmdir(WString path);
 
     /**
      * Creates a directory, taking no permission bits, so the mode passed at the
@@ -130,7 +133,7 @@ public interface Msvcrt extends Library {
      * @param path Path to the directory
      * @return Zero on success, -1 on error
      */
-    int _mkdir(String path);
+    int _wmkdir(WString path);
 
     /**
      * Creates a new file, or truncates an existing one, and opens it.
@@ -138,15 +141,15 @@ public interface Msvcrt extends Library {
      * @param mode Permission bits for a newly created file
      * @return File descriptor on success, -1 on error
      */
-    int _creat(String path, int mode);
+    int _wcreat(WString path, int mode);
 
     /**
-     * Renames a file, the ISO C export without a leading underscore.
+     * Renames a file, the wide twin of the ISO C {@code rename} export.
      * @param from Current path of the file
      * @param target New path of the file
      * @return Zero on success, -1 on error
      */
-    int rename(String from, String target);
+    int _wrename(WString from, WString target);
 
     /**
      * Returns the process identifier of the calling process, the CRT

--- a/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,8 +32,8 @@ public final class OpenFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._open(
-            new Dataized(params[0]).asString(),
+        final int code = Msvcrt.INSTANCE._wopen(
+            new WString(new Dataized(params[0]).asString()),
             new Dataized(params[1]).asNumber().intValue(),
             new Dataized(params[2]).asNumber().intValue()
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,9 +32,9 @@ public final class RenameFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE.rename(
-            new Dataized(params[0]).asString(),
-            new Dataized(params[1]).asString()
+        final int code = Msvcrt.INSTANCE._wrename(
+            new WString(new Dataized(params[0]).asString()),
+            new WString(new Dataized(params[1]).asString())
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,7 +32,7 @@ public final class RmdirFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._rmdir(new Dataized(params[0]).asString());
+        final int code = Msvcrt.INSTANCE._wrmdir(new WString(new Dataized(params[0]).asString()));
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -40,7 +41,7 @@ public final class Stat64FuncCall implements Syscall {
         result.put(
             0,
             new Data.ToPhi(
-                Msvcrt.INSTANCE._stat64(new Dataized(params[0]).asString(), info)
+                Msvcrt.INSTANCE._wstat64(new WString(new Dataized(params[0]).asString()), info)
             )
         );
         final Phi struct = this.win.take("stat64");

--- a/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,7 +32,7 @@ public final class UnlinkFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._unlink(new Dataized(params[0]).asString());
+        final int code = Msvcrt.INSTANCE._wunlink(new WString(new Dataized(params[0]).asString()));
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
@@ -4,7 +4,10 @@
  */
 package org.eolang;
 
+import java.io.IOException;
 import java.lang.management.ManagementFactory;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.eolang.win32.WSAData;
 import org.eolang.win32.Winsock;
 import org.hamcrest.MatcherAssert;
@@ -70,6 +73,32 @@ final class EOwin32EOφTest {
                 ).take("output")
             ).asString(),
             Matchers.containsString("No such file")
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.LINUX, OS.MAC})
+    void accessesFileWithNonAsciiName() throws IOException {
+        final Path file = Files.createTempFile("Ж日本-", ".txt");
+        MatcherAssert.assertThat(
+            String.format("\"_access\" did not find the non-ASCII file %s", file),
+            new Dataized(
+                new PhApplication(
+                    new PhApplication(
+                        Phi.Φ.take("win32").copy(),
+                        "name",
+                        new Data.ToPhi("_access")
+                    ),
+                    "args",
+                    new Data.ToPhi(
+                        new Phi[]{
+                            new Data.ToPhi(file.toString()),
+                            new Data.ToPhi(0),
+                        }
+                    )
+                ).take("code")
+            ).asNumber().intValue(),
+            Matchers.equalTo(0)
         );
     }
 


### PR DESCRIPTION
Every path-taking function in `Msvcrt` was bound as a Java `String`, which JNA hands to the narrow CRT entry point encoded in the process's ANSI code page. On a `windows-2022` runner that is code page 1252, so a name like `Ж` or any CJK character is mangled before the call happens. Meanwhile `Kernel32` already binds `GetFileAttributesW` and sees the name as written, which left `file.is-symlink` and `file.exists` looking at two different files.

All eight now bind their wide twin and take a `WString`: `_wopen`, `_waccess`, `_wstat64`, `_wunlink`, `_wrmdir`, `_wmkdir`, `_wcreat` and `_wrename`. The struct behind `_wstat64` is the same `struct _stat64`, so `WinStat` is untouched. The class docblock used to claim the backend was free of any name mapping; that is no longer true, so it now says what actually happens.

The new test creates a temp file whose name carries `Ж日本` and asks `_access` to find it. It fails before this change because the mangled name reaches the CRT, and passes after. It is Windows-only, like the rest of the win32 tests.

The EO side still asks for the narrow names, so `file.eo` and the `NamedFuncCall` keys are unchanged. Renaming those to match the wide exports, the way `GetFileAttributesW` already reads on the EO side, would touch thirteen `.eo` call sites and eight map keys and is worth a separate issue.

Closes #7029
