### PR TITLE
#7255: fold lints and wpa artifact versions into the lint cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -335,8 +335,9 @@ final class Linting implements Step {
 
     private String cacheVersion() {
         return String.format(
-            "%s-%b-%s",
+            "%s-%s-%b-%s",
             this.version,
+            Manifests.read("Lints-Version"),
             this.experimental,
             new Hashed(
                 this.sourcelints.stream().sorted().collect(Collectors.joining(","))
@@ -375,7 +376,8 @@ final class Linting implements Step {
                         this.cache.resolve(Linting.CACHE),
                         this.version,
                         new WpaCacheKey(
-                            paths, this.programlints, this.experimental
+                            paths, this.programlints, this.experimental,
+                            Manifests.read("Wpa-Version")
                         ).get()
                     ).get(),
                     root -> {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/WpaCacheKey.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/WpaCacheKey.java
@@ -51,7 +51,6 @@ final class WpaCacheKey implements Supplier<String> {
      * @param programlints Program lints to skip
      * @param skip Whether experimental lints are skipped
      * @param wpa The version of the {@code org.eolang:wpa} artifact in use
-     * @checkstyle ParameterNumberCheck (3 lines)
      */
     WpaCacheKey(final Map<String, Path> files, final Collection<String> programlints,
         final boolean skip, final String wpa) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/WpaCacheKey.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/WpaCacheKey.java
@@ -17,7 +17,8 @@ import java.util.TreeMap;
 import java.util.function.Supplier;
 
 /**
- * Fingerprint of XMIR inputs and skip flags that change a WPA verdict.
+ * Fingerprint of XMIR inputs, skip flags and the WPA artifact version that
+ * change a WPA verdict.
  * @since 0.62.0
  */
 final class WpaCacheKey implements Supplier<String> {
@@ -38,16 +39,26 @@ final class WpaCacheKey implements Supplier<String> {
     private final boolean experimental;
 
     /**
+     * The version of the {@code org.eolang:wpa} artifact deciding the
+     * verdict, so an artifact upgrade with everything else unchanged still
+     * invalidates the cache.
+     */
+    private final String version;
+
+    /**
      * Ctor.
      * @param files XMIR files WPA reads
      * @param programlints Program lints to skip
      * @param skip Whether experimental lints are skipped
+     * @param wpa The version of the {@code org.eolang:wpa} artifact in use
+     * @checkstyle ParameterNumberCheck (3 lines)
      */
     WpaCacheKey(final Map<String, Path> files, final Collection<String> programlints,
-        final boolean skip) {
+        final boolean skip, final String wpa) {
         this.paths = files;
         this.skips = programlints;
         this.experimental = skip;
+        this.version = wpa;
     }
 
     @Override
@@ -71,6 +82,7 @@ final class WpaCacheKey implements Supplier<String> {
             } else {
                 digest.update((byte) 0);
             }
+            digest.update(this.version.getBytes(StandardCharsets.UTF_8));
             return HexFormat.of().formatHex(digest.digest());
         } catch (final NoSuchAlgorithmException ex) {
             throw new IllegalStateException("SHA-256 is not available for WPA cache key", ex);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/WpaCacheKeyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/WpaCacheKeyTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.util.Collections;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link WpaCacheKey}.
+ * @since 0.73.4
+ */
+final class WpaCacheKeyTest {
+
+    @Test
+    void changesWhenWpaVersionChanges() {
+        final Map<String, java.nio.file.Path> paths = Collections.emptyMap();
+        MatcherAssert.assertThat(
+            "An upgrade of the wpa artifact must invalidate the cache key even when every other input stays the same",
+            new WpaCacheKey(paths, Collections.emptyList(), false, "0.1.0").get(),
+            Matchers.not(
+                Matchers.equalTo(
+                    new WpaCacheKey(paths, Collections.emptyList(), false, "0.1.1").get()
+                )
+            )
+        );
+    }
+
+    @Test
+    void staysTheSameWhenNothingChanges() {
+        final Map<String, java.nio.file.Path> paths = Collections.emptyMap();
+        MatcherAssert.assertThat(
+            "The same inputs must produce the same cache key",
+            new WpaCacheKey(paths, Collections.emptyList(), false, "0.1.1").get(),
+            Matchers.equalTo(
+                new WpaCacheKey(paths, Collections.emptyList(), false, "0.1.1").get()
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #7255.

`cacheVersion()` (source lints) and the WPA cache key both fold in the plugin version, the skipped lints, and the experimental flag, but neither reads the actual versions of `org.eolang:lints` or `org.eolang:wpa`, the two artifacts that decide the linting outcome. On a build where the plugin version stays the same across a `lints` or `wpa` upgrade, the cache key stays the same too, so `Cache.apply` reuses the previous run's linted XMIR and the new lints never run.

`Manifests.read("Lints-Version")` is already used a few lines above in the same file to print the lints doc link, so `cacheVersion()` now folds that same value in. `WpaCacheKey` gets a new constructor parameter for the `wpa` version, digested alongside the paths, skipped lints and experimental flag; `Linting` passes it `Manifests.read("Wpa-Version")`.

Added `WpaCacheKeyTest` asserting the key changes when the wpa version changes and stays the same when nothing does.
