### PR TITLE
fix(#7264): cover onlyPhiNamingError's auto-named attribute branch

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-arg-auto-named-anonymous-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-arg-auto-named-anonymous-formation.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:4] error: 'an auto-named attribute cannot be a named attribute of an only-phi formation, which binds only its φ decoratee'
+      b >>
+      ^
+input: |
+  [] > obj
+    foo > [] >>
+      b >>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-arg-auto-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-arg-auto-named.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:4] error: 'an auto-named attribute cannot be a named attribute of only-phi formation bar, which binds only its φ decoratee'
+      b >>
+      ^
+input: |
+  [] > obj
+    a > [] > bar
+      b >>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-deep-arg-auto-named.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-deep-arg-auto-named.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  [4:6] error: 'an auto-named attribute cannot be a named attribute of an only-phi formation, which binds only its φ decoratee'
+        baz >>
+        ^
+input: |
+  [] > obj
+    foo > [] >>
+      bar
+        baz >>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-deep-arg-named-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-deep-arg-named-formation.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  [4:6] error: 'x cannot be a named attribute of only-phi formation bar, which binds only its φ decoratee'
+        baz > x
+        ^
+input: |
+  [] > obj
+    foo > [] > bar
+      qux
+        baz > x


### PR DESCRIPTION
Level.onlyPhiNamingError's "an auto-named attribute" branch fires when the offending attribute's label is empty, which happens for a bare `>>` suffix (Suffix keeps an empty label for it). Nothing in the test tree asserted that branch, so rewording it kept the build green.

The two existing yaml cases only covered the named-attribute half of the message: only-phi-arg-with-name.yaml against a named formation, only-phi-deep-arg-with-name.yaml against an anonymous one. Neither exercised the auto-named-attribute wording, and the formation-name x nesting-depth combinations were only partly covered too.

This adds four eo-typos yaml cases, filling out the matrix:

- only-phi-arg-auto-named.yaml - bare >> argument, direct child of a named only-phi formation
- only-phi-deep-arg-auto-named.yaml - bare >> argument, nested under an anonymous only-phi formation
- only-phi-arg-auto-named-anonymous-formation.yaml - bare >> argument, direct child of an anonymous only-phi formation
- only-phi-deep-arg-named-formation.yaml - named argument, nested under a named only-phi formation

Together with the two existing cases, all combinations of named/auto-named attribute, named/anonymous formation, and direct/nested argument position are now pinned down.

No production code changes.

Closes #7264