### PR TITLE
Reject a print pack whose "printed" repeats "origin"

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -148,17 +148,16 @@ final class MjPrintTest {
 
     private String expected(final Xtory xtory) {
         final String origin = (String) xtory.map().get("origin");
-        final String printed = (String) xtory.map().get("printed");
         final String expected;
-        if (printed == null) {
-            expected = origin;
-        } else {
+        if (xtory.map().containsKey("printed")) {
+            expected = (String) xtory.map().get("printed");
             MatcherAssert.assertThat(
                 "The 'printed' section repeats 'origin' verbatim and must be deleted from the pack, since a pack without 'printed' already expects the printer to reproduce its 'origin'",
-                printed,
+                expected,
                 Matchers.not(Matchers.equalTo(origin))
             );
-            expected = printed;
+        } else {
+            expected = origin;
         }
         return expected;
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -147,9 +147,20 @@ final class MjPrintTest {
     }
 
     private String expected(final Xtory xtory) {
-        return (String) xtory.map().getOrDefault(
-            "printed", xtory.map().get("origin")
-        );
+        final String origin = (String) xtory.map().get("origin");
+        final String printed = (String) xtory.map().get("printed");
+        final String expected;
+        if (printed == null) {
+            expected = origin;
+        } else {
+            MatcherAssert.assertThat(
+                "The 'printed' section repeats 'origin' verbatim and must be deleted from the pack, since a pack without 'printed' already expects the printer to reproduce its 'origin'",
+                printed,
+                Matchers.not(Matchers.equalTo(origin))
+            );
+            expected = printed;
+        }
+        return expected;
     }
 
     private static Text printed(final Xtory xtory, final Path temp, final boolean reversed)

--- a/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
@@ -269,17 +269,16 @@ final class XmirTest {
 
     private String printed(final Xtory xtory) {
         final String origin = (String) xtory.map().get("origin");
-        final String printed = (String) xtory.map().get("printed");
         final String expected;
-        if (printed == null) {
-            expected = origin;
-        } else {
+        if (xtory.map().containsKey("printed")) {
+            expected = (String) xtory.map().get("printed");
             MatcherAssert.assertThat(
                 "The 'printed' section repeats 'origin' verbatim and must be deleted from the pack, since a pack without 'printed' already expects the printer to reproduce its 'origin'",
-                printed,
+                expected,
                 Matchers.not(Matchers.equalTo(origin))
             );
-            expected = printed;
+        } else {
+            expected = origin;
         }
         return expected;
     }

--- a/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
@@ -268,9 +268,20 @@ final class XmirTest {
     }
 
     private String printed(final Xtory xtory) {
-        return (String) xtory.map().getOrDefault(
-            "printed", xtory.map().get("origin")
-        );
+        final String origin = (String) xtory.map().get("origin");
+        final String printed = (String) xtory.map().get("printed");
+        final String expected;
+        if (printed == null) {
+            expected = origin;
+        } else {
+            MatcherAssert.assertThat(
+                "The 'printed' section repeats 'origin' verbatim and must be deleted from the pack, since a pack without 'printed' already expects the printer to reproduce its 'origin'",
+                printed,
+                Matchers.not(Matchers.equalTo(origin))
+            );
+            expected = printed;
+        }
+        return expected;
     }
 
     private Xmir asXmir(final String program, final Map<PenaltyKey, Integer> config)

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/vertical-receiver-void.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/vertical-receiver-void.yaml
@@ -14,9 +14,3 @@ origin: |
 
   [] > size /Q.number
     ? > ^
-
-printed: |
-  +package bytes
-
-  [] > size /Q.number
-    ? > ^


### PR DESCRIPTION
Since #7380, a print pack without a `printed` section means "the printer reproduces `origin` verbatim". Nothing stopped a pack from spelling `printed` out anyway with the very same text, which states the same expectation twice and brings back exactly the double-editing the fallback removed.

Both readers of the packs now reject that, and the message names the fix:

```java
private String printed(final Xtory xtory) {
    final String origin = (String) xtory.map().get("origin");
    final String expected;
    if (xtory.map().containsKey("printed")) {
        expected = (String) xtory.map().get("printed");
        MatcherAssert.assertThat(
            "The 'printed' section repeats 'origin' verbatim and must be deleted from the pack, since a pack without 'printed' already expects the printer to reproduce its 'origin'",
            expected,
            Matchers.not(Matchers.equalTo(origin))
        );
    } else {
        expected = origin;
    }
    return expected;
}
```

`containsKey` rather than a null check says what the branch means — the pack either declares a `printed` section or it doesn't — and keeps the `nulls` count where `master` has it.

`MjPrintTest.expected` gets the identical body — the packs are shared between the two modules by the repository's only symlink (`eo-maven-plugin/src/test/resources/org/eolang/maven/print-packs` → `eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml`), so both suites parameterize over the same files and both have to agree on what a pack may say.

One pack in `master` was already a duplicate: `vertical-receiver-void`, added by #7396, repeated its four lines under `printed`. It now carries only `origin`, which asserts the same thing.

## Checks

All 31 checks are green on `3d63ea79`, `qulice` included, and the `counts` bot reports no metric changed.

Locally, from a clean build (`-Pqulice` on both modules):

- `XmirTest` — 334 tests, 0 failures; `eo-printer` overall 379 / 0
- `MjPrintTest` — 155 tests, 0 failures
- `qulice` and `jtcop` — clean on `eo-printer` and `eo-maven-plugin`

The assertion was confirmed to actually fire: re-adding a copy of `origin` as `printed` in `vertical-receiver-void` failed `printsToEo` and `printsToParseableEo` with the message above, and no other pack of the 152 trips it.
