### PR TITLE
#7438: fix inverted javadoc about void answers in Provided

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -29,11 +29,13 @@ import java.util.Map;
  *
  * <p>The walk stops at a type it has already passed, so an object that
  * delegates in a circle is walked once and answers nothing. A void answers
- * nothing either: the table has no row for one, since what a void holds is
- * decided by whoever fills it — unless the source has said what will go in,
- * which a formation only Java ever copies has to do (#6189). Such a void is
- * walked through like a delegation, and the answer is the same for every
- * caller, which is what an annotation claims.</p>
+ * too, but with the name rooted at itself: the table has no row for one,
+ * since what a void holds is decided by whoever fills it, so the answer
+ * holds for every caller and is concrete for none — unless the source has
+ * said what will go in, which a formation only Java ever copies has to do
+ * (#6189). Such a void is walked through like a delegation instead, and the
+ * answer is the same for every caller, which is what an annotation
+ * claims.</p>
  *
  * @since 0.68.0
  */


### PR DESCRIPTION
The `Provided` javadoc says a void answers nothing and defers the "walked through like a delegation" behavior to only the annotated case. The code does the opposite: `kept` returns the name rooted at the void when `blank(type)` holds, which is true for a void with no `held` annotation, and only an annotated void is walked through via `behind`.

This updates the paragraph to say what the code does: an un-annotated void answers with a name rooted at itself, holding for every caller and concrete for none, while an annotated void is walked through like a delegation instead.

No behavior change, docs only.

Fixes #7438
