### PR TITLE
fix(#7267): let `ExInterrupted` through `PhSafe` untouched

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -21,6 +21,12 @@ import java.util.function.Supplier;
  * the failure keeps propagating until it either reaches a recovery or
  * terminates the program.</p>
  *
+ * <p>An {@link ExInterrupted} is the one exception to this: it passes
+ * through untouched, keeping its own type. It is not an EO-level
+ * termination the program may recover from, but a signal that this thread
+ * must stop, and wrapping it into an {@link ExFailure} would let the
+ * nearest {@link EOrecovered} intercept it.</p>
+ *
  * <p>Elsewhere we let Cactoos catch for us, with {@code ScalarWithFallback}.
  * Here we catch by hand, because {@code eo-runtime} ships with no
  * compile-scope dependencies at all.</p>
@@ -186,6 +192,8 @@ public final class PhSafe implements Phi, Atom {
     private <T> T through(final Supplier<T> action, final String suffix) {
         try {
             return action.get();
+        } catch (final ExInterrupted ex) {
+            throw ex;
         } catch (final Throwable ex) {
             throw new ExFailure(
                 String.format("%s; %s", this.label(suffix), PhSafe.message(ex)),

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -123,6 +123,50 @@ final class PhSafeTest {
     }
 
     @Test
+    void letsInterruptedThrough() {
+        MatcherAssert.assertThat(
+            "an interrupt must keep its own message, but it was wrapped",
+            Assertions.assertThrows(
+                ExInterrupted.class,
+                () -> new PhSafe(
+                    new PhDefault() {
+                        @Override
+                        public byte[] delta() {
+                            throw new ExInterrupted("the thread must stop");
+                        }
+                    },
+                    "file.eo", 42, 7
+                ).delta(),
+                "was expected to fail with ExInterrupted"
+            ).getMessage(),
+            Matchers.equalTo("the thread must stop")
+        );
+    }
+
+    @Test
+    void doesNotLetRecoveredInterceptInterrupted() {
+        final Phi recovered = new EOrecovered();
+        recovered.put(
+            "value",
+            new PhSafe(
+                new PhDefault() {
+                    @Override
+                    public Phi normalized() {
+                        throw new ExInterrupted("the thread must stop");
+                    }
+                },
+                "file.eo", 42, 7
+            )
+        );
+        recovered.put("alternative", new Data.ToPhi(42L));
+        Assertions.assertThrows(
+            ExInterrupted.class,
+            ((Atom) recovered)::lambda,
+            "recovered must not intercept an interrupt, but it did"
+        );
+    }
+
+    @Test
     void showsFileNameAndLineNumber() {
         MatcherAssert.assertThat(
             "shows file name, line number and the original cause",

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -145,7 +145,7 @@ final class PhSafeTest {
 
     @Test
     void doesNotLetRecoveredInterceptInterrupted() {
-        final Phi recovered = new EOrecovered();
+        final EOrecovered recovered = new EOrecovered();
         recovered.put(
             "value",
             new PhSafe(
@@ -161,7 +161,7 @@ final class PhSafeTest {
         recovered.put("alternative", new Data.ToPhi(42L));
         Assertions.assertThrows(
             ExInterrupted.class,
-            ((Atom) recovered)::lambda,
+            recovered::lambda,
             "recovered must not intercept an interrupt, but it did"
         );
     }


### PR DESCRIPTION
Closes #7267.

`PhSafe.through` caught `Throwable` and rethrew every one of them as an `ExFailure`, `ExInterrupted` included. Since `EOrecovered.lambda` catches `ExFailure` and reads it as a bottom, an interrupt raised anywhere under a located object reached the nearest `recovered` disguised as an ordinary EO-level termination, and was intercepted there — losing its own type, message and location.

The program did still stop, but only because `PhDefault.take` re-checks the interrupt flag on the very next lookup, so the failure that surfaced was whatever resolving the `alternative` produced rather than the interrupt itself. Any atom that surfaces an interrupt with the flag cleared — the case `AtomSafe.lambda` is careful to avoid by re-interrupting — would have let a recovery swallow it outright.

Changes:

* `PhSafe.through` now has a `catch (final ExInterrupted ex) { throw ex; }` branch ahead of the `Throwable` catch, the way `AtomSafe.lambda` lets a `RuntimeException` through untouched. The interrupt keeps its own type, so `recovered`'s `ExFailure` catch cannot see it.
* The class docblock says so.
* Two tests in `PhSafeTest`: one pins that an `ExInterrupted` raised by the origin leaves `PhSafe` as an `ExInterrupted` with its original message, and one pins that a `recovered` wrapping such a `PhSafe` does not fall back to its `alternative`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014m24GQZVRCZXducPFwCf4t)_