### PR TITLE
fix(#7334): keep a single separator on a normalized root path

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -135,7 +135,17 @@
             core.size.eq 0
             "."
             core.concat
-              trailing.if ^.separator --
+              if.
+                trailing.and rooted.not
+                ^.separator
+                --
+      and. > rooted
+        core.size.gt 0
+        eq.
+          core.slice
+            core.size.plus -1
+            1
+          ^.separator
       and. > trailing
         ubts.size.gt 0
         eq.
@@ -371,6 +381,11 @@
     normalized.
       path.win32 "\\\\server\\share\\..\\..\\folder"
     "\\\\server\\share\\folder"
+
+  eq. ++> can-normalize-a-win32-drive-root-keeping-a-single-separator
+    normalized.
+      path.win32 "C:\\"
+    "C:\\"
 
   eq. ++> can-normalize-a-win32-path-collapsing-to-the-current-directory
     normalized.


### PR DESCRIPTION
Fixes #7334.

`normalized` appended the trailing separator of the original URI even when the assembled core already ended with one, so a root that carries its only separator got a second one:

| input | before | after |
| --- | --- | --- |
| `path.win32 "C:\"` | `C:\\` | `C:\` |
| `path.win32 "\\"` | `\\\` | `\` |
| `path.win32 "\\server\share\..\"` | `\\server\share\` | unchanged |
| `path.win32 "C:\foo\"` | `C:\foo\` | unchanged |
| `path.posix "//"` | `/` | unchanged |

The append is now guarded by a new `rooted` attribute that tells whether `core` already ends with the separator, built the same way as the existing `trailing` check.

Verified against the transpiled runtime before and after the change; the last three rows above are the controls that keep the trailing separator where it belongs. The `++>` example added next to the other normalization tests locks in the drive root, and `can-normalize-a-unc-win32-path-with-a-parent-segment-and-a-trailing-separator` already covers the opposite direction.
