### PR TITLE
let %s conversion in scanf capture an empty value

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -386,7 +386,9 @@
     "%s %d".scanf
       "%s %d".printf
         * "" 8
-    * "" 8
+    *
+      ""
+      8
 
   eq. ++> can-scan-an-empty-value-between-two-literals
     "a%sb".scanf "ab"

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -267,7 +267,7 @@
                 ^.tokenize
                   position.plus 1
                   accumulated.chained
-                    * "(\\S+)"
+                    * "(\\S*)"
                   found.with "s"
                   false
                 T "Unsupported format specifier"
@@ -367,6 +367,50 @@
     "hello"
     head.
       "%s".scanf "hello"
+
+  eq. ++> can-scan-an-empty-value-with-a-standalone-percent-s
+    "%s".scanf ""
+    * ""
+
+  eq. ++> can-scan-an-empty-value-in-brackets
+    "[%s]".scanf "[]"
+    * ""
+
+  eq. ++> can-scan-what-printf-wrote-with-an-empty-string
+    "%s".scanf
+      "%s".printf
+        * ""
+    * ""
+
+  eq. ++> can-scan-what-printf-wrote-with-an-empty-string-followed-by-an-integer
+    "%s %d".scanf
+      "%s %d".printf
+        * "" 8
+    * "" 8
+
+  eq. ++> can-scan-an-empty-value-between-two-literals
+    "a%sb".scanf "ab"
+    * ""
+
+  eq. ++> can-scan-an-empty-value-followed-by-a-float
+    "%s=%f".scanf "=3.14"
+    *
+      ""
+      3.14
+
+  eq. ++> can-scan-an-empty-value-preceded-by-an-integer
+    "%d %s".scanf
+      "%d %s".printf
+        * 5 ""
+    *
+      5
+      ""
+
+  eq. ++> can-scan-two-empty-values-separated-by-a-literal
+    "[%s][%s]".scanf "[][]"
+    *
+      ""
+      ""
 
   eq. ++> can-scan-a-string-an-integer-and-a-float
     "%s %d %f".scanf


### PR DESCRIPTION
The %s conversion in string.scanf translated to the regex group (\S+), which requires at least one non-whitespace character. That made scanf fail to read an empty value through a standalone or bounded %s, and broke the round trip with printf output for an empty string.

The fix relaxes the group to (\S*), allowing zero characters while relying on the surrounding literals and other conversions to keep the match boundary-safe through normal regex backtracking.

Added regressions for a standalone empty %s, a bracketed empty %s, printf round trips with an empty value (alone, before an integer, after an integer), an empty value between arbitrary literals, an empty value followed by a float, and two adjacent empty values separated by literals.

Closes #7232