### PR TITLE
fix(#7190): move as-input size validation into input-block.read

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -88,3 +88,7 @@
   01-02-03-04-05-06.as-input.read 3.read nan --> stops-on-a-nan-byte-count-in-a-chained-read
 
   01-02-03-04-05-06.as-input.read 3.read -5 --> stops-on-a-negative-byte-count-in-a-chained-read
+
+  01-02-03-04-05-06.as-input.read 3.read 1.5 --> stops-on-a-fractional-byte-count-in-a-chained-read
+
+  01-02-03-04-05-06.as-input.read 3.read pinf --> stops-on-an-infinite-byte-count-in-a-chained-read

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -81,14 +81,26 @@
 
   01-02-03.as-input.read 0.5 --> stops-on-a-fractional-byte-count-below-available
 
+  read. --> stops-on-a-fractional-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    1.5
+
   01-02-03.as-input.read nan --> stops-on-a-nan-byte-count
+
+  read. --> stops-on-a-nan-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    nan
+
+  read. --> stops-on-a-negative-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    -5
 
   01-02-03.as-input.read pinf --> stops-on-an-infinite-byte-count
 
-  01-02-03-04-05-06.as-input.read 3.read nan --> stops-on-a-nan-byte-count-in-a-chained-read
-
-  01-02-03-04-05-06.as-input.read 3.read -5 --> stops-on-a-negative-byte-count-in-a-chained-read
-
-  01-02-03-04-05-06.as-input.read 3.read 1.5 --> stops-on-a-fractional-byte-count-in-a-chained-read
-
-  01-02-03-04-05-06.as-input.read 3.read pinf --> stops-on-an-infinite-byte-count-in-a-chained-read
+  read. --> stops-on-an-infinite-byte-count-in-a-chained-read
+    01-02-03-04-05-06.as-input
+    3.read
+    pinf

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -31,37 +31,37 @@
 [] > as-input
   ^ > b
   [size] > read
-    if. > @
-      size.is-finite.not.or
-        size.is-integer.not.or
-          0.gt size
-      T
-        "Can't read a non-integer, non-finite, or negative byte count"
-      @.
-        read.
-          input-block ^.b --
-          size
+    @. > @
+      read.
+        input-block ^.b --
+        size
     [data buffer] > input-block
       buffer > @
       [size] > read
         if. > @
-          available.eq 0
-          ^.^.input-block -- --
-          ^.^.input-block
-            as-bytes.
-              ^.data.slice
-                if. >> next!
-                  gt.
-                    number available
-                    size >> requested!
-                  requested
-                  available
-                minus.
-                  number
-                    ^.data.size >> available!
-                  number next
-            as-bytes.
-              ^.data.slice 0 next
+          size.is-finite.not.or
+            size.is-integer.not.or
+              0.gt size
+          T
+            "Can't read a non-integer, non-finite, or negative byte count"
+          if.
+            available.eq 0
+            ^.^.input-block -- --
+            ^.^.input-block
+              as-bytes.
+                ^.data.slice
+                  if. >> next!
+                    gt.
+                      number available
+                      size >> requested!
+                    requested
+                    available
+                  minus.
+                    number
+                      ^.data.size >> available!
+                    number next
+              as-bytes.
+                ^.data.slice 0 next
 
   ++> can-make-an-input-from-bytes-and-read-it
     and. > @
@@ -84,3 +84,7 @@
   01-02-03.as-input.read nan --> stops-on-a-nan-byte-count
 
   01-02-03.as-input.read pinf --> stops-on-an-infinite-byte-count
+
+  01-02-03-04-05-06.as-input.read 3.read nan --> stops-on-a-nan-byte-count-in-a-chained-read
+
+  01-02-03-04-05-06.as-input.read 3.read -5 --> stops-on-a-negative-byte-count-in-a-chained-read


### PR DESCRIPTION
Closes #7190

`bytes.as-input`'s `read` validated `size` only on the first read — the outer wrapper checked it before dispatching into `input-block`, but `input-block`'s own nested `read`, the one actually used for every subsequent read in a chain (`i1.read 4 > i2`, `i2.read 4 > i3`, ...), had no such guard. A NaN, negative, or fractional byte count silently slipped through on any read past the first, e.g. comparing against NaN always takes the else branch, so `i1.read nan` after a first read quietly returned all remaining bytes instead of raising an error.

Fixed by moving the validation `if` from `as-input`'s outer `read` into `input-block`'s `read`, ahead of the existing available-bytes check, so it now runs on every read in the chain. The outer `read` just delegates straight into `input-block`'s `read`, the same style already used by `console.eo`'s stdin reader.

Added two regression tests, `stops-on-a-nan-byte-count-in-a-chained-read` and `stops-on-a-negative-byte-count-in-a-chained-read`, that read twice and prove validation fires on the second read, not just the first.