### PR TITLE
fix(#7339): reject a fractional insertion index in tuple.withi

### DIFF
--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -1,4 +1,7 @@
 # Insert `item` into collection `list` at the given `index`.
+# The `index` must be an integer, the same requirement `tuple.front` and
+# `tuple.back` make; anything else terminates. A negative index is clamped
+# to the front of the list and an index past the end appends the item.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,12 +11,15 @@
 +spdx SPDX-License-Identifier: MIT
 
 [index item] > withi
-  concat. > @
-    with.
-      list.front bounded
-      item
-    list.back
-      list.length.minus bounded
+  index.is-integer.if > @
+    concat.
+      with.
+        list.front bounded
+        item
+      list.back
+        list.length.minus bounded
+    T
+      "Given index must be an integer"
   if. > bounded
     0.gt index
     0
@@ -86,3 +92,19 @@
       "hello"
       4
       5
+
+  withi. --> stops-on-a-negative-fractional-index
+    *
+      1
+      2
+      3
+    -0.5
+    9
+
+  withi. --> stops-on-a-positive-fractional-index
+    *
+      1
+      2
+      3
+    0.5
+    9


### PR DESCRIPTION
Fixes #7339.

`withi` clamped the index before anyone checked it was an integer, so a negative fraction never reached the validation in `tuple.front` while the mirror-image positive one did. The `is-integer` guard now runs first, with the same message `tuple.front` and `tuple.back` use.

Direct runtime calls on `* 1 2 3` with item `9`, before and after:

| index | before | after |
| --- | --- | --- |
| `-0.5` | `* 9 1 2 3` | terminates: Given index must be an integer |
| `0.5` | terminates | terminates (unchanged) |
| `nan` | terminates | terminates (unchanged) |
| `-1` | `* 9 1 2 3` | unchanged |
| `1` | `* 1 9 2 3` | unchanged |
| `5` | `* 1 2 3 9` | unchanged |

One behavior change beyond the report: an infinite index used to be clamped to the end and silently appended the item, and now terminates the same way. That follows from `is-integer` and matches what `front`, `back`, `slice` and `withouti` already do with an infinite index.

The two `-->` examples are written in the style `front.eo` uses for its fractional index. They are worth having as documentation, but the evidence that the guard works is the table above, taken from the transpiled runtime.
