### PR TITLE
Widen the retry window for the atomic move in `Saved`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -33,6 +33,17 @@ import org.cactoos.scalar.LengthOf;
  * an atomic rename means a reader always sees either the previous complete
  * file or the new one, never a partial one.</p>
  *
+ * <p>On Windows that rename fails with
+ * {@link java.nio.file.AccessDeniedException} while somebody else keeps a
+ * handle on either of the two names: a concurrent reader of {@link #target},
+ * another writer racing on the same path, or an anti-virus scanning the
+ * freshly written temporary file. All of them let go in a moment, so the
+ * only cure is to try again. Ten attempts spread over nine seconds
+ * (200ms, 400ms, ... 1800ms) leave enough room for that, while the first
+ * retries stay short enough to keep a normal save fast. Randomization stays
+ * off on purpose: jcabi randomizes as {@code rand(0, 2^(attempt+1)) * delay},
+ * which at the tenth attempt would sleep for minutes.</p>
+ *
  * @since 0.41.0
  */
 final class Saved implements Scalar<Path> {
@@ -131,7 +142,9 @@ final class Saved implements Scalar<Path> {
         return this.target;
     }
 
-    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS, randomize = false)
+    @RetryOnFailure(
+        attempts = 10, delay = 200L, unit = TimeUnit.MILLISECONDS, randomize = false
+    )
     private static void moved(final Path tmp, final Path target) throws IOException {
         try {
             Files.move(


### PR DESCRIPTION
`SavedTest.exposesNoPartiallyWrittenFileToConcurrentReader` failed on the `windows-2022` leg of [run 32526220123](https://github.com/objectionary/eo/actions/runs/32526220123/job/96908695987?pr=7374). That run was on #7374, which only touched `path.win32`'s `unc` handling in an `.eo` file, so the failure is unrelated to the change — the same test passes on the Linux and macOS legs of the same run.

Unwinding the nested exceptions gets to the cause:

```
Caused by: java.io.IOException: Failed while trying to save to ...\shared.txt
    at org.eolang.maven.Saved.value(Saved.java:124)
Caused by: java.nio.file.AccessDeniedException:
    ...\shared.txt13454255090316470990.tmp -> ...\shared.txt
    at sun.nio.fs.WindowsFileCopy.move(WindowsFileCopy.java:310)
    at org.eolang.maven.Saved.moved(Saved.java:137)
```

`Saved` streams into a sibling temporary file and then renames it onto the target with `ATOMIC_MOVE`, which is the fix from #5873 that stops a reader seeing a half-written XMIR. On Windows that rename fails with `AccessDeniedException` while anyone still holds a handle on either of the two names: a concurrent reader of the target, another writer racing the same path, or an anti-virus scanning the freshly written temporary file. POSIX allows renaming over an open file, which is why only the Windows leg goes red.

So the flake is real, but it is not confined to the test. `Saved` is called from every `Threaded` mojo, so a Windows user can hit `Failed while trying to save to ...` in an ordinary build.

`Saved.moved` already retried, but on jcabi's default of 3 attempts at 1s linear backoff — 3 tries inside a ~3s window. That is thin when an anti-virus scan queue backs up behind eight concurrent 500KB writes onto one path, which is exactly what the test drives. Widened to 10 attempts at 200ms linear backoff: the first retries land sooner for the common sub-second lock, and the window stretches to ~9s for a slow one.

Randomization stays off on purpose. jcabi computes a randomized delay as `rand(0, 2^(attempt+1)) * delay`, so at the tenth attempt it would sleep for minutes; linear backoff is the only workable shape at this attempt count. The reasoning is recorded in the class Javadoc rather than on the method, since qulice forbids Javadoc on private methods.

No test changes — the concurrency stress the test applies is the point of it, and weakening it would give back the guarantee #5873 bought.

### Verification

- `mvn -pl eo-maven-plugin -Dtest=SavedTest test` — 7/7 pass. `retriesMoveWhenTargetTemporarilyBlocked` covers the retry path and still passes; the suite now takes 0.75s instead of ~4s, because its first retry no longer waits a full second.
- `mvn -Pqulice -pl eo-maven-plugin -DskipTests verify` — clean.
- Linux only here, so the Windows leg of CI on this PR is the real check.

---
_Generated by [Claude Code](https://claude.ai/code/session_011sDxsqzvJQhBAZodqHMaHf)_