### PR TITLE
Return a bottom sentinel from Stack.below instead of null

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -91,11 +91,11 @@ final class Bindings {
      * reversed dispatch, a binding on a later link names the whole
      * reversed expression, which is the same as binding the receiver.
      * @param below The chain head's parent (what the upgrade would
-     *  touch), or {@code null} when there is none
+     *  touch), or the stack's bottom sentinel when there is none
      * @param span Source span of the continuation line
      */
     static void checkReceiverUpgrade(final Level below, final Span span) {
-        if (below != null && below.kind() == Kind.BARE_REVERSED && below.children() <= 1) {
+        if (below.kind() == Kind.BARE_REVERSED && below.children() <= 1) {
             throw new ParseError(
                 span.line(), span.indent(),
                 "reversed-dispatch receiver cannot carry a binding"
@@ -121,7 +121,7 @@ final class Bindings {
      */
     static void observeChild(final Stack stack, final String outer, final Span span) {
         final Level parent = stack.below();
-        if (parent == null || parent.kind() == Kind.BARE_FORMATION) {
+        if (parent.kind() == Kind.TOP_LEVEL || parent.kind() == Kind.BARE_FORMATION) {
             Bindings.rejectBinding(outer, span);
         } else if (parent.kind() == Kind.BARE_REVERSED) {
             Bindings.observeReversedChild(parent, outer, span);

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -81,10 +81,9 @@ final class LnMethod implements Line {
         }
         Comments.seal(globals, emit, this.span);
         if (outer != null) {
-            Bindings.checkReceiverUpgrade(stack.below(), this.span);
-            if (stack.below() != null) {
-                stack.below().upgradeArgBinding();
-            }
+            final Level under = stack.below();
+            Bindings.checkReceiverUpgrade(under, this.span);
+            under.upgradeArgBinding();
         }
         stack.seal();
         emit.object(

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -54,6 +54,15 @@ final class Stack {
     private final Opener opener;
 
     /**
+     * Bottom sentinel — the entry {@link #below()} answers when the
+     * stack holds fewer than two entries. Its kind is
+     * {@link Kind#TOP_LEVEL}, so a caller reading the parent of the
+     * bottom entry finds an object saying "top level" rather than an
+     * absence to test for.
+     */
+    private final Level bottom;
+
+    /**
      * Ctor with no-op hooks — useful in tests that exercise structural
      * transitions without semantic checks.
      */
@@ -78,6 +87,7 @@ final class Stack {
         this.levels = new ArrayList<>(8);
         this.closer = closer;
         this.opener = opener;
+        this.bottom = new Level(0, 0, Kind.TOP_LEVEL, Openness.OPEN, Kind.TOP_LEVEL, false);
     }
 
     /**
@@ -135,14 +145,15 @@ final class Stack {
     }
 
     /**
-     * The entry directly below the top, or null if there is none. Used by
-     * the FSM to read a new entry's parent during the push step (R-5.2.8).
-     * @return Entry below top, or null
+     * The entry directly below the top, or the bottom sentinel when the
+     * stack holds fewer than two entries. Used by the FSM to read a new
+     * entry's parent during the push step (R-5.2.8).
+     * @return Entry below top, never null
      */
     Level below() {
         final Level under;
         if (this.levels.size() < 2) {
-            under = null;
+            under = this.bottom;
         } else {
             under = this.levels.get(this.levels.size() - 2);
         }

--- a/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
@@ -199,7 +199,7 @@ final class BindingsTest {
         stack.push(0, 1, Kind.HEAD, Openness.OPEN);
         Assertions.assertThrows(
             ParseError.class,
-            () -> Bindings.observeChild(stack, "\u00e4\u00df", new Span("foo", 1)),
+            () -> Bindings.observeChild(stack, "äß", new Span("foo", 1)),
             "a binding on a top-level line was accepted"
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BindingsTest.java
@@ -192,4 +192,25 @@ final class BindingsTest {
             "a receiver carrying a binding was accepted"
         );
     }
+
+    @Test
+    void rejectsBindingOnAChildOfTheBottomSentinel() {
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.HEAD, Openness.OPEN);
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> Bindings.observeChild(stack, "\u00e4\u00df", new Span("foo", 1)),
+            "a binding on a top-level line was accepted"
+        );
+    }
+
+    @Test
+    void acceptsAnUpgradeAgainstTheBottomSentinel() {
+        Assertions.assertDoesNotThrow(
+            () -> Bindings.checkReceiverUpgrade(
+                new Stack().below(), new Span(".plus 1 > x", 1)
+            ),
+            "a chain continuation with no parent below was rejected"
+        );
+    }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -216,6 +216,47 @@ final class StackTest {
         );
     }
 
+    @Test
+    void answersTopLevelBelowAnEmptyStack() {
+        MatcherAssert.assertThat(
+            "the entry below an empty stack must be the bottom sentinel, whose kind is TOP_LEVEL",
+            new Stack().below().kind(),
+            Matchers.equalTo(Kind.TOP_LEVEL)
+        );
+    }
+
+    @Test
+    void answersTopLevelBelowTheOnlyEntry() {
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.HEAD, Openness.OPEN);
+        MatcherAssert.assertThat(
+            "the entry below the only entry must be the bottom sentinel, whose kind is TOP_LEVEL",
+            stack.below().kind(),
+            Matchers.equalTo(Kind.TOP_LEVEL)
+        );
+    }
+
+    @Test
+    void keepsTheBottomSentinelNonArgumentative() {
+        MatcherAssert.assertThat(
+            "the bottom sentinel cannot put its children in only-phi argument position",
+            new Stack().below().argumentative(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void answersTheRealEntryBelowTheTop() {
+        final Stack stack = new Stack();
+        final Level under = stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        stack.push(2, 2, Kind.HEAD, Openness.OPEN);
+        MatcherAssert.assertThat(
+            "the entry below the top must be the one pushed right before it",
+            stack.below(),
+            Matchers.sameInstance(under)
+        );
+    }
+
     private static ParseError firstPushIndentViolation() {
         return Assertions.assertThrows(
             ParseError.class,


### PR DESCRIPTION
`Stack.below()` used to answer `null` whenever the stack held fewer than two entries, and every caller carried a branch for it: `Bindings.observeChild` opened with a `parent == null` test, `checkReceiverUpgrade` repeated it, and `LnMethod.into` repeated it a third time while calling `stack.below()` three times in five lines.

The stack now owns a bottom sentinel — a `Level` whose kind is `Kind.TOP_LEVEL`, created once per stack — and `below()` answers it instead of `null`. The three null tests are gone: `observeChild` reads the sentinel's kind like any other parent, `checkReceiverUpgrade` asks only about `BARE_REVERSED`, and `LnMethod` reads the entry below once. Behaviour is unchanged — a top-level parent still rejects a binding, exactly as the `null` branch did.

Tests cover what the sentinel answers below an empty stack and below the only entry, that it stays non-argumentative, that a real entry is still returned when one exists, and that the top-level rejection and the parentless chain upgrade still behave.

Closes #7252
