### PR TITLE
#7350: reject the cactus emoji in a void parameter name

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -46,10 +46,12 @@ final class Emissions {
      * special forms — §4.5. Shared by every producer of a void parameter
      * list ({@link LnFormation}, {@link LnOnlyPhi}, this class's own
      * {@link #inlinePhi}), so a bracket list is validated the same way
-     * regardless of which line shape it appears on.
+     * regardless of which line shape it appears on. The cactus emoji is
+     * excluded along with the ordinary NAME terminators, since §2.3 keeps
+     * that glyph for auto-names.
      */
     private static final Pattern PARAM_NAME = Pattern.compile(
-        "[a-z][^ \\t,.|':;!?\\[\\]{}()]*(?:\\.\\.\\.)?"
+        "[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*(?:\\.\\.\\.)?"
     );
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-cactus.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-cactus.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:1] error: 'parameter names in voids must be NAME or @'
+  [foo🌵] > main
+   ^
+input: |
+  [foo🌵] > main
+    5 > x


### PR DESCRIPTION
Closes #7350

`[foo🌵] > main` parsed without complaint and emitted a void child named
`foo🌵`. The NAME pattern that `Emissions.validParam` matches a void parameter
against — `Emissions.PARAM_NAME`, shared by `LnFormation`, `LnOnlyPhi` and
`inlinePhi` since #7315 — listed the ordinary NAME terminators but left the
cactus emoji out, while §2.3 reserves that glyph for auto-names.
`Tokens.readName`, all three suffix paths and `Eo`'s line head reject it
already.

`\x{1F335}` now sits in the excluded set alongside the other terminators, so
`[foo🌵] > main` is rejected with the existing diagnostic:

```
[1:1] error: 'parameter names in voids must be NAME or @'
[foo🌵] > main
 ^
```

Auto-named voids are unaffected: the parser builds those names itself and does
not run them through `validParam`.

Added `eo-typos/void-param-cactus.yaml`. It fails without the source change and
passes with it. The rest of `eo-parser` is unchanged — 1309 tests, no new
failures.

Note on CI: the `mvn` and `qulice` jobs are red on `master` itself right now,
for reasons unrelated to this change. #7386 has the details and the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ5Z3YMbpWN66cenVUJ8JL)_