### PR TITLE
#7254: keep an over-long class name close to the 250-character threshold

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -74,9 +74,11 @@
     <xsl:variable name="codes" select="string-to-codepoints($n)"/>
     <xsl:value-of select="concat('_', string(sum(for $i in 1 to count($codes) return $codes[$i] * $i) mod 100000000))"/>
   </xsl:function>
-  <!-- A cut prefix with any trailing dot dropped, so the digit-starting fingerprint
-  appended after it lands inside an existing identifier segment instead of starting
-  an illegal one of its own (#7254) -->
+  <!--
+  A cut prefix with any trailing dot dropped, so the digit-starting fingerprint
+  appended after it lands inside an existing identifier segment instead of
+  starting an illegal one of its own (#7254).
+  -->
   <xsl:function name="eo:unbroken" as="xs:string">
     <xsl:param name="s" as="xs:string"/>
     <xsl:choose>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -62,16 +62,35 @@
     <xsl:param name="n" as="xs:string"/>
     <xsl:value-of select="concat('EO', eo:identifier(replace(replace(translate(translate(replace($n, '_', '__'), '-', '_'), '@', $eo:phi), $eo:alpha, '_'), '\$', '\$EO')))"/>
   </xsl:function>
-  <!-- Get object name with suffix -->
-  <xsl:function name="eo:suffix" as="xs:string">
-    <xsl:param name="s1"/>
-    <xsl:param name="s2"/>
-    <xsl:value-of select="concat(concat($s1, '_'), $s2)"/>
+  <!--
+  A deterministic digit fingerprint of a name, computed purely from the name's own
+  characters rather than from any surrounding XML node. Two over-long names sharing
+  their first 240-odd characters still disambiguate, and the same name always
+  fingerprints the same way regardless of which call site of "eo:class-name" asks,
+  so a declaration and a reference to the same over-long name never diverge (#7254).
+  -->
+  <xsl:function name="eo:fingerprint" as="xs:string">
+    <xsl:param name="n" as="xs:string"/>
+    <xsl:variable name="codes" select="string-to-codepoints($n)"/>
+    <xsl:value-of select="concat('_', string(sum(for $i in 1 to count($codes) return $codes[$i] * $i) mod 100000000))"/>
+  </xsl:function>
+  <!-- A cut prefix with any trailing dot dropped, so the digit-starting fingerprint
+  appended after it lands inside an existing identifier segment instead of starting
+  an illegal one of its own (#7254) -->
+  <xsl:function name="eo:unbroken" as="xs:string">
+    <xsl:param name="s" as="xs:string"/>
+    <xsl:choose>
+      <xsl:when test="ends-with($s, '.')">
+        <xsl:value-of select="eo:unbroken(substring($s, 1, string-length($s) - 1))"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$s"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
   <!-- Get class name for the object -->
   <xsl:function name="eo:class-name" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
-    <xsl:param name="alt" as="xs:string"/>
     <xsl:variable name="parts" select="tokenize($n, '\.')"/>
     <xsl:variable name="package">
       <xsl:for-each select="$parts">
@@ -94,7 +113,8 @@
     <xsl:variable name="pre" select="concat($package, eo:clean($class))"/>
     <xsl:choose>
       <xsl:when test="string-length($pre)&gt;250">
-        <xsl:value-of select="concat(substring($pre, 1, 25), $alt)"/>
+        <xsl:variable name="fingerprint" select="eo:fingerprint($n)"/>
+        <xsl:value-of select="concat(eo:unbroken(substring($pre, 1, 250 - string-length($fingerprint))), $fingerprint)"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$pre"/>
@@ -297,7 +317,7 @@
         <xsl:value-of select="eo:package-name($pkg)"/>
         <xsl:text>.</xsl:text>
       </xsl:if>
-      <xsl:value-of select="eo:class-name(., eo:suffix(../@line, ../@pos))"/>
+      <xsl:value-of select="eo:class-name(.)"/>
     </xsl:attribute>
   </xsl:template>
   <!-- Class body -->
@@ -318,7 +338,7 @@
     <xsl:text>")</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
     <xsl:text>public final class </xsl:text>
-    <xsl:value-of select="eo:class-name(@name, eo:suffix(@line, @pos))"/>
+    <xsl:value-of select="eo:class-name(@name)"/>
     <xsl:choose>
       <xsl:when test="@base">
         <xsl:text> extends PhOnce {</xsl:text>
@@ -373,7 +393,7 @@
   </xsl:template>
   <!-- Class constructor -->
   <xsl:template match="class" mode="ctors">
-    <xsl:variable name="class" select="eo:class-name(@name, eo:suffix(@line, @pos))"/>
+    <xsl:variable name="class" select="eo:class-name(@name)"/>
     <xsl:text>/**</xsl:text>
     <xsl:value-of select="eo:eol(1)"/>
     <xsl:text> * Ctor.</xsl:text>
@@ -470,7 +490,7 @@
     <xsl:variable name="class">
       <xsl:value-of select="$parent"/>
       <xsl:value-of select="'$'"/>
-      <xsl:value-of select="eo:class-name($name, eo:suffix($argument/@line, $argument/@pos))"/>
+      <xsl:value-of select="eo:class-name($name)"/>
     </xsl:variable>
     <xsl:variable name="variable">
       <xsl:if test="$context!='this'">
@@ -538,7 +558,7 @@
       <xsl:with-param name="parent">
         <xsl:value-of select="$parent"/>
         <xsl:text>$</xsl:text>
-        <xsl:value-of select="eo:class-name($name, eo:suffix(@line, @pos))"/>
+        <xsl:value-of select="eo:class-name($name)"/>
       </xsl:with-param>
       <xsl:with-param name="context" select="$ctx"/>
     </xsl:apply-templates>
@@ -793,7 +813,7 @@
     <xsl:text>")</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
     <xsl:text>public final class </xsl:text>
-    <xsl:value-of select="concat(eo:class-name(@name, eo:suffix(@line, @pos)), 'Test')"/>
+    <xsl:value-of select="concat(eo:class-name(@name), 'Test')"/>
     <xsl:choose>
       <xsl:when test="@base">
         <xsl:text> extends PhOnce {</xsl:text>
@@ -811,7 +831,7 @@
   </xsl:template>
   <!-- Testing ctors. -->
   <xsl:template match="class" mode="testing-ctors">
-    <xsl:variable name="class" select="concat(eo:class-name(@name, eo:suffix(@line, @pos)), 'Test')"/>
+    <xsl:variable name="class" select="concat(eo:class-name(@name), 'Test')"/>
     <xsl:text>/**</xsl:text>
     <xsl:value-of select="eo:eol(1)"/>
     <xsl:text> * Ctor.</xsl:text>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/keeps-an-over-long-class-name-close-to-the-threshold.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/keeps-an-over-long-class-name-close-to-the-threshold.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7254: a class name over 250 characters used to be cut to a 25-character stub
+# plus a disambiguating suffix, discarding almost the entire name. The cut now
+# keeps close to the 250-character threshold it tests, so the java-name still
+# carries most of the original identifier instead of just its first dozen or so
+# characters.
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //@java-name[string-length(.) > 200]
+  - //@java-name[contains(., 'segment20')]
+input: |
+  [] > segment0-segment1-segment2-segment3-segment4-segment5-segment6-segment7-segment8-segment9-segment10-segment11-segment12-segment13-segment14-segment15-segment16-segment17-segment18-segment19-segment20-segment21-segment22-segment23-segment24-segment25-segment26-segment27-segment28-segment29-segment30-segment31-segment32-segment33-segment34-segment35-segment36-segment37-segment38-segment39
+    true > @


### PR DESCRIPTION
Closes #7254.

`eo:class-name` cut an over-long name at 25 characters instead of the 250 the guard actually tests, discarding almost the whole name. The cut was also blind to the dots the dotted name still carries, so it could land right after one, producing a class segment starting with a digit and failing to compile. The disambiguating suffix itself was computed differently at different call sites (some from the enclosing `class` element's own `@line`/`@pos`, one from a different node's), so a declaration and a reference to the same over-long name could diverge above the threshold.

Replaced the per-call-site `eo:suffix(@line, @pos)` with `eo:fingerprint`, computed purely from the name string itself, so every call site of `eo:class-name` derives the same disambiguator for the same name by construction, with nothing left to diverge. The cut now keeps as much of the name as fits alongside that fingerprint, close to 250 characters instead of 25, and `eo:unbroken` trims any trailing dot off the cut first so the fingerprint always lands inside an existing identifier segment rather than starting an illegal one of its own.

Added a transpile-pack test with a single object name close to 400 characters, asserting the resulting `java-name` stays well over 200 characters and still contains a segment from deep in the original name.
