### PR TITLE
#7320: accept : as a text block closer for bound argument syntax

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -365,7 +365,7 @@ final class Eo implements Iterable<Directive> {
         return !span.blank()
             && span.indent() == globals.textBlockOpenIndent()
             && body.startsWith("\"\"\"")
-            && " .".indexOf(body.concat(" ").charAt(3)) >= 0;
+            && " .:".indexOf(body.concat(" ").charAt(3)) >= 0;
     }
 
     private static Line classify(final Span span) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-bound-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-bound-argument.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.q.f']/o[@as='x' and @base='Φ.string' and o/o[text()='68-69']]
+input: |
+  [] > main
+    q.f > a
+      """
+      hi
+      """:x


### PR DESCRIPTION
`Eo.closesTextBlock` accepted only a space, a dot, or end of line right after the closing
triple quote, so `"""` followed by `:x` was never recognized as a closer. The block stayed
open and the parser swallowed the rest of the file as text-block body, even though
`LnTextBlock.into` already calls `LnApplication.readOuterBinding` and is ready to bind the
argument once the block actually closes.

Added `:` to the accepted set in `closesTextBlock`, matching what `"hi":x` already does for
an inline string. Added a parser test pack confirming `q.f > a` with a text block bound as
`:x` parses into `o[@as='x' base='Φ.string']` with no errors.

Closes #7320
