### PR TITLE
Upgrade qulice-maven-plugin to 0.31.2

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -569,15 +569,6 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <configuration>
-              <excludes>
-                <!--
-                Fixture reproducing the tab-separated output of
-                the "git ls-remote" tags command
-                -->
-                <exclude>checkstyle:.*/src/test/resources/org/eolang/maven/commits/tags\.txt</exclude>
-              </excludes>
-            </configuration>
           </plugin>
         </plugins>
       </build>

--- a/pom.xml
+++ b/pom.xml
@@ -532,7 +532,7 @@
           <plugin>
             <groupId>com.qulice</groupId>
             <artifactId>qulice-maven-plugin</artifactId>
-            <version>0.31.1</version>
+            <version>0.31.2</version>
             <configuration>
               <excludes combine.children="append">
                 <exclude>duplicatefinder:.*</exclude>


### PR DESCRIPTION
Bumps `com.qulice:qulice-maven-plugin` from `0.31.1` to `0.31.2`, and drops one exclude that 0.31.2 makes redundant.

## Changes

1. **`pom.xml`** — qulice `0.31.1` → `0.31.2`. The version is declared in exactly one place, the `qulice` profile in the root POM, and every module inherits it.
2. **`eo-maven-plugin/pom.xml`** — removed the exclude below, since 0.31.2 excludes `src/test/resources/` and `src/it/` on its own. It was the only entry in the block, so the surrounding `<configuration>` went with it.
   ```xml
   <exclude>checkstyle:.*/src/test/resources/org/eolang/maven/commits/tags\.txt</exclude>
   ```

## Validation

The reactor stops at `eo-parser` (see below), so CI cannot reach the later modules. Each module was therefore checked individually with 0.31.2, confirming `qulice:0.31.2:check` actually executed in each:

| Module | Result |
| --- | --- |
| `eo-parser` | FAILURE — pre-existing violation, see below |
| `eo-printer` | SUCCESS |
| `eo-inference` | SUCCESS |
| `eo-maven-plugin` (exclude removed) | **SUCCESS** |
| `eo-runtime` | SUCCESS |
| `eo-integration-tests` | SUCCESS |

`eo-parser` is the only module with a violation, so the bump introduces nothing new anywhere in the reactor.

## The `duplicatefinder` exclude has to stay

The other exclude in the root POM is **not** removable:

```xml
<exclude>duplicatefinder:.*</exclude>
```

It disables a validator wholesale rather than excluding a directory, and it carries `combine.children="append"`, so it applies project-wide. Removing it fails `eo-maven-plugin` and `eo-runtime` with real duplicate classes/resources:

- `eo-runtime`: `eo-runtime/target/classes` vs `net.java.dev.jna:jna:5.19.1`
- `eo-maven-plugin`: `eo-maven-plugin/target/classes` vs `org.eolang:eo-parser`, plus `findbugs:annotations` vs `jsr305`/`jcip-annotations`, and `plexus-utils` vs `plexus-xml`

`eo-printer`, `eo-inference`, `eo-integration-tests` and the root module pass without it, but the two failures above are enough. Left in place.

## The `qulice` check is red on `master` already

The `qulice` job fails on this PR, but **not because of these changes**. It fails on `eo-parser` with a pre-existing PMD violation:

```
PMD: eo-parser/src/main/java/org/eolang/parser/Emissions.java[26-26]:
     Possible God Class (WMC=133, ATFD=6, TCC=0.000%) (GodClass)
[ERROR] There are 1 violations
```

Evidence that it is inherited, not introduced:

| Setup | qulice version | Result |
| --- | --- | --- |
| `master` @ `87aef403`, CI, JDK 26 ([run 9471](https://github.com/objectionary/eo/actions/runs/32551144802)) | 0.31.1 | `eo-parser`, 1 violation, FAILURE |
| this branch, local, JDK 21 | 0.31.1 | `eo-parser`, GodClass `Emissions.java` WMC=133, FAILURE |
| this branch, local, JDK 21 | 0.31.2 | `eo-parser`, GodClass `Emissions.java` WMC=133, FAILURE |

The 0.31.1 run reproduces `master` HEAD exactly. `Emissions.java` crossed the `GodClass` threshold in the `#7312` merge (`87aef403`), the first `master` `qulice` run to go red.

Clearing it means refactoring `Emissions.java` (657 lines, WMC 133) or adding a PMD exclusion — a separate decision, out of scope for a version bump. Left in draft rather than widening this PR.
