### PR TITLE
fix(#7238): report chained inline-phi suffixes

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -95,9 +95,7 @@ final class LnOnlyPhi implements Line {
             params = LnOnlyPhi.parseParams(
                 body.substring(bracket + 1, close), this.span, bracket + 1
             );
-            suffix = new Suffix(
-                body.substring(close + 1), this.span, this.span.indent() + close + 1
-            );
+            suffix = LnOnlyPhi.suffix(body, close, this.span);
             origin = bracket + 1;
         } else {
             final int shorthand = LnOnlyPhi.shorthandArrow(body);
@@ -164,6 +162,18 @@ final class LnOnlyPhi implements Line {
             idx = Eo.topLevelMinusMinusArrowIndex(body);
         }
         return idx;
+    }
+
+    private static Suffix suffix(final String body, final int close, final Span span) {
+        final String tail = body.substring(close + 1);
+        final int chained = Eo.topLevelGreaterBracketIndex(tail);
+        if (chained >= 0) {
+            throw new ParseError(
+                span.line(), span.indent() + close + 1 + chained,
+                "chained inline-phi suffixes are not allowed"
+            );
+        }
+        return new Suffix(tail, span, span.indent() + close + 1);
     }
 
     private void emitVoids(final Emit emit, final List<String> params, final int origin) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/chained-inline-phi-suffix-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/chained-inline-phi-suffix-is-rejected.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'chained inline-phi suffixes are not allowed')]
+input: |
+  value > [first] > [second] > result


### PR DESCRIPTION
Closes #7238.

`LnOnlyPhi` now detects a second top-level `> [` after the first inline-phi parameter list and reports the canonical R-3.10.7 diagnostic instead of passing the tail to `Suffix` and reporting a missing name.

A parser syntax pack reproduces `value > [first] > [second] > result` and asserts the exact `chained inline-phi suffixes are not allowed` message.

Tests:
- `mvn -pl eo-parser -Dtest=EoSyntaxTest#validatesEoSyntax test -DskipITs`
- `mvn -pl eo-parser test -DskipITs`
- `mvn -pl eo-parser -Pqulice qulice:check -DskipTests`

@yegor256