### PR TITLE
#7260: fall back to the current directory when a trailing separator has nothing in front of it

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -92,6 +92,38 @@
             normalized.size.eq 0
             "."
             string normalized
+      concat. > core!
+        ^.drive.concat
+          ^.is-absolute.if
+            ^.unc.if
+              ^.separator.concat ^.separator
+              ^.separator
+            --
+        ^.separator.joined >> body!
+          reduced.
+            ^.driveless.split ^.separator
+            *
+            if. > [accum segment] >>
+              segment.eq ".."
+              if.
+                and.
+                  accum.length.gt 0
+                  not.
+                    accum.head.eq ".."
+                if.
+                  ^.^.unc.and
+                    accum.length.lte 2
+                  accum
+                  accum.tail
+                ^.^.is-absolute.not.if
+                  accum.with segment
+                  accum
+              if.
+                or.
+                  segment.eq "."
+                  segment.eq ""
+                accum
+                accum.with segment
       as-bytes. > normalized!
         if.
           ^.driveless.size.eq 0
@@ -99,34 +131,11 @@
             ^.drive.size.eq 0
             "."
             ^.drive
-          concat.
-            concat.
-              ^.drive.concat
-                ^.is-absolute.if
-                  ^.unc.if (^.separator.concat ^.separator) ^.separator
-                  --
-              ^.separator.joined >> body!
-                reduced.
-                  ^.driveless.split ^.separator
-                  *
-                  if. > [accum segment] >>
-                    segment.eq ".."
-                    if.
-                      and.
-                        accum.length.gt 0
-                        not. (accum.head.eq "..")
-                      if.
-                        ^.^.unc.and (accum.length.lte 2)
-                        accum
-                        accum.tail
-                      ^.^.is-absolute.not.if (accum.with segment) accum
-                    if.
-                      or.
-                        segment.eq "."
-                        segment.eq ""
-                      accum
-                      accum.with segment
-            trailing.if ^.separator --
+          if.
+            core.size.eq 0
+            "."
+            core.concat
+              trailing.if ^.separator --
       and. > trailing
         ubts.size.gt 0
         eq.
@@ -286,6 +295,11 @@
       path.posix "foo/.."
     "."
 
+  eq. ++> can-normalize-a-posix-path-collapsing-to-the-current-directory-with-a-trailing-separator
+    normalized.
+      path.posix "a/b/../../"
+    "."
+
   eq. ++> can-normalize-a-relative-posix-path
     normalized.
       path.posix "../../foo/./bar/../x/../y"
@@ -349,6 +363,11 @@
   eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.
       path.win32 "foo\\.."
+    "."
+
+  eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory-with-a-trailing-separator
+    normalized.
+      path.win32 ".\\"
     "."
 
   eq. ++> can-normalize-a-win32-path-down-to-a-drive-with-a-separator


### PR DESCRIPTION
Closes #7260.

`normalized!` appended the trailing separator (`trailing.if separator --`) to whatever the prefix-plus-body concat produced, without checking whether that concat was empty. For a relative path that collapses to nothing but ends with a separator (`"./"`, `"foo/../"`), the prefix is empty (not absolute) and the body is empty (every segment collapses), so the result was just the trailing separator on its own, i.e. the filesystem root.

Extracted the prefix-plus-body concat into `core!`. `normalized!` now falls back to `"."` when `core` is empty, the same fallback the outer `driveless.size.eq 0` branch already uses, and only appends the trailing separator when `core` is non-empty.

Added a posix case (`"a/b/../../"`) and a win32 case (`".\\"`), both expected to normalize to `"."`.
