### PR TITLE
Read a string literal's escapes somewhere else

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -4,10 +4,8 @@
  */
 package org.eolang.parser;
 
-import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -24,11 +22,6 @@ import java.util.regex.Pattern;
  * @since 0.1
  */
 final class Emissions {
-
-    /**
-     * Maximum value of a {@code \NNN} octal byte escape (0o377, one byte).
-     */
-    private static final int MAX_OCTAL_BYTE = 0xFF;
 
     /**
      * Bits an IEEE-754 double keeps below the leading one of its
@@ -215,15 +208,6 @@ final class Emissions {
     }
 
     /**
-     * Decode a string body to its raw byte representation.
-     * @param inner Source body without surrounding quotes
-     * @return Decoded bytes
-     */
-    static byte[] unescapeBytes(final String inner) {
-        return Emissions.unescapeRawBytes(inner);
-    }
-
-    /**
      * Reject a void parameter name the grammar does not accept — §4.5.
      * @param raw The parameter text, as written
      * @param line Source line (for error reporting)
@@ -303,7 +287,7 @@ final class Emissions {
         emit.object(name, "Φ.string", line, value.pos());
         final byte[] unescaped;
         try {
-            unescaped = Emissions.unescapeBytes(
+            unescaped = Escapes.bytes(
                 value.raw().substring(1, value.raw().length() - 1)
             );
         } catch (final NumberFormatException ex) {
@@ -317,28 +301,6 @@ final class Emissions {
             emit, line, value.pos(),
             new Hex(unescaped).asString()
         );
-    }
-
-    private static void rejectLoneSurrogates(final CharSequence text) {
-        int cursor = 0;
-        while (cursor < text.length()) {
-            final char glyph = text.charAt(cursor);
-            if (Character.isHighSurrogate(glyph)
-                && cursor + 1 < text.length()
-                && Character.isLowSurrogate(text.charAt(cursor + 1))) {
-                cursor = cursor + 2;
-                continue;
-            }
-            if (Character.isSurrogate(glyph)) {
-                throw new NumberFormatException(
-                    String.format(
-                        "unicode escape \\u%04X is a lone surrogate, not a valid standalone codepoint",
-                        (int) glyph
-                    )
-                );
-            }
-            cursor = cursor + 1;
-        }
     }
 
     private static void number(
@@ -445,111 +407,6 @@ final class Emissions {
             mapped = raw;
         }
         return mapped;
-    }
-
-    private static byte[] unescapeRawBytes(final String inner) {
-        final ByteArrayOutputStream out = new ByteArrayOutputStream(inner.length());
-        final StringBuilder text = new StringBuilder(inner.length());
-        int idx = 0;
-        while (idx < inner.length()) {
-            final char glyph = inner.charAt(idx);
-            if (glyph != '\\' || idx + 1 >= inner.length()) {
-                text.append(glyph);
-                idx = idx + 1;
-                continue;
-            }
-            final char next = inner.charAt(idx + 1);
-            if (next == 'u') {
-                idx = Emissions.appendUnicode(text, inner, idx + 1);
-            } else if (next >= '0' && next <= '7') {
-                idx = Emissions.rawOctal(out, text, inner, idx + 1);
-            } else {
-                text.append(Emissions.singleCharEscape(glyph, next));
-                idx = idx + 2;
-            }
-        }
-        Emissions.appendText(out, text);
-        return out.toByteArray();
-    }
-
-    private static int rawOctal(
-        final ByteArrayOutputStream out, final StringBuilder text,
-        final String body, final int start
-    ) {
-        Emissions.appendText(out, text);
-        int cursor = start;
-        int value = 0;
-        while (cursor < body.length() && cursor < start + 3
-            && body.charAt(cursor) >= '0' && body.charAt(cursor) <= '7') {
-            value = value * 8 + body.charAt(cursor) - '0';
-            cursor = cursor + 1;
-        }
-        if (value > Emissions.MAX_OCTAL_BYTE) {
-            throw new NumberFormatException(
-                String.format(
-                    "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
-                    body.substring(start, cursor), value
-                )
-            );
-        }
-        out.write(value);
-        return cursor;
-    }
-
-    private static void appendText(
-        final ByteArrayOutputStream out, final StringBuilder text
-    ) {
-        Emissions.rejectLoneSurrogates(text);
-        final byte[] bytes = text.toString().getBytes(StandardCharsets.UTF_8);
-        out.write(bytes, 0, bytes.length);
-        text.setLength(0);
-    }
-
-    private static int appendUnicode(
-        final StringBuilder out, final String body, final int start
-    ) {
-        int cursor = start;
-        while (cursor < body.length() && body.charAt(cursor) == 'u') {
-            cursor = cursor + 1;
-        }
-        boolean valid = cursor + 4 <= body.length();
-        for (int idx = cursor; valid && idx < cursor + 4; idx = idx + 1) {
-            valid = Character.digit(body.charAt(idx), 16) >= 0;
-        }
-        if (!valid) {
-            throw new NumberFormatException(
-                String.format(
-                    "unicode escape \\%s is not exactly four hexadecimal digits",
-                    body.substring(start, Math.min(body.length(), cursor + 4))
-                )
-            );
-        }
-        out.append(
-            (char) Integer.parseInt(body.substring(cursor, cursor + 4), 16)
-        );
-        return cursor + 4;
-    }
-
-    private static String singleCharEscape(final char head, final char next) {
-        final String decoded;
-        if (next == 'n') {
-            decoded = String.valueOf((char) 10);
-        } else if (next == 't') {
-            decoded = String.valueOf((char) 9);
-        } else if (next == 'r') {
-            decoded = String.valueOf((char) 13);
-        } else if (next == 'b') {
-            decoded = String.valueOf((char) 8);
-        } else if (next == 'f') {
-            decoded = String.valueOf((char) 12);
-        } else if (next == '"' || next == '\'' || next == '\\') {
-            decoded = String.valueOf(next);
-        } else {
-            throw new NumberFormatException(
-                String.format("unrecognised escape sequence '%c%c'", head, next)
-            );
-        }
-        return decoded;
     }
 
     private static boolean reversedDispatch(final Tokens tokens, final Value head) {

--- a/eo-parser/src/main/java/org/eolang/parser/Escapes.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Escapes.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * The bytes a string literal stands for, with its escapes read out.
+ *
+ * <p>Between the quotes a source file may write a byte in four ways — as
+ * itself, as {@code \n} and its kin, as a unicode escape of four hexadecimal
+ * digits, or as the octal {@code \101} — and every one of them has to come out
+ * as the same bytes the program will hold at runtime. That reading is a
+ * subject of its own, sharing nothing with the emission of XMIR around it, so
+ * it lives on its own.</p>
+ *
+ * <p>A text escape and a byte escape do not go into the same place. A unicode
+ * escape is a character and becomes whatever UTF-8 makes of it, while a
+ * {@code \101} is one byte and goes in as it stands, so the text gathers in a
+ * builder and is flushed into the stream whenever an octal escape interrupts
+ * it.</p>
+ *
+ * @since 0.1
+ */
+final class Escapes {
+
+    /**
+     * Maximum value of a {@code \NNN} octal byte escape (0o377, one byte).
+     */
+    private static final int MAX_OCTAL_BYTE = 0xFF;
+
+    /**
+     * No instances.
+     */
+    private Escapes() {
+    }
+
+    /**
+     * Decode a string body to its raw byte representation.
+     * @param inner Source body without surrounding quotes
+     * @return Decoded bytes
+     */
+    static byte[] bytes(final String inner) {
+        final ByteArrayOutputStream out = new ByteArrayOutputStream(inner.length());
+        final StringBuilder text = new StringBuilder(inner.length());
+        int idx = 0;
+        while (idx < inner.length()) {
+            final char glyph = inner.charAt(idx);
+            if (glyph != '\\' || idx + 1 >= inner.length()) {
+                text.append(glyph);
+                idx = idx + 1;
+                continue;
+            }
+            final char next = inner.charAt(idx + 1);
+            if (next == 'u') {
+                idx = Escapes.appendUnicode(text, inner, idx + 1);
+            } else if (next >= '0' && next <= '7') {
+                idx = Escapes.rawOctal(out, text, inner, idx + 1);
+            } else {
+                text.append(Escapes.singleCharEscape(glyph, next));
+                idx = idx + 2;
+            }
+        }
+        Escapes.appendText(out, text);
+        return out.toByteArray();
+    }
+
+    private static int rawOctal(
+        final ByteArrayOutputStream out, final StringBuilder text,
+        final String body, final int start
+    ) {
+        Escapes.appendText(out, text);
+        int cursor = start;
+        int value = 0;
+        while (cursor < body.length() && cursor < start + 3
+            && body.charAt(cursor) >= '0' && body.charAt(cursor) <= '7') {
+            value = value * 8 + body.charAt(cursor) - '0';
+            cursor = cursor + 1;
+        }
+        if (value > Escapes.MAX_OCTAL_BYTE) {
+            throw new NumberFormatException(
+                String.format(
+                    "octal escape \\%s is out of range: value %d exceeds the 1-byte limit of 0o377 (255)",
+                    body.substring(start, cursor), value
+                )
+            );
+        }
+        out.write(value);
+        return cursor;
+    }
+
+    private static void appendText(
+        final ByteArrayOutputStream out, final StringBuilder text
+    ) {
+        Escapes.rejectLoneSurrogates(text);
+        final byte[] bytes = text.toString().getBytes(StandardCharsets.UTF_8);
+        out.write(bytes, 0, bytes.length);
+        text.setLength(0);
+    }
+
+    private static int appendUnicode(
+        final StringBuilder out, final String body, final int start
+    ) {
+        int cursor = start;
+        while (cursor < body.length() && body.charAt(cursor) == 'u') {
+            cursor = cursor + 1;
+        }
+        boolean valid = cursor + 4 <= body.length();
+        for (int idx = cursor; valid && idx < cursor + 4; idx = idx + 1) {
+            valid = Character.digit(body.charAt(idx), 16) >= 0;
+        }
+        if (!valid) {
+            throw new NumberFormatException(
+                String.format(
+                    "unicode escape \\%s is not exactly four hexadecimal digits",
+                    body.substring(start, Math.min(body.length(), cursor + 4))
+                )
+            );
+        }
+        out.append(
+            (char) Integer.parseInt(body.substring(cursor, cursor + 4), 16)
+        );
+        return cursor + 4;
+    }
+
+    private static String singleCharEscape(final char head, final char next) {
+        final String decoded;
+        if (next == 'n') {
+            decoded = String.valueOf((char) 10);
+        } else if (next == 't') {
+            decoded = String.valueOf((char) 9);
+        } else if (next == 'r') {
+            decoded = String.valueOf((char) 13);
+        } else if (next == 'b') {
+            decoded = String.valueOf((char) 8);
+        } else if (next == 'f') {
+            decoded = String.valueOf((char) 12);
+        } else if (next == '"' || next == '\'' || next == '\\') {
+            decoded = String.valueOf(next);
+        } else {
+            throw new NumberFormatException(
+                String.format("unrecognised escape sequence '%c%c'", head, next)
+            );
+        }
+        return decoded;
+    }
+
+    private static void rejectLoneSurrogates(final CharSequence text) {
+        int cursor = 0;
+        while (cursor < text.length()) {
+            final char glyph = text.charAt(cursor);
+            if (Character.isHighSurrogate(glyph)
+                && cursor + 1 < text.length()
+                && Character.isLowSurrogate(text.charAt(cursor + 1))) {
+                cursor = cursor + 2;
+                continue;
+            }
+            if (Character.isSurrogate(glyph)) {
+                throw new NumberFormatException(
+                    String.format(
+                        "unicode escape \\u%04X is a lone surrogate, not a valid standalone codepoint",
+                        (int) glyph
+                    )
+                );
+            }
+            cursor = cursor + 1;
+        }
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -66,7 +66,7 @@ final class LnTextBlock implements Line {
         }
         final byte[] joined;
         try {
-            joined = Emissions.unescapeBytes(
+            joined = Escapes.bytes(
                 String.join(String.valueOf('\n'), globals.tbody())
             );
         } catch (final NumberFormatException ex) {


### PR DESCRIPTION
Master is red on qulice and takes every pull request down with it:

```text
PMD: eo-parser/src/main/java/org/eolang/parser/Emissions.java[26-26]:
  Possible God Class (WMC=133, ATFD=6, TCC=0.000%) (GodClass)
```

No single commit broke it. `a30153e7db` moved qulice from 0.31.1 to
0.31.2 and #7319 added the reversed-dispatch receiver check to
`Emissions.expression` at about the same time; each was green on its own
branch and the two together are over the line.

The measurement is fair. `Emissions` was 657 lines and seventeen methods
doing three unrelated things, and one of them belongs least: reading the
escapes out of a string literal. Between the quotes a byte can be written
as itself, as `\n` and its kin, as a unicode escape, or as the octal
`\101`, and every one has to come out as the bytes the program will hold
at runtime. That is a subject of its own and shares nothing with emitting
XMIR, so it moves to `Escapes` — seven methods and the octal byte cap they
are the only users of.

Enough to clear the rule, and it clears it honestly rather than by
shaving a metric: `Escapes` is cohesive, and what is left in `Emissions`
is emission.

`Emissions.unescapeBytes` went with it instead of staying behind as a
one-line delegator, so both callers ask directly:

```java
    static byte[] bytes(final String inner) {
        final ByteArrayOutputStream out = new ByteArrayOutputStream(inner.length());
        final StringBuilder text = new StringBuilder(inner.length());
```

No behaviour changes. 1,307 parser tests pass, and `mvn -Pqulice verify`
is clean across every module.

Two subjects are still sharing `Emissions` — the canonical spelling of a
double (`overPrecise`, `exact`, `exactly`, `canonicalInteger`) and the
inline-phi machinery (`group`, `topLevelInlinePhi`, `inlinePhi`,
`splitParams`). Both would read better on their own, and neither is
needed to get the build green, so they are left for a ticket of their own
rather than smuggled in here.
