### PR TITLE
#7351: reject the cactus emoji in a META directive name

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -24,13 +24,6 @@ import java.util.List;
 final class LnMeta implements Line {
 
     /**
-     * A directive name, which is a NAME — §2.3. The excluded set holds the
-     * ordinary NAME terminators and the cactus emoji, which §2.3 keeps for
-     * auto-names.
-     */
-    private static final String NAME = "[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*";
-
-    /**
      * The meta line's span.
      */
     private final Span span;
@@ -90,7 +83,7 @@ final class LnMeta implements Line {
                 "meta directive requires a name"
             );
         }
-        if (!head.matches(LnMeta.NAME)) {
+        if (!head.matches("[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*")) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + 1,
                 "meta name must be a NAME starting with a lowercase letter"

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -24,6 +24,13 @@ import java.util.List;
 final class LnMeta implements Line {
 
     /**
+     * A directive name, which is a NAME — §2.3. The excluded set holds the
+     * ordinary NAME terminators and the cactus emoji, which §2.3 keeps for
+     * auto-names.
+     */
+    private static final String NAME = "[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*";
+
+    /**
      * The meta line's span.
      */
     private final Span span;
@@ -83,7 +90,7 @@ final class LnMeta implements Line {
                 "meta directive requires a name"
             );
         }
-        if (!head.matches("[a-z][^ \\t,.|':;!?\\[\\]{}()]*")) {
+        if (!head.matches(LnMeta.NAME)) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + 1,
                 "meta name must be a NAME starting with a lowercase letter"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-cactus.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-cactus.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  [1:1] error: 'meta name must be a NAME starting with a lowercase letter'
+  +foo🌵
+   ^
+input: |
+  +foo🌵
+
+  [] > main
+    5 > x


### PR DESCRIPTION
Closes #7351

`+foo🌵` parsed without complaint and emitted `foo🌵` as the directive name.
`LnMeta.checkHead` matched the head against a hand-written NAME pattern that
listed the ordinary NAME terminators but left the cactus emoji out, while §2.3
reserves that glyph for auto-names and `Tokens.readName` rejects it in an
ordinary identifier.

The pattern now lives in a named constant with `\x{1F335}` in its excluded set,
so `+foo🌵` is rejected with the existing meta-name diagnostic:

```
[1:1] error: 'meta name must be a NAME starting with a lowercase letter'
+foo🌵
 ^
```

A legal `+foo` is still accepted, as the rest of the meta fixtures show.

Added `eo-typos/meta-name-cactus.yaml`. It fails without the source change and
passes with it. `eo-parser` is otherwise unchanged — 1309 tests, no new
failures.

Note on CI: the `mvn` and `qulice` jobs are red on `master` itself right now,
for reasons unrelated to this change. #7386 has the details and the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ5Z3YMbpWN66cenVUJ8JL)_