### PR TITLE
chore: drop the no-op `groovy-all` exclusion from `lints`

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -37,12 +37,6 @@
       <groupId>org.eolang</groupId>
       <artifactId>lints</artifactId>
       <version>0.4.6</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.groovy</groupId>
-          <artifactId>groovy-all</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.eolang</groupId>


### PR DESCRIPTION
Removes the `org.codehaus.groovy:groovy-all` exclusion from the `org.eolang:lints` dependency in `eo-maven-plugin/pom.xml`. It never excluded anything.

## Does `lints` actually drag Groovy in?

No. `lints-0.4.6.pom` declares no Groovy dependency, and none of its dependencies bring one. Resolved trees for every `lints` release checked contain zero Groovy nodes:

| lints | Groovy nodes in tree |
|---|---|
| 0.0.44, 0.1.0, 0.2.0, 0.3.0, 0.4.0, 0.4.5, 0.4.6 | 0 |

## Then why does `lints` mention Groovy at all?

It uses Groovy at **build time only**. `src/main/groovy/org/eolang/lints/ReserveNames.groovy` is executed by `gmavenplus-plugin` at `process-classes` to generate `reserved.csv`; the plain-Java `ReservedNames` (a `MapEnvelope` over `tojos`) reads that CSV at runtime. No Groovy is needed to *use* `lints`.

The Groovy that compiles and runs that script comes from the `groovy` profile of `com.jcabi:parent`, whose activation is a single file-existence check — an `activation` holding a `file` whose `exists` is `${basedir}/src/main/groovy`.

File-based activation is evaluated against the building project's `basedir`, so the profile never activates when the published POM is consumed as a dependency — its dependency stays out of the released tree. And that profile asks for `org.apache.groovy:groovy` (Groovy 5), not the pre-4 `org.codehaus.groovy` coordinates: even if it had leaked, an exclusion on `org.codehaus.groovy:groovy-all` would not have matched it.

## Verification

- `dependency:tree` for `eo-maven-plugin` is **byte-identical** with and without the exclusion.
- The module builds clean after removal.
- `org.codehaus.groovy` now appears nowhere in the repo.
- The only Groovy left on the `eo-maven-plugin` tree is the parent POM's test-scoped `org.apache.groovy:groovy` 5.1.0 (and `groovy-xml`), used by `verify.groovy` in the invoker tests — unrelated to `lints`.

## Not fixed here (upstream observation, no action needed for this PR)

`lints-0.4.6.jar` does ship `org/eolang/lints/ReserveNames.class`, compiled from the Groovy script and extending `groovy.lang.Script` with references to `org.codehaus.groovy.runtime.*` internals — while the published POM declares no Groovy dependency. Nothing in the jar references that class (it is only reachable by being loaded by name), so it is inert dead weight rather than a broken classpath, and its build-time-only nature is why `lints`' ProGuard config carries `-dontwarn groovy.**` / `-dontwarn org.codehaus.groovy.**`. Worth a small upstream cleanup in `objectionary/lints` (stop packaging the build-time script, e.g. drop `addSources`/`compile` for it and keep only `execute`), but it does not affect this repo and is not the reason the exclusion existed.