### PR TITLE
#7314: map ^ to ρ for a parenthesised inline-phi receiver parameter

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -579,6 +579,8 @@ final class Emissions {
             final String mapped;
             if ("@".equals(param)) {
                 mapped = "φ";
+            } else if ("^".equals(param)) {
+                mapped = "ρ";
             } else {
                 mapped = param;
             }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rho-param-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rho-param-inside-paren-group.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='ρ' and @base='∅']
+input: |
+  [] > foo
+    q.f (a > [^ x] > y) > z


### PR DESCRIPTION
`Emissions.inlinePhi`'s parameter loop only mapped `@` to `φ`, leaving `^` as a literal
attribute name. `LnFormation.mapParam` and `LnOnlyPhi.emitVoids`, the other two producers
of void parameters, both map `^` to `ρ`, so a receiver parameter meant something different
depending on whether the inline-phi sat on a line or inside parentheses.

Added the same `^` -> `ρ` mapping to `inlinePhi`, matching the other two producers.

Closes #7314
