### PR TITLE
#7428: hand `capped` the raw `datum` at the `%s` site

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -185,8 +185,7 @@
         seq *
           length.
             string datum
-          capped
-            string datum
+          capped datum
       if.
         64-.eq conv
         as-decimal.
@@ -380,6 +379,11 @@
         * "Jeff"
     11
 
+  eq. ++> can-apply-a-precision-to-a-non-ascii-string
+    "Жир"
+    "%.3s".printf
+      * "Жирафы"
+
   eq. ++> can-apply-a-precision-to-a-string
     "Jef"
     "%.3s".printf
@@ -389,6 +393,11 @@
     "40-"
     "%.3x".printf
       * 42.as-bytes
+
+  eq. ++> can-apply-a-precision-wider-than-a-non-ascii-string
+    "Жирафы"
+    "%.10s".printf
+      * "Жирафы"
 
   eq. ++> can-apply-a-width-to-bytes
     "  40-45-00-00-00-00-00-00"


### PR DESCRIPTION
Closes #7428.

`printf` terminated for every `%.Ns` conversion whose argument contains a non-ASCII character, even when the precision was wider than the text and nothing would be truncated:

```
"%.3s".printf  * "Жирафы"   ->  the 'x' attribute must be a number
"%.10s".printf * "Жирафы"   ->  the same, though 6 characters fit in 10
```

`capped` already wraps its argument in `string` before handing it to `string.truncated`, and the `%s` site wrapped it too, so the argument arrived as `string (string datum)`. With that double wrap the UTF-8 walk in `string.length` compares a two-byte lead against a one-byte mask, `bytes.and` gets operands of different lengths, and `truncated` ends on its `limit.lt text.length` comparison. ASCII survived only because every character there is one byte.

The fix passes the raw `datum` at that site, so the wrap inside `capped` is the only one. The `length. (string datum)` step above it stays as it is — that is what rejects an argument whose bytes are not UTF-8, which `stops-on-a-non-utf8-byte-argument-as-a-string` covers. The other two `capped` call sites are untouched: `capped (bytes datum).as-hex` needs its inner `string` because its argument is bytes, and `capped (arg.as-bool.if "true" "false")` passes ASCII.

Two examples added, both failing before the change:

* `can-apply-a-precision-to-a-non-ascii-string` — `"%.3s".printf * "Жирафы"` is `"Жир"`, so characters are counted rather than bytes.
* `can-apply-a-precision-wider-than-a-non-ascii-string` — `"%.10s".printf * "Жирафы"` is the whole string, the case that truncates nothing yet ended today.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkE9NiMQ6RPrVuCXPSXnGy)_