### PR TITLE
#7424: build the `**/` glob token from the path separator

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -242,7 +242,8 @@
         opening.if
           negated.if "[^" "["
           slashed.if
-            "(?:.*/)?"
+            "".joined
+              * "(?:.*" literal ")?"
             double.if
               ".*"
               if.
@@ -474,6 +475,31 @@
         length.
           d.as-dir.walk "**/*.txt"
         2
+    as-path. > d
+      made.
+        directory mktemp.tmpfile.deleted
+
+  ++> can-walk-recursively-across-nested-directories
+    seq * > @
+      made.
+        as-dir.
+          d.resolved "foo/bar"
+      touched.
+        as-file.
+          d.resolved "foo/bar/test.txt"
+      made.
+        as-dir.
+          d.resolved "x/y/z"
+      touched.
+        as-file.
+          d.resolved "x/y/z/a.txt"
+      eq.
+        ",".joined
+          d.as-dir.walk "**/*.txt"
+        ",".joined
+          *
+            d.resolved "foo/bar/test.txt"
+            d.resolved "x/y/z/a.txt"
     as-path. > d
       made.
         directory mktemp.tmpfile.deleted


### PR DESCRIPTION
Closes #7424.

On Windows a `**/` glob prefix matched nothing below the walked directory, so `directory.walk "**/*.txt"` returned `0` entries over the tree `can-walk-recursively` builds, while `walk "**.txt"` found the same two files.

`walk` matches its regex against a relative path assembled with `path.separator`, and every separator in the translator is built from `path.separator` too — `single`, `literal`, and a plain `/` in the glob. The `**/` token was the one exception: it was spelled `(?:.*/)?` with a hard-coded forward slash. On Windows the relative paths contain `\`, so that group could only ever take its empty alternative (the one #7233 added), leaving `**/*.txt` to mean `*.txt` — which is why the direct children still matched and everything deeper was dropped.

The token now reuses `literal`, so the group is `(?:.*/)?` on POSIX and `(?:.*\\)?` on Windows. POSIX behaviour is unchanged, since `literal` is `escaped path.separator` and `/` is not one of the characters `escaped` touches.

`can-walk-recursively-across-nested-directories` asserts the nested matches themselves rather than a count, so it fails on Windows before the change instead of being satisfiable by the empty alternative. Like every `can-walk-*` example it is aborted as skipped before it finishes (#7110, #7262, #7429), which is why the Windows leg of the matrix never executed the assertion this broke.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkE9NiMQ6RPrVuCXPSXnGy)_