### PR TITLE
#7300: keep @local for a handle dispatched on by a sibling reference

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -196,6 +196,21 @@
     <xsl:sequence select="not(eo:abstract($target)) and not(exists($target/@const)) and not($target/@base = '.as-bytes') and exists($target/o) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and o and not(ancestor-or-self::o[. is $target])])"/>
   </xsl:function>
   <!--
+  Whether a reference in the auto-named binding's owner reaches it through a
+  method dispatch "ξ.&lt;name&gt;.&lt;seg&gt;" — its base carries the binding's name
+  followed by a further segment. "inline-cactoos" refuses to inline such a
+  reference (its receiver is not a bare cactus name) and keeps the binding
+  for "merge-monikers" instead (see "eo:dispatched" there, #6015); this sheet
+  must agree, or the binding survives with its readable "@local" handle
+  dropped and "to-eo-tree" prints the bare cactus reference with no
+  declaration to back it (#7300).
+  -->
+  <xsl:function name="eo:dispatched" as="xs:boolean">
+    <xsl:param name="target" as="element()"/>
+    <xsl:param name="name" as="xs:string?"/>
+    <xsl:sequence select="exists($target/../o[contains(@base, concat($name, '.')) and not(. is $target)])"/>
+  </xsl:function>
+  <!--
   Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,
   R-3.10.12) that is referenced more than once. "const-to-dataized" wraps such
   a const in a `.as-bytes` over `Φ.dataized` node carrying the obfuscated
@@ -288,7 +303,7 @@
   handle; drop it on the other non-void formations, whose handle is inlined
   away by "inline-cactoos".
   -->
-  <xsl:template match="o[not(@base=$eo:empty) and not(@pipe) and not(eo:recursive(., @name/string())) and not(eo:applied-receiver(., @name/string())) and not(eo:multi-referenced(., @name/string())) and not(eo:unreferenced(., @name/string())) and not(eo:nested-referenced(., @name/string())) and not(eo:reapplied(., @name/string())) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
+  <xsl:template match="o[not(@base=$eo:empty) and not(@pipe) and not(eo:recursive(., @name/string())) and not(eo:dispatched(., @name/string())) and not(eo:applied-receiver(., @name/string())) and not(eo:multi-referenced(., @name/string())) and not(eo:unreferenced(., @name/string())) and not(eo:nested-referenced(., @name/string())) and not(eo:reapplied(., @name/string())) and not(eo:const-handle(parent::o/parent::o))]/@local"/>
   <!--
   When a recursive "&gt;&gt; name" handle is restored, its cactus name is
   promoted to the visible "@name" and every reference is rewritten from the

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatched-handle-keeps-its-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/dispatched-handle-keeps-its-name.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    eq. > e
+      5 >> b
+      6
+
+printed: |
+  [] > main
+    eq. > e
+      5 >> b
+      6


### PR DESCRIPTION
`inline-cactoos.xsl` refuses to inline a handle that a sibling reference dispatches through
(`eo:dispatched`, #6015) and keeps the binding standing. `restore-local-names.xsl`'s drop
template didn't know about that case, so it dropped `@local` anyway on the assumption the
binding was about to be inlined away. The binding survives with no readable name, and
`to-eo-tree.xsl` falls through to the `starts-with(@name, 'a🌵')` arm, printing a bare `>>`
with nothing after it.

Added the same check to the drop template, scoped to a direct sibling reference (matching
what `vars-float-up` actually produces here: the handle floats up to sit beside its owner,
not nested inside it). A version scoped to any descendant reference also fixed the reported
case but broke `moniker-dispatch.yaml`, an existing test where a same-shaped dispatch
reference sits nested inside a formation and is later folded by `merge-monikers.xsl` into a
reversed-dispatch receiver, correctly losing its name in the process; the sibling-only scope
leaves that path alone.

Closes #7300
