### PR TITLE
#7408: take `λ` from a non-atom the way every absent attribute is taken

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -229,7 +229,7 @@ public class PhDefault implements Phi, Cloneable {
             final Attribute attr = this.loaded().get(name);
             if (attr != null) {
                 resolved = attr.get();
-            } else if (name.equals(Phi.LAMBDA)) {
+            } else if (name.equals(Phi.LAMBDA) && this instanceof Atom) {
                 resolved = new AtomTyped(
                     this, PhDefault.ATOMS.declared(this.forma())
                 ).lambda();

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -62,6 +62,15 @@ final class PhiTest {
     }
 
     @Test
+    void takesLambdaOfNonAtomAsAbsent() {
+        MatcherAssert.assertThat(
+            "Taking λ from a non-atom must return a terminator, not throw a cast error",
+            new PhDefault().take(Phi.LAMBDA),
+            Matchers.instanceOf(PhTerminator.class)
+        );
+    }
+
+    @Test
     void tellsWhyANonFiniteNumberHasNoDecimalForm() {
         MatcherAssert.assertThat(
             "asking nan for its decimal form must not lose the reason written for that moment",


### PR DESCRIPTION
Closes #7408.

Taking `λ` from an object that is not an `Atom` threw a raw `ClassCastException` out of the runtime, with no EO wording and no coordinates:

```
take(λ) on bare PhDefault -> java.lang.ClassCastException: class org.eolang.PhDefault
                             cannot be cast to class org.eolang.Atom
take(absent)              -> org.eolang.PhTerminator
```

`PhDefault.take` routed `λ` through `AtomTyped` whenever no `λ` attribute was registered, whether or not the object implements `Atom`. `AtomSafe.lambda` casts and rethrows a `RuntimeException` untouched, so the cast error escaped as it was. The `PhSafe.lambda` path that #6606 repaired is unaffected — there the cast happens inside `through`, which wraps it.

`delta()`, `normalized()` and `absent()` all guard that dispatch with `this instanceof Atom`; `take()` was the one that did not. It now does, so `λ` falls to `absent` and is reported the way every other missing attribute is:

```
take(λ) on bare PhDefault -> org.eolang.PhTerminator
dataized                  -> org.eolang.ExFailure: the attribute "λ" is not found in []
```

`returnsTerminatorForLambdaOfNonAtom` covers it, alongside the existing `returnsTerminatorForAbsentAttribute`. Verified against the transpiled runtime both ways: the cast error on `master`, the terminator with this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkE9NiMQ6RPrVuCXPSXnGy)_