### PR TITLE
fix(#7306): honour Maven proxy credentials

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MvnProxy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MvnProxy.java
@@ -4,7 +4,9 @@
  */
 package org.eolang.maven;
 
+import java.net.Authenticator;
 import java.net.InetSocketAddress;
+import java.net.PasswordAuthentication;
 import java.net.Proxy;
 import java.util.Arrays;
 
@@ -12,14 +14,6 @@ import java.util.Arrays;
  * One active proxy of Maven settings, carrying the excluded hosts that a
  * plain {@link Proxy} drops.
  * @since 0.73.4
- * @todo #7257:40min Honour the proxy credentials too. A proxy with a
- *  {@code username} and {@code password} in {@code settings.xml} still gets
- *  407 on every request, because nothing answers its authentication
- *  challenge. Add a {@code java.net.Authenticator} built from these two
- *  fields and hand it to the {@code HttpClient} in {@code OyRemote}. The
- *  {@code protocol} field is a separate matter: {@code java.net.http} only
- *  speaks to HTTP proxies, so a {@code socks5} one has to either fail loudly
- *  or go through the {@code socksProxyHost} system properties.
  */
 final class MvnProxy {
 
@@ -45,6 +39,30 @@ final class MvnProxy {
             Proxy.Type.HTTP,
             new InetSocketAddress(this.origin.getHost(), this.origin.getPort())
         );
+    }
+
+    /**
+     * The authenticator carrying this proxy's credentials.
+     * @return The authenticator
+     */
+    Authenticator authenticator() {
+        final String username = this.origin.getUsername();
+        final String password = this.origin.getPassword();
+        return new Authenticator() {
+            @Override
+            protected PasswordAuthentication getPasswordAuthentication() {
+                PasswordAuthentication result = null;
+                if (
+                    this.getRequestorType() == RequestorType.PROXY
+                        && username != null && password != null
+                ) {
+                    result = new PasswordAuthentication(
+                        username, password.toCharArray()
+                    );
+                }
+                return result;
+            }
+        };
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -175,7 +175,9 @@ final class OyRemote implements Objectionary {
         final HttpClient.Builder builder = HttpClient.newBuilder()
             .followRedirects(HttpClient.Redirect.NORMAL);
         if (proxies.length > 0) {
-            builder.proxy(new NonProxyHostsSelector(proxies[0]));
+            builder
+                .proxy(new NonProxyHostsSelector(proxies[0]))
+                .authenticator(proxies[0].authenticator());
         }
         return builder.build();
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyRemoteTest.java
@@ -12,6 +12,8 @@ import java.net.InetSocketAddress;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -147,6 +149,45 @@ final class OyRemoteTest {
     }
 
     @Test
+    void answersProxyAuthenticationChallenge() throws Exception {
+        final String username = "proxy-user";
+        final String password = "proxy-password";
+        final String source = "[] > authenticated";
+        final HttpServer server = OyRemoteTest.proxy(
+            String.format(
+                "Basic %s",
+                Base64.getEncoder().encodeToString(
+                    String.format("%s:%s", username, password)
+                        .getBytes(StandardCharsets.UTF_8)
+                )
+            ),
+            source
+        );
+        try {
+            final org.apache.maven.settings.Proxy origin =
+                new org.apache.maven.settings.Proxy();
+            origin.setHost(server.getAddress().getHostString());
+            origin.setPort(server.getAddress().getPort());
+            origin.setUsername(username);
+            origin.setPassword(password);
+            final String template = "http://origin.example/%s/%s.eo";
+            MatcherAssert.assertThat(
+                "OyRemote must answer the proxy challenge with Maven credentials",
+                new TextOf(
+                    new OyRemote(
+                        new UrlOy(template, "hash"),
+                        new UrlOy(template, "hash"),
+                        new MvnProxy(origin)
+                    ).get("org.eolang.authenticated")
+                ).asString(),
+                Matchers.equalTo(source)
+            );
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    @Test
     void reportsNameInTheEoObjectSlotWhenObjectNotFound() throws Exception {
         MatcherAssert.assertThat(
             "The object name must show up in the 'EO object' slot of the message",
@@ -211,5 +252,34 @@ final class OyRemoteTest {
         } finally {
             server.stop(0);
         }
+    }
+
+    private static HttpServer proxy(final String credentials, final String body)
+        throws IOException {
+        final HttpServer server = HttpServer.create(
+            new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0
+        );
+        server.createContext(
+            "/",
+            exchange -> {
+                if (
+                    credentials.equals(
+                        exchange.getRequestHeaders().getFirst("Proxy-Authorization")
+                    )
+                ) {
+                    final byte[] source = body.getBytes(StandardCharsets.UTF_8);
+                    exchange.sendResponseHeaders(200, source.length);
+                    exchange.getResponseBody().write(source);
+                } else {
+                    exchange.getResponseHeaders().add(
+                        "Proxy-Authenticate", "Basic realm=\"eo\""
+                    );
+                    exchange.sendResponseHeaders(407, -1L);
+                }
+                exchange.close();
+            }
+        );
+        server.start();
+        return server;
     }
 }


### PR DESCRIPTION
Closes #7306.

`OyRemote` now uses the username and password configured for the active Maven proxy. This allows requests to respond to a `407 Proxy Authentication Required` challenge and retry with Basic proxy authentication, while preserving the existing proxy and `nonProxyHosts` behavior.

A regression test starts a local authenticated proxy, verifies the initial `407` response, validates the configured credentials, and confirms that the requested content is successfully retrieved after authentication.

Tests:

* `mvn -pl eo-maven-plugin -Dtest=OyRemoteTest test -DskipITs`
* `mvn -pl eo-maven-plugin test -DskipITs` — 684 tests passed
* `mvn -pl eo-maven-plugin -Pqulice qulice:check -DskipTests`
* JTCOP check — passed

@yegor256
