### PR TITLE
fix(#7352): validate a formation outer binding like every other label

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -62,7 +62,9 @@ final class LnFormation implements Line {
             final int close = LnFormation.findClosing(body, this.span);
             params = LnFormation.params(body, close, this.span);
             final String raw = body.substring(close + 1);
-            binding = LnFormation.outerBinding(raw);
+            binding = LnFormation.outerBinding(
+                raw, this.span, this.span.indent() + close + 2
+            );
             final String tail;
             if (binding == null) {
                 tail = raw;
@@ -85,7 +87,7 @@ final class LnFormation implements Line {
         this.emit(emit, suffix, params, binding);
     }
 
-    private static String outerBinding(final String raw) {
+    private static String outerBinding(final String raw, final Span span, final int pos) {
         final String label;
         if (raw.startsWith(":")) {
             int idx = 1;
@@ -93,6 +95,7 @@ final class LnFormation implements Line {
                 idx = idx + 1;
             }
             label = raw.substring(1, idx);
+            Tokens.checkBinding(label, span, pos);
         } else {
             label = null;
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -500,19 +500,32 @@ final class Tokens {
             );
         }
         final String text = this.body.substring(start, this.cursor);
+        Tokens.checkBinding(text, this.span, this.span.indent() + start);
+        return text;
+    }
+
+    /**
+     * Check an inline-binding label or numeric slot against §3.12 and
+     * reject anything that is neither a NAME-initial label nor a plain
+     * slot number. Shared by {@link Tokens#readBinding()} and the outer
+     * binding of a vertical formation, so both spell the same grammar.
+     * @param text Binding text, without the leading {@code :}
+     * @param span Source span
+     * @param pos Source column of the label (for errors)
+     */
+    static void checkBinding(final String text, final Span span, final int pos) {
         if (Tokens.cactus(text)) {
             throw new ParseError(
-                this.span.line(), this.span.indent() + start,
+                span.line(), pos,
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
         if (!Tokens.validBinding(text)) {
             throw new ParseError(
-                this.span.line(), this.span.indent() + start,
+                span.line(), pos,
                 "Invalid bound object declaration"
             );
         }
-        return text;
     }
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-outer-binding-labels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-outer-binding-labels.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7352: an outer binding on a vertical formation obeys the same :label
+# grammar as every other inline binding, so a NAME label and a slot number
+# both stay legal.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@as='slot' and @base='ξ.named']
+  - //o[@as='α0' and @base='ξ.numbered']
+input: |
+  [] > main
+    x > y
+      []:slot > named
+    x > z
+      []:0 > numbered

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-leading-zero.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-leading-zero.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: "Invalid bound object declaration"
+input: |
+  [] > main
+    x > y
+      []:00 > slot

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-uppercase.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-uppercase.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: "Invalid bound object declaration"
+input: |
+  [] > main
+    x > y
+      []:A > slot


### PR DESCRIPTION
Fixes #7352.

`LnFormation.outerBinding` scanned to the next space or `>` and handed whatever it found to `Emissions.bindingTag`, so a vertical formation could carry an `@as` value the inline `:label` grammar rejects.

The validation `readBinding` already performs is now a named method, `Tokens.checkBinding`, and both call sites go through it. `[]:slot > ok` and `[]:0 > ok` stay legal (the latter still emits `as="α0"`); `[]:A`, `[]:00` and an empty `[]:` now fail with the same `Invalid bound object declaration` as their inline counterparts.

Fixtures: `eo-syntax/formation-outer-binding-labels.yaml` for the two legal forms, `eo-typos/formation-outer-binding-uppercase.yaml` and `eo-typos/formation-outer-binding-leading-zero.yaml` for the rejections. Both typo packs were checked against the unpatched parser and fail there as `no error was reported on line 3`, so they are not vacuous.

The cactus case from the report is not covered here: #7390 adds that check inside `readBinding`, and once it lands this call site inherits it for free.
