### PR TITLE
#7315: validate void parameter names the same way on every line shape

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -9,6 +9,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.regex.Pattern;
 
 /**
  * Shared {@link Value}-to-XMIR rendering helpers.
@@ -39,6 +40,17 @@ final class Emissions {
      * The void the identity object {@code I} binds and decorates.
      */
     private static final String IDENTITY = "x";
+
+    /**
+     * A valid void parameter name, other than the {@code @} and {@code ^}
+     * special forms — §4.5. Shared by every producer of a void parameter
+     * list ({@link LnFormation}, {@link LnOnlyPhi}, this class's own
+     * {@link #inlinePhi}), so a bracket list is validated the same way
+     * regardless of which line shape it appears on.
+     */
+    private static final Pattern PARAM_NAME = Pattern.compile(
+        "[a-z][^ \\t,.|':;!?\\[\\]{}()]*(?:\\.\\.\\.)?"
+    );
 
     /**
      * No instances.
@@ -576,6 +588,7 @@ final class Emissions {
         emit.object(name, null, line, column);
         int pcol = column + bracket + 1;
         for (final String param : Emissions.splitParams(params)) {
+            Emissions.validParam(param, line, pcol);
             final String mapped;
             if ("@".equals(param)) {
                 mapped = "φ";
@@ -588,6 +601,21 @@ final class Emissions {
         final Span sub = new Span(" ".repeat(column).concat(lhs), line);
         Emissions.expression(emit, "φ", new Tokens(sub.body(), sub), line);
         emit.close();
+    }
+
+    /**
+     * Reject a void parameter name the grammar does not accept — §4.5.
+     * @param raw The parameter text, as written
+     * @param line Source line (for error reporting)
+     * @param pos Source column of the parameter's first character
+     */
+    static void validParam(final String raw, final int line, final int pos) {
+        if (!"@".equals(raw) && !"^".equals(raw) && !Emissions.PARAM_NAME.matcher(raw).matches()) {
+            throw new ParseError(
+                line, pos,
+                "parameter names in voids must be NAME or @"
+            );
+        }
     }
 
     private static List<String> splitParams(final String text) {

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -220,6 +220,21 @@ final class Emissions {
         return Emissions.unescapeRawBytes(inner);
     }
 
+    /**
+     * Reject a void parameter name the grammar does not accept — §4.5.
+     * @param raw The parameter text, as written
+     * @param line Source line (for error reporting)
+     * @param pos Source column of the parameter's first character
+     */
+    static void validParam(final String raw, final int line, final int pos) {
+        if (!"@".equals(raw) && !"^".equals(raw) && !Emissions.PARAM_NAME.matcher(raw).matches()) {
+            throw new ParseError(
+                line, pos,
+                "parameter names in voids must be NAME or @"
+            );
+        }
+    }
+
     private static void openBase(
         final Emit emit, final String name, final Value value, final int line
     ) {
@@ -601,21 +616,6 @@ final class Emissions {
         final Span sub = new Span(" ".repeat(column).concat(lhs), line);
         Emissions.expression(emit, "φ", new Tokens(sub.body(), sub), line);
         emit.close();
-    }
-
-    /**
-     * Reject a void parameter name the grammar does not accept — §4.5.
-     * @param raw The parameter text, as written
-     * @param line Source line (for error reporting)
-     * @param pos Source column of the parameter's first character
-     */
-    static void validParam(final String raw, final int line, final int pos) {
-        if (!"@".equals(raw) && !"^".equals(raw) && !Emissions.PARAM_NAME.matcher(raw).matches()) {
-            throw new ParseError(
-                line, pos,
-                "parameter names in voids must be NAME or @"
-            );
-        }
     }
 
     private static List<String> splitParams(final String text) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -209,18 +209,14 @@ final class LnFormation implements Line {
     }
 
     private static String mapParam(final String raw, final Span span, final int pos) {
+        Emissions.validParam(raw, span.line(), pos);
         final String mapped;
         if ("@".equals(raw)) {
             mapped = "φ";
         } else if ("^".equals(raw)) {
             mapped = "ρ";
-        } else if (raw.matches("[a-z][^ \\t,.|':;!?\\[\\]{}()]*(?:\\.\\.\\.)?")) {
-            mapped = raw;
         } else {
-            throw new ParseError(
-                span.line(), pos,
-                "parameter names in voids must be NAME or @"
-            );
+            mapped = raw;
         }
         return mapped;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -292,7 +292,9 @@ final class LnOnlyPhi implements Line {
             while (end < text.length() && text.charAt(end) != ' ') {
                 end = end + 1;
             }
-            out.add(text.substring(idx, end));
+            final String raw = text.substring(idx, end);
+            Emissions.validParam(raw, span.line(), span.indent() + origin + idx);
+            out.add(raw);
             if (end < text.length()) {
                 if (end + 1 < text.length() && text.charAt(end + 1) == ' ') {
                     throw new ParseError(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-invalid-void-param-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-invalid-void-param-name.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'parameter names in voids must be NAME or @')]
+input: |
+  [] > main
+    q.f (a > [X.Y 9z]) > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-rejects-invalid-void-param-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-rejects-invalid-void-param-name.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'parameter names in voids must be NAME or @')]
+input: |
+  [] > main
+    a > [X.Y 9z] > z


### PR DESCRIPTION
`LnFormation.mapParam` enforced the `[a-z][^ \t,.|':;!?\[\]{}()]*(?:\.\.\.)?` name pattern
for a void parameter, but `LnOnlyPhi.parseParams` and `Emissions.splitParams` (the
only-phi-on-a-line and parenthesised-inline-phi producers of the same bracket list) did no
such check, so `a > [X.Y 9z] > z` and `q.f (a > [X.Y 9z]) > z` parsed clean while
`[X.Y 9z] > z` on its own correctly rejected the identical names. Beside accepting a name
the grammar forbids, the dot inside `X.Y` corrupts the locator.

Extracted the validation into one shared `Emissions.validParam`, used by all three
producers, so a bracket list is validated the same way regardless of which line shape it
appears on. `LnFormation.mapParam` now calls it instead of carrying its own copy of the
regex.

Closes #7315
