### PR TITLE
#7427: stop peeling digits past the double accumulator range in as-fixed

### DIFF
--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -87,16 +87,22 @@
     count.eq 0
     acc
     ^.rec-pad
-      floor.
+      if.
+        value.gte 9007199254740992
         value.div 10
+        floor.
+          value.div 10
       as-number.
         count.minus 1
       concat.
         as-char.
           plus.
-            floor.
-              value.minus
-                times. (value.div 10).floor 10
+            if.
+              value.gte 9007199254740992
+              0
+              floor.
+                value.minus
+                  times. (value.div 10).floor 10
             48
         acc
 
@@ -243,6 +249,11 @@
     string
       0.as-fixed 2
 
+  eq. ++> can-write-a-fraction-of-places-past-the-double-accumulator-range
+    "123.45600000000000300000"
+    string
+      123.456.as-fixed 20
+
   eq. ++> can-write-a-negative-value
     "-2.500000"
     string
@@ -252,6 +263,16 @@
     "2.5"
     string
       2.5.as-fixed 1
+
+  eq. ++> can-write-a-whole-number-far-past-the-double-accumulator-range
+    "2.0000000000000000000000000000000000000000"
+    string
+      2.as-fixed 40
+
+  eq. ++> can-write-places-past-the-double-accumulator-range
+    "1.5000000000000000000000000"
+    string
+      1.5.as-fixed 25
 
   eq. ++> can-write-zero-with-places
     "0.000000"


### PR DESCRIPTION
`number.as-fixed` terminates for a `places` past about twenty digits, even for ordinary values, because `rec-pad` peels decimal digits off a double accumulator that starts at `digits`, the fraction scaled by `10^places`. Once that accumulator passes 2^53, `floor(value / 10) * 10` no longer rounds down to something at or below `value`, so the digit goes negative and `as-char` rejects it, which is why the error names `as-char` rather than `as-fixed`.

This stops peeling once the accumulator leaves the range where a double is an exact integer, and emits `0` for the remaining places, matching the existing convention below the threshold (the digits a double cannot represent already come out as zeros for smaller `places`).

Added regression tests for `1.5.as-fixed 25` and `123.456.as-fixed 20`, both of which terminate on master, plus `2.0.as-fixed 40` as a control that already passes. Values computed by simulating the fixed digit-peeling algorithm in Python and cross-checked against the exact controls already given for smaller `places` counts.

Fixes #7427
