### PR TITLE
#7338: preserve the UNC share for a root-relative resolved path

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -81,6 +81,9 @@
       eq.
         driveless.slice 0 1
         separator
+    concat. > mount
+      separator.concat separator
+      separator.joined share
     [] > normalized
       ^.^.impl > @
         ^.sys
@@ -172,6 +175,15 @@
         as-bytes.
           ^.sys.sanitized other
     sys.separator > separator
+    reduced. > share
+      driveless.split separator
+      *
+      if. > [accum segment]
+        or.
+          segment.eq ""
+          accum.length.gte 2
+        accum
+        accum.with segment
     if. > [tail] > stripped
       or.
         tail.size.eq 0
@@ -194,18 +206,6 @@
         driveless.size.gt 1
         driveless.starts-with
           separator.concat separator
-    concat. > mount
-      separator.concat separator
-      separator.joined share
-    reduced. > share
-      driveless.split separator
-      *
-      if. > [accum segment]
-        or.
-          segment.eq ""
-          accum.length.gte 2
-        accum
-        accum.with segment
   [paths] > joined
     normalized. > @
       os.is-windows.if

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -165,7 +165,7 @@
                       valid.slice 0 1
                       ^.separator
                     ^.unc.if
-                      ^.unc-root.concat valid
+                      ^.mount.concat valid
                       ^.drive.concat valid
                     concat. (^.uri.concat ^.separator) valid
       string > valid!
@@ -194,13 +194,13 @@
         driveless.size.gt 1
         driveless.starts-with
           separator.concat separator
-    concat. > unc-root
+    concat. > mount
       separator.concat separator
-      separator.joined unc-share
-    reduced. > unc-share
+      separator.joined share
+    reduced. > share
       driveless.split separator
       *
-      if. > [accum segment] >>
+      if. > [accum segment]
         or.
           segment.eq ""
           accum.length.gte 2

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -164,7 +164,9 @@
                     eq.
                       valid.slice 0 1
                       ^.separator
-                    ^.drive.concat valid
+                    ^.unc.if
+                      ^.unc-root.concat valid
+                      ^.drive.concat valid
                     concat. (^.uri.concat ^.separator) valid
       string > valid!
         as-bytes.
@@ -192,6 +194,18 @@
         driveless.size.gt 1
         driveless.starts-with
           separator.concat separator
+    concat. > unc-root
+      separator.concat separator
+      separator.joined unc-share
+    reduced. > unc-share
+      driveless.split separator
+      *
+      if. > [accum segment] >>
+        or.
+          segment.eq ""
+          accum.length.gte 2
+        accum
+        accum.with segment
   [paths] > joined
     normalized. > @
       os.is-windows.if
@@ -500,6 +514,12 @@
       path.win32 ".\\temp\\var"
       "\\\\server\\share\\report.txt"
     "\\\\server\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-path-against-a-root-relative-path
+    resolved.
+      path.win32 "\\\\server\\share\\folder"
+      "\\other"
+    "\\\\server\\share\\other"
 
   eq. ++> can-resolve-a-unc-win32-path-against-another-unc-path
     resolved.


### PR DESCRIPTION
`resolved`'s root-relative branch always prefixed the second operand with `^.drive`, which
is empty for a UNC path (a UNC path has no drive letter), so
`resolved.(path.win32 "\\server\share\folder") "\other"` dropped the server and share
entirely and returned `\other`.

Added `unc-root`, deriving the `\\server\share` prefix from the first two non-empty
segments of `driveless`, the same information `normalized`'s own UNC-root protection
already relies on (`accum.length.lte 2`). The root-relative branch now uses `unc-root`
instead of `drive` when the base path is a UNC one.

Closes #7338
