### PR TITLE
#7312: parse the name suffix after ] in a parenthesised inline-phi

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -573,9 +573,10 @@ final class Emissions {
         }
         final String lhs = inner.substring(0, phi).stripTrailing();
         final String params = inner.substring(bracket + 1, close);
-        final Span span = new Span(" ".repeat(column).concat(inner), line);
         final Suffix suffix = new Suffix(
-            inner.substring(close + 1), span, column + close + 1
+            inner.substring(close + 1),
+            new Span(" ".repeat(column).concat(inner), line),
+            column + close + 1
         );
         final String label;
         if (suffix.present()) {

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -573,7 +573,23 @@ final class Emissions {
         }
         final String lhs = inner.substring(0, phi).stripTrailing();
         final String params = inner.substring(bracket + 1, close);
-        emit.object(name, null, line, column);
+        final Span span = new Span(" ".repeat(column).concat(inner), line);
+        final Suffix suffix = new Suffix(
+            inner.substring(close + 1), span, column + close + 1
+        );
+        final String label;
+        if (suffix.present()) {
+            label = suffix.attribute(line, column);
+        } else {
+            label = name;
+        }
+        emit.object(label, null, line, column);
+        if (!suffix.handle().isEmpty()) {
+            emit.local(suffix.handle());
+        }
+        if (suffix.constant()) {
+            emit.constant();
+        }
         int pcol = column + bracket + 1;
         for (final String param : Emissions.splitParams(params)) {
             final String mapped;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-keeps-its-own-name-suffix.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-keeps-its-own-name-suffix.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.q.f']/o[@base='ξ.y']
+  - //o[@name='y' and o[@name='x']]
+input: |
+  [] > main
+    q.f (a > [x] > y) > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-trailing-garbage-after-bracket.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-trailing-garbage-after-bracket.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'trailing garbage')]
+input: |
+  [] > main
+    q.f (a > [x] this is garbage) > z


### PR DESCRIPTION
`Emissions.inlinePhi` computed `close`, the index of the closing `]`, and never looked at
`inner.substring(close + 1)`. Anything after `]` inside the parentheses — a name suffix, or
outright garbage — was silently thrown away, so `q.f (a > [x] > y) > z` dropped the `> y`
with no error, and nothing in the file could refer to `y`.

`LnOnlyPhi.into`, the line-level twin of this same shape, already parses that tail through
`Suffix`. Did the same here: build a `Suffix` from the text after `]` and use its
`attribute`/`handle`/`constant` the way `LnOnlyPhi` does, falling back to the caller-supplied
name only when no suffix is present. `Suffix`'s own parser already rejects genuine garbage
with "trailing garbage after name suffix", so that error now surfaces here too instead of
being swallowed.

Closes #7312
