### PR TITLE
#7218: host a moniker binding on the reference that will actually print first

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -26,13 +26,13 @@
   hostable reference exists, the binding is left in place.
 
   A binding with several hostable references still becomes a moniker,
-  landing on the first one in document order (#5739). This deliberately
-  gives up the print/parse fixpoint that a single-reference-only merge
-  (#5707) guaranteed: canonical attribute ordering (#5706) can reorder the
-  sibling bindings a reference sits inside, so "the first reference" may
-  shift between passes and the printed moniker may move with it. Since only
-  the compiler's obfuscated names are merged (#5738), this shift stays
-  hidden inside auto-generated plumbing and never moves an author's name.
+  landing on the first one to print (#5739, #7218), which need not be the
+  first one in document order: canonical attribute ordering (#5706) can
+  reorder the sibling bindings a reference sits inside, so document order and
+  print order disagree exactly when a later-printing binding hosts an
+  earlier-printing one. Ranking candidates by where they will actually print
+  (`eo:host-key`) keeps the chosen host stable across passes instead of
+  drifting with the resort.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -141,6 +141,26 @@
     <xsl:sequence select="exists($attr/@name) and (starts-with($attr/@name, concat('a', $eo:cactoos)) or eo:recursive-handle($attr)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
+  The key `to-eo-tree.xsl` will sort a reference's own top-level binding
+  under, once it lays out the owning formation's bindings alphabetically by
+  `(@local, @name)[1]` (a non-sortable, void, `φ` or test binding keeps its
+  own separate bucket ahead of or behind that alphabetical run, matching that
+  sheet's own sort exactly). Host selection below picks "the first" candidate
+  reference by this key rather than by raw document order, so the chosen host
+  is the one that will actually print first; picking a document-order-first
+  host that prints later let a later resort see a different reference sort
+  first, relocate the binding again, and never settle (#7218).
+  -->
+  <xsl:function name="eo:host-key" as="xs:string">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:param name="owner" as="element()"/>
+    <xsl:variable name="binding" select="$ref/ancestor-or-self::o[parent::*[. is $owner]][1]"/>
+    <xsl:variable name="sortable" select="eo:abstract($owner) and empty($owner/o[@pipe])"/>
+    <xsl:variable name="bucket" select="if (not($sortable)) then 0 else if (eo:void($binding)) then 1 else if ($binding/@name = $eo:phi) then 2 else if (eo:test-attr($binding)) then 4 else 3"/>
+    <xsl:variable name="name" select="if ($bucket = (0, 1, 2)) then '' else string(($binding/@local, $binding/@name)[1])"/>
+    <xsl:sequence select="concat($bucket, ' ', $name)"/>
+  </xsl:function>
+  <!--
   The references that can host the binding `$attr`, shortest spelling first: a
   bare `ξ.<name>` reference or a dispatch chain `ξ.<name>.<seg1>.<seg2>…`
   (#5782, #5970) whose nearest formation ancestor is the binding's own owner and
@@ -163,7 +183,12 @@
   <xsl:function name="eo:moniker-refs" as="element()*">
     <xsl:param name="attr" as="element()"/>
     <xsl:variable name="owner" select="$attr/.."/>
-    <xsl:variable name="refs" select="key('moniker-ref', concat(generate-id($owner), ' ', $attr/@name), root($attr))[not(ancestor::o[. is $attr])]"/>
+    <xsl:variable name="unordered" select="key('moniker-ref', concat(generate-id($owner), ' ', $attr/@name), root($attr))[not(ancestor::o[. is $attr])]"/>
+    <xsl:variable name="refs" as="element()*">
+      <xsl:perform-sort select="$unordered">
+        <xsl:sort select="eo:host-key(., $owner)"/>
+      </xsl:perform-sort>
+    </xsl:variable>
     <xsl:variable name="dispatch" as="element()*">
       <xsl:perform-sort select="$refs[eo:dispatch-seg(.) != '']">
         <xsl:sort select="count(tokenize(eo:dispatch-seg(.), '\.'))" data-type="number" order="ascending"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -27,12 +27,8 @@
 
   A binding with several hostable references still becomes a moniker,
   landing on the first one to print (#5739, #7218), which need not be the
-  first one in document order: canonical attribute ordering (#5706) can
-  reorder the sibling bindings a reference sits inside, so document order and
-  print order disagree exactly when a later-printing binding hosts an
-  earlier-printing one. Ranking candidates by where they will actually print
-  (`eo:host-key`) keeps the chosen host stable across passes instead of
-  drifting with the resort.
+  first in document order, since canonical attribute ordering (#5706)
+  reorders the sibling bindings a reference sits inside.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
@@ -141,24 +137,17 @@
     <xsl:sequence select="exists($attr/@name) and (starts-with($attr/@name, concat('a', $eo:cactoos)) or eo:recursive-handle($attr)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
-  The key `to-eo-tree.xsl` will sort a reference's own top-level binding
-  under, once it lays out the owning formation's bindings alphabetically by
-  `(@local, @name)[1]` (a non-sortable, void, `φ` or test binding keeps its
-  own separate bucket ahead of or behind that alphabetical run, matching that
-  sheet's own sort exactly). Host selection below picks "the first" candidate
-  reference by this key rather than by raw document order, so the chosen host
-  is the one that will actually print first; picking a document-order-first
-  host that prints later let a later resort see a different reference sort
-  first, relocate the binding again, and never settle (#7218).
+  The key `to-eo-tree.xsl` sorts a reference's own top-level binding under:
+  an alphabetical run by `(@local, @name)[1]`, with a non-sortable, void, `φ`
+  or test binding in its own bucket. Hosting by this key, not by document
+  order, makes a reprint settle instead of moving the binding again.
   -->
   <xsl:function name="eo:host-key" as="xs:string">
     <xsl:param name="ref" as="element()"/>
     <xsl:param name="owner" as="element()"/>
     <xsl:variable name="binding" select="$ref/ancestor-or-self::o[parent::*[. is $owner]][1]"/>
-    <xsl:variable name="sortable" select="eo:abstract($owner) and empty($owner/o[@pipe])"/>
-    <xsl:variable name="bucket" select="if (not($sortable)) then 0 else if (eo:void($binding)) then 1 else if ($binding/@name = $eo:phi) then 2 else if (eo:test-attr($binding)) then 4 else 3"/>
-    <xsl:variable name="name" select="if ($bucket = (0, 1, 2)) then '' else string(($binding/@local, $binding/@name)[1])"/>
-    <xsl:sequence select="concat($bucket, ' ', $name)"/>
+    <xsl:variable name="bucket" select="if (not(eo:abstract($owner) and empty($owner/o[@pipe]))) then 0 else if (eo:void($binding)) then 1 else if ($binding/@name = $eo:phi) then 2 else if (eo:test-attr($binding)) then 4 else 3"/>
+    <xsl:sequence select="concat($bucket, ' ', if ($bucket = (0, 1, 2)) then '' else string(($binding/@local, $binding/@name)[1]))"/>
   </xsl:function>
   <!--
   The references that can host the binding `$attr`, shortest spelling first: a

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-host-matches-print-order.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-host-matches-print-order.yaml
@@ -2,14 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# #7218: merge-monikers.xsl used to host a binding onto its first reference
-# in document order ("z" before "w" here), but to-eo-tree.xsl later sorts a
-# formation's bindings alphabetically by name ("w" before "z"), so the
-# printed output no longer matched the reference the merge had picked and a
-# reprint of that output picked a different "first" reference, moving the
-# handle again. Ranking candidate hosts by where they will actually print,
-# not by document order, makes the first pass already choose "w" (the name
-# that sorts first) and keeps the output stable across passes.
+# #7218: the host must be "w", the one that prints first, not "z".
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -23,7 +16,6 @@ origin: |
       5 > y
     h.y > z
     h.y > w
-
 printed: |
   [] > main
     y. > w

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-host-matches-print-order.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-host-matches-print-order.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7218: merge-monikers.xsl used to host a binding onto its first reference
+# in document order ("z" before "w" here), but to-eo-tree.xsl later sorts a
+# formation's bindings alphabetically by name ("w" before "z"), so the
+# printed output no longer matched the reference the merge had picked and a
+# reprint of that output picked a different "first" reference, moving the
+# handle again. Ranking candidate hosts by where they will actually print,
+# not by document order, makes the first pass already choose "w" (the name
+# that sorts first) and keeps the output stable across passes.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    [] >> h
+      5 > y
+    h.y > z
+    h.y > w
+
+printed: |
+  [] > main
+    y. > w
+      [] >> h
+        5 > y
+    h.y > z

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -18,12 +18,12 @@
 [] > sine
   times. > @
     minus. >> reduced
-      minus.
-        number ^.as-bytes >> arg
+      arg.minus
         times.
           floor. >> k
             plus.
-              arg.div
+              div.
+                number ^.as-bytes >> arg
                 pi.times 2
               0.5
           6.283185303211212

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -27,19 +27,57 @@
   text > @
   string > authority
     has-authority.if >> authority-bytes!
-      has-authority-path.if
-        after-slashes.slice 0 authority-path-idx
+      if.
+        not. >> has-authority-path
+          eq.
+            after-slashes.index-of "/" >> authority-path-idx
+            -1
+        slice.
+          string >> after-slashes
+            if. >> after-slashes-bytes!
+              hier-part.starts-with "//" >> has-authority
+              slice.
+                string >> hier-part
+                  if. >> hier-bytes!
+                    not. >> has-query
+                      eq.
+                        before-fragment.index-of "?" >> question-idx
+                        -1
+                    slice.
+                      if. >> before-fragment
+                        not. (hash-idx.eq -1) >> has-fragment
+                        slice.
+                          text.slice >> rest
+                            plus.
+                              if. >> scheme-colon
+                                or.
+                                  eq.
+                                    text.index-of ":" >> raw-colon
+                                    -1
+                                  not.
+                                    "/[A-Za-z][A-Za-z0-9+.-]*/".regex.compiled.matches
+                                      text.slice 0 raw-colon
+                                -1
+                                raw-colon
+                              1
+                            text.length.minus
+                              number (scheme-colon.plus 1)
+                          0
+                          hash-idx
+                        rest
+                      0
+                      question-idx
+                    before-fragment
+                2
+                hier-part.length.minus
+                  number 2
+              ""
+          0
+          authority-path-idx
         after-slashes
       ""
-  if. > fragment
-    not. >> has-fragment
-      hash-idx.eq -1
-    slice.
-      text.slice >> rest
-        scheme-colon.plus 1
-        text.length.minus
-          number
-            scheme-colon.plus 1
+  has-fragment.if > fragment
+    rest.slice
       plus.
         rest.index-of "#" >> hash-idx
         1
@@ -64,44 +102,29 @@
             -1
             rel-colon.plus
               plus. >> bracket-start
-                host-port.index-of "]" >>
+                index-of. >>
+                  string >> host-port
+                    if. >> host-port-bytes!
+                      not. >> has-userinfo
+                        eq.
+                          authority.last-index-of "@" >> userinfo-at-idx
+                          -1
+                      authority.slice
+                        userinfo-at-idx.plus 1
+                        authority.length.minus
+                          number (userinfo-at-idx.plus 1)
+                      authority
+                  "]"
                 1
           host-port.index-of ":"
         -1
-    slice.
-      string >> host-port
-        has-userinfo.if >> host-port-bytes!
-          authority.slice
-            plus.
-              authority.last-index-of "@" >> userinfo-at-idx
-              1
-            authority.length.minus
-              number
-                userinfo-at-idx.plus 1
-          authority
+    host-port.slice
       0
       port-colon-idx
     host-port
-  if. > path
-    starts-with. >> has-authority
-      string >> hier-part
-        has-query.if >> hier-bytes!
-          before-fragment.slice 0 question-idx
-          before-fragment
-      "//"
-    if.
-      not. >> has-authority-path
-        eq.
-          after-slashes.index-of "/" >> authority-path-idx
-          -1
-      slice.
-        string >> after-slashes
-          has-authority.if >> after-slashes-bytes!
-            hier-part.slice
-              2
-              hier-part.length.minus
-                number 2
-            ""
+  has-authority.if > path
+    has-authority-path.if
+      after-slashes.slice
         authority-path-idx
         after-slashes.length.minus
           number authority-path-idx
@@ -120,40 +143,20 @@
       raw-port
       ""
     ""
-  if. > query
-    not. >> has-query
-      question-idx.eq -1
-    slice.
-      has-fragment.if >> before-fragment
-        rest.slice 0 hash-idx
-        rest
-      plus.
-        before-fragment.index-of "?" >> question-idx
-        1
+  has-query.if > query
+    before-fragment.slice
+      question-idx.plus 1
       before-fragment.length.minus
         number
           question-idx.plus 1
     ""
   if. > scheme
-    eq.
-      if. >> scheme-colon
-        or.
-          eq.
-            text.index-of ":" >> raw-colon
-            -1
-          not.
-            "/[A-Za-z][A-Za-z0-9+.-]*/".regex.compiled.matches
-              text.slice 0 raw-colon
-        -1
-        raw-colon
-      -1
+    scheme-colon.eq -1
     ""
     text.slice
       0
       scheme-colon
-  if. > userinfo
-    not. >> has-userinfo
-      userinfo-at-idx.eq -1
+  has-userinfo.if > userinfo
     authority.slice
       0
       userinfo-at-idx


### PR DESCRIPTION
Closes #7218.

`merge-monikers.xsl` hosted a multi-referenced binding onto its first reference in document order. `to-eo-tree.xsl` later sorts a formation's bindings alphabetically by name, so the reference chosen as host does not always print first, and a reprint of the printed output can see a different reference sort first and relocate the binding again.

Added `eo:host-key`, which ranks a candidate reference by the same alphabetical key `to-eo-tree.xsl` sorts bindings with, and used it to order `eo:moniker-refs` so the chosen host is the one that will actually print first. Added a print-pack reproducing the issue's example and asserting the output reprints to itself.
