### PR TITLE
#7355: reject a tab between META parts

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -110,8 +110,14 @@ final class LnMeta implements Line {
                 );
             }
             int end = idx;
-            while (end < tail.length() && tail.charAt(end) != ' ') {
+            while (end < tail.length() && !Character.isWhitespace(tail.charAt(end))) {
                 end = end + 1;
+            }
+            if (end < tail.length() && tail.charAt(end) != ' ') {
+                throw new ParseError(
+                    span.line(), span.indent() + base + end,
+                    "meta parts must be separated by a single ASCII space"
+                );
             }
             out.add(LnMeta.promoteQ(tail.substring(idx, end)));
             idx = end;

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -117,6 +117,16 @@ final class LnMetaTest {
     }
 
     @Test
+    void rejectsATabBetweenParts() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnMeta(new Span("+rt jvm\torg.eolang:eo-runtime:0.0.0", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a tab between meta parts must be rejected, since only a single ASCII space separates them"
+        );
+    }
+
+    @Test
     void clearsPendingBlanksOnEmission() {
         final Globals globals = new Globals();
         globals.blank();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/meta-parts-separated-by-a-tab-are-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/meta-parts-separated-by-a-tab-are-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'single ASCII space')]
+input: "+rt jvm\torg.eolang:eo-runtime:0.0.0\n\n[] > app\n  42 > x\n"


### PR DESCRIPTION
`LnMeta.split` scanned each META part until the first literal space, copying every other
character — including a tab — into the part text. META parts must be non-whitespace tokens
separated by exactly one ASCII space (R-3.2.4); a tab is whitespace and cannot appear inside
a part or serve as a separator, but `+rt jvm\torg.eolang:eo-runtime:0.0.0` parsed clean into
one `<part>` carrying the tab.

Widened the part-scan to stop at any whitespace character, not only a literal space, and
report a parse error when it stops at something other than a space.

Closes #7355
