### PR TITLE
Fix the broken "iterate" example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,20 +153,20 @@ Now, the object `app` has two "attached" attributes: `@` and `msg`. The attribut
 This is how you iterate:
 
 ```eo
-malloc.empty > [args] > app
-  seq * > [x] >>
-    x.put 2
-    while
-      ^.x.as-number.lt 6 > [i] >>
-      seq * > [i] >>
-        stdout
-          "%d x %1$d = %d\n".printf
-            *
-              ^.x
-              ^.x.as-number.times ^.x
-        ^.x.put
-          ^.x.as-number.plus 1
-    true
+[args] > app
+  malloc.for > @
+    2
+    [x] >>
+      while > @
+        ^.x.as-number.lt 6 > [i] >>
+        seq * > [i] >>
+          stdout
+            "%d x %1$d = %d\n".printf
+              *
+                ^.x.as-number
+                ^.x.as-number.times ^.x.as-number
+          ^.x.put
+            ^.x.as-number.plus 1
 ```
 
 This code will print this:


### PR DESCRIPTION
The "This is how you iterate" snippet in README.md didn't compile anymore
under the current EO grammar, which is why the `snippets` check has been red
on master (and on every PR that merges master).

This rewrites it to use `malloc.for` + `while`, the same pattern that's already
verified in `eo-runtime/src/main/eo/while.eo`. The behavior is unchanged: it
counts from 2 and prints the little `2×2=4 … 5×5=25` table.

I ran `ReadmeSnippetsIT` locally and all five README snippets now build
successfully (BUILD SUCCESS).

Closes #7454
