### PR TITLE
Ask carried for a bool before branching in as-scientific

### DIFF
--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -45,7 +45,7 @@
         number exponent
     6
   ^ > n
-  carried.if > normalized!
+  carried.as-bool.if > normalized!
     "-1.000000".as-bytes
     "1.000000".as-bytes
   if. > [m count] >> rec-exponent


### PR DESCRIPTION
`number.as-scientific` branched on `carried` with `if`, but `carried` holds a
const marker, so it dataizes to bytes, and bytes has no `if`. The dispatch fell
through and the object terminated with its own first argument as the message,
`-1.000000`. This asks bytes for a bool first, the way `string/printf.eo`
already does for its own const bools.

Every mantissa that rounding carried up to ten went through that branch, so a
carry ended in a panic instead of a number, for both signs. That left the fix
of #7183 inert: all four carry tests in the file were failing. They were out of
sight because they sit right at the one-second `eo.deadline`, which reports them
as skipped rather than failed.

Two things a reviewer may want to know. The tests pass now, with nothing
skipped, when the class is run with a longer deadline. And the full
`EOnumberTest` takes noticeably longer than it did before this change, since
tests that used to panic immediately now do the arithmetic they were written
for; I have not finished timing it, so if the `number` tests look slower in CI
than you expect, that is where I would look first.

Closes #7270
