### PR TITLE
#7319: check the reversed-dispatch receiver for a binding in Emissions.expression

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -65,6 +65,9 @@ final class Emissions {
         if (Emissions.reversedDispatch(tokens, head)) {
             tokens.seek(tokens.cursor() + 1);
             final List<Value> rargs = tokens.readArgs();
+            if (!rargs.isEmpty()) {
+                Bindings.checkReceiver(rargs.get(0), new Span(tokens.body(), line));
+            }
             emit.object(name, ".".concat(head.raw()), line, head.pos());
             for (final Value arg : rargs) {
                 Emissions.emitArg(emit, arg, line);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-receiver-binding-rejected-as-only-phi-lhs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-receiver-binding-rejected-as-only-phi-lhs.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]
+input: |
+  [] > main
+    if. 1:x 2:y > [m] > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-receiver-binding-rejected-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-receiver-binding-rejected-inside-paren-group.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]
+input: |
+  [] > main
+    q.f (if. 1:x 2:y) > z


### PR DESCRIPTION
`LnReversed.into` guards its horizontal form with `Bindings.checkReceiver(args.get(0), span)`,
since a reversed-dispatch receiver fills the `ρ` slot and cannot carry an inline binding. The
reversed branch of `Emissions.expression` — the shared reader for paren-group contents and
the only-phi left-hand side — reads its arguments and emits them straight through with no
such guard, so `q.f (if. 1:x 2:y) > y` silently produced XMIR with no receiver at all instead
of being rejected.

Added the same `Bindings.checkReceiver` call on the first reversed argument.

Closes #7319
