### PR TITLE
fix(#7268): reject unknown fake Maven parameters

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.maven;
 
+import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.yegor256.tojos.TjSmart;
 import java.io.File;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.descriptor.PluginDescriptor;
 import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.apache.maven.plugins.annotations.Mojo;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.scalar.Synced;
 import org.cactoos.set.SetOf;
@@ -43,6 +45,16 @@ import org.cactoos.text.UncheckedText;
 })
 @NotThreadSafe
 final class FakeMaven {
+
+    /**
+     * Fields declared by all Mojos.
+     */
+    private static final Set<String> MOJO_FIELDS = new ClassFileImporter()
+        .importPackages("org.eolang.maven")
+        .stream()
+        .filter(clazz -> clazz.isAnnotatedWith(Mojo.class))
+        .flatMap(clazz -> FakeMaven.fields(clazz.reflect()))
+        .collect(Collectors.toUnmodifiableSet());
 
     /**
      * Test workspace where we place all programs, files, compilation results, etc.
@@ -114,6 +126,14 @@ final class FakeMaven {
      * @return The same maven instance
      */
     FakeMaven with(final String param, final Object value) {
+        if (!FakeMaven.MOJO_FIELDS.contains(param)) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The parameter '%s' is not declared by any Mojo",
+                    param
+                )
+            );
+        }
         this.params.put(param, value);
         return this;
     }
@@ -441,6 +461,10 @@ final class FakeMaven {
         descriptor.setArtifactId("eo-maven-plugin");
         descriptor.setVersion(FakeMaven.pluginVersion());
         return descriptor;
+    }
+
+    private static Stream<String> fields(final Class<?> mojo) {
+        return FakeMaven.mojoFields(mojo, new HashSet<>()).stream();
     }
 
     private static Set<String> mojoFields(final Class<?> mojo, final Set<String> fields) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMavenTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMavenTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link FakeMaven}.
+ * @since 0.1
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@ExtendWith(MktmpResolver.class)
+final class FakeMavenTest {
+
+    @Test
+    void rejectsUnknownParameter(@Mktmp final Path temp) {
+        final String unknown = "unknownParameter";
+        MatcherAssert.assertThat(
+            "The failure must identify the unknown parameter",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new FakeMaven(temp).with(unknown, true)
+            ).getMessage(),
+            Matchers.containsString(unknown)
+        );
+    }
+
+    @Test
+    void acceptsParameterDeclaredByAnyMojo(@Mktmp final Path temp) {
+        Assertions.assertDoesNotThrow(
+            () -> new FakeMaven(temp).with("sources", temp.toFile()),
+            "A field declared by MjPrint must be accepted"
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -141,13 +141,12 @@ final class MjPrintTest {
         Assumptions.assumeTrue(xtory.map().get("skip") == null);
         MatcherAssert.assertThat(
             "PrintMojo should print EO in straight notation, but it didn't",
-            MjPrintTest.printed(xtory, this.dir, false).asString(),
+            MjPrintTest.printed(xtory, this.dir).asString(),
             Matchers.equalTo((String) xtory.map().get("printed"))
         );
     }
 
-    private static Text printed(final Xtory xtory, final Path temp, final boolean reversed)
-        throws Exception {
+    private static Text printed(final Xtory xtory, final Path temp) throws Exception {
         new Saved(
             new EoSyntax(
                 new InputOf(xtory.map().get("origin").toString())
@@ -156,8 +155,7 @@ final class MjPrintTest {
         ).value();
         final FakeMaven maven = new FakeMaven(temp)
             .with("sources", temp.resolve("xmir").toFile())
-            .with("output", temp.resolve("eo").toFile())
-            .with("printReversed", reversed);
+            .with("output", temp.resolve("eo").toFile());
         final Object pins = xtory.map().get("penalties");
         if (pins != null) {
             for (final Map.Entry<?, ?> pin : ((Map<?, ?>) pins).entrySet()) {


### PR DESCRIPTION
Closes #7268.

`FakeMaven.with()` now rejects parameter names that are not declared by any Mojo instead of silently discarding them during execution. The allowed field set is discovered from all `@Mojo` classes and reuses the existing inherited-field reflection.

The stale `printReversed` test parameter and its dead helper argument were removed.

Tests:
- `mvn -pl eo-maven-plugin test -DskipITs -Dinvoker.skip=true`
- `mvn clean install -Pqulice`

@yegor256