### PR TITLE
#7317: skip parens and strings when compactStar finds the head

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -224,7 +224,7 @@ final class LnOnlyPhi implements Line {
     }
 
     private static int compactStar(final String lhs, final Span span) {
-        final int space = lhs.indexOf(' ');
+        final int space = LnOnlyPhi.topLevelSpace(lhs);
         final int result;
         if (space > 0 && lhs.charAt(space - 1) != '.'
             && space + 1 < lhs.length() && lhs.charAt(space + 1) == '*') {
@@ -241,12 +241,40 @@ final class LnOnlyPhi implements Line {
         if (stars < 0) {
             head = lhs;
         } else {
-            head = lhs.substring(0, lhs.indexOf(' '));
+            head = lhs.substring(0, LnOnlyPhi.topLevelSpace(lhs));
         }
         final Span span = new Span(
             " ".repeat(inner.indent()).concat(head), inner.line()
         );
         return new Tokens(span.body(), span);
+    }
+
+    /**
+     * The index of the first space at paren depth 0 and outside any
+     * string literal, or -1 if none exists. {@link #compactStar} and
+     * {@link #reader} both need the same head boundary, the way
+     * {@code Eo.topLevelMarker} finds other top-level markers.
+     * @param body Line body to scan
+     * @return Index of the top-level space, or -1
+     */
+    private static int topLevelSpace(final String body) {
+        int depth = 0;
+        int found = -1;
+        int idx = 0;
+        while (idx < body.length() && found < 0) {
+            final char glyph = body.charAt(idx);
+            if (glyph == '"') {
+                idx = Tokens.closingQuote(body, idx);
+            } else if (glyph == '(') {
+                depth = depth + 1;
+            } else if (glyph == ')') {
+                depth = depth - 1;
+            } else if (depth == 0 && glyph == ' ') {
+                found = idx;
+            }
+            idx = idx + 1;
+        }
+        return found;
     }
 
     private static int starCount(final String lhs, final int from, final Span span) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -56,6 +56,10 @@ import java.util.List;
  * scanner exclusion (formations and reversed-with-hargs LHS are not
  * accepted as inputs because their classifiers fire first). *
  *
+ * <p>The head of a line ends at the first space that sits at paren depth 0
+ * and outside any string literal, which is what {@code topLevelSpace} finds,
+ * the way {@code Eo.topLevelMarker} finds other top-level markers.</p>
+ *
  * @since 0.1
  */
 final class LnOnlyPhi implements Line {
@@ -249,14 +253,6 @@ final class LnOnlyPhi implements Line {
         return new Tokens(span.body(), span);
     }
 
-    /**
-     * The index of the first space at paren depth 0 and outside any
-     * string literal, or -1 if none exists. {@link #compactStar} and
-     * {@link #reader} both need the same head boundary, the way
-     * {@code Eo.topLevelMarker} finds other top-level markers.
-     * @param body Line body to scan
-     * @return Index of the top-level space, or -1
-     */
     private static int topLevelSpace(final String body) {
         int depth = 0;
         int found = -1;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-compact-star-with-parenthesized-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-compact-star-with-parenthesized-head.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.q.a']
+  - //o[@base='Φ.tuple' and count(o) > 1]
+input: |
+  [] > main
+    (q.a 1) *1 > [m] > y
+      2
+      3


### PR DESCRIPTION
`LnOnlyPhi.compactStar` and `reader` found the head boundary with the raw first space
(`lhs.indexOf(' ')`), the same bug shape as `Eo.compactTuple`. With a parenthesised head
like `(q.a 1) *1 > [m] > y`, the first space sits inside the parentheses, so the `*1` marker
is never seen: `readArgs` reads the `*` as an ordinary argument, the tuple ends up empty,
and the level is pushed as `HCOMPLETED`, refusing every following indented line.

Added `LnOnlyPhi.topLevelSpace`, tracking paren depth and skipping string literals via
`Tokens.closingQuote` the same way `Eo.topLevelMarker` finds other top-level markers in the
parser, and used it in both `compactStar` and `reader` instead of the raw `indexOf`.

Closes #7317
