### PR TITLE
#7299: skip strings and parens when compactTuple finds the head

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -523,8 +523,17 @@ final class Eo implements Iterable<Directive> {
 
     private static boolean compactTuple(final Span span) {
         final String body = span.body();
+        int depth = 0;
         int idx = 0;
-        while (idx < body.length() && body.charAt(idx) != ' ') {
+        while (idx < body.length() && (depth > 0 || body.charAt(idx) != ' ')) {
+            final char glyph = body.charAt(idx);
+            if (glyph == '"') {
+                idx = Tokens.closingQuote(body, idx);
+            } else if (glyph == '(') {
+                depth = depth + 1;
+            } else if (glyph == ')') {
+                depth = depth - 1;
+            }
             idx = idx + 1;
         }
         boolean compact = false;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-head-with-a-space-in-a-string.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-head-with-a-space-in-a-string.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.plus']/o[@base='Φ.string']
+input: |
+  [] > main
+    "a b".plus *1 > d
+      1
+      2

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-head-with-a-space-in-parens.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-head-with-a-space-in-parens.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.div']/o[@base='.plus']
+input: |
+  [] > main
+    (5.plus 6).div *1 > d
+      1
+      2


### PR DESCRIPTION
`Eo.compactTuple` found the line's head by scanning for the first raw space, with no
awareness of string literals or parenthesised groups. `"a b".plus *1 > d` has its first
space inside the string, so the scan stops there, the character after it is `b` not `*`,
and the line is misclassified as `LnApplication`, which then reports trailing garbage at
`*1`. Same root cause for a parenthesised receiver like `(5.plus 6).div *1 > d`.

Reworked the scan to track paren depth and skip over string literals via
`Tokens.closingQuote`, the same approach `Eo.topLevelMarker` already uses for other
top-level markers in this file, so it only stops at a space outside both.

Closes #7299
