### PR TITLE
#7258: put the glob-parse-error fallback where it belongs, one level up

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -146,9 +146,9 @@
                           "/^"
                           translated 0 "" false false
                           "$/"
-                  T > [message] >>
-                    "Can't parse '%s' as a glob pattern, %s".printf
-                      * ^.glob message
+                T > [message] >>
+                  "Can't parse '%s' as a glob pattern, %s".printf
+                    * ^.glob message
               text
     "".joined >> single
       *


### PR DESCRIPTION
Closes #7258.

`string.regex` declares no void attributes at all: `cant-compile` belongs to `compile`, but `T > [message]` sat one level too deep in `directory.eo`, as the second operand of `regex.` instead of `compile.`. With no vacant void, `compile.regex(...)` bound the argument onto an existing attribute and dataization failed with `Can't overwrite the cached attribute`, breaking `directory.walk` and `directory.deleted` entirely.

Moved `T > [message]` up one level so it sits as `compile.`'s own second argument, filling `cant-compile` the way `string/joined.eo`'s canonical use of `regex.` already does (a receiver and no argument).
