### PR TITLE
#7298: map the bottom glyph to T in eo:translate-path

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -22,7 +22,7 @@
   <!-- Translate a dotted path to EO surface form: ρ -> ^, φ -> @. -->
   <xsl:function name="eo:translate-path" as="xs:string">
     <xsl:param name="path" as="xs:string"/>
-    <xsl:sequence select="string-join(for $seg in tokenize($path, '\.') return (if ($seg = $eo:rho) then '^' else if ($seg = $eo:phi) then '@' else $seg), '.')"/>
+    <xsl:sequence select="string-join(for $seg in tokenize($path, '\.') return (if ($seg = $eo:rho) then '^' else if ($seg = $eo:phi) then '@' else if ($seg = $eo:bottom) then 'T' else $seg), '.')"/>
   </xsl:function>
   <!--
   Render a base as an EO head: drop implicit ξ./Φ. roots, render a

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bottom-term-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bottom-term-dispatch.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > app
+    T.plus 5 > a
+
+printed: |
+  [] > app
+    T.plus 5 > a


### PR DESCRIPTION
`eo:translate-path` maps `ρ` to `^` and `φ` to `@` per segment, but had no case for `⊥`.
The bottom-term head arm in the printer only tests `@base=$eo:bottom` for an exact match,
so it catches a bare `T` but misses `T` as the first segment of a dispatch base like
`⊥.plus`. That base falls through to `eo:surface`/`eo:translate-path`, which had no
mapping for the glyph and printed it verbatim, producing output the grammar rejects.

Added the same per-segment mapping for `⊥` -> `T` that already exists for `ρ` and `φ`, so
`T.plus 5 > a` round-trips through print and parse.

Closes #7298
