### PR TITLE
fix(#7241): reject non-progressing partition counts

### DIFF
--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -1,6 +1,8 @@
 # Calculates the integral from `a` to `b`.
 # Here `func` is the integration function, `a` is the lower limit,
 # `b` is the upper limit, `n` is the number of partitions of the integration interval.
+# `n` must be smaller than 2^53, because the loop advances its counter by one
+# and larger IEEE-754 integers cannot advance by that amount.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -11,9 +13,11 @@
 
 [fun a b n] > integral
   if. > @
-    n.is-finite.and
-      n.is-integer.and
-        n.gt 0
+    and.
+      n.is-finite.and
+        n.is-integer.and
+          n.gt 0
+      n.lt safe
     as-number.
       malloc.of
         8
@@ -37,7 +41,8 @@
               ^.b.minus ^.a
               ^.n
     T
-      "the number of partitions must be a finite positive integer"
+      "the number of partitions must be a finite positive integer smaller than 2^53"
+  9007199254740992 > safe
   times. > [a b] >> subsection
     div.
       b.minus a
@@ -162,6 +167,16 @@
         value.gte 0
         value
         value.neg
+
+  eq. ++> can-recover-from-partitions-at-the-precision-boundary
+    "recovered"
+    recovered
+      integral
+        I
+        0
+        1
+        9007199254740992
+      "recovered"
 
   integral --> stops-on-fractional-partitions
     I

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -94,6 +94,24 @@ final class PhiTest {
     }
 
     @Test
+    void tellsWhyAPrecisionBoundaryPartitionCountIsRefused() {
+        MatcherAssert.assertThat(
+            "integrating at the unit-step precision boundary must fail before the loop starts",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new PhApplication(
+                        Phi.Φ.take("number.integral").copy(),
+                        "n",
+                        new Data.ToPhi(9007199254740992D)
+                    )
+                ).take()
+            ).getMessage(),
+            Matchers.containsString("smaller than 2^53")
+        );
+    }
+
+    @Test
     void getsLocation() {
         MatcherAssert.assertThat(
             "Phi should return correct locator, but it didn't",

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -103,7 +103,7 @@ final class PhiTest {
                     new PhApplication(
                         Phi.Φ.take("number.integral").copy(),
                         "n",
-                        new Data.ToPhi(9007199254740992D)
+                        new Data.ToPhi(9_007_199_254_740_992d)
                     )
                 ).take()
             ).getMessage(),


### PR DESCRIPTION
Closes #7241.

## What changed

[`number.integral`](https://github.com/gemshrine/eo/blob/7241-integral-large-partitions/eo-runtime/src/main/eo/number/integral.eo#L14-L45) advances its integration index with `i.plus 1`. IEEE-754 numbers at `2^53` and above cannot represent that increment, yet the previous validation accepted them as finite positive integers; the `while` loop could therefore never make progress.

The validation now also requires `n` to be below the exact `2^53` boundary (`9007199254740992`). Invalid values use the existing termination path, with an error message that states the bound. The limit is a literal so rejecting it does not itself invoke an expensive numeric calculation.

## Regression coverage

The EO regression in [`integral.eo`](https://github.com/gemshrine/eo/blob/7241-integral-large-partitions/eo-runtime/src/main/eo/number/integral.eo#L171-L179) calls the boundary value through `recovered`, proving that execution terminates instead of entering the loop. [`PhiTest`](https://github.com/gemshrine/eo/blob/7241-integral-large-partitions/eo-runtime/src/test/java/org/eolang/PhiTest.java#L96-L112) independently checks that the public `Phi` surface rejects the same value before the loop begins and retains the reason.

## Verification

`git diff --check` passed. The local EO formatter and transpilation pipeline were run with a one-core affinity and a 768 MiB JVM cap. The normal `eo-runtime` lifecycle is substantially heavier because of global inference; GitHub Actions will run that complete project pipeline.
