### PR TITLE
#7352: validate a formation's outer :label the same way as every other binding

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -62,7 +62,7 @@ final class LnFormation implements Line {
             final int close = LnFormation.findClosing(body, this.span);
             params = LnFormation.params(body, close, this.span);
             final String raw = body.substring(close + 1);
-            binding = LnFormation.outerBinding(raw);
+            binding = LnFormation.outerBinding(raw, this.span, this.span.indent() + close + 1);
             final String tail;
             if (binding == null) {
                 tail = raw;
@@ -85,7 +85,7 @@ final class LnFormation implements Line {
         this.emit(emit, suffix, params, binding);
     }
 
-    private static String outerBinding(final String raw) {
+    private static String outerBinding(final String raw, final Span span, final int pos) {
         final String label;
         if (raw.startsWith(":")) {
             int idx = 1;
@@ -93,6 +93,11 @@ final class LnFormation implements Line {
                 idx = idx + 1;
             }
             label = raw.substring(1, idx);
+            if (!Tokens.validBinding(label)) {
+                throw new ParseError(
+                    span.line(), pos + 1, "Invalid bound object declaration"
+                );
+            }
         } else {
             label = null;
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -637,7 +637,16 @@ final class Tokens {
         return Tokens.TERMINATORS.indexOf(glyph) >= 0;
     }
 
-    private static boolean validBinding(final String text) {
+    /**
+     * Whether a {@code :label} outer binding is a legal NAME or a legal
+     * non-leading-zero decimal slot — R-3.7.1. Shared by {@link #readBinding}
+     * and {@link LnFormation}'s own outer-binding scan, so a bound object
+     * declaration is validated the same way on every line shape that
+     * carries one.
+     * @param text The candidate binding label, without the leading `:`
+     * @return True if the label is legal
+     */
+    static boolean validBinding(final String text) {
         final boolean valid;
         if (text.isEmpty()) {
             valid = false;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-outer-binding-accepts-a-name-label.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-outer-binding-accepts-a-name-label.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@as='slot']
+input: |
+  [] > main
+    x > y
+      []:slot > ok

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-outer-binding-accepts-a-numeric-slot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/formation-outer-binding-accepts-a-numeric-slot.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@as='α0']
+input: |
+  [] > main
+    x > y
+      []:0 > ok

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-rejects-cactus-glyph.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-rejects-cactus-glyph.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:7] error: 'Invalid bound object declaration'
+      []:🌵 > slot
+         ^
+input: |
+  [] > main
+    x > y
+      []:🌵 > slot

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-rejects-leading-zero-slot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-rejects-leading-zero-slot.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:7] error: 'Invalid bound object declaration'
+      []:00 > slot
+         ^
+input: |
+  [] > main
+    x > y
+      []:00 > slot

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-rejects-uppercase-label.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-rejects-uppercase-label.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:7] error: 'Invalid bound object declaration'
+      []:A > slot
+         ^
+input: |
+  [] > main
+    x > y
+      []:A > slot


### PR DESCRIPTION
`LnFormation.outerBinding` scanned a `:label` after a formation head with an ad-hoc loop
that stopped at a space or `>`, never calling `Tokens.validBinding` the way
`Tokens.readBinding` does for every other `:label` / `:N` binding. `[]:A > slot`,
`[]:00 > slot`, and even the reserved cactus glyph all parsed clean, emitting whatever text
followed the colon straight into `@as`.

Widened `Tokens.validBinding` to package-visible and called it from `outerBinding`, throwing
the same "Invalid bound object declaration" `readBinding` throws elsewhere, pointed at the
label's first character for consistency with that message's existing position convention.

Closes #7352
