### PR TITLE
#7253: compute the commit hash lazily from the injected tag

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -372,11 +372,16 @@ abstract class MjSafe extends AbstractMojo {
     protected Settings settings = new Settings();
 
     /**
-     * The Git hash to pull objects from.
-     * If not set, will be computed from {@code tag} field.
+     * The Git hash to pull objects from, computed from {@code tag} field.
+     *
+     * <p>Built lazily behind {@link ChCached} rather than eagerly from
+     * {@code this.tag} here: this field initializer runs during
+     * construction, before Maven injects the configured {@code eo.tag}
+     * value by reflection, so an eager {@code new ChBrief(this.tag)} would
+     * capture the {@code "master"} default forever.</p>
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
-    protected CommitHash hash = new ChBrief(this.tag);
+    protected CommitHash hash = new ChCached(() -> new ChBrief(this.tag).value());
 
     /**
      * Resolve default JNA dependency or not.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjSafe.java
@@ -379,6 +379,7 @@ abstract class MjSafe extends AbstractMojo {
      * construction, before Maven injects the configured {@code eo.tag}
      * value by reflection, so an eager {@code new ChBrief(this.tag)} would
      * capture the {@code "master"} default forever.</p>
+     *
      * @checkstyle VisibilityModifierCheck (5 lines)
      */
     protected CommitHash hash = new ChCached(() -> new ChBrief(this.tag).value());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjSafeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjSafeTest.java
@@ -39,6 +39,18 @@ final class MjSafeTest {
         );
     }
 
+    @Test
+    void computesHashFromTagInjectedAfterConstruction() {
+        final MjSafeTest.Failing mojo = new MjSafeTest.Failing();
+        final String hex = "abcdefabcdefabcdefabcdefabcdefabcdefabcd";
+        mojo.tag = hex;
+        Assertions.assertEquals(
+            hex.substring(0, 7),
+            mojo.hash.value(),
+            "hash must be computed from the tag Maven injects after construction, not from the constructor-time default"
+        );
+    }
+
     /**
      * The mojo whose exec() always fails.
      * @since 0.1


### PR DESCRIPTION
Closes #7253.

`MjSafe.hash` was initialized eagerly in a field initializer, `new ChBrief(this.tag)`, which runs during construction before Maven injects the configured `eo.tag` value by reflection. The `ChRemote` inside captures that string eagerly too, so `eo.tag` was silently ignored and objects were always pulled and cached under the hash of `master`.

Wrapped the construction in a lambda passed to `ChCached`, so `this.tag` is read the first time `hash.value()` is actually called, which happens after Maven's property injection.

Added a test that sets `tag` on a fresh mojo instance and asserts `hash.value()` reflects it, using a full 40-hex-char tag so the assertion needs no network access.
