### PR TITLE
#7426: scale a `%f` mantissa in steps that stay inside the double range

### DIFF
--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -32,6 +32,8 @@
 
   -42.eq "-42".as-number ++> can-convert-negative-text
 
+  1.0e-320.eq "1e-320".as-number ++> can-convert-subnormal-exponent-text
+
   5.eq "5".as-number ++> can-convert-text
 
   42.5.eq "42.5".as-number ++> can-convert-text-through-an-implicit-dispatch

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -7,6 +7,16 @@
 # - %d - parse as integer and convert to `number`
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
+#
+# The `%f` conversion never materializes the whole power of ten at once,
+# because `10.power 309` is already infinity: a single multiplication by it
+# turns every mantissa into infinity and a single division by it turns every
+# mantissa into zero, whatever the written value is. `raised` and `lowered`
+# therefore scale in steps of at most `10^300`, so every intermediate stays
+# inside the double range and an underflow happens only when the value itself
+# underflows. Both stop as soon as the value is zero or infinite, since no
+# further step can move it, and that is what keeps the recursion short for an
+# exponent written far outside the range, such as `1e999999999`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -56,6 +66,16 @@
             eloc.plus 1
             esign.length.minus
               eloc.plus 1
+      if. > [value power] > lowered
+        and.
+          power.gt 300
+          ^.scalable value
+        ^.lowered
+          value.div
+            10.power 300
+          power.minus 300
+        value.div
+          10.power power
       if. > magnitude
         not.
           dot.eq -1
@@ -79,16 +99,29 @@
         "-"
       mantissa.length.minus > places
         dot.plus 1
+      if. > [value power] > raised
+        and.
+          power.gt 300
+          ^.scalable value
+        ^.raised
+          value.times
+            10.power 300
+          power.minus 300
+        value.times
+          10.power power
+      and. > [value] > scalable
+        not.
+          value.eq 0
+        value.is-finite
       if. > scaled
         exponent.eq 0
         magnitude
         if.
           exponent.gt 0
-          magnitude.times
-            10.power exponent
-          magnitude.div
-            10.power
-              exponent.times -1
+          raised magnitude exponent
+          lowered
+            magnitude
+            exponent.times -1
       negative.or > signed
         eq.
           text.slice 0 1
@@ -459,3 +492,27 @@
     1
     head.
       "%f".scanf "1e0"
+
+  eq. ++> can-scan-a-float-at-the-edge-of-the-power-of-ten-range
+    1.0e-309
+    head.
+      "%f".scanf "0.1e-308"
+
+  eq. ++> can-scan-a-subnormal-float-with-an-exponent-below-the-range
+    1.0e-320
+    head.
+      "%f".scanf "1e-320"
+
+  eq. ++> can-scan-the-smallest-positive-float
+    4.9e-324
+    head.
+      "%f".scanf "5e-324"
+
+  gt. ++> can-scan-a-normal-float-with-an-exponent-below-the-range
+    head.
+      "%f".scanf "123.456e-310"
+    1.0e-308
+
+  is-finite. ++> can-scan-a-finite-float-with-an-exponent-above-the-range
+    head.
+      "%f".scanf "0.001e311"


### PR DESCRIPTION
Closes #7426.

`"%f".scanf`, and `string.as-number` which delegates to it, returned `0` or `Infinity` for text whose value is an ordinary finite double, whenever the written exponent was past ±308.

`as-float` materialized the power of ten on its own before combining it with the mantissa. `10.power 309` is already `+∞`, so dividing by it gives `0` and multiplying by it gives `Infinity` no matter what the mantissa is. Only the magnitude of the *written exponent* was consulted, never the magnitude of the result — which is why `123.456e-310` was lost even though its value is `1.23456e-308`, six orders of magnitude above the smallest normal double.

`raised` and `lowered` now apply the scaling in steps of at most `10^300`, so the mantissa absorbs part of the exponent on each step and an intermediate underflows only when the final value truly does. Both stop as soon as the value is zero or infinite, since no further step can move it; that is what keeps the recursion short for an exponent written far outside the range, where the old code got its answer from a single saturated `10.power`.

Measured against the transpiled runtime, before and after:

| text | before | after | `Double.parseDouble` |
| --- | --- | --- | --- |
| `123.456e-310` | `0.0` | `1.2345599999999995E-308` | `1.23456E-308` |
| `1e-309` | `0.0` | `9.99999999999997E-310` | `1.0E-309` |
| `1e-320` | `0.0` | `1.0E-320` | `1.0E-320` |
| `5e-324` | `0.0` | `4.9E-324` | `4.9E-324` |
| `0.001e311` | `Infinity` | `1.0000000000000006E308` | `1.0E308` |
| `0.00001e310` | `Infinity` | `1.0000000000000007E305` | `1.0E305` |
| `0.1e-308` | `1.0E-309` | `1.0E-309` | `1.0E-309` |
| `1e309` | `Infinity` | `Infinity` | `Infinity` |
| `1e999999999` | `Infinity` | `Infinity` | `Infinity` |
| `1e-999999999` | `0.0` | `0.0` | `0.0` |

The residual ULP-level differences from `parseDouble` are the documented decimal-to-double rounding path of this conversion, not part of this fix, so the two rows that land a ULP away assert a bound rather than an exact value; the rows that come out exactly are asserted exactly.

Examples added: `can-scan-a-subnormal-float-with-an-exponent-below-the-range`, `can-scan-the-smallest-positive-float`, `can-scan-a-normal-float-with-an-exponent-below-the-range`, `can-scan-a-finite-float-with-an-exponent-above-the-range`, `can-scan-a-float-at-the-edge-of-the-power-of-ten-range` (the control that already passed), and `can-convert-subnormal-exponent-text` for the `as-number` entry point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CkE9NiMQ6RPrVuCXPSXnGy)_