### PR TITLE
fix(#7335): keep the share when taking the dirname of a UNC root

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -35,20 +35,36 @@
       string pth > text
     [] > dirname
       string > @
-        ^.drive.concat
-          if.
-            len.eq -1
+        if.
+          ^.unc.and root
+          text
+          ^.drive.concat
             if.
-              ^.drive.size.eq 0
-              "."
-              --
-            if.
-              len.eq 0
-              ^.separator
-              as-bytes.
-                text.slice
-                  0
-                  text.last-index-of ^.separator >> len!
+              len.eq -1
+              if.
+                ^.drive.size.eq 0
+                "."
+                --
+              if.
+                len.eq 0
+                ^.separator
+                as-bytes.
+                  text.slice
+                    0
+                    text.last-index-of ^.separator >> len!
+      tail.index-of ^.separator > first!
+      and. > root
+        text.length.gt 2
+        and.
+          not.
+            first.eq -1
+          first.eq
+            tail.last-index-of ^.separator
+      string > tail
+        as-bytes.
+          text.slice
+            2
+            text.length.minus 2
       string > text
         ^.stripped ^.driveless
     sys.drive uri > drive
@@ -628,6 +644,21 @@
     dirname.
       path.win32 "C:\\foo"
     "C:\\"
+
+  eq. ++> can-return-the-dirname-of-a-win32-unc-share-root
+    dirname.
+      path.win32 "\\\\server\\share"
+    "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-a-win32-unc-share-root-with-a-trailing-separator
+    dirname.
+      path.win32 "\\\\server\\share\\"
+    "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-a-win32-unc-share-subfolder
+    dirname.
+      path.win32 "\\\\server\\share\\folder"
+    "\\\\server\\share"
 
   eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
     dirname.


### PR DESCRIPTION
Fixes #7335.

`dirname` sliced at the last separator no matter what came before it, so the share of a UNC root was treated as an ordinary final segment. It now recognizes a share root, the same boundary `normalized` already protects when it resolves `..`, and returns it unchanged.

Direct runtime calls, before and after:

| input | before | after |
| --- | --- | --- |
| `\\server\share` | `\\server` | `\\server\share` |
| `\\server\share\` | `\\server` | `\\server\share` |
| `\\server\share\folder` | `\\server\share` | unchanged |
| `\\server\share\folder\file.txt` | `\\server\share\folder` | unchanged |
| `C:\foo\bar` | `C:\foo` | unchanged |
| `foo\bar`, `foo`, `` | `foo`, `.`, `.` | unchanged |
| posix `/a/b`, `/a`, `/`, `//a//b` | `/a`, `/`, `/`, `//a/` | unchanged |

The share test only runs for a win32 UNC path, and `and` is lazy on its argument, so nothing new is dataized on the posix side. `\\` alone still gives `\`: `stripped` cuts it to one separator, which the length guard keeps out of the new branch.

Three `++>` examples cover the share root, the same root with a trailing separator, and a child below it.
