### PR TITLE
fix(#7237): preserve surplus spaces in text blocks

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Globals.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Globals.java
@@ -255,7 +255,8 @@ final class Globals {
      */
     void appendTextLine(final String raw) {
         final String stripped;
-        if (raw.chars().allMatch(c -> c == ' ')) {
+        if (raw.length() < this.tindent
+            && raw.chars().allMatch(c -> c == ' ')) {
             stripped = "";
         } else if (raw.length() >= this.tindent
             && raw.substring(0, Math.min(this.tindent, raw.length()))

--- a/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
@@ -109,6 +109,18 @@ final class GlobalsTest {
     }
 
     @Test
+    void keepsSurplusSpacesOnIndentedBlankLine() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 2);
+        globals.appendTextLine("    ");
+        MatcherAssert.assertThat(
+            "a blank line must retain spaces beyond the opener's indent",
+            globals.tbody(),
+            Matchers.contains("  ")
+        );
+    }
+
+    @Test
     void closesTextBlockState() {
         final Globals globals = new Globals();
         globals.openTextBlock(3);


### PR DESCRIPTION
Closes #7237.

## What changed

[`Globals.appendTextLine()`](https://github.com/gemshrine/eo/blob/7237-text-block-blank-lines/eo-parser/src/main/java/org/eolang/parser/Globals.java#L256-L268) used to turn every whitespace-only text-block body line into an empty string before considering the opening indent. As a result, a body line with four spaces below a two-space opener lost the two spaces that are part of the text value.

The empty-line shortcut now applies only when the body line is shorter than the opener's indent. Lines at least as wide as that indent use the normal prefix-removal path, so a line with `M` spaces contributes `M - N` spaces after an `N`-space opener. The existing treatment of under-indented blank lines is unchanged.

## Verification

Added [`GlobalsTest.keepsSurplusSpacesOnIndentedBlankLine()`](https://github.com/gemshrine/eo/blob/7237-text-block-blank-lines/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java#L111-L121), which opens a two-space text block, appends a four-space body line, and asserts that the buffered text retains two spaces. The adjacent existing test continues to cover an under-indented blank line.

Ran:

```text
MAVEN_OPTS='-Xmx1024m' mvn -pl eo-parser test -DtrimStackTrace=false
```

Result: the complete `eo-parser` suite passed, including `GlobalsTest` (14 tests).
