### PR TITLE
Drop the unused Span parameter from Level.commitArg

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -580,7 +580,7 @@ final class Eo implements Iterable<Directive> {
 
     private static void checkOnClose(final Level level, final Emit emit, final boolean naming) {
         try {
-            level.commitArg(null);
+            level.commitArg();
         } catch (final ParseError err) {
             emit.error(err.line(), err.pos(), err.getMessage());
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -131,7 +131,7 @@ final class Level {
     /**
      * Whether a child arg is currently being tracked but has not yet
      * been committed into {@link #bindings} — see
-     * {@link #observeBinding(boolean, Span)} / {@link #commitArg(Span)}.
+     * {@link #observeBinding(boolean, Span)} / {@link #commitArg()}.
      */
     private boolean argpending;
 
@@ -145,7 +145,7 @@ final class Level {
 
     /**
      * Source span recorded with the in-progress arg, used for error
-     * positioning when {@link #commitArg(Span)} rejects the arg
+     * positioning when {@link #commitArg()} rejects the arg
      * against the group mode.
      */
     private Span argspan;
@@ -487,7 +487,7 @@ final class Level {
      * @param span Source span of the child (for error positioning)
      */
     void observeBinding(final boolean bound, final Span span) {
-        this.commitArg(span);
+        this.commitArg();
         this.argpending = true;
         this.argbound = bound;
         this.argspan = span;
@@ -507,9 +507,8 @@ final class Level {
      * Commit the currently in-progress arg's binding state into the
      * group mode and verify against the all-or-nothing rule. Called
      * before starting a new arg and at parent close time.
-     * @param span Span for error positioning when the rule is violated
      */
-    void commitArg(final Span span) {
+    void commitArg() {
         if (this.argpending) {
             final int code;
             if (this.argbound) {

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -150,7 +150,7 @@ final class LevelTest {
     }
 
     @Test
-    void commitArgIsNoopWithoutPendingArg() {
+    void toleratesCommitArgWithoutPendingArg() {
         final Level level = new Level(
             0, 1, Kind.COMPACT_TUPLE, Openness.OPEN, Kind.TOP_LEVEL, false
         );

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -137,25 +137,23 @@ final class LevelTest {
         );
         level.observeBinding(false, new Span("first", 1));
         level.observeBinding(true, new Span("second", 9));
-        final ParseError error = Assertions.assertThrows(
-            ParseError.class,
-            level::commitArg,
-            "commitArg must reject a binding that flips mode mid-group"
-        );
         MatcherAssert.assertThat(
             "error must be positioned at the line of the arg that broke the rule",
-            error.line(),
+            Assertions.assertThrows(
+                ParseError.class,
+                level::commitArg,
+                "commitArg must reject a binding that flips mode mid-group"
+            ).line(),
             Matchers.equalTo(9)
         );
     }
 
     @Test
     void toleratesCommitArgWithoutPendingArg() {
-        final Level level = new Level(
-            0, 1, Kind.COMPACT_TUPLE, Openness.OPEN, Kind.TOP_LEVEL, false
-        );
         Assertions.assertDoesNotThrow(
-            level::commitArg,
+            new Level(
+                0, 1, Kind.COMPACT_TUPLE, Openness.OPEN, Kind.TOP_LEVEL, false
+            )::commitArg,
             "commitArg must not raise when no arg is currently pending"
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -6,6 +6,7 @@ package org.eolang.parser;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -126,6 +127,36 @@ final class LevelTest {
             "compactN() must round-trip the assigned N",
             level.count(),
             Matchers.equalTo(3)
+        );
+    }
+
+    @Test
+    void positionsMismatchedBindingErrorAtObservedSpan() {
+        final Level level = new Level(
+            0, 1, Kind.COMPACT_TUPLE, Openness.OPEN, Kind.TOP_LEVEL, false
+        );
+        level.observeBinding(false, new Span("first", 1));
+        level.observeBinding(true, new Span("second", 9));
+        final ParseError error = Assertions.assertThrows(
+            ParseError.class,
+            level::commitArg,
+            "commitArg must reject a binding that flips mode mid-group"
+        );
+        MatcherAssert.assertThat(
+            "error must be positioned at the line of the arg that broke the rule",
+            error.line(),
+            Matchers.equalTo(9)
+        );
+    }
+
+    @Test
+    void commitArgIsNoopWithoutPendingArg() {
+        final Level level = new Level(
+            0, 1, Kind.COMPACT_TUPLE, Openness.OPEN, Kind.TOP_LEVEL, false
+        );
+        Assertions.assertDoesNotThrow(
+            level::commitArg,
+            "commitArg must not raise when no arg is currently pending"
         );
     }
 


### PR DESCRIPTION
Level.commitArg(Span) never read the span it took — the error it raises is positioned from this.argspan, which observeBinding already recorded when the argument started. The parameter had no effect at either call site: observeBinding forwarded its own span right back in, and Eo.checkOnClose had no span to give at close time, so it passed null just to fill the slot.

This drops the parameter. commitArg() now reads the span it actually uses off the field, observeBinding stops forwarding one, and Eo.checkOnClose stops passing null.

Added two LevelTest cases: one confirms a mismatched binding still raises the error at the line where the mode actually flipped (this.argspan, not any caller-supplied span), and the other confirms commitArg() is a no-op when nothing is pending.

Closes #7200