### PR TITLE
Lock the xmir.xsd resource in DrProgramTest to stop the concurrent JUnit race

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/DrProgramTest.java
@@ -19,6 +19,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.parallel.ResourceAccessMode;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.xembly.Directives;
 import org.xembly.Xembler;
 
@@ -29,6 +31,7 @@ import org.xembly.Xembler;
 final class DrProgramTest {
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ)
     void buildsProgramElement() throws Exception {
         MatcherAssert.assertThat(
             "XMIR program element is built",
@@ -42,6 +45,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ)
     void setsSchemaLocation() throws Exception {
         MatcherAssert.assertThat(
             "XSD location is set",
@@ -52,6 +56,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ)
     void checksThatSchemaLocationPointToFile() throws Exception {
         MatcherAssert.assertThat(
             "URL of XSD is set to file",
@@ -62,6 +67,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ)
     void checksThatSchemaLocationPointToExistingFile() throws Exception {
         MatcherAssert.assertThat(
             "XSD file exists",
@@ -77,6 +83,7 @@ final class DrProgramTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ)
     void doesNotDuplicateSlashesInSchemaLocation() throws Exception {
         MatcherAssert.assertThat(
             "URL of XSD has no redundant slash after the scheme",
@@ -87,6 +94,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ_WRITE)
     void honorsExplicitXmirXsdProperty() throws Exception {
         final Path file = Files.createTempFile("xmir", ".xsd");
         Files.write(file, "<xsd/>".getBytes(StandardCharsets.UTF_8));
@@ -105,6 +113,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ_WRITE)
     void ignoresMissingXmirXsdProperty() throws Exception {
         final Path missing = Paths.get("does-not-exist-1234567890.xsd").toAbsolutePath();
         System.setProperty("xmir.xsd", missing.toString());
@@ -121,6 +130,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ_WRITE)
     void ignoresEmptyXmirXsdProperty() throws Exception {
         System.setProperty("xmir.xsd", "");
         try {
@@ -136,6 +146,7 @@ final class DrProgramTest {
     }
 
     @Test
+    @ResourceLock(value = "xmir.xsd", mode = ResourceAccessMode.READ)
     void validatesAgainstSchema() {
         Assertions.assertDoesNotThrow(
             new StrictXML(


### PR DESCRIPTION
JUnit 5's concurrent execution is enabled project-wide, so the tests in DrProgramTest that set and clear the JVM-wide xmir.xsd system property can overlap with any other test in the same class that constructs a DrProgram, which reads that property.

Two symptoms of this race showed up independently: honorsExplicitXmirXsdProperty failed because another thread had already reset the property to its default, and validatesAgainstSchema hit a FileNotFoundException because the temp XSD file it depended on was deleted out from under it by a finishing test on another thread.

This adds @ResourceLock(value = "xmir.xsd", ...) to every test in DrProgramTest: READ for tests that only build a DrProgram, READ_WRITE for the three tests that mutate the property. JUnit's scheduler serializes any test holding a write lock against every other test holding a lock on the same resource, so a property mutation can no longer land between another test's read of it.

Closes #7292