### PR TITLE
#7316: recognise fragile and root-headed reversed dispatch in parens and only-phi LHS

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -70,12 +70,15 @@ final class Emissions {
     ) {
         final Value head = tokens.readValue();
         if (Emissions.reversedDispatch(tokens, head)) {
-            tokens.seek(tokens.cursor() + 1);
+            final boolean fragile = tokens.consumeDispatch();
             final List<Value> rargs = tokens.readArgs();
             if (!rargs.isEmpty()) {
                 Bindings.checkReceiver(rargs.get(0), new Span(tokens.body(), line));
             }
-            emit.object(name, ".".concat(head.raw()), line, head.pos());
+            emit.object(name, ".".concat(Emissions.reversedHead(head)), line, head.pos());
+            if (fragile) {
+                emit.fragile();
+            }
             for (final Value arg : rargs) {
                 Emissions.emitArg(emit, arg, line);
             }
@@ -413,15 +416,33 @@ final class Emissions {
 
     private static boolean reversedDispatch(final Tokens tokens, final Value head) {
         final boolean reversed;
-        if (head.kind() == Value.Kind.IDENTIFIER
-            && !tokens.atEnd() && tokens.current() == '.') {
-            final int probe = tokens.cursor() + 1;
+        if ((head.kind() == Value.Kind.IDENTIFIER || head.kind() == Value.Kind.ROOT)
+            && !tokens.atEnd() && tokens.dispatchAhead()) {
+            final int probe = tokens.cursor() + (tokens.current() == '?' ? 2 : 1);
             reversed = probe >= tokens.body().length()
                 || tokens.body().charAt(probe) == ' ';
         } else {
             reversed = false;
         }
         return reversed;
+    }
+
+    /**
+     * The reversed-dispatch head text to emit as the {@code .}-prefixed
+     * base — a root glyph ({@code ^}, {@code @}, {@code $}) maps to
+     * {@code ρ}/{@code φ}/{@code ξ} the way {@link LnReversed#readHead}
+     * does; any other head keeps its own text.
+     * @param head The parsed head value
+     * @return The text to append after the leading dot
+     */
+    private static String reversedHead(final Value head) {
+        final String mapped;
+        if (head.kind() == Value.Kind.ROOT) {
+            mapped = LnReversed.rootSymbol(head.raw().charAt(0));
+        } else {
+            mapped = head.raw();
+        }
+        return mapped;
     }
 
     private static int topLevelInlinePhi(final String body) {

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -19,6 +19,11 @@ import java.util.regex.Pattern;
  * literals and chains in exactly the same way (§9.0.3 / §9.4 /
  * §9.4.2).</p>
  *
+ * <p>A reversed dispatch emitted here keeps the head text as the
+ * {@code .}-prefixed base, except a root glyph ({@code ^}, {@code @},
+ * {@code $}), which maps to {@code ρ}/{@code φ}/{@code ξ} the way
+ * {@link LnReversed#readHead} does.</p>
+ *
  * @since 0.1
  */
 final class Emissions {
@@ -418,7 +423,13 @@ final class Emissions {
         final boolean reversed;
         if ((head.kind() == Value.Kind.IDENTIFIER || head.kind() == Value.Kind.ROOT)
             && !tokens.atEnd() && tokens.dispatchAhead()) {
-            final int probe = tokens.cursor() + (tokens.current() == '?' ? 2 : 1);
+            final int skip;
+            if (tokens.current() == '?') {
+                skip = 2;
+            } else {
+                skip = 1;
+            }
+            final int probe = tokens.cursor() + skip;
             reversed = probe >= tokens.body().length()
                 || tokens.body().charAt(probe) == ' ';
         } else {
@@ -427,14 +438,6 @@ final class Emissions {
         return reversed;
     }
 
-    /**
-     * The reversed-dispatch head text to emit as the {@code .}-prefixed
-     * base — a root glyph ({@code ^}, {@code @}, {@code $}) maps to
-     * {@code ρ}/{@code φ}/{@code ξ} the way {@link LnReversed#readHead}
-     * does; any other head keeps its own text.
-     * @param head The parsed head value
-     * @return The text to append after the leading dot
-     */
     private static String reversedHead(final Value head) {
         final String mapped;
         if (head.kind() == Value.Kind.ROOT) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -206,7 +206,13 @@ final class LnOnlyPhi implements Line {
         final boolean result;
         if ((head.kind() == Value.Kind.IDENTIFIER || head.kind() == Value.Kind.ROOT)
             && !tokens.atEnd() && tokens.dispatchAhead()) {
-            final int probe = tokens.cursor() + (tokens.current() == '?' ? 2 : 1);
+            final int skip;
+            if (tokens.current() == '?') {
+                skip = 2;
+            } else {
+                skip = 1;
+            }
+            final int probe = tokens.cursor() + skip;
             result = probe >= tokens.body().length()
                 || tokens.body().charAt(probe) == ' ';
         } else {

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -195,7 +195,7 @@ final class LnOnlyPhi implements Line {
 
     private static boolean bare(final Tokens tokens) {
         if (LnOnlyPhi.reversedAhead(tokens, tokens.readValue())) {
-            tokens.seek(tokens.cursor() + 1);
+            tokens.consumeDispatch();
         } else {
             tokens.readChain();
         }
@@ -204,9 +204,9 @@ final class LnOnlyPhi implements Line {
 
     private static boolean reversedAhead(final Tokens tokens, final Value head) {
         final boolean result;
-        if (head.kind() == Value.Kind.IDENTIFIER
-            && !tokens.atEnd() && tokens.current() == '.') {
-            final int probe = tokens.cursor() + 1;
+        if ((head.kind() == Value.Kind.IDENTIFIER || head.kind() == Value.Kind.ROOT)
+            && !tokens.atEnd() && tokens.dispatchAhead()) {
+            final int probe = tokens.cursor() + (tokens.current() == '?' ? 2 : 1);
             result = probe >= tokens.body().length()
                 || tokens.body().charAt(probe) == ' ';
         } else {

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -151,7 +151,7 @@ final class LnReversed implements Line {
         return glyph == '@' || glyph == '^' || glyph == '$';
     }
 
-    private static String rootSymbol(final char glyph) {
+    static String rootSymbol(final char glyph) {
         final String mapped;
         if (glyph == '@') {
             mapped = "φ";

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -114,6 +114,18 @@ final class LnReversed implements Line {
         return value;
     }
 
+    static String rootSymbol(final char glyph) {
+        final String mapped;
+        if (glyph == '@') {
+            mapped = "φ";
+        } else if (glyph == '^') {
+            mapped = "ρ";
+        } else {
+            mapped = "ξ";
+        }
+        return mapped;
+    }
+
     private void emit(
         final Emit emit, final Suffix suffix, final String base,
         final boolean fragile, final List<Value> args, final String outer
@@ -149,17 +161,5 @@ final class LnReversed implements Line {
 
     private static boolean rootHead(final char glyph) {
         return glyph == '@' || glyph == '^' || glyph == '$';
-    }
-
-    static String rootSymbol(final char glyph) {
-        final String mapped;
-        if (glyph == '@') {
-            mapped = "φ";
-        } else if (glyph == '^') {
-            mapped = "ρ";
-        } else {
-            mapped = "ξ";
-        }
-        return mapped;
     }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-reversed-dispatch-as-only-phi-lhs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-reversed-dispatch-as-only-phi-lhs.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.if' and @fragile]
+input: |
+  [] > main
+    if?. 1 2 > [x] > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-reversed-dispatch-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-reversed-dispatch-inside-paren-group.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.q.f']/o[@base='.if' and @fragile]
+input: |
+  [] > main
+    q.f (if?. 1 2) > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/root-reversed-dispatch-as-only-phi-lhs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/root-reversed-dispatch-as-only-phi-lhs.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.ρ']
+input: |
+  [] > main
+    ^. 1 2 > [x] > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/root-reversed-dispatch-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/root-reversed-dispatch-inside-paren-group.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.q.f']/o[@base='.ρ']
+input: |
+  [] > main
+    q.f (^. 1 2) > y


### PR DESCRIPTION
`Emissions.reversedDispatch` and `LnOnlyPhi.reversedAhead` only recognised a plain-identifier
head followed by a bare `.`, unlike the line-level classifier: `Eo.reversedDispatch` also
accepts the fragile `?.` through `Eo.qdot`, and `Eo.rootReversedDispatch` accepts the `^`,
`@`, `$` root heads. Inside parentheses or as an only-phi left-hand side, the predicate
returned false for those shapes, control fell through to `tokens.readChain()`, and
`readMethodName` hit the space after the dot and threw "expected identifier".

Widened both predicates to accept a `Value.Kind.ROOT` head in addition to `IDENTIFIER`, and
to use `tokens.dispatchAhead()` (already fragile-aware) instead of a bare `.` check, probing
one or two characters ahead depending on which. `Emissions.expression`'s emission side now
consumes the dispatch with `tokens.consumeDispatch()`, emits `@fragile` when it was `?.`, and
maps a root head to `ρ`/`φ`/`ξ` via `LnReversed.rootSymbol` (widened to package-visible) the
way `LnReversed.readHead` already does for the line-level shape.

Closes #7316
