### PR TITLE
Add jacoco CI job

### DIFF
--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: jacoco
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+concurrency:
+  group: jacoco-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  jacoco:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: 21
+      - uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            maven-
+      - uses: JesseTG/rm@v1.0.3
+        with:
+          path: ~/.m2/repository/org/eolang
+      - run: mvn clean install -DskipITs -Pjacoco --errors --batch-mode

--- a/.github/workflows/jacoco.yml
+++ b/.github/workflows/jacoco.yml
@@ -4,15 +4,9 @@
 # yamllint disable rule:line-length
 name: jacoco
 'on':
-  push:
-    branches:
-      - master
   pull_request:
     branches:
       - master
-concurrency:
-  group: jacoco-${{ github.ref }}
-  cancel-in-progress: true
 jobs:
   jacoco:
     timeout-minutes: 30
@@ -32,4 +26,4 @@ jobs:
       - uses: JesseTG/rm@v1.0.3
         with:
           path: ~/.m2/repository/org/eolang
-      - run: mvn clean install -DskipITs -Pjacoco --errors --batch-mode
+      - run: mvn clean install -ntp -DskipITs -Pjacoco --errors --batch-mode


### PR DESCRIPTION
The `jacoco` profile is defined in `eo-parser/pom.xml`, `eo-runtime/pom.xml` and `eo-maven-plugin/pom.xml`, but it is not exercised by CI on pull requests — only `codecov.yml` uses it, and that workflow runs on pushes to `master` only. So the coverage thresholds enforced by `jacoco:check` are not validated before merge.

This adds `.github/workflows/jacoco.yml`, a single-job workflow that runs:

```
mvn clean install -ntp -DskipITs -Pjacoco --errors --batch-mode
```

on pull requests against `master`. It follows the shape of the existing `mvn.yml` job: `ubuntu-24.04`, Temurin JDK 21, `~/.m2/repository` cache keyed on `**/pom.xml`, and a removal of `~/.m2/repository/org/eolang` so stale locally-installed artifacts don't leak into the build.

The profile stays disabled by default: none of the three `jacoco` profiles has an `<activation>` block, so they are only ever enabled by an explicit `-Pjacoco`. No POM changes were needed and none were made — the diff is the one new workflow file.

Note that `-DskipITs` also activates the repo's own `skipITs` profile in the root `pom.xml` (it activates on the presence of the `skipITs` property), which sets the `skipITs` property to `true` — that is the intended effect here.