### PR TITLE
fix(#7353): validate the dotted type path for void annotations too

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -282,6 +282,10 @@ final class Suffix {
      * and rejected. Every other token is a concrete forma, returned
      * verbatim for {@code add-default-package} to home.</p>
      *
+     * <p>A concrete forma is a {@code NAME ('.' NAME)*} path, so a
+     * leading dot, a trailing dot, or an empty segment is rejected
+     * here, for the signature and the annotation alike.</p>
+     *
      * @param raw Raw token, without a trailing {@code ?}
      * @param span Source span
      * @param pos Source column of the token (for errors)
@@ -294,6 +298,12 @@ final class Suffix {
             throw new ParseError(
                 span.line(), pos,
                 "type variable must be one of A-F"
+            );
+        }
+        if (raw.startsWith(".") || raw.endsWith(".") || raw.contains("..")) {
+            throw new ParseError(
+                span.line(), pos,
+                "type must be a dotted name with no leading, trailing, or empty segment"
             );
         }
         final String promoted;
@@ -522,12 +532,6 @@ final class Suffix {
             throw new ParseError(
                 span.line(), home + after,
                 "atom signature requires a name"
-            );
-        }
-        if (raw.startsWith(".") || raw.endsWith(".") || raw.contains("..")) {
-            throw new ParseError(
-                span.line(), home + after,
-                "atom signature must be a dotted name with no leading, trailing, or empty segment"
             );
         }
         return Suffix.typeAtom(raw, span, home + after);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/type-empty-segment.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/type-empty-segment.yaml
@@ -2,10 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 1
-message: |-
-  [1:8] error: 'type must be a dotted name with no leading, trailing, or empty segment'
-  [] > f /Q.
-          ^
+line: 2
+message: "type must be a dotted name with no leading, trailing, or empty segment"
 input: |
-  [] > f /Q.
+  [] > main /Q.string
+    ? > x /a..b


### PR DESCRIPTION
Fixes #7353.

`Suffix.signature()` rejected a leading dot, a trailing dot and an empty segment, while `Suffix.typeAtom()`, which also serves void annotations and `/{…}` lists, let them through, so `? > x /a..b` reached XMIR as `type="a..b"`.

The check now lives in `typeAtom`, the one place both call sites go through, and the signature-only copy is gone. Its message loses the `atom signature` prefix, since it now speaks for the annotation as well: `type must be a dotted name with no leading, trailing, or empty segment`. `eo-typos/atom-sig-dot.yaml` is updated for the new wording, and `eo-typos/void/type-empty-segment.yaml` adds the case from the report.

Checked that the new fixture discriminates: with the `typeAtom` guard removed it fails as `no error was reported on line 2`, and passes with the guard in place. `EoSyntaxTest`, `SuffixTest` and `LnVoidTest` are otherwise green locally.
