### PR TITLE
#7318: enforce the all-or-nothing binding rule in Emissions.expression

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -68,12 +68,14 @@ final class Emissions {
     static void expression(
         final Emit emit, final String name, final Tokens tokens, final int line
     ) {
+        final Span span = new Span(tokens.body(), line);
         final Value head = tokens.readValue();
         if (Emissions.reversedDispatch(tokens, head)) {
             tokens.seek(tokens.cursor() + 1);
             final List<Value> rargs = tokens.readArgs();
+            Bindings.checkAllOrNothing(rargs, span);
             if (!rargs.isEmpty()) {
-                Bindings.checkReceiver(rargs.get(0), new Span(tokens.body(), line));
+                Bindings.checkReceiver(rargs.get(0), span);
             }
             emit.object(name, ".".concat(head.raw()), line, head.pos());
             for (final Value arg : rargs) {
@@ -83,6 +85,7 @@ final class Emissions {
         }
         final List<MethodChain> chain = tokens.readChain();
         final List<Value> args = tokens.readArgs();
+        Bindings.checkAllOrNothing(args, span);
         ChainEmission.link(emit, line, head, chain, name);
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, line);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-rejected-as-only-phi-lhs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-rejected-as-only-phi-lhs.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'argument bindings must be all-or-nothing')]
+input: |
+  [] > main
+    q.a 1:x 2 > [m] > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-rejected-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-rejected-inside-paren-group.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'argument bindings must be all-or-nothing')]
+input: |
+  [] > main
+    q.f (q.a 1:x 2) > y


### PR DESCRIPTION
`LnApplication.into`, `LnPipe.into` and `LnMethod.into` all call
`Bindings.checkAllOrNothing(args, span)` right after `readArgs`. `Emissions.expression`, the
shared reader for paren-group contents and for the only-phi left-hand side, calls `readArgs`
on both of its branches and never checks. The unbound argument still gets numbered from
zero, so `q.f (q.a 1:x 2) > y` silently produces the wrong tree, with `2` landing in `α0`
instead of being rejected.

Added the same `Bindings.checkAllOrNothing` call to both branches of `Emissions.expression`.

Closes #7318
