### PR TITLE
#7304: key memory blocks by a monotonic counter instead of Phi.hashCode

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof.java
+++ b/eo-runtime/src/main/java/org/eolang/EOmalloc$EOof.java
@@ -28,7 +28,6 @@ public final class EOmalloc$EOof extends PhDefault implements Atom {
     @Override
     public Phi lambda() {
         return Heaps.INSTANCE.malloc(
-            this,
             new Natural(Expect.at(this, "size")).it(),
             identifier -> {
                 final Phi chunk = Phi.Φ.take("chunk").copy();

--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -8,6 +8,7 @@ package org.eolang;
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.IntFunction;
@@ -34,23 +35,28 @@ final class Heaps {
     private final Lock lock;
 
     /**
+     * Next identifier to hand out.
+     */
+    private final AtomicInteger next;
+
+    /**
      * Ctor.
      */
     private Heaps() {
         this.blocks = new ConcurrentHashMap<>(0);
         this.lock = new ReentrantLock();
+        this.next = new AtomicInteger();
     }
 
     /**
      * Allocate a block in memory, let the scope use it, and free it afterwards.
-     * @param phi Object
      * @param size How many bytes
      * @param scope What to do with the identifier of the block
      * @param <T> Type of what the scope returns
      * @return What the scope returns
      */
-    <T> T malloc(final Phi phi, final int size, final IntFunction<T> scope) {
-        final int identifier = this.malloc(phi, size);
+    <T> T malloc(final int size, final IntFunction<T> scope) {
+        final int identifier = this.malloc(size);
         try {
             return scope.apply(identifier);
         } finally {
@@ -211,22 +217,21 @@ final class Heaps {
         }
     }
 
-    private int malloc(final Phi phi, final int size) {
+    private int malloc(final int size) {
         if (size < 0) {
             throw new ExFailure(
                 "Can't allocate block in memory with negative size '%d'",
                 size
             );
         }
-        final int identifier = phi.hashCode();
+        final int identifier = this.next.getAndIncrement();
+        if (identifier < 0) {
+            throw new ExFailure(
+                "Can't allocate a block in memory, ran out of identifiers"
+            );
+        }
         this.lock.lock();
         try {
-            if (this.blocks.containsKey(identifier)) {
-                throw new ExFailure(
-                    "Can't allocate block in memory with identifier '%d' because it's already allocated",
-                    identifier
-                );
-            }
             this.blocks.put(identifier, new byte[size]);
         } finally {
             this.lock.unlock();

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -25,6 +25,13 @@ import java.util.stream.Collectors;
  * <p>The class is thread-safe.</p>
  *
  * @since 0.1
+ * @todo #7304:60min Stop deciding identity from a hash code in
+ *  {@code equals}. The hash of a Phi is its identity hash, which repeats:
+ *  two unrelated objects that collide compare equal today, as the run in
+ *  #7304 shows: 2135 colliding pairs among three million objects, every one
+ *  of them reported equal. Memory blocks no longer depend on it, but this
+ *  method still does. Compare identity directly, and check what breaks in
+ *  the tests that lean on the current behaviour before changing it.
  * @checkstyle DesignForExtensionCheck (500 lines)
  */
 @SuppressWarnings("PMD.GodClass")
@@ -157,19 +164,6 @@ public class PhDefault implements Phi, Cloneable {
         this.lock = new ReentrantLock();
     }
 
-    /**
-     * Compare with another object.
-     *
-     * @param obj The object to compare with
-     * @return TRUE if they are equal
-     * @todo #7304:60min Stop deciding identity from a hash code here. The
-     *  hash of a Phi is its identity hash, which repeats: two unrelated
-     *  objects that collide compare equal today, as the run in #7304 shows
-     *  (2135 colliding pairs among three million objects, every one of them
-     *  reported equal). Memory blocks no longer depend on it, but this
-     *  method still does. Compare identity directly, and check what breaks
-     *  in the tests that lean on the current behaviour before changing it.
-     */
     @Override
     public boolean equals(final Object obj) {
         return obj instanceof Phi && this.hashCode() == obj.hashCode();

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -157,6 +157,19 @@ public class PhDefault implements Phi, Cloneable {
         this.lock = new ReentrantLock();
     }
 
+    /**
+     * Compare with another object.
+     *
+     * @param obj The object to compare with
+     * @return TRUE if they are equal
+     * @todo #7304:60min Stop deciding identity from a hash code here. The
+     *  hash of a Phi is its identity hash, which repeats: two unrelated
+     *  objects that collide compare equal today, as the run in #7304 shows
+     *  (2135 colliding pairs among three million objects, every one of them
+     *  reported equal). Memory blocks no longer depend on it, but this
+     *  method still does. Compare identity directly, and check what breaks
+     *  in the tests that lean on the current behaviour before changing it.
+     */
     @Override
     public boolean equals(final Object obj) {
         return obj instanceof Phi && this.hashCode() == obj.hashCode();

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -12,7 +12,8 @@ package org.eolang;
  * name would be "Object", but it's already occupied by Java. That's why
  * we call it Phi.</p>
  *
- * <p>It is guaranteed that the hash codes of different Phi are different.</p>
+ * <p>The hash code of a Phi is its identity hash, which is not unique:
+ * two different objects can share one (see #7304).</p>
  *
  * @since 0.1
  */

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -5,6 +5,8 @@
 
 package org.eolang;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -27,30 +29,36 @@ final class HeapsTest {
     }
 
     @Test
-    void allocatesDistinctBlocksEvenForColliderProneOwners() {
-        Heaps.INSTANCE.malloc(
-            10,
-            outer -> {
-                Heaps.INSTANCE.malloc(
+    void handsOutDistinctIdentifiersToNestedBlocks() {
+        MatcherAssert.assertThat(
+            "Heaps must give distinct identifiers to two blocks alive at the same time",
+            Heaps.INSTANCE.malloc(
+                10,
+                outer -> Heaps.INSTANCE.malloc(
+                    10,
+                    inner -> new HashSet<>(Arrays.asList(outer, inner)).size()
+                )
+            ),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void keepsNestedBlocksApartOnWrite() {
+        MatcherAssert.assertThat(
+            "A write to the inner block must not corrupt the outer one",
+            Heaps.INSTANCE.malloc(
+                10,
+                outer -> Heaps.INSTANCE.malloc(
                     10,
                     inner -> {
-                        MatcherAssert.assertThat(
-                            "Heaps must hand out distinct identifiers to two concurrently allocated blocks",
-                            inner,
-                            Matchers.not(Matchers.equalTo(outer))
-                        );
                         Heaps.INSTANCE.write(outer, 0, new byte[] {1});
                         Heaps.INSTANCE.write(inner, 0, new byte[] {2});
-                        MatcherAssert.assertThat(
-                            "A write to the inner block must not corrupt the outer block",
-                            Heaps.INSTANCE.read(outer, 0, 1),
-                            Matchers.equalTo(new byte[] {1})
-                        );
-                        return inner;
+                        return Heaps.INSTANCE.read(outer, 0, 1);
                     }
-                );
-                return outer;
-            }
+                )
+            ),
+            Matchers.equalTo(new byte[] {1})
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -5,7 +5,6 @@
 
 package org.eolang;
 
-import java.util.function.Supplier;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -21,36 +20,46 @@ final class HeapsTest {
     void allocatesMemory() {
         Assertions.assertDoesNotThrow(
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 10, idx -> Heaps.INSTANCE.read(idx, 0, 10)
+                10, idx -> Heaps.INSTANCE.read(idx, 0, 10)
             ),
             "Heaps should successfully read from allocated memory, but it didn't"
         );
     }
 
     @Test
-    void failsOnDoubleAllocation() {
-        final Phi phi = new HeapsTest.PhFake();
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.malloc(
-                phi, 10, idx -> Heaps.INSTANCE.malloc(phi, 10, Heaps.INSTANCE::size)
-            ),
-            "Heaps should throw an exception on attempting to allocate already allocated memory, but it didn't"
+    void allocatesDistinctBlocksEvenForColliderProneOwners() {
+        Heaps.INSTANCE.malloc(
+            10,
+            outer -> {
+                Heaps.INSTANCE.malloc(
+                    10,
+                    inner -> {
+                        MatcherAssert.assertThat(
+                            "Heaps must hand out distinct identifiers to two concurrently allocated blocks",
+                            inner,
+                            Matchers.not(Matchers.equalTo(outer))
+                        );
+                        Heaps.INSTANCE.write(outer, 0, new byte[] {1});
+                        Heaps.INSTANCE.write(inner, 0, new byte[] {2});
+                        MatcherAssert.assertThat(
+                            "A write to the inner block must not corrupt the outer block",
+                            Heaps.INSTANCE.read(outer, 0, 1),
+                            Matchers.equalTo(new byte[] {1})
+                        );
+                        return inner;
+                    }
+                );
+                return outer;
+            }
         );
     }
 
     @Test
     void failsCleanlyOnMallocWithNegativeSize() {
-        final Phi phi = new HeapsTest.PhFake();
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.malloc(phi, -1, idx -> idx),
+            () -> Heaps.INSTANCE.malloc(-1, idx -> idx),
             "Heaps must reject a negative malloc size with a clean ExFailure, not a raw JVM exception"
-        );
-        Assertions.assertThrows(
-            ExFailure.class,
-            () -> Heaps.INSTANCE.size(phi.hashCode()),
-            "Heaps must not leave a block allocated after a rejected negative malloc, but it did"
         );
     }
 
@@ -59,7 +68,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should return empty bytes after memory allocation, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5, idx -> Heaps.INSTANCE.read(idx, 0, 5)
+                5, idx -> Heaps.INSTANCE.read(idx, 0, 5)
             ),
             Matchers.equalTo(new byte[] {0, 0, 0, 0, 0})
         );
@@ -71,7 +80,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should successfully read exactly same bytes that were written, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, bytes);
                     return Heaps.INSTANCE.read(idx, 0, bytes.length);
@@ -85,7 +94,7 @@ final class HeapsTest {
     void failsOnWriteToEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.write(new HeapsTest.PhFake().hashCode(), 0, new byte[] {0x01}),
+            () -> Heaps.INSTANCE.write(Integer.MAX_VALUE, 0, new byte[] {0x01}),
             "Heaps should throw an exception on writing to an unallocated block, but it didn't"
         );
     }
@@ -95,7 +104,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 10,
+                10,
                 idx -> {
                     Heaps.INSTANCE.write(idx, Integer.MAX_VALUE, new byte[] {0x01});
                     return idx;
@@ -110,7 +119,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 10,
+                10,
                 idx -> {
                     Heaps.INSTANCE.write(idx, -1, new byte[] {0x01});
                     return idx;
@@ -125,7 +134,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps must leave the block untouched after a rejected negative-offset write, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 3,
+                3,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {7, 8, 9});
                     Assertions.assertThrows(
@@ -144,7 +153,7 @@ final class HeapsTest {
     void failsOnReadFromEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.read(new HeapsTest.PhFake().hashCode(), 0, 1),
+            () -> Heaps.INSTANCE.read(Integer.MAX_VALUE, 0, 1),
             "Heaps should throw an exception on reading from an unallocated block, but it didn't"
         );
     }
@@ -154,7 +163,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 2, idx -> Heaps.INSTANCE.read(idx, 1, 3)
+                2, idx -> Heaps.INSTANCE.read(idx, 1, 3)
             ),
             "Heaps should throw an exception on out-of-bounds read, but it didn't"
         );
@@ -165,7 +174,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 10,
+                10,
                 idx -> Heaps.INSTANCE.read(idx, Integer.MAX_VALUE - 1, Integer.MAX_VALUE - 1)
             ),
             "Heaps must fail on out-of-bounds read when offset + length overflows int"
@@ -175,7 +184,7 @@ final class HeapsTest {
     @Test
     void failsCleanlyOnNegativeReadArguments() {
         Heaps.INSTANCE.malloc(
-            new HeapsTest.PhFake(), 10,
+            10,
             idx -> {
                 Assertions.assertThrows(
                     ExFailure.class,
@@ -196,7 +205,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should successfully read correct slice when reading with offset and length, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
                     return Heaps.INSTANCE.read(idx, 1, 3);
@@ -207,17 +216,23 @@ final class HeapsTest {
     }
 
     @Test
-    void reusesObjectAfterScopeThrows() {
-        final Phi phi = new HeapsTest.PhFake();
+    void freesBlockWhenScopeThrows() {
+        final int[] captured = new int[1];
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.malloc(phi, 10, idx -> Heaps.INSTANCE.read(idx, 0, 20)),
+            () -> Heaps.INSTANCE.malloc(
+                10,
+                idx -> {
+                    captured[0] = idx;
+                    return Heaps.INSTANCE.read(idx, 0, 20);
+                }
+            ),
             "Heaps should propagate the failure raised inside the scope, but it didn't"
         );
-        MatcherAssert.assertThat(
-            "Heaps must free the block when the scope throws, but the same object could not allocate",
-            Heaps.INSTANCE.malloc(phi, 5, Heaps.INSTANCE::size),
-            Matchers.equalTo(5)
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> Heaps.INSTANCE.size(captured[0]),
+            "Heaps must free the block when the scope throws, but it left it allocated"
         );
     }
 
@@ -227,7 +242,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps must leave the allocated block unchanged after rejecting an out-of-bounds write",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), original.length,
+                original.length,
                 idx -> HeapsTest.rejectedWrite(idx, original)
             ),
             Matchers.equalTo(original)
@@ -239,7 +254,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 0,
+                0,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {1});
                     return idx;
@@ -254,7 +269,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should return correct bytes after partial overwrite preserving trailing bytes, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {1, 1, 3, 4, 5});
                     Heaps.INSTANCE.write(idx, 2, new byte[] {2, 2});
@@ -267,7 +282,7 @@ final class HeapsTest {
 
     @Test
     void freesSuccessfully() {
-        final int idx = Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5, ident -> ident);
+        final int idx = Heaps.INSTANCE.malloc(5, ident -> ident);
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.read(idx, 0, 5),
@@ -279,7 +294,7 @@ final class HeapsTest {
     void throwsOnGettingSizeOfEmptyBlock() {
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.size(new HeapsTest.PhFake().hashCode()),
+            () -> Heaps.INSTANCE.size(Integer.MAX_VALUE),
             "Heaps should throw an exception on trying to get size of an empty block, but it didn't"
         );
     }
@@ -288,7 +303,7 @@ final class HeapsTest {
     void returnsValidSize() {
         MatcherAssert.assertThat(
             "Heaps should return valid size of allocated block, but it didn't",
-            Heaps.INSTANCE.malloc(new HeapsTest.PhFake(), 5, Heaps.INSTANCE::size),
+            Heaps.INSTANCE.malloc(5, Heaps.INSTANCE::size),
             Matchers.equalTo(5)
         );
     }
@@ -298,7 +313,7 @@ final class HeapsTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.resize(idx, -1);
                     return idx;
@@ -312,7 +327,7 @@ final class HeapsTest {
     void throwsOnChangeSizeOfEmtpyBlock() {
         Assertions.assertThrows(
             ExFailure.class,
-            () -> Heaps.INSTANCE.resize(new HeapsTest.PhFake().hashCode(), 10),
+            () -> Heaps.INSTANCE.resize(Integer.MAX_VALUE, 10),
             "Heaps should throw an exception on changing size of empty block, but it didn't"
         );
     }
@@ -322,7 +337,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should successfully increase size of allocated block, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
                     Heaps.INSTANCE.resize(idx, 7);
@@ -338,7 +353,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should successfully decrease size of allocated block, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
                     Heaps.INSTANCE.resize(idx, 3);
@@ -354,7 +369,7 @@ final class HeapsTest {
         MatcherAssert.assertThat(
             "Heaps should return valid size after decreasing, but it didn't",
             Heaps.INSTANCE.malloc(
-                new HeapsTest.PhFake(), 5,
+                5,
                 idx -> {
                     Heaps.INSTANCE.write(idx, 0, new byte[] {1, 2, 3, 4, 5});
                     Heaps.INSTANCE.resize(idx, 3);
@@ -386,30 +401,5 @@ final class HeapsTest {
             Matchers.equalTo(original.length)
         );
         return Heaps.INSTANCE.read(identifier, 0, original.length);
-    }
-
-    /**
-     * Fake object, mostly for unit tests.
-     * @since 0.29
-     */
-    private static final class PhFake extends PhDefault {
-
-        /**
-         * Ctor.
-         */
-        PhFake() {
-            this(() -> Phi.Φ);
-        }
-
-        /**
-         * Ctor.
-         * @param sup The function to return the real object
-         * @checkstyle ConstructorsCodeFreeCheck (10 lines)
-         */
-        @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
-        PhFake(final Supplier<Phi> sup) {
-            this.add("args", new AtVoid("args"));
-            this.add("φ", new AtComposite(this, rho -> sup.get()));
-        }
     }
 }


### PR DESCRIPTION
`Heaps.malloc` used the owner object's `hashCode()` as the memory block identifier.
`PhDefault.hashCode()` is `System.identityHashCode(this) + 1`, a 31-bit value that
repeats: 2135 colliding pairs among three million fresh objects. Two live `malloc.of`
blocks with colliding owners abort with "already allocated", and on the read/write side
one chunk can address another one's bytes.

The identifier is now a monotonic counter private to `Heaps`, handed out per allocation
and independent of any property of the owner object. The `phi` parameter is no longer
needed by `malloc` and is gone from its signature and from the one call site in
`EOmalloc$EOof`.

The javadoc on `Phi` claimed "It is guaranteed that the hash codes of different Phi are
different". That was never true, so it now says what actually holds.

`HeapsTest` no longer needs a `PhFake` object. Its double-allocation test is replaced by
one that checks two concurrently allocated blocks get distinct identifiers and do not
corrupt each other, which is the scenario the issue reports.

`PhDefault.equals` still decides identity from the hash code, so two colliding objects
still compare equal. That is the other half of #7257's sibling problem and it is marked
with a `@todo` rather than changed here: memory blocks no longer depend on it, but some
tests may, and untangling that is its own task.
