### PR TITLE
fix(#7349): return cant-print for a magnitude past the decimal range

### DIFF
--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -8,7 +8,9 @@
 #
 # The value is split into its integer and fraction parts before scaling, so
 # only the fraction is multiplied by a power of ten and every magnitude that
-# `as-decimal` writes exactly is written exactly here too.
+# `as-decimal` writes exactly is written exactly here too. A magnitude of
+# 2^63 or larger is past what `as-decimal` can write, so it returns the
+# `cant-print` fallback as well, instead of terminating.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -20,15 +22,18 @@
 [places cant-print] > as-fixed
   if. > @
     n.is-finite.not.or
-      or.
-        0.gt places
-        places.is-integer.not.or
-          places.gt 9007199254740991
+      huge.or
+        or.
+          0.gt places
+          places.is-integer.not.or
+            places.gt 9007199254740991
     cant-print
       n.is-finite.not.if
         "Can't write a non-finite number as a fixed-point decimal"
-        "Can't write a fixed-point decimal with %f fraction places".printf
-          * places
+        huge.if
+          "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"
+          "Can't write a fixed-point decimal with %f fraction places".printf
+            * places
     if.
       n.as-bytes.eq 80-00-00-00-00-00-00-00
       "-".as-bytes.concat
@@ -67,6 +72,8 @@
             positive a
         | (n.times -1)
         positive n
+  n.abs.gte > huge
+    2.power 63
   ^ > n
   if. > [p] >> pow10
     p.eq 0
@@ -113,6 +120,12 @@
     string
       -0.001.as-fixed 2
 
+  eq. ++> can-format-the-error-message-of-a-magnitude-past-the-decimal-range
+    "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"
+    9.223372036854776e18.as-fixed
+      0
+      I
+
   eq. ++> can-format-the-error-message-of-a-non-decrementable-precision
     "Can't write a fixed-point decimal with 9007199254740992.000000 fraction places"
     1.25.as-fixed
@@ -149,6 +162,12 @@
     "-0.00"
     string
       0.neg.as-fixed 2
+
+  eq. ++> can-recover-from-a-magnitude-past-the-decimal-range
+    "recovered"
+    9.223372036854776e18.as-fixed
+      2
+      "recovered" > [message]
 
   eq. ++> can-recover-from-a-negative-number-with-a-non-decrementable-precision
     "recovered"


### PR DESCRIPTION
Fixes #7349.

`as-fixed` delegated the integer unit to `as-decimal`, which intentionally rejects a magnitude of 2^63 or larger. `as-fixed` never stated that narrower limit, so the call terminated with an unrelated `as-decimal` message instead of going through `cant-print` like every other rejected input.

The report leaves the choice open between widening the writer and making the limit explicit; the latter is the contained fix, in line with how the rest of the method already handles every other unsupported input. A new `huge` check joins the existing guard and gets its own message rather than reusing the `places`-fraction wording, since it depends on `n`, not `places`.

Direct runtime calls, before and after:

| input | before | after |
| --- | --- | --- |
| `as-fixed(2^63, 0)` | terminates via `as-decimal` | `cant-print` fallback, same as any other rejected input |
| `as-fixed(2^63, 2)` | terminates | `cant-print` fallback |
| `as-fixed(-2^63, 0)` | terminates | `cant-print` fallback |
| `as-fixed(1e30, 2)` | terminates | `cant-print` fallback |
| `as-fixed(2^62, 0)` | `4611686018427387904` | unchanged |
| `as-fixed(42.5, 2)`, `as-fixed(0.9999999, 6)`, `as-fixed(-1e-4, 2)`, `as-fixed(0, 0)` | as before | unchanged |

Two `++>` examples cover the error text and the recovery path, next to the existing ones for the `places` boundary.
