### PR TITLE
#7357: make `Dep.equals()` symmetric

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Dep.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Dep.java
@@ -63,7 +63,7 @@ final class Dep implements Comparable<Dep>, Supplier<Dependency> {
 
     @Override
     public boolean equals(@Nonnull final Object other) {
-        return this.toString().equals(String.valueOf(other));
+        return other instanceof Dep && this.toString().equals(other.toString());
     }
 
     @Override

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DepTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DepTest.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Dep}.
+ * @since 0.56.9
+ */
+final class DepTest {
+
+    @Test
+    void equalsToAnotherDepWithSameCoordinate() {
+        MatcherAssert.assertThat(
+            "Two deps with the same coordinate must be equal",
+            DepTest.runtime(),
+            Matchers.equalTo(DepTest.runtime())
+        );
+    }
+
+    @Test
+    void doesNotEqualToDepWithAnotherVersion() {
+        MatcherAssert.assertThat(
+            "Deps with different versions must not be equal",
+            DepTest.runtime(),
+            Matchers.not(
+                Matchers.equalTo(
+                    new Dep()
+                        .withGroupId("org.eolang")
+                        .withArtifactId("eo-runtime")
+                        .withVersion("0.0.1")
+                )
+            )
+        );
+    }
+
+    @Test
+    void doesNotEqualToItsOwnCoordinateString() {
+        MatcherAssert.assertThat(
+            "Dep must not be equal to a plain string, since that breaks symmetry",
+            DepTest.runtime(),
+            Matchers.not(Matchers.<Object>equalTo("org.eolang:eo-runtime:0.0.0"))
+        );
+    }
+
+    @Test
+    void doesNotEqualToWrappedDependency() {
+        MatcherAssert.assertThat(
+            "Dep must not be equal to the Maven dependency it wraps",
+            DepTest.runtime(),
+            Matchers.not(Matchers.<Object>equalTo(DepTest.runtime().get()))
+        );
+    }
+
+    @Test
+    void makesSameHashCodeForSameCoordinate() {
+        MatcherAssert.assertThat(
+            "Equal deps must have equal hash codes",
+            DepTest.runtime().hashCode(),
+            Matchers.equalTo(DepTest.runtime().hashCode())
+        );
+    }
+
+    private static Dep runtime() {
+        return new Dep()
+            .withGroupId("org.eolang")
+            .withArtifactId("eo-runtime")
+            .withVersion("0.0.0");
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DepTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DepTest.java
@@ -18,8 +18,8 @@ final class DepTest {
     void equalsToAnotherDepWithSameCoordinate() {
         MatcherAssert.assertThat(
             "Two deps with the same coordinate must be equal",
-            DepTest.runtime(),
-            Matchers.equalTo(DepTest.runtime())
+            this.runtime(),
+            Matchers.equalTo(this.runtime())
         );
     }
 
@@ -27,7 +27,7 @@ final class DepTest {
     void doesNotEqualToDepWithAnotherVersion() {
         MatcherAssert.assertThat(
             "Deps with different versions must not be equal",
-            DepTest.runtime(),
+            this.runtime(),
             Matchers.not(
                 Matchers.equalTo(
                     new Dep()
@@ -43,7 +43,7 @@ final class DepTest {
     void doesNotEqualToItsOwnCoordinateString() {
         MatcherAssert.assertThat(
             "Dep must not be equal to a plain string, since that breaks symmetry",
-            DepTest.runtime(),
+            this.runtime(),
             Matchers.not(Matchers.<Object>equalTo("org.eolang:eo-runtime:0.0.0"))
         );
     }
@@ -52,8 +52,8 @@ final class DepTest {
     void doesNotEqualToWrappedDependency() {
         MatcherAssert.assertThat(
             "Dep must not be equal to the Maven dependency it wraps",
-            DepTest.runtime(),
-            Matchers.not(Matchers.<Object>equalTo(DepTest.runtime().get()))
+            this.runtime(),
+            Matchers.not(Matchers.<Object>equalTo(this.runtime().get()))
         );
     }
 
@@ -61,12 +61,12 @@ final class DepTest {
     void makesSameHashCodeForSameCoordinate() {
         MatcherAssert.assertThat(
             "Equal deps must have equal hash codes",
-            DepTest.runtime().hashCode(),
-            Matchers.equalTo(DepTest.runtime().hashCode())
+            this.runtime().hashCode(),
+            Matchers.equalTo(this.runtime().hashCode())
         );
     }
 
-    private static Dep runtime() {
+    private Dep runtime() {
         return new Dep()
             .withGroupId("org.eolang")
             .withArtifactId("eo-runtime")


### PR DESCRIPTION
Closes #7357

`Dep.equals()` compared its own coordinate against `String.valueOf(other)` without
checking the type of the other object. A `Dep` was therefore equal to a plain
`String` carrying the same coordinate, while the reverse comparison was `false` —
a violation of the symmetry contract of `Object.equals()`. Since `hashCode()` is
derived from the same string, the `Dep` and that `String` also shared a hash code,
which made collection lookups order-dependent.

Now `equals()` is guarded with `other instanceof Dep`, so a `Dep` is equal only to
another `Dep` representing the same coordinate. `hashCode()` is unchanged, still
derived from the same `Dep` value.

All existing equality use of `Dep` is `Dep`-to-`Dep` (the `HashSet<Dep>` in
`DpsDefault`, `ResolvedVersions`, and `.distinct()` in `Resolving`), so nothing
relied on the old cross-type behaviour.

Added `DepTest` with regression tests for symmetry with the coordinate string,
for the wrapped `Dependency`, and for `hashCode()` consistency.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ5Z3YMbpWN66cenVUJ8JL)_