### PR TITLE
Diagnose de-indented and interrupted multi-line BYTES continuations

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -182,10 +182,22 @@ final class Eo implements Iterable<Directive> {
         final Span head = spans.get(start);
         final StringBuilder body = new StringBuilder(head.body().stripTrailing());
         int idx = start + 1;
+        boolean broken = false;
         while (idx < spans.size()) {
             final Span next = spans.get(idx);
             final String trimmed = next.body().stripTrailing();
-            if (next.indent() < head.indent() || !Eo.isBytesOnly(trimmed)) {
+            if (!next.blank() && next.indent() < head.indent()) {
+                emit.error(
+                    next.line(), 0, "multi-line bytes continuation must not de-indent"
+                );
+                broken = true;
+                break;
+            }
+            if (!Eo.isBytesOnly(trimmed)) {
+                emit.error(
+                    next.line(), 0, "multi-line bytes interrupted by non-byte content"
+                );
+                broken = true;
                 break;
             }
             body.append(trimmed);
@@ -195,7 +207,9 @@ final class Eo implements Iterable<Directive> {
             }
         }
         final int resumption;
-        if (Eo.process(
+        if (broken) {
+            resumption = recovery.skip(idx, head.indent());
+        } else if (Eo.process(
             new Span(" ".repeat(head.indent()).concat(body.toString()), head.line()),
             stack, globals, emit
         )) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/bytes-continuation-interrupted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/bytes-continuation-interrupted.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7236: a multi-line BYTES continuation interrupted by non-byte content
+# must be diagnosed as an interruption, not reparsed alone as a dangling dash.
+line: 3
+message: "multi-line bytes interrupted by non-byte content"
+input: |
+  [] > example
+    CA-FE-
+      foo > value

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/bytes-continuation-must-not-deindent.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/bytes-continuation-must-not-deindent.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7236: a multi-line BYTES continuation that de-indents below its opener
+# must be diagnosed as a de-indent, not reparsed alone as a dangling dash.
+line: 3
+message: "multi-line bytes continuation must not de-indent"
+input: |
+  [] > example
+    CA-FE-
+  00-01 > another


### PR DESCRIPTION
Eo.mergeBytesContinuation() stopped merging as soon as a continuation line either de-indented below its opener or held non-BYTES content, and let the still-dangling opener fall through to the ordinary one-line parser. That path only ever reports the generic "bytes literal ends with a dangling continuation dash", which hides which of the two conditions actually broke the literal.

The merge step now reports the specific diagnostic from the spec at the point it detects the problem:

- a shallower continuation line reports "multi-line bytes continuation must not de-indent" (R-3.13.2)
- a blank, comment, or otherwise non-BYTES line reports "multi-line bytes interrupted by non-byte content" (R-3.13.4)

Recovery reuses the existing Recovery#skip(from, indent) path already used for a failed merge, so the block under the failed continuation is skipped the same way other merged-literal failures are.

Two eo-typos regression packs cover the snippets from the issue: a de-indented continuation and one interrupted by a nested object.

Closes #7236