### PR TITLE
#7217: keep the fragile marker in front of the method name when suffixing

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -427,11 +427,12 @@ final class Node {
     private Optional<Node> suffixed() {
         Optional<Node> result = Optional.empty();
         if (this.reversed && !this.children.isEmpty()) {
+            final String dot = this.base.endsWith("?.") ? "?." : ".";
             result = this.children.get(0).braced().map(
                 glued -> new Node(
                     String.join(
-                        ".", glued,
-                        this.base.substring(0, this.base.length() - 1)
+                        dot, glued,
+                        this.base.substring(0, this.base.length() - dot.length())
                     ),
                     this.tail, this.abstractt, this.test, false, false,
                     this.children.subList(1, this.children.size())

--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -427,7 +427,12 @@ final class Node {
     private Optional<Node> suffixed() {
         Optional<Node> result = Optional.empty();
         if (this.reversed && !this.children.isEmpty()) {
-            final String dot = this.base.endsWith("?.") ? "?." : ".";
+            final String dot;
+            if (this.base.endsWith("?.")) {
+                dot = "?.";
+            } else {
+                dot = ".";
+            }
             result = this.children.get(0).braced().map(
                 glued -> new Node(
                     String.join(

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-on-reversed-receiver.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-dispatch-on-reversed-receiver.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7217: a reversed dispatch whose receiver cannot fold into a dotted @base
+# (a data literal here) keeps @base="?.eq" with @fragile set. Node.suffixed()
+# stripped one trailing character assuming it was a plain dot, so the marker
+# stayed glued to the method name instead of moving in front of it: "5.eq? 3"
+# instead of "5?.eq 3". That printed form does not reparse.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    5?.eq 3 > x
+
+printed: |
+  [] > main
+    5?.eq 3 > x


### PR DESCRIPTION
Closes #7217.

`Node.suffixed()` assumed the trailing character of a reversed head was always the plain dot, so for a fragile receiver (`base="eq?."`) it stripped one character off the wrong end and joined with a plain `.`, producing `5.eq? 3` instead of `5?.eq 3`. The fix detects the `?.` marker and both cuts and joins with it when present, so the whole `?.` moves in front of the method name.

Added a print-pack asserting `5?.eq 3 > x` round-trips to itself.
