### PR TITLE
#7261: restrict the unc concept to path.win32

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -187,9 +187,11 @@
     string > [] > trimmed
       ^.stripped ^.uri
     and. > unc
-      driveless.size.gt 1
-      driveless.starts-with
-        separator.concat separator
+      separator.eq "\\"
+      and.
+        driveless.size.gt 1
+        driveless.starts-with
+          separator.concat separator
   [paths] > joined
     normalized. > @
       os.is-windows.if
@@ -265,6 +267,11 @@
       path.win32.separator
       path.posix.separator
 
+  eq. ++> can-normalize-a-double-separator-posix-path-to-the-root
+    normalized.
+      path.posix "//"
+    "/"
+
   eq. ++> can-normalize-a-drive-only-win32-path
     normalized.
       path.win32 "C:"
@@ -314,6 +321,11 @@
     normalized.
       path.win32 "\\server\\share"
     "\\server\\share"
+
+  eq. ++> can-normalize-a-triple-separator-posix-path-to-the-root
+    normalized.
+      path.posix "///"
+    "/"
 
   eq. ++> can-normalize-a-unc-win32-path-keeping-its-double-separator-prefix
     normalized.


### PR DESCRIPTION
`unc` (the `\\server\share` concept) was evaluated for both `path.win32` and `path.posix`,
since it lives in the shared `impl` object. For a POSIX path, `driveless.size.gt 1` and a
leading double separator is common (any path starting with `//`), so the `unc` branch fires
for POSIX too, producing an extra separator: `(path.posix "//").normalized` and
`(path.posix "///").normalized` both grew to `"///"` instead of collapsing to `"/"`.

Gated `unc` on `separator.eq "\\"`, so it only applies to `path.win32`, where the concept
actually exists. `path.posix` now always takes the plain-separator branch for the absolute
prefix, and both cases normalize to `"/"`.

Closes #7261
