### PR TITLE
fix(#7281): move formation-body and star-chain decisions off kind() onto value

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -129,7 +129,7 @@ final class LnApplication implements Line {
 
     private static Kind bare(final Value head) {
         final Kind kind;
-        if (head.kind() == Value.Kind.IDENTITY) {
+        if (head.identity()) {
             kind = Kind.IDENTITY_OBJECT;
         } else {
             kind = Kind.HEAD;
@@ -141,48 +141,19 @@ final class LnApplication implements Line {
         final Value head, final List<MethodChain> chain, final List<Value> args,
         final String outer
     ) {
-        if (head.kind() == Value.Kind.GROUP
+        if (head.group()
             && chain.isEmpty() && args.isEmpty() && outer == null) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "redundant parentheses around a top-level expression — drop the outer `(` and `)`"
             );
         }
-        if (!args.isEmpty() && this.opensFormationBody(head)) {
+        if (!args.isEmpty() && head.opensFormationBody()) {
             throw new ParseError(
                 this.span.line(), head.pos(),
                 "horizontal formation not allowed as argument"
             );
         }
-    }
-
-    private boolean opensFormationBody(final Value head) {
-        return head.kind() == Value.Kind.IDENTITY
-            || head.kind() == Value.Kind.GROUP && this.wrapsInlinePhi(head);
-    }
-
-    // @checkstyle NonStaticMethodCheck (2 lines)
-    private boolean wrapsInlinePhi(final Value head) {
-        final String raw = head.raw();
-        final String inner = raw.substring(1, raw.length() - 1);
-        boolean found = false;
-        int depth = 0;
-        int idx = 0;
-        while (idx < inner.length() - 2 && !found) {
-            final char glyph = inner.charAt(idx);
-            if (glyph == '"') {
-                idx = Tokens.closingQuote(inner, idx);
-            } else if (glyph == '(') {
-                depth = depth + 1;
-            } else if (glyph == ')') {
-                depth = depth - 1;
-            } else if (depth == 0 && glyph == '>'
-                && inner.charAt(idx + 1) == ' ' && inner.charAt(idx + 2) == '[') {
-                found = true;
-            }
-            idx = idx + 1;
-        }
-        return found;
     }
 
     private void transition(

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -61,10 +61,10 @@ final class LnCompactTuple implements Line {
         final Tokens tokens = new Tokens(this.span.body(), this.span);
         final Value head = tokens.readValue();
         final List<MethodChain> chain;
-        if (head.kind() == Value.Kind.STAR) {
-            chain = new java.util.ArrayList<>(0);
-        } else {
+        if (head.chainable()) {
             chain = tokens.readChain();
+        } else {
+            chain = new java.util.ArrayList<>(0);
         }
         if (tokens.atEnd() || tokens.current() != ' ') {
             throw new ParseError(

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -195,10 +195,61 @@ final class Value {
         return Value.CHAINABLE.contains(this.kind);
     }
 
-    // @todo #7016:30min Move the remaining kind()/raw()-driven decisions out
-    //  of Emissions, LnMethod, LnPipe, LnCompactTuple, LnApplication and
-    //  LnOnlyPhi onto Value, then drop the @SuppressWarnings("PMD.DataClass")
-    //  above along with the accessors it no longer needs.
+    /**
+     * The {@code I} identity object (§3.16)?
+     * @return True for {@link Kind#IDENTITY}
+     */
+    boolean identity() {
+        return this.kind == Kind.IDENTITY;
+    }
+
+    /**
+     * A paren group — {@code (expr)} (§3.6)?
+     * @return True for {@link Kind#GROUP}
+     */
+    boolean group() {
+        return this.kind == Kind.GROUP;
+    }
+
+    /**
+     * Does this head open a formation body?
+     * @return True for identity, or a group wrapping inline {@code > [...]}
+     */
+    boolean opensFormationBody() {
+        return this.identity()
+            || this.group() && this.wrapsInlinePhi();
+    }
+
+    /**
+     * Does this group's raw text wrap an inline {@code > [...]}?
+     * @return True if found
+     */
+    private boolean wrapsInlinePhi() {
+        final String inner = this.raw.substring(1, this.raw.length() - 1);
+        boolean found = false;
+        int depth = 0;
+        int idx = 0;
+        while (idx < inner.length() - 2 && !found) {
+            final char glyph = inner.charAt(idx);
+            if (glyph == '"') {
+                idx = Tokens.closingQuote(inner, idx);
+            } else if (glyph == '(') {
+                depth = depth + 1;
+            } else if (glyph == ')') {
+                depth = depth - 1;
+            } else if (depth == 0 && glyph == '>'
+                && inner.charAt(idx + 1) == ' ' && inner.charAt(idx + 2) == '[') {
+                found = true;
+            }
+            idx = idx + 1;
+        }
+        return found;
+    }
+
+    // @todo #7281:30min Move the remaining kind()/raw()-driven decisions out
+    //  of Emissions and LnOnlyPhi onto Value, then drop the
+    //  @SuppressWarnings("PMD.DataClass") above along with the accessors it
+    //  no longer needs.
     /**
      * The kinds of value recognised by the parser. Further kinds
      * (HEX, BYTES, paren groups) attach as the corresponding line

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -21,7 +21,6 @@ import java.util.Set;
  *
  * @since 0.1
  */
-@SuppressWarnings("PMD.DataClass")
 final class Value {
 
     /**
@@ -220,10 +219,6 @@ final class Value {
             || this.group() && this.wrapsInlinePhi();
     }
 
-    /**
-     * Does this group's raw text wrap an inline {@code > [...]}?
-     * @return True if found
-     */
     private boolean wrapsInlinePhi() {
         final String inner = this.raw.substring(1, this.raw.length() - 1);
         boolean found = false;
@@ -247,9 +242,8 @@ final class Value {
     }
 
     // @todo #7281:30min Move the remaining kind()/raw()-driven decisions out
-    //  of Emissions and LnOnlyPhi onto Value, then drop the
-    //  @SuppressWarnings("PMD.DataClass") above along with the accessors it
-    //  no longer needs.
+    //  of Emissions and LnOnlyPhi onto Value, then drop the kind()/raw()
+    //  accessors it no longer needs.
     /**
      * The kinds of value recognised by the parser. Further kinds
      * (HEX, BYTES, paren groups) attach as the corresponding line


### PR DESCRIPTION
The puzzle from #7016 asked to move the remaining kind()/raw()-driven decisions out of Emissions, LnMethod, LnPipe, LnCompactTuple, LnApplication and LnOnlyPhi onto Value.

Looking closer, LnMethod's and LnPipe's `kind()` calls turn out to be `Line.Kind`, not `Value.Kind` — unrelated to this puzzle, so they were out of scope from the start.

This PR moves the LnApplication decisions (identity object, paren group, and the "does this head open a formation body" check) onto Value as new query methods: `identity()`, `group()`, `opensFormationBody()`. It also fixes LnCompactTuple's star-vs-chainable check to reuse the existing `chainable()` query instead of comparing `kind()` to `Value.Kind.STAR` directly. No behavior change — these are straight moves of existing logic.

The remaining kind()/raw() usages in Emissions and LnOnlyPhi are a much larger change (Emissions alone dispatches on kind() in over a dozen places across its rendering logic) that would blow past this repo's PR size band, so they're left as a new, narrower puzzle in Value.java: `@todo #7281:30min`.

Closes #7281