### PR TITLE
#7356: normalize the mantissa for a magnitude below one with a negative exponent

### DIFF
--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -1,10 +1,11 @@
 # Writes the number `n` in scientific notation, as a mantissa with six fraction
 # digits, the letter `e`, and the power of ten that scales the mantissa back to
-# `n`, so that `1.0e19` becomes `1.000000e19`. A magnitude past the range of a
-# signed 64-bit integer is named this way, since `as-decimal` writes only what
-# it spells out digit by digit, and a non-finite number becomes `nan`,
-# `infinity` or `-infinity`, having no digits at all. The power is never
-# negative, so a magnitude below one keeps it at zero, as `0.500000e0` for `0.5`.
+# `n`, so that `1.0e19` becomes `1.000000e19`, and `1e-7` becomes
+# `1.000000e-7`. A magnitude past the range of a signed 64-bit integer is
+# named this way, since `as-decimal` writes only what it spells out digit by
+# digit, and a non-finite number becomes `nan`, `infinity` or `-infinity`,
+# having no digits at all. The mantissa is always normalized to `[1, 10)`, so
+# a magnitude below one carries a negative power, as `5.000000e-1` for `0.5`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -49,12 +50,22 @@
     "-1.000000".as-bytes
     "1.000000".as-bytes
   if. > [m count] >> rec-exponent
-    m.lt 10
+    or.
+      m.eq 0
+      and.
+        m.gte 1
+        m.lt 10
     count
-    ^.rec-exponent
-      m.div 10
-      as-number.
-        count.plus 1
+    if.
+      m.lt 1
+      ^.rec-exponent
+        m.times 10
+        as-number.
+          count.minus 1
+      ^.rec-exponent
+        m.div 10
+        as-number.
+          count.plus 1
 
   eq. ++> can-carry-a-rounded-mantissa-into-the-next-power-of-ten
     "1.000000e1"
@@ -79,6 +90,14 @@
   eq. ++> can-name-a-negative-magnitude
     "-9.223372e18"
     string -9.223372036854776e18.as-scientific
+
+  eq. ++> can-name-a-negative-small-magnitude-with-a-negative-power
+    "-1.000000e-7"
+    string -1.0e-7.as-scientific
+
+  eq. ++> can-name-a-small-magnitude-with-a-negative-power
+    "1.000000e-7"
+    string 1.0e-7.as-scientific
 
   eq. ++> can-name-nan
     "nan"


### PR DESCRIPTION
`rec-exponent` started at zero and stopped as soon as the magnitude was below ten, never
scaling a magnitude below one upward. `0.0000001.as-scientific` therefore sent `1e-7`
straight to `as-fixed` with exponent `0`, which rounds to six fraction digits and produces
`0.000000` — a nonzero input rendered as zero.

Added the symmetric branch: when the magnitude is below one, multiply by ten and decrement
the exponent, the same way the existing branch divides by ten and increments it for a
magnitude at or above ten. The mantissa is now always normalized to `[1, 10)` (except for
exactly zero), so a magnitude below one gets a negative exponent, e.g. `1.000000e-7` for
`0.0000001` and `5.000000e-1` for `0.5`. Updated the class doc comment, which previously
stated the exponent is never negative.

Closes #7356
