### PR TITLE
fix(#7338): resolve a root-relative path inside the UNC share

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -33,6 +33,7 @@
               text.length.minus
                 number index
       string pth > text
+    driveless.split separator > chunks
     [] > dirname
       string > @
         ^.drive.concat
@@ -164,12 +165,23 @@
                     eq.
                       valid.slice 0 1
                       ^.separator
-                    ^.drive.concat valid
+                    ^.unc.if
+                      ^.share.concat valid
+                      ^.drive.concat valid
                     concat. (^.uri.concat ^.separator) valid
       string > valid!
         as-bytes.
           ^.sys.sanitized other
     sys.separator > separator
+    if. > share
+      chunks.length.gt 3
+      concat.
+        concat.
+          separator.concat separator
+          chunks.at 2
+        separator.concat
+          chunks.at 3
+      uri
     if. > [tail] > stripped
       or.
         tail.size.eq 0
@@ -501,11 +513,23 @@
       "\\\\server\\share\\report.txt"
     "\\\\server\\share\\report.txt"
 
+  eq. ++> can-resolve-a-unc-win32-path-against-a-root-relative-path
+    resolved.
+      path.win32 "\\\\server\\share\\folder"
+      "\\other"
+    "\\\\server\\share\\other"
+
   eq. ++> can-resolve-a-unc-win32-path-against-another-unc-path
     resolved.
       path.win32 "\\\\server\\share\\project"
       "\\\\other\\share\\report.txt"
     "\\\\other\\share\\report.txt"
+
+  eq. ++> can-resolve-a-unc-win32-share-root-against-a-root-relative-path
+    resolved.
+      path.win32 "\\\\server\\share"
+      "\\other"
+    "\\\\server\\share\\other"
 
   eq. ++> can-resolve-a-win32-path-against-an-empty-one
     resolved.


### PR DESCRIPTION
Fixes #7338.

The single-separator branch of `resolved` prefixed the operand with `drive` only. A UNC base has no drive letter, so the server and share were dropped and the result left the volume. It now prefixes with the share root when the base is UNC, reusing the same `server/share` boundary the normalizer protects.

`share` is built from the split components (`\\` plus the first two), and falls back to the whole URI when there are fewer than two, so an incomplete `\\server` still behaves as before.

Direct runtime calls, before and after:

| base | operand | before | after |
| --- | --- | --- | --- |
| `\\server\share\folder` | `\other` | `\other` | `\\server\share\other` |
| `\\server\share` | `\other` | `\other` | `\\server\share\other` |
| `\\server` | `\other` | `\other` | `\\server\other` |
| `\\server\share\folder` | `\\other-server\sh\x` | `\\other-server\sh\x` | unchanged |
| `\\server\share\folder` | `sub\x` | `\\server\share\folder\sub\x` | unchanged |
| `\\server\share\folder` | `C:\x` | `C:\x` | unchanged |
| `C:\foo` | `\other` | `C:\other` | unchanged |
| `C:foo` | `\other` | `C:\other` | unchanged |
| `\foo\bar` | `\other` | `\other` | unchanged |
| posix `/foo/bar` | `/other` | `/other` | unchanged |

Two `++>` examples cover a path below the share and the share root itself; the fully qualified UNC operand already has its own example right next to them.
