### PR TITLE
Hold a declared receiver by reference

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -448,9 +448,17 @@
   <!-- Void attribute -->
   <xsl:template match="void">
     <xsl:param name="name"/>
-    <xsl:text>new AtVoid("</xsl:text>
-    <xsl:value-of select="eo:literal($name)"/>
-    <xsl:text>")</xsl:text>
+    <xsl:choose>
+      <!-- A receiver is held by reference, so it survives a copy untouched -->
+      <xsl:when test="$name=$eo:rho">
+        <xsl:text>new AtRho()</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>new AtVoid("</xsl:text>
+        <xsl:value-of select="eo:literal($name)"/>
+        <xsl:text>")</xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <!--
   Atom as attribute.

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/receiver-void-as-rho.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/receiver-void-as-rho.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/package.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - /object/class/java[contains(text(), 'this.add("ρ", new AtRho());')]
+  - /object/class/java[contains(text(), 'this.add("x", new AtVoid("x"));')]
+input: |
+  x > [^ x] > receiver

--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -15,7 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
  *
  * @since 0.36.0
  */
-final class AtRho implements Attribute {
+public final class AtRho implements Attribute {
 
     /**
      * Rho.
@@ -25,7 +25,7 @@ final class AtRho implements Attribute {
     /**
      * Ctor.
      */
-    AtRho() {
+    public AtRho() {
         this(null);
     }
 

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -320,7 +320,11 @@ public class PhDefault implements Phi, Cloneable {
             if (PhDefault.SORTABLE.matcher(name).matches()) {
                 this.order.add(name);
             }
-            this.loaded().put(name, new AtWithRho(attr, this));
+            if (Phi.RHO.equals(name)) {
+                this.loaded().put(name, attr);
+            } else {
+                this.loaded().put(name, new AtWithRho(attr, this));
+            }
         } finally {
             this.lock.unlock();
         }

--- a/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
@@ -130,4 +130,18 @@ final class AtWithRhoTest {
             Matchers.containsString("the deep reason")
         );
     }
+
+    @Test
+    void leavesADeclaredReceiverUnwrapped() {
+        final PhDefault host = new PhDefault();
+        host.add(
+            "kid",
+            new AtComposite(host, rho -> new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho()))))
+        );
+        MatcherAssert.assertThat(
+            "a declared receiver must hand out the host itself, but it didnt",
+            host.take("kid").take(Phi.RHO),
+            Matchers.is(host)
+        );
+    }
 }


### PR DESCRIPTION
Every void became an `AtVoid`, whatever its name. Since #7134 a formation may declare its receiver as `[^ x] > foo`, which arrives here as a void named `ρ`, and the two are not interchangeable: a void owns what fills it, so `AtVoid.copy` copies the value, while a receiver points up at the object this one hangs off, so `AtRho.copy` carries the reference over. An object that declared its receiver cloned its parent on every copy.

```xml
<xsl:when test="$name=$eo:rho">
  <xsl:text>new AtRho()</xsl:text>
</xsl:when>
```

`AtRho` had to become public for that, since `+package` puts generated classes outside `org.eolang`.

One more site assumed the receiver is never declared. `PhDefault.add` wraps every attribute in `AtWithRho`, which stamps a rho onto whatever it hands back, while `defaults()` installs `AtRho` unwrapped — so reading a declared receiver returned a stamped copy of the host instead of the host. `add` now leaves `ρ` alone, as `defaults()` always did.

Nothing in the language declares a receiver yet, so no behaviour changes here. It is the groundwork for declaring `^` across the runtime, after which `defaults()` can stop seeding one into every object.