### PR TITLE
#7341: preserve the device-namespace marker during normalization

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -34,6 +34,16 @@
                 number index
       string pth > text
     driveless.split separator > chunks
+    unc.and > device
+      and.
+        driveless.size.gt 2
+        or.
+          eq.
+            driveless.slice 2 1
+            "."
+          eq.
+            driveless.slice 2 1
+            "?"
     [] > dirname
       string > @
         if.
@@ -136,11 +146,19 @@
                   accum.with segment
                   accum
               if.
-                or.
-                  segment.eq "."
-                  segment.eq ""
-                accum
+                ^.^.device.and
+                  and.
+                    accum.length.eq 0
+                    or.
+                      segment.eq "."
+                      segment.eq "?"
                 accum.with segment
+                if.
+                  or.
+                    segment.eq "."
+                    segment.eq ""
+                  accum
+                  accum.with segment
       as-bytes. > normalized!
         if.
           ^.driveless.size.eq 0
@@ -304,6 +322,11 @@
     os.is-windows.if
       path.win32.separator
       path.posix.separator
+
+  eq. ++> can-normalize-a-device-namespace-win32-path-reducing-a-child-directory
+    normalized.
+      path.win32 "\\\\.\\C:\\foo\\.."
+    "\\\\.\\C:"
 
   eq. ++> can-normalize-a-double-separator-posix-path-to-the-root
     normalized.


### PR DESCRIPTION
`path.eo` classifies every double-backslash path as UNC and protects its first two
components from `..` reduction. A device-namespace path like `\\.\C:\foo\..` has the same
double-backslash shape, but its first two components are `.` (the device marker) and `C:`
(the device name), not a server and a share. The reducer's ordinary dot-segment rule
discarded the `.` marker before the UNC-root protection ever saw it, so only `C:` and `foo`
remained as the "protected" root, letting `foo` incorrectly survive the `..` instead of
being reduced away, and losing the `.` marker in the process.

Added a `device` check (a UNC-shaped path whose third character is `.` or `?`, the two
Windows device-namespace prefixes) and, in the reducer, kept that leading marker segment as
a real path component instead of discarding it as a no-op dot-segment. With the marker kept,
the existing UNC-root protection (`accum.length.lte 2`) naturally treats `[".", "C:"]` as
the protected 2-element root, the same mechanism it already uses for `[server, share]`, so
`foo` reduces correctly once the root is 3 segments deep.

Closes #7341
