### PR TITLE
#7311: let a JVM Error pass through PhSafe untouched

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -21,10 +21,13 @@ import java.util.function.Supplier;
  * the failure keeps propagating until it either reaches a recovery or
  * terminates the program.</p>
  *
- * <p>An {@link ExInterrupted} is the one exception to this: it passes
- * through untouched, keeping its own type. It is not an EO-level
- * termination the program may recover from, but a signal that this thread
- * must stop, and wrapping it into an {@link ExFailure} would let the
+ * <p>An {@link ExInterrupted} and a JVM {@link Error} are the exceptions to
+ * this: they pass through untouched, keeping their own type. Neither is an
+ * EO-level termination the program may recover from — an
+ * {@link ExInterrupted} is a signal that this thread must stop, and an
+ * {@link Error} such as {@link StackOverflowError} or
+ * {@link OutOfMemoryError} means the JVM itself can no longer be trusted to
+ * carry on — and wrapping either into an {@link ExFailure} would let the
  * nearest {@link EOrecovered} intercept it.</p>
  *
  * <p>Elsewhere we let Cactoos catch for us, with {@code ScalarWithFallback}.
@@ -193,6 +196,8 @@ public final class PhSafe implements Phi, Atom {
         try {
             return action.get();
         } catch (final ExInterrupted ex) {
+            throw ex;
+        } catch (final Error ex) {
             throw ex;
         } catch (final Throwable ex) {
             throw new ExFailure(

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -191,7 +191,7 @@ public final class PhSafe implements Phi, Atom {
     }
 
     // @checkstyle IllegalCatchCheck (20 lines)
-    @SuppressWarnings("PMD.AvoidCatchingGenericException")
+    @SuppressWarnings({"PMD.AvoidCatchingGenericException", "java:S1181"})
     private <T> T through(final Supplier<T> action, final String suffix) {
         try {
             return action.get();

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -195,9 +195,7 @@ public final class PhSafe implements Phi, Atom {
     private <T> T through(final Supplier<T> action, final String suffix) {
         try {
             return action.get();
-        } catch (final ExInterrupted ex) {
-            throw ex;
-        } catch (final Error ex) {
+        } catch (final ExInterrupted | Error ex) {
             throw ex;
         } catch (final Throwable ex) {
             throw new ExFailure(

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -144,6 +144,50 @@ final class PhSafeTest {
     }
 
     @Test
+    void letsErrorThrough() {
+        MatcherAssert.assertThat(
+            "a JVM Error must keep its own type, but it was wrapped",
+            Assertions.assertThrows(
+                StackOverflowError.class,
+                () -> new PhSafe(
+                    new PhDefault() {
+                        @Override
+                        public byte[] delta() {
+                            throw new StackOverflowError("the stack is exhausted");
+                        }
+                    },
+                    "file.eo", 42, 7
+                ).delta(),
+                "was expected to fail with StackOverflowError"
+            ).getMessage(),
+            Matchers.equalTo("the stack is exhausted")
+        );
+    }
+
+    @Test
+    void doesNotLetRecoveredInterceptError() {
+        final EOrecovered recovered = new EOrecovered();
+        recovered.put(
+            "value",
+            new PhSafe(
+                new PhDefault() {
+                    @Override
+                    public Phi normalized() {
+                        throw new OutOfMemoryError("the heap is exhausted");
+                    }
+                },
+                "file.eo", 42, 7
+            )
+        );
+        recovered.put("alternative", new Data.ToPhi(42L));
+        Assertions.assertThrows(
+            OutOfMemoryError.class,
+            recovered::lambda,
+            "recovered must not intercept a JVM Error, but it did"
+        );
+    }
+
+    @Test
     void doesNotLetRecoveredInterceptInterrupted() {
         final EOrecovered recovered = new EOrecovered();
         recovered.put(


### PR DESCRIPTION
`PhSafe.through` wrapped every `Throwable` into an `ExFailure` except `ExInterrupted`
(#7267). A JVM `Error` had no such arm, so a `StackOverflowError` or `OutOfMemoryError`
came out as an ordinary `ExFailure`, which `EOrecovered.lambda` reads as a bottom and
recovers from via its `alternative` branch. A program that has exhausted its stack or heap
then keeps running instead of stopping.

Added an `Error` arm above the generic `Throwable` catch, mirroring the existing
`ExInterrupted` one, so an `Error` passes through `PhSafe` untouched and out of
`EOrecovered`'s reach, same as an interrupt.

Closes #7311
