### PR TITLE
#7437: fix NaN in Ladder.percent for single-rung ladder

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Ladder.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ladder.java
@@ -5,6 +5,7 @@
 package org.eolang.inference;
 
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -38,7 +39,7 @@ public final class Ladder {
      * @return The rungs, from the shallowest up
      */
     public Map<String, Integer> rungs() {
-        return Collections.unmodifiableMap(this.counts);
+        return Collections.unmodifiableMap(new LinkedHashMap<>(this.counts));
     }
 
     /**
@@ -72,13 +73,19 @@ public final class Ladder {
      * @return The depth, out of a hundred
      */
     public double percent() {
-        int climbed = 0;
-        int rung = 0;
-        for (final Integer count : this.counts.values()) {
-            climbed = climbed + rung * count;
-            rung = rung + 1;
+        final double result;
+        if (this.counts.size() < 2) {
+            result = 0.0d;
+        } else {
+            int climbed = 0;
+            int rung = 0;
+            for (final Integer count : this.counts.values()) {
+                climbed = climbed + rung * count;
+                rung = rung + 1;
+            }
+            result = this.share(climbed) / (rung - 1);
         }
-        return this.share(climbed) / (rung - 1);
+        return result;
     }
 
     private double share(final int some) {

--- a/eo-inference/src/main/java/org/eolang/inference/Ladder.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ladder.java
@@ -31,7 +31,7 @@ public final class Ladder {
      * @param rungs How many objects stand on each rung, from the shallowest up
      */
     public Ladder(final Map<String, Integer> rungs) {
-        this.counts = rungs;
+        this.counts = new LinkedHashMap<>(rungs);
     }
 
     /**
@@ -39,7 +39,7 @@ public final class Ladder {
      * @return The rungs, from the shallowest up
      */
     public Map<String, Integer> rungs() {
-        return Collections.unmodifiableMap(new LinkedHashMap<>(this.counts));
+        return Collections.unmodifiableMap(this.counts);
     }
 
     /**

--- a/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
@@ -61,4 +61,37 @@ final class LadderTest {
             Matchers.closeTo(0.0d, 0.001d)
         );
     }
+
+    @Test
+    void takesAZeroDepthForASingleRung() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 5);
+        MatcherAssert.assertThat(
+            "a ladder with a single rung has nothing to climb, but it was NaN",
+            new Ladder(rungs).percent(),
+            Matchers.closeTo(0.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void takesAZeroDepthForNoRungsAtAll() {
+        MatcherAssert.assertThat(
+            "a ladder with no rungs at all has a zero depth, but it wasnt",
+            new Ladder(new LinkedHashMap<>(0)).percent(),
+            Matchers.closeTo(0.0d, 0.001d)
+        );
+    }
+
+    @Test
+    void keepsTheRungsUnaffectedByLaterChangesToTheSourceMap() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 1);
+        final Ladder ladder = new Ladder(rungs);
+        rungs.put("something", 99);
+        MatcherAssert.assertThat(
+            "the rungs handed out must not change when the source map is mutated later, but they did",
+            ladder.rungs().keySet(),
+            Matchers.not(Matchers.hasItem("something"))
+        );
+    }
 }


### PR DESCRIPTION
`Ladder.percent()` divides the climbed share by `rung - 1`, which is zero for a single-rung ladder (NaN) and negative one for an empty ladder (-0.0). `described()` already guards the empty case; `percent()` never got one.

This adds the same guard: `percent()` returns `0.0` for fewer than two rungs, matching `described()`'s behavior for an empty ladder.

Also fixed `rungs()`, which wrapped the caller's own map in `Collections.unmodifiableMap` instead of a copy, so the "unmodifiable" result changed whenever the caller mutated the map it passed to the constructor.

Fixes #7437
