### PR TITLE
fix(#7233): make **/ optionally match zero directories in directory.walk

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -190,8 +190,7 @@
                 false
                 braced
           within
-      if. > advance
-        slashed
+      slashed.if > advance
         3
         if.
           double.or negated

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -191,9 +191,12 @@
                 braced
           within
       if. > advance
-        double.or negated
-        2
-        1
+        slashed
+        3
+        if.
+          double.or negated
+          2
+          1
       if. > alternated
         char.eq "{"
         "("
@@ -226,6 +229,12 @@
           char.eq "["
           closes
             index.plus 1
+      double.and > slashed
+        eq.
+          ^.glob.at
+            index.plus 2
+            "" > [space]
+          "/"
       classed.if > token
         if.
           char.eq "]"
@@ -233,19 +242,21 @@
           classified char
         opening.if
           negated.if "[^" "["
-          double.if
-            ".*"
-            if.
-              char.eq "*"
-              "".joined
-                * single "*"
+          slashed.if
+            "(?:.*/)?"
+            double.if
+              ".*"
               if.
-                char.eq "?"
-                single
+                char.eq "*"
+                "".joined
+                  * single "*"
                 if.
-                  char.eq "/"
-                  literal
-                  alternated
+                  char.eq "?"
+                  single
+                  if.
+                    char.eq "/"
+                    literal
+                    alternated
       opening.if > within
         true
         if.
@@ -460,6 +471,25 @@
       touched.
         as-file.
           d.resolved "x/y/z/a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**/*.txt"
+        2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-recursively-including-direct-children
+    seq * > @
+      touched.
+        as-file.
+          d.resolved "root.txt"
+      made.
+        as-dir.
+          d.resolved "sub"
+      touched.
+        as-file.
+          d.resolved "sub/nested.txt"
       eq.
         length.
           d.as-dir.walk "**/*.txt"


### PR DESCRIPTION
directory.walk "**/*.txt" was skipping direct children of the walked directory. \`directory.eo\` translated \`**\` to \`.*\` and treated the following slash as a mandatory literal, so the compiled regex looked like \`^.*/[^/]*\.txt$\` — a file with no slash before it, such as \`root.txt\`, could never match.

The fix adds a \`slashed\` check to the glob translator: when a \`**\` is immediately followed by a \`/\`, the pair is translated to the optional non-capturing group \`(?:.*/)?\` and the cursor advances 3 characters (the two stars and the slash) instead of 2. A plain \`**\` not followed by a slash keeps its previous \`.*\` translation, and a single \`*\` is unaffected.

Added \`can-walk-recursively-including-direct-children\` to \`eo-runtime/src/main/eo/directory.eo\`, which creates a tree with one direct child (\`root.txt\`) and one nested child (\`sub/nested.txt\`) and asserts \`walk "**/*.txt"\` returns both.

Closes #7233