### PR TITLE
#7348: force each accumulated hex chunk once per rec-hex step

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-hex.eo
+++ b/eo-runtime/src/main/eo/bytes/as-hex.eo
@@ -23,15 +23,16 @@
       ^.rec-hex
         as-number.
           index.plus 1
-        if.
-          index.eq 0
-          pair
-          concat.
-            acc.concat "-".as-bytes
-            pair
+        next
     as-ascii. > bval
       string
         ^.b.slice index 1
+    if. > next!
+      index.eq 0
+      pair
+      concat.
+        acc.concat "-".as-bytes
+        pair
     concat. > pair
       hex-digit
         floor.
@@ -65,3 +66,8 @@
   eq. ++> can-write-empty-bytes
     ""
     string --.as-hex
+
+  eq. ++> can-write-a-64-byte-input-promptly
+    "00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00"
+    string
+      00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00-00.as-hex


### PR DESCRIPTION
`rec-hex` passed its accumulator to the next recursive step as an unevaluated `concat.`
expression over the *previous* unevaluated accumulator, so dataizing the final result at
index N requires re-deriving the chain from index 0 every time a `concat` call touches its
own accumulator argument, with no memoization between recursive steps. Confirmed directly:
reverting the fix and dataizing a 256-byte input drives the JVM heap to its cap (tested at
8GB) before the test's own deadline can even interrupt it, while 16-32 byte inputs stay
fast, matching the issue's report.

Bound the next accumulator through a `!` file-local (`next!`), the const-marker idiom this
codebase already uses elsewhere to force a value to its dataized bytes once and cache it
(e.g. `path.eo`'s `core!`, `as-scientific.eo`'s `mantissa`). Each recursive step's
accumulator is now a concrete, cached byte value instead of an ever-growing lazy expression
tree, so later steps build on it in O(1) rather than re-deriving it.

Added a regression against a 64-byte input, matching the issue's own reproducer size; it
completes well within the test suite's deadline with the fix, and reliably exhausts memory
without it.

Closes #7348
