### PR TITLE
#7310: print trailing dash for single-byte data in PhDefault.termBytes

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -480,6 +480,8 @@ public class PhDefault implements Phi, Cloneable {
         final String result;
         if (data.length == 0) {
             result = "--";
+        } else if (data.length == 1) {
+            result = String.format("%02X-", data[0]);
         } else {
             final StringBuilder out = new StringBuilder(data.length * 3);
             for (final byte bte : data) {

--- a/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
@@ -31,7 +31,7 @@ final class AtVoidTest {
         MatcherAssert.assertThat(
             "Set void attribute must render the value φ-term, but it didnt",
             attr.φTerm(),
-            Matchers.equalTo("[D> 01]")
+            Matchers.equalTo("[D> 01-]")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -26,7 +26,7 @@ final class PhApplicationTest {
                 new Bind(0, new PhDefault(new byte[] {(byte) 0x01})),
                 new Bind(1, new PhDefault(new byte[] {(byte) 0x02}))
             ).φTerm(),
-            Matchers.equalTo("[](0->[D> 01],1->[D> 02])")
+            Matchers.equalTo("[](0->[D> 01-],1->[D> 02-])")
         );
     }
 
@@ -167,7 +167,7 @@ final class PhApplicationTest {
         MatcherAssert.assertThat(
             "PhApplication must render positional binding in φ-term, but it didnt",
             new PhApplication(new PhDefault(), 0, new PhDefault(new byte[] {(byte) 0x2A})).φTerm(),
-            Matchers.equalTo("[](0->[D> 2A])")
+            Matchers.equalTo("[](0->[D> 2A-])")
         );
     }
 
@@ -178,7 +178,7 @@ final class PhApplicationTest {
             new PhApplication(
                 new PhDefault(), "x", new PhDefault(new byte[] {(byte) 0x2A})
             ).φTerm(),
-            Matchers.equalTo("[](x->[D> 2A])")
+            Matchers.equalTo("[](x->[D> 2A-])")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -42,9 +42,9 @@ final class PhDefaultTest {
     @Test
     void printsSingleByteDataAsTerm() {
         MatcherAssert.assertThat(
-            "Object with one data byte must render it without trailing dash in φ-term",
+            "Object with one data byte must render it with a trailing dash in φ-term, matching the R-3.13.1 BYTES literal form",
             new PhDefault(new byte[] {(byte) 0x01}).φTerm(),
-            Matchers.equalTo("[D> 01]")
+            Matchers.equalTo("[D> 01-]")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -20,7 +20,7 @@ final class PhLoggedTest {
         MatcherAssert.assertThat(
             "PhLogged must delegate φ-term to its origin, but it didnt",
             new PhLogged(new PhDefault(new byte[] {(byte) 0x01})).φTerm(),
-            Matchers.equalTo("[D> 01]")
+            Matchers.equalTo("[D> 01-]")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
@@ -19,7 +19,7 @@ final class PhOnceTest {
         MatcherAssert.assertThat(
             "PhOnce without explicit term must delegate φ-term to the wrapped object, but it didnt",
             new PhOnce(() -> new PhDefault(new byte[] {(byte) 0x01})).φTerm(),
-            Matchers.equalTo("[D> 01]")
+            Matchers.equalTo("[D> 01-]")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -20,7 +20,7 @@ final class PhSafeTest {
         MatcherAssert.assertThat(
             "PhSafe must delegate φ-term to its origin, but it didnt",
             new PhSafe(new PhDefault(new byte[] {(byte) 0x01})).φTerm(),
-            Matchers.equalTo("[D> 01]")
+            Matchers.equalTo("[D> 01-]")
         );
     }
 


### PR DESCRIPTION
`PhDefault.termBytes` had no single-byte case, so the separator-between-bytes loop never
appends anything for one byte, printing `01` instead of `01-`. `BytesRaw.asString()` already
fixed the same encoder in #5253 with a dedicated one-byte branch; `PhDefault.termBytes` is
another copy of the same encoder that was left behind.

Added the same one-byte branch, matching `BytesRaw.asString()` exactly and R-3.13.1's
canonical `BB-` single-byte form. Updated the existing `printsSingleByteDataAsTerm` test,
which asserted the old, wrong `[D> 01]` output.

Closes #7310
