### PR TITLE
#7349: handle the exact positive 2^63 boundary in as-fixed

### DIFF
--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -35,12 +35,18 @@
         [a] >> positive
           if. > @
             digits.eq scale
-            if. > [unit rest] >> written
-              ^.^.places.eq 0
-              unit.as-decimal
-              concat.
-                unit.as-decimal.concat ".".as-bytes
-                rec-pad rest ^.^.places --
+            [unit rest] >> written
+              if. > @
+                ^.^.places.eq 0
+                unit-decimal
+                concat.
+                  unit-decimal.concat ".".as-bytes
+                  rec-pad rest ^.^.places --
+              if. > unit-decimal
+                unit.eq
+                  2.power 63
+                "9223372036854775808".as-bytes
+                unit.as-decimal
             | (whole.plus 1) 0
             written whole digits
           floor. > digits
@@ -233,6 +239,16 @@
     "2.5"
     string
       2.5.as-fixed 1
+
+  eq. ++> can-write-the-exact-two-to-the-63rd-boundary-with-places
+    "9223372036854775808.00"
+    string
+      9.223372036854776e18.as-fixed 2
+
+  eq. ++> can-write-the-exact-two-to-the-63rd-boundary-with-zero-places
+    "9223372036854775808"
+    string
+      9.223372036854776e18.as-fixed 0
 
   eq. ++> can-write-zero-with-places
     "0.000000"

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -38,11 +38,11 @@
             [unit rest] >> written
               if. > @
                 ^.^.places.eq 0
-                unit-decimal
+                decimal
                 concat.
-                  unit-decimal.concat ".".as-bytes
+                  decimal.concat ".".as-bytes
                   rec-pad rest ^.^.places --
-              if. > unit-decimal
+              if. > decimal
                 unit.eq
                   2.power 63
                 "9223372036854775808".as-bytes


### PR DESCRIPTION
`as-fixed`'s integer unit is written through `unit.as-decimal`, which intentionally rejects
a magnitude of `2^63` or more, since it converts through a signed 64-bit integer whose range
tops out at `2^63 - 1`. Positive `2^63` is exactly representable as a finite double, so
`as-fixed` should still be able to write it, but it inherited `as-decimal`'s narrower limit
without documenting or handling it, leaking `as-decimal`'s unrelated error message instead
of routing through `cant-print` or succeeding.

`as-decimal` already carves out its own negative boundary (`-2^63`, i64's minimum) with a
hand-written literal instead of going through the i64 conversion. Added the matching
carve-out for the positive boundary inside `as-fixed`'s own `written` helper: when the
integer unit equals exactly `2^63`, write `"9223372036854775808"` directly instead of
delegating to `as-decimal`.

Added the two regression cases from the issue: `2^63` with zero and with two fraction
places.

Closes #7349
