### PR TITLE
#7425: don't offer the walked directory itself to the glob matcher

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -99,7 +99,10 @@
       [rest] >> stepped
         if. > @
           rest.length.eq 0
-          picked ^.accum ^.prefix
+          if.
+            ^.prefix.length.eq 0
+            ^.accum
+            picked ^.accum ^.prefix
           if.
             and.
               entry.is-directory false
@@ -439,6 +442,15 @@
       made.
         directory mktemp.tmpfile.deleted
 
+  ++> can-walk-an-empty-directory-with-a-glob-matching-an-empty-path
+    eq. > @
+      length.
+        d.as-dir.walk "*"
+      0
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
   ++> can-walk-past-a-symbolic-link-to-its-own-parent
     os.is-windows.or > @
       seq *
@@ -493,6 +505,28 @@
         length.
           d.as-dir.walk "**/*.txt"
         2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-recursively-without-including-the-walked-directory
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo/bar"
+      touched.
+        as-file.
+          d.resolved "foo/bar/test.txt"
+      made.
+        as-dir.
+          d.resolved "x/y/z"
+      touched.
+        as-file.
+          d.resolved "x/y/z/a.txt"
+      eq.
+        length.
+          d.as-dir.walk "**"
+        7
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted
@@ -665,6 +699,22 @@
         ",".joined
           d.as-dir.walk "[.txt"
         d.resolved "[.txt"
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-without-including-the-walked-directory
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo"
+      touched.
+        as-file.
+          d.resolved "a.txt"
+      eq.
+        length.
+          d.as-dir.walk "*"
+        2
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted


### PR DESCRIPTION
Closes #7425.

`directory.walk` returned the walked directory itself among its results whenever the glob matched an empty relative path (`*`, `**`).

`walked` offers the current directory to the matcher once its listing is exhausted. For a subdirectory that is right — it is how `sub` appears among the results of `**`. But the top-level application enters `walked` with an empty prefix, so the base was offered as the relative path `""`, and `picked` appended `base.resolved ""`, which is the base itself.

The matching is not the anomaly (`java.nio.file.PathMatcher` also reports `glob:*` as matching an empty relative path); the anomaly is that the base is submitted as a candidate at all. So `stepped` now skips the offer when the prefix is empty. A subdirectory always enters `walked` with a non-empty prefix, so recursive matching is unaffected.

Three examples added, each of which fails before the change:

* `can-walk-an-empty-directory-with-a-glob-matching-an-empty-path` — `length (walk "*")` on an empty directory is `0`, not `1`.
* `can-walk-without-including-the-walked-directory` — `length (walk "*")` over two children is `2`, not `3`.
* `can-walk-recursively-without-including-the-walked-directory` — `length (walk "**")` over `foo/bar/test.txt` and `x/y/z/a.txt` is `7`, not `8`.

The merged `can-walk-past-a-symbolic-link-to-its-own-parent` example already asserted the post-fix value (`2` for `walk "**"` over two entries); it never caught the bug because, like every `can-walk-*` example, it is aborted as skipped before it finishes (#7110, #7262, #7429).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkE9NiMQ6RPrVuCXPSXnGy)_