### PR TITLE
#7240: accept the limited-broadcast address as a valid IPv4 conversion

### DIFF
--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -138,7 +138,10 @@
               * ^.sys.message
           ^.^.guarded opened ^.sys.cleanup
         if. > converted
-          ^.addr.eq ^.sys.none
+          and.
+            ^.addr.eq ^.sys.none
+            not.
+              ^.^.address.eq "255.255.255.255"
           cant
             "Couldn't convert an IPv4 address '%s' into a 32-bit integer because %s".printf
               * ^.^.address ^.sys.message

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -94,6 +94,21 @@ final class SyscallTest {
     }
 
     @Test
+    void acceptsTheBroadcastAddressAsAValidConversion(@Ephemeral final int port) {
+        final Phi socket = Phi.Φ.take("socket").copy();
+        socket.put(0, new Data.ToPhi("255.255.255.255"));
+        socket.put(1, new Data.ToPhi(port));
+        final Phi listen = socket.take("listen").copy();
+        listen.put(0, new SyscallTest.Simple());
+        listen.put(1, Phi.Φ.take("dataized").copy());
+        MatcherAssert.assertThat(
+            "the limited-broadcast address 255.255.255.255 must be accepted as a valid IPv4 conversion, not rejected as unparsable",
+            new Dataized(listen).asString(),
+            Matchers.not(Matchers.containsString("into a 32-bit integer"))
+        );
+    }
+
+    @Test
     void tellsTheFallbackWhichAddressItFailedToBind(@Ephemeral final int port) throws IOException {
         final SyscallTest.RandomServer taken = new SyscallTest.RandomServer(port).started();
         try {


### PR DESCRIPTION
Closes #7240.

`socket`'s address conversion checked `addr.eq sys.none` after `inet_addr()`, but `INADDR_NONE` (the error sentinel `inet_addr()` returns) and `255.255.255.255` (the valid IPv4 limited-broadcast address) are the same bit pattern. The valid address was rejected as unparsable before any connection attempt.

Added a check for the literal address string alongside the sentinel comparison, so `255.255.255.255` is no longer treated as a conversion failure.

Added `SyscallTest.acceptsTheBroadcastAddressAsAValidConversion`, which builds a `socket("255.255.255.255", port).listen(...)` and asserts the fallback message (if any) is not the address-conversion one. Verified it fails with the exact message from the issue before the fix and passes after.
