### PR TITLE
#7439: fix stale javadoc about ξ.ρ resolution

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -53,11 +53,11 @@ import java.util.Map;
  *
  * <p>A name that resolves to nothing gets no row and no complaint: a
  * missing row makes a later check stay undecided, while a wrong row would
- * make it decide wrongly. On the runtime this happens to 730 references out
- * of 21,555, and every one of them is {@code ξ.ρ} — the object one step
- * out, which no formation binds as an attribute and which therefore cannot
- * be found by looking for a name. Linking it needs the notion of "the
- * object I am inside of", which the checking loop will have anyway.</p>
+ * make it decide wrongly. On the runtime this still happens to references
+ * such as dispatches, {@code .eq}, {@code .if}, {@code .empty}, and bottoms
+ * {@code ∅} — not to {@code ξ.ρ}, the object one step out, which
+ * {@link Scope#target(String, String)} resolves by walking two formations
+ * outward from the reference.</p>
  *
  * @since 0.68.0
  */

--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -54,8 +54,8 @@ import java.util.Map;
  * <p>A name that resolves to nothing gets no row and no complaint: a
  * missing row makes a later check stay undecided, while a wrong row would
  * make it decide wrongly. On the runtime this still happens to references
- * such as dispatches, {@code .eq}, {@code .if}, {@code .empty}, and bottoms
- * {@code ∅} — not to {@code ξ.ρ}, the object one step out, which
+ * such as dispatches, {@code .eq}, {@code .if}, {@code .empty}, and
+ * terminators — not to {@code ξ.ρ}, the object one step out, which
  * {@link Scope#target(String, String)} resolves by walking two formations
  * outward from the reference.</p>
  *

--- a/eo-inference/src/main/java/org/eolang/inference/Scope.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Scope.java
@@ -18,11 +18,14 @@ import java.util.Collection;
  *
  * <p>A ξ-name is looked for outwards: the nearest formation around the
  * reference that binds it wins, and if none does, the next one out is tried,
- * up to the top. Nothing else is consulted — an attribute reachable only
- * through {@code φ} or through a package member is not found here, and the
- * name simply stays unresolved. The checker is allowed to know less; it is
- * not allowed to guess, because a wrong link would make every later answer
- * wrong with it.</p>
+ * up to the top. The one exception is {@code ξ.ρ}, the object one step out,
+ * which no formation binds as an attribute; it is found by walking two
+ * formations out from the reference instead of by name. Beyond that, nothing
+ * else is consulted — an attribute reachable only through {@code φ} or
+ * through a package member is not found here, and the name simply stays
+ * unresolved. The checker is allowed to know less; it is not allowed to
+ * guess, because a wrong link would make every later answer wrong with
+ * it.</p>
  *
  * @since 0.68.0
  */


### PR DESCRIPTION
The `Links` javadoc still describes `ξ.ρ` as unresolvable and defers the work to a checking loop that #6661 removed. `Scope.target` has resolved `ξ.ρ` since #6653 by walking two formations out from the reference. This updates both javadocs to describe the current behavior: `Links` no longer cites the stale 730/21,555 figures, and `Scope`'s own javadoc now mentions its `ξ.ρ` branch.

No behavior change, docs only.

Fixes #7439
