### PR TITLE
#7354: reject the cactus emoji in an atom signature and a void type

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -288,6 +288,7 @@ final class Suffix {
      * @return Emitted token — variable verbatim, forma promoted
      */
     static String typeAtom(final String raw, final Span span, final int pos) {
+        Suffix.checkCactus(raw, span, pos);
         final char first = raw.charAt(0);
         if (first >= 'A' && first <= 'Z' && !raw.matches("[A-F]") && !raw.startsWith("Q.")) {
             throw new ParseError(
@@ -366,15 +367,19 @@ final class Suffix {
             );
         }
         final String name = tail.substring(start, idx);
-        if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
-            throw new ParseError(
-                span.line(), home + start,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
+        Suffix.checkCactus(name, span, home + start);
         Suffix.checkLowercaseStart(name, span, home, start);
         Suffix.endsClean(tail, idx, span, home);
         return new Suffix(form, name, "", false);
+    }
+
+    private static void checkCactus(final String name, final Span span, final int pos) {
+        if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
+            throw new ParseError(
+                span.line(), pos,
+                "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
     }
 
     private static void checkLowercaseStart(
@@ -420,12 +425,7 @@ final class Suffix {
                 )
             );
         }
-        if (handle.codePoints().anyMatch(cp -> cp == 0x1F335)) {
-            throw new ParseError(
-                span.line(), home + begin,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
+        Suffix.checkCactus(handle, span, home + begin);
         Suffix.checkLowercaseStart(handle, span, home, begin);
         if (!cnst && tail.startsWith("!", rest)) {
             cnst = true;
@@ -455,12 +455,7 @@ final class Suffix {
         int idx = Suffix.skipName(tail, begin);
         Suffix.checkNamePresent(tail, begin, idx, span, home);
         final String name = tail.substring(begin, idx);
-        if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
-            throw new ParseError(
-                span.line(), home + begin,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
+        Suffix.checkCactus(name, span, home + begin);
         Suffix.checkLowercaseStart(name, span, home, begin);
         boolean cnst = false;
         if (idx < tail.length() && tail.charAt(idx) == '!') {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/atom-signature-cactus.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/atom-signature-cactus.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  error: 'cactus emoji is reserved for auto-names; not allowed in identifiers'
+input: |
+  [] > main /foo🌵bar
+    5 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-type-cactus.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-type-cactus.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  error: 'cactus emoji is reserved for auto-names; not allowed in identifiers'
+input: |
+  [] > main /foo
+    ? > x /bar🌵baz


### PR DESCRIPTION
Closes #7354

`[] > main /foo🌵bar` parsed without complaint and left the reserved glyph in
the public `@atom` value. `Suffix.signature` checked a signature for malformed
dots, a bare `Q` and a stray `?`, then handed the rest to `Suffix.typeAtom`,
which never looked at the component names — while §2.3 reserves that glyph for
auto-names and `Tokens.readName` rejects it in any ordinary identifier.

`LnVoid` reaches `typeAtom` too, both for a `/type` annotation and for each
member of a `/{…}` list, so a void type annotation had the same hole. The issue
asks for the two to be validated uniformly, and putting the check in `typeAtom`
is what makes that true by construction.

The check itself was already written out three times in `Suffix` — in `named`,
`auto` and `test`. It is now one `checkCactus` helper, called from those three
places and from `typeAtom`, so a signature and a void type are rejected with the
diagnostic the parser gives everywhere else:

```
error: 'cactus emoji is reserved for auto-names; not allowed in identifiers'
```

Generated auto-names never pass through `typeAtom` — it only ever sees a
user-written signature or type annotation — so nothing that legitimately carries
the glyph is affected.

Added `eo-typos/atom-signature-cactus.yaml` and `eo-typos/void-type-cactus.yaml`.
Both fail without the source change and pass with it. `eo-parser` is otherwise
unchanged — 1311 tests, no new failures, and `qulice` reports nothing new on the
module.

Note on CI: the `mvn` and `qulice` jobs are red on `master` itself right now,
for reasons unrelated to this change. #7386 has the details and the fix.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GJ5Z3YMbpWN66cenVUJ8JL)_