### PR TITLE
Fix broken master: drop the removed `%` token from the self-fibo syntax test

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/self-reference-in-a-nested-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/self-reference-in-a-nested-formation.yaml
@@ -9,13 +9,13 @@ input: |
   +package snippets
 
   [] > self-fibo
-    [n] >>
+    [n] >> fibo
       if. > @
         n.lt 2
         n
         plus.
-          % (n.minus 1)
-          % (n.minus 2)
+          fibo (n.minus 1)
+          fibo (n.minus 2)
     | 6 > num
     stdout > @
       "%d is the %dth number\n".printf


### PR DESCRIPTION
Master is red: [run 32554398354](https://github.com/objectionary/eo/actions/runs/32554398354/job/96986208091) fails in `eo-parser` with `Tests run: 1307, Failures: 1` — `EoSyntaxTest.validatesEoSyntax` on `eo-syntax/self-reference-in-a-nested-formation.yaml`.

## Root cause

A semantic merge conflict between two PRs that were each green on their own branch:

- #7229 (`6d99640a`) added `self-reference-in-a-nested-formation.yaml`, whose recursive calls are spelled with the `%` self-reference token.
- #7325 (`f89ea7e6`, for #7286) removed `%` from the parser — "the `%` token was unfinished WIP sugar that resolved to the auto-name of the enclosing anonymous (`>>`) formation".

Neither CI run saw the other's change, so master went red the moment they met. `Eo.classify` now falls through to `rejected` for a `%` head, and the two rejected lines also strip the `plus.` reversed dispatch above them of its receiver:

```
[9:8] error: 'line shape not yet implemented in spec parser'
[10:8] error: 'line shape not yet implemented in spec parser'
[8:6] error: 'reversed dispatch missing receiver'
```

That yaml is the only remaining `%` usage in the repo, so nothing else is affected.

## Fix

`%` resolved to the auto-name of the enclosing `>>` formation, so the surviving spelling is the file-local handle itself. The handle is given the name `fibo` and called by that name — the same shape `eo-packs/parse/resolve-local-names.yaml` already uses and asserts on:

```diff
   [] > self-fibo
-    [n] >>
+    [n] >> fibo
       if. > @
         n.lt 2
         n
         plus.
-          % (n.minus 1)
-          % (n.minus 2)
+          fibo (n.minus 1)
+          fibo (n.minus 2)
```

The test keeps its original intent — a formation referring to itself from a nested scope — and no parser change is needed. Test-resource change only.

## Verification

Reproduced the failure on unmodified master locally (`EoSyntaxTest#validatesEoSyntax`: `Tests run: 159, Failures: 1`), then with the fix:

```
$ mvn -pl eo-parser test
Tests run: 1307, Failures: 0, Errors: 0, Skipped: 6
BUILD SUCCESS
```

Same 1307 tests CI ran, now all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1XN62cknuTADqJiLTwXvn)_