### PR TITLE
#7347: grow the read chunk exponentially to bound rec-read's recursion depth

### DIFF
--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -9,19 +9,21 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > length
-  [input length] >> rec-read
+  [input length chunk-size] >> rec-read
     if. > @
       chunk.size.eq 0
       length
       ^.rec-read
         chunk
         length.plus chunk.size
+        chunk-size.times 2
     ^. > chunk
       read.
-        input.read 4096
+        input.read chunk-size
   | > @
     origin
     0
+    4096
   ^ > origin
 
   eq. ++> can-read-all-bytes-and-return-the-length

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -9,17 +9,17 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > length
-  [input length chunk-size] >> rec-read
+  [input length step] >> rec-read
     if. > @
       chunk.size.eq 0
       length
       ^.rec-read
         chunk
         length.plus chunk.size
-        chunk-size.times 2
+        step.times 2
     ^. > chunk
       read.
-        input.read chunk-size
+        input.read step
   | > @
     origin
     0

--- a/eo-runtime/src/test/java/org/eolang/InputLengthTest.java
+++ b/eo-runtime/src/test/java/org/eolang/InputLengthTest.java
@@ -1,0 +1,28 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@code input.length} on a multi-megabyte input.
+ * @since 0.75.0
+ */
+final class InputLengthTest {
+
+    @Test
+    void measuresAMultiMegabyteInput() {
+        final int size = 2 * 1024 * 1024;
+        final Phi block = new Data.ToPhi(new byte[size]).take("as-input");
+        final Phi input = new PhApplication(Phi.Φ.take("input").copy(), 0, block);
+        MatcherAssert.assertThat(
+            "input.length must measure a multi-megabyte input without a stack-depth failure",
+            new Dataized(input.take("length")).asNumber().intValue(),
+            Matchers.equalTo(size)
+        );
+    }
+}


### PR DESCRIPTION
`rec-read` reads a fixed 4096-byte chunk and recurses once per non-empty chunk, so a
multi-megabyte input creates hundreds of nested EO evaluations before EOF, bounded by the
thread stack rather than by available memory.

Doubled the chunk size on every recursive call instead of keeping it fixed at 4096. For an
N-byte input this bounds recursion depth to O(log(N)) instead of O(N/4096): a 2 MiB input
needs about 10 recursive calls instead of over 500, and even a multi-gigabyte input stays
well within a normal thread stack. `input.read` already returns fewer bytes than requested
near EOF, so a growing request size changes nothing about correctness, only how many calls
it takes to drain the input.

Added a JUnit regression against a 2 MiB `bytes.as-input` fixture, matching the issue's own
reproducer; a multi-megabyte byte literal isn't practical to write inline at the `.eo` test
level, so the existing `++>` tests (small fixed inputs) remain the portable correctness
check and are unaffected by this change.

Closes #7347
