### PR TITLE
#7256: log package-level lint defects on the cached path too

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Linting.java
@@ -403,9 +403,11 @@ final class Linting implements Step {
             counts.compute(
                 Severity.parsed(defect.severity().mnemo()), (sev, before) -> before + 1
             );
-            seen.add(
-                Linting.format(defect.object(), defect.rule(), defect.line(), defect.text())
+            final String message = Linting.format(
+                defect.object(), defect.rule(), defect.line(), defect.text()
             );
+            seen.add(message);
+            Linting.logOne(defect.severity().mnemo(), message);
         }
         return progs.size();
     }
@@ -427,12 +429,6 @@ final class Linting implements Step {
                     ).applyQuietly(node);
                     if (Linting.notSuppressed(new Xnav(node), defect)) {
                         defects.add(defect);
-                        Linting.logOne(
-                            defect.severity().mnemo(),
-                            Linting.format(
-                                defect.object(), defect.rule(), defect.line(), defect.text()
-                            )
-                        );
                     }
                 }
             );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLintTest.java
@@ -12,10 +12,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.apache.log4j.Appender;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
 import org.cactoos.io.ResourceOf;
 import org.cactoos.scalar.Unchecked;
 import org.cactoos.set.SetOf;
@@ -282,6 +289,60 @@ final class MjLintTest {
                 "Second (cached) run must report the WPA error too"
             ).getCause().getCause().getMessage(),
             Matchers.containsString("foo.x.main")
+        );
+    }
+
+    @Test
+    void logsWholeProgramAnalysisDefectFromCache(@Mktmp final Path temp) throws IOException {
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("lintAsPackage", true)
+            .withProgram(MjLintTest.problematic());
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> maven.execute(new PpLint()),
+            "First (uncached) run must report the WPA error"
+        );
+        final List<String> messages = new ArrayList<>(0);
+        final Appender appender = new AppenderSkeleton() {
+            @Override
+            protected void append(final LoggingEvent event) {
+                messages.add(String.valueOf(event.getRenderedMessage()));
+            }
+
+            @Override
+            public void close() {
+                // Nothing to release.
+            }
+
+            @Override
+            public boolean requiresLayout() {
+                return false;
+            }
+        };
+        final Logger logger = Logger.getLogger(Linting.class);
+        final Level level = logger.getLevel();
+        logger.setLevel(Level.ALL);
+        logger.addAppender(appender);
+        try {
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> maven.execute(new PpLint()),
+                "Second (cached) run must report the WPA error too"
+            );
+        } finally {
+            logger.removeAppender(appender);
+            logger.setLevel(level);
+        }
+        MatcherAssert.assertThat(
+            "A WPA defect read back from the cache must still be logged, but it wasn't",
+            messages,
+            Matchers.hasItem(
+                Matchers.<String>allOf(
+                    Matchers.containsString("[LINT]"),
+                    Matchers.containsString("foo.x.main"),
+                    Matchers.containsString("not in scope")
+                )
+            )
         );
     }
 


### PR DESCRIPTION
Closes #7256.

`Linting.wpa()` was the only place that called `logOne()` for a package-level
(WPA) defect, but that method runs only inside the `Cache` compile lambda, that
is only on a cache miss. On a cache hit `lintAll()` takes `defects = Linting.read(out)`
and the loop that follows only counted the defects and added them to `seen`, so
the second run of `eo:lint` printed nothing while still reporting them in the
summary. With `failOnWarning=false` the log is the only channel, so the defects
were lost entirely.

The `logOne()` call now lives in the loop in `lintAll()` that both paths reach.
The defect lists are equivalent on either path — the cache-miss lambda writes
exactly the suppression-filtered list that `wpa()` returns — so the console
output no longer depends on whether the cache happens to be warm. Per-file
defects were never affected and are untouched.

## Regression test

`MjLintTest.logsWholeProgramAnalysisDefectFromCache` runs `eo:lint` twice with
`lintAsPackage=true` and asserts that the WPA defect is logged on the second
(cached) run, captured through a log4j appender on `Linting`. The assertion
matches the WPA defect text specifically, since the per-file lints log their own
`[LINT] foo.x.main:…` lines on every run.

Verified against `master` without the `Linting.java` change: the test fails with

```
Expected: a collection containing (a string containing "[LINT]" and a string
containing "foo.x.main" and a string containing "not in scope")
     but: mismatches were: [... "Linted 1 out of 1 XMIR program(s) ...: 1 critical error and 7 warnings" ...]
```

showing the defect counted into the summary but never logged. With the change,
all 30 tests in `MjLintTest` pass, `LintingTest` passes, and `mvn -Pqulice
qulice:check` on `eo-maven-plugin` is clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_016BB2MJNPtcCeJMUX31hfnC)_