### PR TITLE
Rename "bottom object" to "terminator"

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Forms.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Forms.java
@@ -48,7 +48,7 @@ final class Forms {
     Forms(final XML links) {
         this(
             new HashSet<>(links.xpath("/links/type[data]/@id")),
-            new HashSet<>(links.xpath("/links/type[bottom]/@id")),
+            new HashSet<>(links.xpath("/links/type[terminator]/@id")),
             new HashSet<>(links.xpath("/links/type[var]/@id"))
         );
     }
@@ -56,16 +56,16 @@ final class Forms {
     /**
      * Ctor.
      * @param data The objects that are data
-     * @param bottoms The objects that terminate
+     * @param terminators The objects that terminate
      * @param voids The objects that are voids
      */
     Forms(
         final Collection<String> data,
-        final Collection<String> bottoms,
+        final Collection<String> terminators,
         final Collection<String> voids
     ) {
         this.ground = data;
-        this.dead = bottoms;
+        this.dead = terminators;
         this.free = voids;
     }
 
@@ -80,7 +80,7 @@ final class Forms {
         if (this.ground.contains(object)) {
             found = "data";
         } else if (this.dead.contains(object)) {
-            found = "bottom";
+            found = "terminator";
         } else {
             found = object;
         }
@@ -97,7 +97,7 @@ final class Forms {
         if (this.ground.contains(object)) {
             found = new Data();
         } else if (this.dead.contains(object)) {
-            found = new Bottom();
+            found = new Terminator();
         } else if (this.free.contains(object)) {
             found = new Var(object);
         } else {

--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -82,8 +82,8 @@ final class Links implements Clue {
         for (final XML datum : world.data()) {
             found.put(datum.xpath("@loc").get(0), new Data());
         }
-        for (final XML dead : world.bottoms()) {
-            found.put(dead.xpath("@loc").get(0), new Bottom());
+        for (final XML dead : world.terminators()) {
+            found.put(dead.xpath("@loc").get(0), new Terminator());
         }
         for (final XML hollow : world.voids()) {
             found.put(hollow.xpath("@loc").get(0), new Var());

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -64,7 +64,7 @@ final class Pairs {
      * @return The locators
      */
     Collection<String> certain() {
-        return this.table.xpath("/links/type[data or bottom]/@id");
+        return this.table.xpath("/links/type[data or terminator]/@id");
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Terminator.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Terminator.java
@@ -19,10 +19,10 @@ import org.xembly.Directives;
  *
  * @since 0.69.0
  */
-final class Bottom implements Type {
+final class Terminator implements Type {
 
     @Override
     public Directives directives() {
-        return new Directives().add("bottom").up();
+        return new Directives().add("terminator").up();
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -77,7 +77,7 @@ final class Xmirs {
      * Every termination of the program.
      *
      * <p>The {@code T} of the code, which the parser writes down as an
-     * object based on the bottom sign. It names no other object, so nothing
+     * object based on the {@code ⊥} sign. It names no other object, so nothing
      * looks for what it is a copy of: it is not a copy of anything, it is
      * the one answer that fits everywhere.</p>
      *
@@ -85,7 +85,7 @@ final class Xmirs {
      *  the code
      * @throws IOException If a file cannot be read
      */
-    Collection<XML> bottoms() throws IOException {
+    Collection<XML> terminators() throws IOException {
         return this.matching("//o[@loc and @base='⊥']");
     }
 

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -77,7 +77,7 @@ final class Xmirs {
      * Every termination of the program.
      *
      * <p>The {@code T} of the code, which the parser writes down as an
-     * object based on the {@code ⊥} sign. It names no other object, so nothing
+     * object based on the terminator sign. It names no other object, so nothing
      * looks for what it is a copy of: it is not a copy of anything, it is
      * the one answer that fits everywhere.</p>
      *

--- a/eo-inference/src/test/java/org/eolang/inference/PairsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PairsTest.java
@@ -24,13 +24,13 @@ final class PairsTest {
                     new XMLDocument(
                         String.join(
                             "",
-                            "<links><type id='a'><bottom/></type>",
+                            "<links><type id='a'><terminator/></type>",
                             "<type id='b'><ref loc='x'/></type></links>"
                         )
                     )
                 ).others()
             ).asXml(),
-            XhtmlMatchers.hasXPath("/links/type[@id='a']/bottom")
+            XhtmlMatchers.hasXPath("/links/type[@id='a']/terminator")
         );
     }
 }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-is-an-answer.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-is-an-answer.yaml
@@ -9,5 +9,5 @@ eo:
     [] > app
       T > dead
 links:
-  - "/links/type[@id='Φ.app.dead']/bottom"
+  - "/links/type[@id='Φ.app.dead']/terminator"
   - "/links/type[@id='Φ.app.dead'][not(ref)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-keeps-its-cause.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/termination-keeps-its-cause.yaml
@@ -12,5 +12,5 @@ eo:
   why.eo: |
     [] > why
 links:
-  - "/links/type[@id='Φ.app.dead']/bottom"
+  - "/links/type[@id='Φ.app.dead']/terminator"
   - "/links/type[@id='Φ.app.dead.α0']/ref[@loc='Φ.why']"

--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -169,7 +169,7 @@ The parser recognises the following lexical tokens:
 | `RHO` | `^` |
 | `ROOT` | `Q` |
 | `XI` | `$` |
-| `TERM` | `T` — the bottom term (§9.3), similar to `⊥` in 𝜑-calculus. A value: it may carry arguments, horizontal (`T 42`) or vertical, which are the cause of the bottom, the way `T "why it failed"` is used across the runtime, and a `.method` chain (`T.foo` parses as `⊥.foo`), like any other head. |
+| `TERM` | `T` — the terminator term (§9.3), similar to `⊥` in 𝜑-calculus. A value: it may carry arguments, horizontal (`T 42`) or vertical, which are the cause of the terminator, the way `T "why it failed"` is used across the runtime, and a `.method` chain (`T.foo` parses as `⊥.foo`), like any other head. |
 | `IDENTITY` | `I` — the identity object (§3.16), the one-character spelling of `x > [x]`. A value: it may carry arguments (`I 5`) and a `.method` chain, like any other head. |
 | `VOID` | `?` — the vertical-void marker (§3.4). A `? > name` body line declares a void attribute, equivalent to listing `name` in `[…]`. |
 | `QDOT` | `?.` — the fragile-dispatch operator (§3.5). Accepted in every position the plain `.` dispatch is, recorded as `@fragile` in XMIR. A `?` immediately followed by `.` is `QDOT`; a `?` followed by space (`? > name`) is `VOID`. |
@@ -1228,7 +1228,7 @@ R-9.2.4. **Scope resolution adds no hops.** The `build-fqns` reshape that follow
 | `^` (RHO) | `ρ` | `@base='ρ'` for parent reference; `@name='ρ'` for the receiver void (R-3.4.11); `@as='ρ'` for a `:^` binding (R-3.12.2a) |
 | `Q` (ROOT) | `Φ` | `@base='Φ...'` for root-rooted FQNs |
 | `$` (XI) | `ξ` | `@base='ξ'` for self reference |
-| `T` (TERM) | `⊥` | `@base='⊥'` for the bottom term |
+| `T` (TERM) | `⊥` | `@base='⊥'` for the terminator term |
 | `I` (IDENTITY) | — | base-less `<o>` with a single void `<o name='x' base='∅'/>` and the decoratee `<o name='φ' base='x'/>` — the identity object (§3.16) |
 | atom signature head `Q` | `Φ` | `@atom='Φ....'` |
 | generic type variable `A`–`F` | (verbatim) | `@atom`, `@type`, `@args` member — never `Φ`-promoted or alias-expanded (§3.10.11) |

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -395,7 +395,7 @@ final class Emit {
      * Add the {@code @type="type"} attribute to the most recently opened
      * {@code <o>} — the declared type of an atom's vertical void
      * attribute (R-3.4.8): a concrete forma or a generic type variable,
-     * with an optional trailing {@code ?} marking a maybe-bottom value.
+     * with an optional trailing {@code ?} marking a maybe-terminator value.
      * @param type The declared type
      */
     void type(final String type) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -29,7 +29,7 @@ import java.util.regex.Pattern;
  * <ul>
  * <li>{@code /type} — the void's own type: a concrete forma or a
  * generic type variable ({@code A}–{@code F}), with an optional
- * trailing {@code ?} marking a maybe-bottom value. Emits
+ * trailing {@code ?} marking a maybe-terminator value. Emits
  * {@code @type}.</li>
  * <li>{@code /{type …}} — the void is a callback formation;
  * the brace list gives the types of its void parameters (the arguments

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -290,7 +290,7 @@ final class Value {
          * {@code T} — the terminator term of 𝜑-calculus (§9.3). A value:
          * it may carry arguments, which are the cause of the terminator,
          * as in {@code T "why it failed"};
-         * {@link Emissions} maps it to a {@code ⊥}-based object.
+         * {@link Emissions} maps it to a terminator object.
          */
         TERM,
 

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -287,10 +287,10 @@ final class Value {
         ROOT,
 
         /**
-         * {@code T} — the bottom term of 𝜑-calculus (§9.3). A value:
-         * it may carry arguments, which are the cause of the bottom,
+         * {@code T} — the terminator term of 𝜑-calculus (§9.3). A value:
+         * it may carry arguments, which are the cause of the terminator,
          * as in {@code T "why it failed"};
-         * {@link Emissions} maps it to a bottom-based object.
+         * {@link Emissions} maps it to a {@code ⊥}-based object.
          */
         TERM,
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -401,9 +401,9 @@ final class EoTest {
     }
 
     @Test
-    void parsesBottomTermInsideFormation() {
+    void parsesTerminatorTermInsideFormation() {
         MatcherAssert.assertThat(
-            "a bare T term inside a formation must emit the bottom object as @base='⊥'",
+            "a bare T term inside a formation must emit the terminator as @base='⊥'",
             EoTest.render("[] > main", "  T > x"),
             XhtmlMatchers.hasXPath("/object/o[@name='main']/o[@name='x' and @base='⊥']")
         );

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -143,7 +143,7 @@ final class ValueTest {
     @Test
     void retainsTermKind() {
         MatcherAssert.assertThat(
-            "TERM must be one of the recognised value kinds for the bottom term T",
+            "TERM must be one of the recognised value kinds for the terminator term T",
             new Value(Value.Kind.TERM, "T", 0).kind(),
             Matchers.equalTo(Value.Kind.TERM)
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/terminator-term-with-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/terminator-term-with-arguments.yaml
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-# #6707: `T` takes arguments - they are the cause of the bottom, the way
+# #6707: `T` takes arguments - they are the cause of the terminator, the way
 # `T "why it failed"` is used across the runtime. Both the horizontal and the
 # vertical form are accepted, the arguments land under the `⊥` object, and a
-# `.method` chain on `T` is read as a dispatch on the bottom.
+# `.method` chain on `T` is read as a dispatch on the terminator.
 sheets: []
 asserts:
   - /object[not(errors)]

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -3,8 +3,8 @@
 # four places becomes `2.5000` and `0.9999999` with six places becomes `1.000000`.
 # If `places` is not a finite non-negative integer below 2^53 (negative,
 # fractional, nan, infinite, or too large to reach zero by repeated
-# subtraction of one), the `cant-print` fallback is returned, or the bottom
-# object when unbound.
+# subtraction of one), the `cant-print` fallback is returned, or the
+# terminator when unbound.
 #
 # The value is split into its integer and fraction parts before scaling, so
 # only the fraction is multiplied by a power of ten and every magnitude that

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -1,7 +1,7 @@
 # Calculate MOD.
 # An operation that finds the remainder after dividing `x` by `y`. When `y`
 # is zero, the result is the caller-supplied `cant-mod` fallback, or the
-# bottom object when none was provided, which terminates on use. Otherwise
+# terminator when none was provided, which terminates on use. Otherwise
 # the divisor is doubled until it reaches the dividend and then halved back
 # down, subtracting it from the dividend whenever it fits. Doubling and
 # halving a double are exact, and every subtraction happens while the

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -17,7 +17,7 @@
 # When you dataize `socket.connect`, it creates new socket, connects to the given
 # IP on given port, dataizes provided scope, closes the socket and returns bytes
 # retrieved from scope dataization. On failure at any of the described steps, the fallback of the
-# corresponding operation is returned (or the bottom object when it is left unbound).
+# corresponding operation is returned (or the terminator when it is left unbound).
 #
 # To listen to the incoming connections as server you should do:
 #
@@ -40,7 +40,7 @@
 # and returns `bytes` retrieved from scope dataization. When `s.accept` is dataized - it dataizes
 # given scope, closes client socket and returns `bytes` retrieved from scope dataization.
 # On failure at any of the described steps, the fallback of the corresponding operation is
-# returned (or the bottom object when it is left unbound).
+# returned (or the terminator when it is left unbound).
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -2,8 +2,8 @@
 # The byte of `char` is left-padded with a zero byte into a 16-bit word,
 # read as an integer and then expressed as a number. If `char` is not
 # exactly one byte wide (an empty string, or a multi-byte UTF-8
-# character), the `cant-read` fallback is returned, or the bottom
-# object when unbound.
+# character), the `cant-read` fallback is returned, or the terminator
+# when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -1,6 +1,6 @@
 # Returns the original `text` as `number`.
 # If the text is not numeric, the `cant-parse` fallback is returned,
-# or the bottom object when unbound.
+# or the terminator when unbound.
 # The whole `text` must be the number: `scanf` matches its `%f` pattern
 # unanchored (via `find`), so on its own it would accept any text that
 # merely contains a number-shaped substring, e.g. `"$100"` or `"12.34.56"`.

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -2,7 +2,7 @@
 # A negative `index` counts from the end of `text` (`length + index`).
 # If `index` is not a finite integer (fractional, nan or infinite), or the
 # resolved index is still negative or is >= `text.length`, the `fallback`
-# value is returned, or the bottom object when unbound.
+# value is returned, or the terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -2,7 +2,7 @@
 # The last element contains the remainder of the string after splitting.
 # If `delimiter` is empty, or `limit` is not a finite integer of at least 1
 # (fractional, nan, infinite, zero or negative), the `cant-split` fallback is
-# returned, or the bottom object when unbound, the same way `split` behaves.
+# returned, or the terminator when unbound, the same way `split` behaves.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/padded-left.eo
+++ b/eo-runtime/src/main/eo/string/padded-left.eo
@@ -5,7 +5,7 @@
 # or longer is returned unchanged.
 # If `width` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), or `fill` is not a single character, the `cant-pad` fallback
-# is returned, or the bottom object when unbound.
+# is returned, or the terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -5,7 +5,7 @@
 # or longer is returned unchanged.
 # If `width` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), or `fill` is not a single character, the `cant-pad` fallback
-# is returned, or the bottom object when unbound.
+# is returned, or the terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/padded-zeros.eo
+++ b/eo-runtime/src/main/eo/string/padded-zeros.eo
@@ -4,7 +4,7 @@
 # counted, and not bytes. A `text` of `width` characters or longer is
 # returned unchanged.
 # If `width` is not a finite non-negative integer (negative, fractional, nan
-# or infinite), the `cant-pad` fallback is returned, or the bottom object
+# or infinite), the `cant-pad` fallback is returned, or the terminator
 # when unbound.
 
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -1,7 +1,7 @@
 # Returns `text` repeated `times` times.
 # If `times` is not a finite non-negative integer (negative, fractional, nan
 # or infinite), the `cant-repeat` fallback is returned,
-# or the bottom object when unbound.
+# or the terminator when unbound.
 # If `times` == 0, empty text is returned.
 
 +architect yegor256@gmail.com

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -1,6 +1,6 @@
 # Returns a `tuple` of `strings`: `text` separated by `delimiter`.
 # If `delimiter` is empty, the `cant-split` fallback is returned, or the
-# bottom object when unbound.
+# terminator when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/truncated.eo
+++ b/eo-runtime/src/main/eo/string/truncated.eo
@@ -4,8 +4,8 @@
 # or shorter is returned unchanged, which is how this differs from `slice`,
 # where a `limit` beyond the end of the `text` terminates the computation.
 # If `limit` is not a finite non-negative integer (negative, fractional, nan
-# or infinite), the `cant-truncate` fallback is returned, or the bottom
-# object when unbound.
+# or infinite), the `cant-truncate` fallback is returned, or the terminator
+# when unbound.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/java/org/eolang/AtWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtWithRho.java
@@ -7,7 +7,7 @@ package org.eolang;
 
 /**
  * The attribute that tries to copy object and set \rho to it if it has not already set.
- * The bottom terminator ({@link PhTerminator}) silently ignores this \rho itself, so no container
+ * The terminator ({@link PhTerminator}) silently ignores this \rho itself, so no container
  * leaks into it and its cause is not masked as it propagates.
  * This attribute is NOT thread safe!
  * @since 0.36.0

--- a/eo-runtime/src/main/java/org/eolang/AtomTyped.java
+++ b/eo-runtime/src/main/java/org/eolang/AtomTyped.java
@@ -17,7 +17,7 @@ package org.eolang;
  * <p>The check is <em>opt-in</em>, controlled by the {@code eo.typing} system
  * property (default {@code false}). It is off by default because an atom with
  * an error-branch returns a union — the declared forma <em>or</em> a caller
- * fallback or bottom — that a single declared forma cannot express, so the
+ * fallback or a terminator — that a single declared forma cannot express, so the
  * check would reject valid fallbacks. Enable it (e.g. {@code -Deo.typing=true})
  * to verify atom return types where no error-branches are used.</p>
  *

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -40,7 +40,7 @@ public final class Dataized {
      *
      * <p>This method performs the dataization process, which involves converting
      * the EO object into a byte array. If the object cannot be dataized — for
-     * example when it is a terminated computation (bottom) — the failure propagates
+     * example when it is a terminated computation (a terminator) — the failure propagates
      * as an {@link ExFailure} and is not caught here.</p>
      *
      * <p>Usage example:</p>

--- a/eo-runtime/src/main/java/org/eolang/EOrecovered.java
+++ b/eo-runtime/src/main/java/org/eolang/EOrecovered.java
@@ -9,11 +9,11 @@ package org.eolang;
  * RECOVERED.
  *
  * <p>Resolves {@code value} to its normal form; if that is a terminated
- * computation (bottom), behaves as {@code alternative}, otherwise as {@code value}.
- * A bottom on both sides stays a bottom, so an outer recovery can still intercept it.
- * This is the only way to intercept a bottom and keep going.</p>
+ * computation (a terminator), behaves as {@code alternative}, otherwise as {@code value}.
+ * A terminator on both sides stays a terminator, so an outer recovery can still
+ * intercept it. This is the only way to intercept a terminator and keep going.</p>
  *
- * <p>A bottom arrives in two shapes. It is a {@link PhTerminator} when nothing
+ * <p>A terminator arrives in two shapes. It is a {@link PhTerminator} when nothing
  * forced it on the way here, and it is an {@link ExFailure} when something did:
  * a {@code seq} step, a const, or anything else that dataizes while the normal
  * form is computed. Both are the same termination, so both are intercepted.</p>

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -5,29 +5,29 @@
 package org.eolang;
 
 /**
- * The bottom object of φ-calculus — a terminated computation.
+ * The terminator of φ-calculus — a terminated computation.
  *
  * <p>It is a value that can be carried around — returned, copied, and
  * have an object put into it — but it has no data and no behaviour.
  * It detonates only when something tries to <em>force</em> it: reading
  * its data ({@link #delta()}) aborts through an {@link ExFailure}, which
  * only {@link EOrecovered} intercepts, and only while it resolves its own
- * {@code value}, so forcing bottom anywhere else terminates the program
+ * {@code value}, so forcing a terminator anywhere else terminates the program
  * for good.</p>
  *
  * <p>The remaining operations are tolerant on purpose: {@link #copy()}
- * yields the same bottom and {@link #take(String)} yields another one carrying
+ * yields the same terminator and {@link #take(String)} yields another one carrying
  * the same reason, so it propagates through copying and dispatch and surfaces
  * the failure at the outer dataization, not at the point it was produced.</p>
  *
- * <p>A bottom may carry a <em>cause</em>: it has a single slot, addressable only
- * at position 0 (as in {@code T "why it failed"}). Only a bottom without a cause
- * listens to that slot, and a dispatch hands one to the bottom it yields, so the
- * arguments that follow a propagated bottom, as in {@code (T).if a b}, are
+ * <p>A terminator may carry a <em>cause</em>: it has a single slot, addressable only
+ * at position 0 (as in {@code T "why it failed"}). Only a terminator without a cause
+ * listens to that slot, and a dispatch hands one to the terminator it yields, so the
+ * arguments that follow a propagated terminator, as in {@code (T).if a b}, are
  * dropped instead of being read as the reason it terminated. A {@code put} by
- * name other than ρ aborts — bottom has no named attributes. The ρ-binding the
+ * name other than ρ aborts — a terminator has no named attributes. The ρ-binding the
  * runtime attempts on every take (via {@link AtWithRho}) is silently ignored,
- * since a bottom has no ρ; this keeps its cause from being masked by a
+ * since a terminator has no ρ; this keeps its cause from being masked by a
  * ρ-rejection while it propagates. The cause is write-once and never handed back
  * by {@link #take(String)}, so EO code can neither read it nor catch it — it
  * exists only to explain the termination at the very top.</p>
@@ -44,15 +44,15 @@ public final class PhTerminator implements Phi {
 
     /**
      * The reason this computation terminated, used only as the panic
-     * message when the bottom is forced, or {@code null} when none was given.
+     * message when the terminator is forced, or {@code null} when none was given.
      */
     private Phi cause;
 
     /**
      * The reason to fall back to if nothing is ever {@code put} into this
-     * bottom. Unlike {@link #cause}, a birth-site default never blocks a
+     * terminator. Unlike {@link #cause}, a birth-site default never blocks a
      * later, more specific {@code put} — a caller that takes a void
-     * attribute's bottom and immediately puts its own reason (as
+     * attribute's terminator and immediately puts its own reason (as
      * {@code bytes.slice} does with its {@code cant-slice} fallback) must
      * still win.
      */
@@ -66,7 +66,7 @@ public final class PhTerminator implements Phi {
     }
 
     /**
-     * Make a bottom that explains, by default, why it was born without a
+     * Make a terminator that explains, by default, why it was born without a
      * dispatch ever reaching it, while still letting a caller that takes it
      * and puts its own, more specific reason override that default.
      * @param reason The default reason for the termination
@@ -76,10 +76,10 @@ public final class PhTerminator implements Phi {
     }
 
     /**
-     * Make a bottom that already carries the given reason as its cause.
+     * Make a terminator that already carries the given reason as its cause.
      *
-     * <p>The reason is remembered and used as the panic message when this bottom
-     * is finally forced; until then it flows like any other bottom.</p>
+     * <p>The reason is remembered and used as the panic message when this
+     * terminator is finally forced; until then it flows like any other one.</p>
      *
      * @param cause The reason for the termination
      */

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -92,12 +92,12 @@ public interface Phi extends Data, Term {
      * without extracting its data.
      *
      * <p>The point is to reveal whether the object is a terminated
-     * computation (bottom) without forcing it: a bottom — whether written as {@code T},
-     * produced by an unset void, or returned by a failing atom — surfaces here
-     * as a {@link PhTerminator} instance, detectable by identity. A genuine,
-     * unrecoverable failure encountered while resolving (a type violation, a
-     * missing Δ) propagates as an {@link ExFailure}, exactly as it would
-     * during dataization.</p>
+     * computation (a terminator) without forcing it: a terminator — whether
+     * written as {@code T}, produced by an unset void, or returned by a
+     * failing atom — surfaces here as a {@link PhTerminator} instance,
+     * detectable by identity. A genuine, unrecoverable failure encountered
+     * while resolving (a type violation, a missing Δ) propagates as an
+     * {@link ExFailure}, exactly as it would during dataization.</p>
      *
      * @return The object in its normal form
      */

--- a/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtVoidTest.java
@@ -58,7 +58,7 @@ final class AtVoidTest {
     @Test
     void returnsTerminatorOnGettingUnsetAttribute() {
         MatcherAssert.assertThat(
-            "AtVoid must return the bottom object when getting an unset attribute",
+            "AtVoid must return a terminator when getting an unset attribute",
             new AtVoid("attr").get(),
             Matchers.instanceOf(PhTerminator.class)
         );
@@ -67,7 +67,7 @@ final class AtVoidTest {
     @Test
     void namesTheUnsetAttributeInTheTerminatorsCause() {
         MatcherAssert.assertThat(
-            "The bottom object returned for an unset attribute must name it in its cause",
+            "The terminator returned for an unset attribute must name it in its cause",
             Assertions.assertThrows(
                 ExFailure.class,
                 () -> new Dataized(new AtVoid("attr").get()).take()

--- a/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
@@ -110,9 +110,9 @@ final class AtWithRhoTest {
     }
 
     @Test
-    void keepsCauseVisibleWhenBindingRhoOntoWrappedBottom() {
+    void keepsCauseVisibleWhenBindingRhoOntoWrappedTerminator() {
         MatcherAssert.assertThat(
-            "AtWithRho must not mask the cause of a wrapped bottom object when it binds ρ",
+            "AtWithRho must not mask the cause of a wrapped terminator when it binds ρ",
             Assertions.assertThrows(
                 ExFailure.class,
                 () -> new Dataized(

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -264,7 +264,7 @@ final class PhDefaultTest {
             () -> new Dataized(
                 new PhSafe(PhDefaultTest.Int.made()).copy().take(this.getVoid())
             ).take(),
-            "Copying must preserve the unset void, which reads as the bottom object and fails when dataized"
+            "Copying must preserve the unset void, which reads as a terminator and fails when dataized"
         );
     }
 
@@ -310,7 +310,7 @@ final class PhDefaultTest {
             () -> new Dataized(
                 new PhSafe(PhDefaultTest.Int.made().copy()).take(Phi.PHI)
             ).take(),
-            "Phi depending on an unset void (now the bottom object) must fail when dataized, but it did not"
+            "Phi depending on an unset void (now a terminator) must fail when dataized, but it did not"
         );
     }
 
@@ -368,7 +368,7 @@ final class PhDefaultTest {
             () -> new Dataized(
                 new PhSafe(new Data.ToPhi("Hey")).take("missing-attr")
             ).take(),
-            "Dataizing a missing attribute (now the bottom object) should fail, but it didn't"
+            "Dataizing a missing attribute (now a terminator) should fail, but it didn't"
         );
     }
 
@@ -588,7 +588,7 @@ final class PhDefaultTest {
     @Test
     void returnsTerminatorForAbsentAttribute() {
         MatcherAssert.assertThat(
-            "Taking an absent attribute must return the bottom object, not throw",
+            "Taking an absent attribute must return a terminator, not throw",
             this.phiWithContextAttribute(
                 "context-returnsTerminatorForAbsentAttribute"
             ).take("non-existent-attribute"),

--- a/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
@@ -33,9 +33,9 @@ final class PhOnceTest {
     }
 
     @Test
-    void letsANormalizedBottomPropagateBare() {
+    void letsANormalizedTerminatorPropagateBare() {
         MatcherAssert.assertThat(
-            "normalized() must not re-wrap a bottom, so callers can still detect it with instanceof, but it did",
+            "normalized() must not re-wrap a terminator, so callers can still detect it with instanceof",
             new PhOnce(PhTerminator::new).normalized(),
             Matchers.instanceOf(PhTerminator.class)
         );

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -22,14 +22,14 @@ final class PhTerminatorTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new Dataized(new PhTerminator()).take(),
-            "dataizing the bottom object must abort instead of returning data"
+            "dataizing the terminator must abort instead of returning data"
         );
     }
 
     @Test
     void propagatesOnDispatch() {
         MatcherAssert.assertThat(
-            "dispatching an attribute on the bottom object must propagate another bottom, not abort",
+            "dispatching an attribute on the terminator must propagate another one, not abort",
             new PhTerminator().take("any"),
             Matchers.instanceOf(PhTerminator.class)
         );
@@ -38,7 +38,7 @@ final class PhTerminatorTest {
     @Test
     void copiesIntoAnotherTerminator() {
         MatcherAssert.assertThat(
-            "copying the bottom object must yield another bottom, not abort",
+            "copying the terminator must yield another one, not abort",
             new PhTerminator().copy(),
             Matchers.instanceOf(PhTerminator.class)
         );
@@ -48,19 +48,19 @@ final class PhTerminatorTest {
     void toleratesBinding() {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(0, new PhTerminator()),
-            "putting an object into the bottom object must not abort"
+            "putting an object into the terminator must not abort"
         );
     }
 
     @Test
     void reportsTheGivenCauseOnPanic() {
-        final PhTerminator bottom = new PhTerminator();
-        bottom.put(0, new Data.ToPhi("cannot proceed here"));
+        final PhTerminator terminator = new PhTerminator();
+        terminator.put(0, new Data.ToPhi("cannot proceed here"));
         MatcherAssert.assertThat(
-            "forcing the bottom object must not hide the cause that was put into it",
+            "forcing the terminator must not hide the cause that was put into it",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Dataized(bottom).take()
+                () -> new Dataized(terminator).take()
             ).getMessage(),
             Matchers.containsString("cannot proceed here")
         );
@@ -69,12 +69,12 @@ final class PhTerminatorTest {
     @Test
     void preservesPercentSignsInCause() {
         final String cause = "100% complete";
-        final PhTerminator bottom = new PhTerminator(new Data.ToPhi(cause));
+        final PhTerminator terminator = new PhTerminator(new Data.ToPhi(cause));
         MatcherAssert.assertThat(
-            "forcing the bottom object must treat its cause as literal text",
+            "forcing the terminator must treat its cause as literal text",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Dataized(bottom).take()
+                () -> new Dataized(terminator).take()
             ).getMessage(),
             Matchers.equalTo(cause)
         );
@@ -82,14 +82,14 @@ final class PhTerminatorTest {
 
     @Test
     void keepsTheFirstCause() {
-        final PhTerminator bottom = new PhTerminator();
-        bottom.put(0, new Data.ToPhi("the birth reason"));
-        bottom.put(0, new Data.ToPhi("a later reason"));
+        final PhTerminator terminator = new PhTerminator();
+        terminator.put(0, new Data.ToPhi("the birth reason"));
+        terminator.put(0, new Data.ToPhi("a later reason"));
         MatcherAssert.assertThat(
-            "a later object put into the bottom object must not overwrite its first cause",
+            "a later object put into the terminator must not overwrite its first cause",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Dataized(bottom).take()
+                () -> new Dataized(terminator).take()
             ).getMessage(),
             Matchers.containsString("the birth reason")
         );
@@ -97,11 +97,11 @@ final class PhTerminatorTest {
 
     @Test
     void hidesTheCauseFromTake() {
-        final PhTerminator bottom = new PhTerminator();
-        bottom.put(0, new Data.ToPhi("secret cause"));
+        final PhTerminator terminator = new PhTerminator();
+        terminator.put(0, new Data.ToPhi("secret cause"));
         MatcherAssert.assertThat(
-            "taking an attribute must not hand back the cause, only another bottom",
-            bottom.take("cause"),
+            "taking an attribute must not hand back the cause, only another terminator",
+            terminator.take("cause"),
             Matchers.instanceOf(PhTerminator.class)
         );
     }
@@ -147,7 +147,7 @@ final class PhTerminatorTest {
     @Test
     void keepsDispatchArgumentsOutOfTheCause() {
         MatcherAssert.assertThat(
-            "a bottom reached by a dispatch names the argument it was handed, not the termination",
+            "a terminator reached by a dispatch names the argument it got, not the termination",
             Assertions.assertThrows(
                 ExFailure.class,
                 () -> new Dataized(
@@ -165,7 +165,7 @@ final class PhTerminatorTest {
     @Test
     void carriesTheCauseThroughDispatch() {
         MatcherAssert.assertThat(
-            "the reason a bottom was born with is lost once it travels through a dispatch",
+            "the reason a terminator was born with is lost once it travels through a dispatch",
             Assertions.assertThrows(
                 ExFailure.class,
                 () -> new Dataized(
@@ -183,7 +183,7 @@ final class PhTerminatorTest {
     void toleratesPutAtOtherPositions() {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(1, new Data.ToPhi("nope")),
-            "putting into the bottom object away from position 0 must not abort"
+            "putting into the terminator away from position 0 must not abort"
         );
     }
 
@@ -192,7 +192,7 @@ final class PhTerminatorTest {
         Assertions.assertThrows(
             ExFailure.class,
             () -> new PhTerminator().put("cause", new Data.ToPhi("nope")),
-            "putting into the bottom object by name, even cause, must abort"
+            "putting into the terminator by name, even cause, must abort"
         );
     }
 
@@ -200,32 +200,32 @@ final class PhTerminatorTest {
     void toleratesRhoBinding() {
         Assertions.assertDoesNotThrow(
             () -> new PhTerminator().put(Phi.RHO, new PhDefault()),
-            "binding ρ onto the bottom object must not abort"
+            "binding ρ onto the terminator must not abort"
         );
     }
 
     @Test
-    void resolvesADataValueToNonBottom() {
+    void resolvesADataValueToNonTerminator() {
         MatcherAssert.assertThat(
-            "resolving a real data value must not be seen as a bottom",
+            "resolving a real data value must not be seen as a terminator",
             new Data.ToPhi(42L).normalized(),
             Matchers.not(Matchers.instanceOf(PhTerminator.class))
         );
     }
 
     @Test
-    void resolvesTheBottomToItself() {
+    void resolvesTheTerminatorToItself() {
         MatcherAssert.assertThat(
-            "resolving the bottom object must reveal a bottom",
+            "resolving the terminator must reveal a terminator",
             new PhTerminator().normalized(),
             Matchers.instanceOf(PhTerminator.class)
         );
     }
 
     @Test
-    void resolvesALazyDispatchToBottom() {
+    void resolvesALazyDispatchToTerminator() {
         MatcherAssert.assertThat(
-            "a lazy dispatch that yields a bottom must resolve to a PhTerminator without forcing",
+            "a lazy dispatch that yields a terminator must resolve to a PhTerminator lazily",
             new PhDispatch(new PhDefault(), "missing").normalized(),
             Matchers.instanceOf(PhTerminator.class)
         );


### PR DESCRIPTION
"Bottom object" is not an accurate term for the object that stands for a
terminated computation. Everywhere the code and the documentation called it
that, it is now called a **terminator** — which is what the runtime class
`PhTerminator` has been called all along.

### Renamed in prose

* `PhTerminator` — the class Javadoc, which opened with "The bottom object of
  φ-calculus", and the field/ctor docs that spoke of "a bottom".
* `EOrecovered`, `Phi.normalized()`, `Dataized`, `AtWithRho`, `AtomTyped` —
  the same term in their Javadoc.
* The header comments of the `.eo` objects that mention it: `string.at`,
  `string.as-ascii`, `string.as-number`, `string.split`, `string.nsplit`,
  `string.repeated`, `string.truncated`, `string.padded-left`,
  `string.padded-right`, `string.padded-zeros`, `number.mod`,
  `number.as-fixed`, `socket`.
* Assertion messages and test names in `PhTerminatorTest`, `PhDefaultTest`,
  `PhOnceTest`, `AtVoidTest`, `AtWithRhoTest`, `EoTest`, `ValueTest`; the
  local variables in `PhTerminatorTest` are now `terminator` rather than
  `bottom`.
* `PARSER_SPEC.md` and `Value.Kind.TERM` — the `T` token is the "terminator
  term" instead of the "bottom term". The syntax pack
  `bottom-term-with-arguments.yaml` is renamed accordingly.

### Renamed in code

* `eo-inference`: the type `Bottom` becomes `Terminator`, and the row it
  writes into the links table is `<terminator/>` instead of `<bottom/>`.
  `Xmirs.bottoms()` becomes `Xmirs.terminators()`. The XPaths in `Forms`,
  `Pairs`, `PairsTest` and the two inference packs in `eo-maven-plugin`
  follow. This one goes beyond the phrase itself, since the class named the
  same concept; it is easy to drop if the type-lattice name should stay.

### Left alone

* The `⊥` glyph itself, and its `$eo:bottom` alias in `_specials.xsl` — that
  is the name of the sign, like `$eo:phi` and `$eo:rho`, not the name of the
  object, and outside packages may reference it.
* Every unrelated "bottom": the parser stack's bottom sentinel and
  bottom-to-top invariants, the printer's bottom-up traversal, padding, and
  CSS in `xs3p.xsl`.

### Verification

* `mvn -pl eo-inference test` — all green.
* `mvn -pl eo-parser test -Dtest=EoSyntaxTest,EoTest,ValueTest` — 677 tests,
  no failures (the renamed syntax pack is picked up by the glob).
* `mvn -pl eo-runtime -am test-compile` — clean.

No behaviour changes: the only non-comment edits are the `eo-inference`
identifiers and the element name in its internal links table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PohiyS9qShWgifaDd4h7gC


---
_Generated by [Claude Code](https://claude.ai/code/session_01PohiyS9qShWgifaDd4h7gC)_