### PR TITLE
#7346: reject the cactus emoji in an inline binding label

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -203,7 +203,7 @@ final class Tokens {
             idx = idx + 1;
         }
         final String raw = this.body.substring(start, idx);
-        if (raw.codePoints().anyMatch(cp -> cp == 0x1F335)) {
+        if (Tokens.cactus(raw)) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + start,
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
@@ -500,6 +500,12 @@ final class Tokens {
             );
         }
         final String text = this.body.substring(start, this.cursor);
+        if (Tokens.cactus(text)) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + start,
+                "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
         if (!Tokens.validBinding(text)) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + start,
@@ -635,6 +641,10 @@ final class Tokens {
 
     private static boolean terminates(final char glyph) {
         return Tokens.TERMINATORS.indexOf(glyph) >= 0;
+    }
+
+    private static boolean cactus(final String text) {
+        return text.codePoints().anyMatch(cp -> cp == 0x1F335);
     }
 
     private static boolean validBinding(final String text) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-label-cactus.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-label-cactus.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  error: 'cactus emoji is reserved for auto-names; not allowed in identifiers'
+input: |
+  [] > main
+    foo bar:good🌵 > result


### PR DESCRIPTION
Closes #7346

`foo bar:good🌵 > result` parsed without complaint and serialized `good🌵` as
an `@as` value. `Tokens.validBinding` accepted any label whose first character
was lowercase and never looked for the glyph that §2.3 reserves for auto-names,
even though `Tokens.readName` and all three suffix paths reject it.

The check that `readName` already performed is now a shared private helper, and
`readBinding` runs the label through it before `validBinding`, so a binding
label is rejected with the same diagnostic the parser gives everywhere else:

```
error: 'cactus emoji is reserved for auto-names; not allowed in identifiers'
```

`validBinding`'s two special forms are untouched — an all-digit slot
(`bar:0`) and a standalone `^` (`y:^`) still pass, and so does an ordinary
`bar:good`.

Added `eo-typos/binding-label-cactus.yaml`. It fails without the source change
and passes with it. `eo-parser` is otherwise unchanged — 1309 tests, no new
failures, and `qulice` reports nothing new on the module.

Note on CI: the `mvn` and `qulice` jobs are red on `master` itself right now,
for reasons unrelated to this change. #7386 has the details and the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ5Z3YMbpWN66cenVUJ8JL)_