### PR TITLE
#7435: serialize Resolving.cleanPlace per directory

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -144,6 +144,49 @@ final class Resolving implements Step {
         }
     }
 
+    /**
+     * Delete every stale sibling version found in the given directory.
+     * @param dir The directory shared by every version of one dependency
+     * @param version The version being resolved
+     * @param keep The versions to keep, everything else in {@code dir} is stale
+     * @return The place of the version being resolved
+     * @throws IOException If fails to delete a stale version
+     */
+    Path cleanPlace(
+        final Path dir, final String version, final Set<String> keep
+    ) throws IOException {
+        final ReentrantLock lock = this.locks.computeIfAbsent(
+            dir.normalize(), key -> new ReentrantLock()
+        );
+        lock.lock();
+        try {
+            final File[] subs = dir.toFile().listFiles();
+            if (subs != null) {
+                for (final File sub : subs) {
+                    final String base = sub.getName();
+                    if (keep.contains(base)) {
+                        continue;
+                    }
+                    final Path bad = dir.resolve(base);
+                    try (Stream<Path> walk = Files.walk(bad)) {
+                        walk
+                            .map(Path::toFile)
+                            .sorted(Comparator.reverseOrder())
+                            .forEach(File::delete);
+                    }
+                    Logger.info(
+                        this,
+                        "Directory %[file]s deleted because it contained a stale version (not %s)",
+                        bad, keep
+                    );
+                }
+            }
+        } finally {
+            lock.unlock();
+        }
+        return dir.resolve(version);
+    }
+
     private int resolved(
         final Dep dep, final Path dest, final Map<String, Set<String>> versions
     ) throws IOException {
@@ -194,41 +237,6 @@ final class Resolving implements Step {
             );
         }
         return 1;
-    }
-
-    private Path cleanPlace(
-        final Path dir, final String version, final Set<String> keep
-    ) throws IOException {
-        final ReentrantLock lock = this.locks.computeIfAbsent(
-            dir.normalize(), key -> new ReentrantLock()
-        );
-        lock.lock();
-        try {
-            final File[] subs = dir.toFile().listFiles();
-            if (subs != null) {
-                for (final File sub : subs) {
-                    final String base = sub.getName();
-                    if (keep.contains(base)) {
-                        continue;
-                    }
-                    final Path bad = dir.resolve(base);
-                    try (Stream<Path> walk = Files.walk(bad)) {
-                        walk
-                            .map(Path::toFile)
-                            .sorted(Comparator.reverseOrder())
-                            .forEach(File::delete);
-                    }
-                    Logger.info(
-                        this,
-                        "Directory %[file]s deleted because it contained a stale version (not %s)",
-                        bad, keep
-                    );
-                }
-            }
-        } finally {
-            lock.unlock();
-        }
-        return dir.resolve(version);
     }
 
     private Collection<Dep> deps() {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Resolving.java
@@ -13,6 +13,9 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -75,6 +78,13 @@ final class Resolving implements Step {
     private final boolean noconflicts;
 
     /**
+     * Locks serializing {@link #cleanPlace(Path, String, Set)} per directory,
+     * since sibling versions of a dependency share a directory and are
+     * cleaned up concurrently by {@link Threaded}.
+     */
+    private final ConcurrentMap<Path, ReentrantLock> locks;
+
+    /**
      * Ctor.
      * @param tjs Tojos
      * @param tgt Target directory
@@ -106,6 +116,7 @@ final class Resolving implements Step {
         this.noruntime = norun;
         this.runtime = runtime;
         this.noconflicts = noconf;
+        this.locks = new ConcurrentHashMap<>(0);
     }
 
     @Override
@@ -188,26 +199,34 @@ final class Resolving implements Step {
     private Path cleanPlace(
         final Path dir, final String version, final Set<String> keep
     ) throws IOException {
-        final File[] subs = dir.toFile().listFiles();
-        if (subs != null) {
-            for (final File sub : subs) {
-                final String base = sub.getName();
-                if (keep.contains(base)) {
-                    continue;
+        final ReentrantLock lock = this.locks.computeIfAbsent(
+            dir.normalize(), key -> new ReentrantLock()
+        );
+        lock.lock();
+        try {
+            final File[] subs = dir.toFile().listFiles();
+            if (subs != null) {
+                for (final File sub : subs) {
+                    final String base = sub.getName();
+                    if (keep.contains(base)) {
+                        continue;
+                    }
+                    final Path bad = dir.resolve(base);
+                    try (Stream<Path> walk = Files.walk(bad)) {
+                        walk
+                            .map(Path::toFile)
+                            .sorted(Comparator.reverseOrder())
+                            .forEach(File::delete);
+                    }
+                    Logger.info(
+                        this,
+                        "Directory %[file]s deleted because it contained a stale version (not %s)",
+                        bad, keep
+                    );
                 }
-                final Path bad = dir.resolve(base);
-                try (Stream<Path> walk = Files.walk(bad)) {
-                    walk
-                        .map(Path::toFile)
-                        .sorted(Comparator.reverseOrder())
-                        .forEach(File::delete);
-                }
-                Logger.info(
-                    this,
-                    "Directory %[file]s deleted because it contained a stale version (not %s)",
-                    bad, keep
-                );
             }
+        } finally {
+            lock.unlock();
         }
         return dir.resolve(version);
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolvingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolvingTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.cactoos.Scalar;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Resolving}.
+ * @since 0.61.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class ResolvingTest {
+
+    @Test
+    void cleansUpSharedPlaceConcurrentlyWithoutFailing(@Mktmp final Path tmp) throws Exception {
+        final Resolving resolving = new Resolving(
+            null, tmp, (dep, place) -> { }, false, false, false, false,
+            (Scalar<Dep>) () -> null, false
+        );
+        final Method cleaner = Resolving.class.getDeclaredMethod(
+            "cleanPlace", Path.class, String.class, Set.class
+        );
+        cleaner.setAccessible(true);
+        final int threads = 8;
+        for (int trial = 0; trial < 20; ++trial) {
+            final Path stale = tmp.resolve("stale-version");
+            Files.createDirectories(stale.resolve("nested"));
+            Files.createFile(stale.resolve("nested").resolve("file.txt"));
+            final CountDownLatch ready = new CountDownLatch(threads);
+            final CountDownLatch go = new CountDownLatch(1);
+            final ExecutorService pool = Executors.newFixedThreadPool(threads);
+            final List<Future<Object>> futures = new ArrayList<>(threads);
+            try {
+                final Callable<Object> job = () -> {
+                    ready.countDown();
+                    go.await();
+                    return cleaner.invoke(
+                        resolving, tmp, "1.0.0", new HashSet<>(Collections.emptySet())
+                    );
+                };
+                for (int idx = 0; idx < threads; ++idx) {
+                    futures.add(pool.submit(job));
+                }
+                ready.await();
+                go.countDown();
+                for (final Future<Object> future : futures) {
+                    future.get(1, TimeUnit.MINUTES);
+                }
+            } finally {
+                pool.shutdownNow();
+            }
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolvingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolvingTest.java
@@ -6,21 +6,16 @@ package org.eolang.maven;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
-import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import org.cactoos.Scalar;
+import org.cactoos.experimental.Threads;
+import org.cactoos.iterable.Mapped;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -39,41 +34,32 @@ final class ResolvingTest {
             null, tmp, (dep, place) -> { }, false, false, false, false,
             (Scalar<Dep>) () -> null, false
         );
-        final Method cleaner = Resolving.class.getDeclaredMethod(
-            "cleanPlace", Path.class, String.class, Set.class
-        );
-        cleaner.setAccessible(true);
         final int threads = 8;
+        final List<Integer> slots = new ArrayList<>(threads);
+        for (int idx = 0; idx < threads; ++idx) {
+            slots.add(idx);
+        }
         for (int trial = 0; trial < 20; ++trial) {
             final Path stale = tmp.resolve("stale-version");
             Files.createDirectories(stale.resolve("nested"));
-            Files.createFile(stale.resolve("nested").resolve("file.txt"));
-            final CountDownLatch ready = new CountDownLatch(threads);
-            final CountDownLatch go = new CountDownLatch(1);
-            final ExecutorService pool = Executors.newFixedThreadPool(threads);
-            final List<Future<Object>> futures = new ArrayList<>(threads);
-            try {
-                final Callable<Object> job = () -> {
-                    ready.countDown();
-                    go.await();
-                    return cleaner.invoke(
-                        resolving, tmp, "1.0.0", new HashSet<>(Collections.emptySet())
-                    );
-                };
-                for (int idx = 0; idx < threads; ++idx) {
-                    futures.add(pool.submit(job));
-                }
-                ready.await();
-                go.countDown();
-                for (final Future<Object> future : futures) {
-                    MatcherAssert.assertThat(
-                        "cleanPlace must resolve to the requested version directory, but it didnt",
-                        future.get(1, TimeUnit.MINUTES),
-                        Matchers.equalTo(tmp.resolve("1.0.0"))
-                    );
-                }
-            } finally {
-                pool.shutdownNow();
+            Files.write(
+                stale.resolve("nested").resolve("file.txt"),
+                "stale".getBytes(StandardCharsets.UTF_8)
+            );
+            for (final Path place : new Threads<Path>(
+                threads,
+                new Mapped<Scalar<Path>>(
+                    idx -> () -> resolving.cleanPlace(
+                        tmp, "1.0.0", new HashSet<>(Collections.emptySet())
+                    ),
+                    slots
+                )
+            )) {
+                MatcherAssert.assertThat(
+                    "cleanPlace must resolve to the requested version directory, but it didnt",
+                    place,
+                    Matchers.equalTo(tmp.resolve("1.0.0"))
+                );
             }
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ResolvingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ResolvingTest.java
@@ -21,6 +21,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Scalar;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -64,7 +66,11 @@ final class ResolvingTest {
                 ready.await();
                 go.countDown();
                 for (final Future<Object> future : futures) {
-                    future.get(1, TimeUnit.MINUTES);
+                    MatcherAssert.assertThat(
+                        "cleanPlace must resolve to the requested version directory, but it didnt",
+                        future.get(1, TimeUnit.MINUTES),
+                        Matchers.equalTo(tmp.resolve("1.0.0"))
+                    );
                 }
             } finally {
                 pool.shutdownNow();


### PR DESCRIPTION
`Resolving.cleanPlace()` deletes a stale-version subdirectory without any locking, but `Resolving.exec()` calls it once per dependency through `Threaded`, which runs every dependency's `resolved()` concurrently. Two dependencies with the same groupId:artifactId:classifier but different versions (the sibling-version case from #6904) resolve to the same directory and can both call `cleanPlace` on it at once. When both threads walk and delete the same stale subdirectory, one can delete a file the other's stream is still walking, throwing `NoSuchFileException` wrapped as `UncheckedIOException`, which `Threaded` turns into an `IllegalStateException` that aborts the whole `eo:resolve` goal.

This serializes `cleanPlace` per directory with a `ConcurrentMap<Path, ReentrantLock>` keyed by the normalized directory, mirroring the pattern already used by `ConcurrentCache` for a similar shared-path problem.

Added a test that calls `cleanPlace` from 8 threads at once against a shared stale subdirectory, repeated over 20 trials. Without the lock it reproduces the exact exception from the report (`UncheckedIOException` wrapping `NoSuchFileException`); with the lock it passes.

Fixes #7435
