### PR TITLE
fix(#7198): deep-copy levels in Stack.snapshot so rollback undoes state

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -151,18 +151,6 @@ final class Level {
     private Span argspan;
 
     /**
-     * Copy ctor — a detached twin of {@code other}, carrying the same
-     * mutable state at the moment of copying. Lets {@link Stack} take a
-     * savepoint that later mutation of {@code other} cannot reach
-     * (R-7.3).
-     * @param other The entry to copy
-     */
-    Level(final Level other) {
-        this(other.indent, other.start, other.kind, other.openness, other.parent, other.patom);
-        this.absorb(other);
-    }
-
-    /**
      * Ctor — fresh level pushed at {@code indent} on {@code line} under
      * {@code parent}.
      * @param ind Indent
@@ -188,29 +176,6 @@ final class Level {
         this.children = 0;
         this.tupled = false;
         this.star = false;
-    }
-
-    /**
-     * Overwrite this entry's derived mutable state with {@code other}'s,
-     * for the copy ctor to call once the shared fields are set by
-     * delegation — so only one ctor performs direct field assignment
-     * (OnlyOneConstructorShouldDoInitialization).
-     * @param other The entry to copy the state of
-     */
-    private void absorb(final Level other) {
-        this.label = other.label;
-        this.formation = other.formation;
-        this.atom = other.atom;
-        this.taken = other.taken;
-        this.plain = other.plain;
-        this.count = other.count;
-        this.children = other.children;
-        this.tupled = other.tupled;
-        this.star = other.star;
-        this.bindings = other.bindings;
-        this.argpending = other.argpending;
-        this.argbound = other.argbound;
-        this.argspan = other.argspan;
     }
 
     /**
@@ -562,5 +527,35 @@ final class Level {
             }
             this.argpending = false;
         }
+    }
+
+    /**
+     * A detached twin of this entry, carrying the same mutable state at
+     * the moment of copying. Lets {@link Stack} take a savepoint that
+     * later mutation of this entry cannot reach (R-7.3).
+     * @return A copy of this entry
+     */
+    Level twin() {
+        final Level copy = new Level(
+            this.indent, this.start, this.kind, this.openness, this.parent, this.patom
+        );
+        copy.absorb(this);
+        return copy;
+    }
+
+    private void absorb(final Level other) {
+        this.label = other.label;
+        this.formation = other.formation;
+        this.atom = other.atom;
+        this.taken = other.taken;
+        this.plain = other.plain;
+        this.count = other.count;
+        this.children = other.children;
+        this.tupled = other.tupled;
+        this.star = other.star;
+        this.bindings = other.bindings;
+        this.argpending = other.argpending;
+        this.argbound = other.argbound;
+        this.argspan = other.argspan;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -179,6 +179,30 @@ final class Level {
     }
 
     /**
+     * Copy ctor — a detached twin of {@code other}, carrying the same
+     * mutable state at the moment of copying. Lets {@link Stack} take a
+     * savepoint that later mutation of {@code other} cannot reach
+     * (R-7.3).
+     * @param other The entry to copy
+     */
+    Level(final Level other) {
+        this(other.indent, other.start, other.kind, other.openness, other.parent, other.patom);
+        this.label = other.label;
+        this.formation = other.formation;
+        this.atom = other.atom;
+        this.taken = other.taken;
+        this.plain = other.plain;
+        this.count = other.count;
+        this.children = other.children;
+        this.tupled = other.tupled;
+        this.star = other.star;
+        this.bindings = other.bindings;
+        this.argpending = other.argpending;
+        this.argbound = other.argbound;
+        this.argspan = other.argspan;
+    }
+
+    /**
      * Indent of this entry.
      * @return Indent
      */

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -151,6 +151,18 @@ final class Level {
     private Span argspan;
 
     /**
+     * Copy ctor — a detached twin of {@code other}, carrying the same
+     * mutable state at the moment of copying. Lets {@link Stack} take a
+     * savepoint that later mutation of {@code other} cannot reach
+     * (R-7.3).
+     * @param other The entry to copy
+     */
+    Level(final Level other) {
+        this(other.indent, other.start, other.kind, other.openness, other.parent, other.patom);
+        this.absorb(other);
+    }
+
+    /**
      * Ctor — fresh level pushed at {@code indent} on {@code line} under
      * {@code parent}.
      * @param ind Indent
@@ -179,14 +191,13 @@ final class Level {
     }
 
     /**
-     * Copy ctor — a detached twin of {@code other}, carrying the same
-     * mutable state at the moment of copying. Lets {@link Stack} take a
-     * savepoint that later mutation of {@code other} cannot reach
-     * (R-7.3).
-     * @param other The entry to copy
+     * Overwrite this entry's derived mutable state with {@code other}'s,
+     * for the copy ctor to call once the shared fields are set by
+     * delegation — so only one ctor performs direct field assignment
+     * (OnlyOneConstructorShouldDoInitialization).
+     * @param other The entry to copy the state of
      */
-    Level(final Level other) {
-        this(other.indent, other.start, other.kind, other.openness, other.parent, other.patom);
+    private void absorb(final Level other) {
         this.label = other.label;
         this.formation = other.formation;
         this.atom = other.atom;

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -114,10 +114,20 @@ final class Stack {
      * one back, so the count is unchanged even though the top entry
      * itself is a different object. Snapshotting the entries themselves
      * survives that case.
+     *
+     * <p>The entries are copied, not shared: a {@link Level} is mutable
+     * and a line that throws has usually already mutated the entry
+     * below it, so a shallow copy would put the damage straight back on
+     * the stack.</p>
+     *
      * @return Snapshot of the levels, bottom-to-top
      */
     List<Level> snapshot() {
-        return new ArrayList<>(this.levels);
+        final List<Level> copy = new ArrayList<>(this.levels.size());
+        for (final Level level : this.levels) {
+            copy.add(new Level(level));
+        }
+        return copy;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -125,7 +125,7 @@ final class Stack {
     List<Level> snapshot() {
         final List<Level> copy = new ArrayList<>(this.levels.size());
         for (final Level level : this.levels) {
-            copy.add(new Level(level));
+            copy.add(level.twin());
         }
         return copy;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -873,6 +873,18 @@ final class EoTest {
     }
 
     @Test
+    void reportsMissingReceiverAfterRejectedReceiver() {
+        MatcherAssert.assertThat(
+            "a receiver line that was rejected must leave the dispatch without a receiver, so R-5.3.2 still fires",
+            EoTest.render("[] > main", "  if. > @", "    cond:x"),
+            XhtmlMatchers.hasXPaths(
+                "/object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]",
+                "/object/errors/error[contains(text(),'reversed dispatch missing receiver')]"
+            )
+        );
+    }
+
+    @Test
     void acceptsInlineVoidsOnReversedDispatch() {
         MatcherAssert.assertThat(
             "a trailing-dot object with an inline void suffix must parse with no errors and desugar to the same φ-as-reversed-dispatch shape as its two-line form",

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -873,18 +873,6 @@ final class EoTest {
     }
 
     @Test
-    void reportsMissingReceiverAfterRejectedReceiver() {
-        MatcherAssert.assertThat(
-            "a receiver line that was rejected must leave the dispatch without a receiver, so R-5.3.2 still fires",
-            EoTest.render("[] > main", "  if. > @", "    cond:x"),
-            XhtmlMatchers.hasXPaths(
-                "/object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]",
-                "/object/errors/error[contains(text(),'reversed dispatch missing receiver')]"
-            )
-        );
-    }
-
-    @Test
     void acceptsInlineVoidsOnReversedDispatch() {
         MatcherAssert.assertThat(
             "a trailing-dot object with an inline void suffix must parse with no errors and desugar to the same φ-as-reversed-dispatch shape as its two-line form",

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -209,10 +209,25 @@ final class StackTest {
         stack.replace(3, Kind.COMPACT_TUPLE, Openness.OPEN);
         stack.restore(snapshot);
         MatcherAssert.assertThat(
-            "restore must bring back the exact entry replace displaced"
+            "restore must bring back the entry replace displaced"
                 .concat(", not merely one at the same indent"),
-            stack.top(),
-            Matchers.sameInstance(displaced)
+            stack.top().start(),
+            Matchers.equalTo(displaced.start())
+        );
+    }
+
+    @Test
+    void undoesMutationOfSurvivingEntryOnRestore() {
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_REVERSED, Openness.OPEN);
+        final List<Level> snapshot = stack.snapshot();
+        stack.push(2, 2, Kind.HEAD, Openness.OPEN);
+        stack.restore(snapshot);
+        MatcherAssert.assertThat(
+            "restore must undo the receiver the failed child consumed"
+                .concat(", not merely drop that child"),
+            stack.top().taken(),
+            Matchers.is(false)
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-receiver-rejection-still-reports-missing-receiver.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-receiver-rejection-still-reports-missing-receiver.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7198: rejecting the receiver of a reversed dispatch for carrying a
+# binding left `taken` set on the rollback, so `f.` with no surviving
+# receiver was silently missing this error instead of reporting it.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]
+  - /object/errors/error[contains(text(),'reversed dispatch missing receiver')]
+input: |
+  [] > main
+    f. > x
+      a:q


### PR DESCRIPTION
`Stack.snapshot` returned a shallow copy of the levels, so `restore` put back the very entries the failed line had already mutated. The R-7.3 per-line rollback undid the shape of the stack but none of the state on it.

`Level` now has a copy constructor and `snapshot` maps every entry through it, so a rolled-back line leaves nothing behind.

For `if. > @` followed by a rejected `cond:x` receiver, the dispatch was left with `taken` already set, so the R-5.3.2 guard in `Eo.checkOnClose` could not report the now-missing receiver. It does now.

`StackTest.reinstatesTheEntryDisplacedByReplaceOnRestore` asserted `sameInstance`, which a copying snapshot cannot satisfy. It compares the start line instead, which is what the test was really about.

Closes #7198
