### PR TITLE
#7344: preserve the current-directory marker after a drive-relative path collapses

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -151,11 +151,23 @@
           if.
             core.size.eq 0
             "."
-            core.concat
-              if.
-                trailing.and rooted.not
-                ^.separator
-                --
+            if.
+              and.
+                body.size.eq 0
+                and.
+                  ^.drive.size.gt 0
+                  ^.is-absolute.not
+              core.concat
+                ".".concat
+                  if.
+                    trailing.and rooted.not
+                    ^.separator
+                    --
+              core.concat
+                if.
+                  trailing.and rooted.not
+                  ^.separator
+                  --
       and. > rooted
         core.size.gt 0
         eq.
@@ -320,6 +332,11 @@
       path.win32 "C:\\Ж"
     "C:\\Ж"
 
+  eq. ++> can-normalize-a-drive-relative-win32-path-collapsing-to-the-current-directory-with-a-trailing-separator
+    normalized.
+      path.win32 "C:foo\\..\\"
+    "C:.\\"
+
   eq. ++> can-normalize-a-drive-relative-win32-path-keeping-a-leading-dotdot
     normalized.
       path.win32 "C:..\\foo"
@@ -433,7 +450,7 @@
   eq. ++> can-normalize-a-win32-path-down-to-a-drive-without-a-separator
     normalized.
       path.win32 "C:hello\\.."
-    "C:"
+    "C:."
 
   eq. ++> can-normalize-a-win32-path-replacing-slashes
     normalized.


### PR DESCRIPTION
`normalized` only checked `core.size.eq 0` to decide when to fall back to `.`. For a
drive-relative path like `C:foo\..`, reduction removes `foo` and leaves the body empty, but
`core` still carries the bare drive (`C:`), so `core.size` is 2, not 0, and the `.` fallback
never fires. `C:` and `C:.` are different Windows path spellings — the latter names the
current directory on drive C, the former is a bare drive designator — so collapsing one into
the other is wrong, not just imprecise.

Added a check for the specific case that collapses to an empty *drive-relative* remainder
(non-empty `drive`, not absolute, and the reduced body is empty): append `.` before the
existing trailing-separator logic, so `C:foo\..` normalizes to `C:.` and
`C:foo\..\` normalizes to `C:.\`.

The existing `can-normalize-a-win32-path-down-to-a-drive-without-a-separator` test asserted
the old, buggy `C:` result for exactly this shape (`C:hello\..`); updated its expectation to
`C:.` to match. Also added the trailing-separator variant as a new regression.

Closes #7344
