### PR TITLE
#7445: place an argument by its @as index, not its document position

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -83,7 +83,7 @@ final class Bound {
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (int place = 0; place < given.size(); place += 1) {
             final String hollow = this.owned.slot(copied, place);
-            if (!hollow.isEmpty()) {
+            if (!hollow.isEmpty() && !given.get(place).isEmpty()) {
                 found.put(hollow, given.get(place));
             }
         }

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -104,7 +104,7 @@ final class Filled {
                 final List<String> given = this.args.get(walked);
                 for (int place = 0; place < given.size(); place += 1) {
                     final String hollow = this.owned.slot(this.end(copied), place);
-                    if (!hollow.isEmpty()) {
+                    if (!hollow.isEmpty() && !given.get(place).isEmpty()) {
                         found.putIfAbsent(hollow, this.end(given.get(place)));
                     }
                 }

--- a/eo-inference/src/main/java/org/eolang/inference/Given.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Given.java
@@ -14,10 +14,12 @@ import java.util.Map;
 /**
  * What every application puts into the voids of what it copies.
  *
- * <p>An argument goes into a void by its place and not by its name, so the
- * order is the whole of the fact and it is kept. What the argument is stays a
- * locator here, since the type of it is a question for the links table and the
- * answer changes as the passes go on.</p>
+ * <p>An argument goes into a void by its place and not by its name, and the
+ * place is what {@code @as} says, not where the argument sits among its
+ * siblings: an inline binding such as {@code pair 5:1} names its void
+ * directly and can leave an earlier one for whoever applies next. What the
+ * argument is stays a locator here, since the type of it is a question for
+ * the links table and the answer changes as the passes go on.</p>
  *
  * @since 0.69.0
  */
@@ -38,17 +40,34 @@ final class Given {
 
     /**
      * The arguments of every application, by the locator of the application.
-     * @return The arguments, each list in the order the places run
+     * @return The arguments, each list in the order the places run, with an
+     *  empty locator where an inline binding has left a place unfilled
      */
     Map<String, List<String>> arguments() {
         final Map<String, List<String>> found = new HashMap<>(0);
         for (final XML application : this.all) {
-            final List<String> args = new ArrayList<>(1);
-            for (final XML arg : application.nodes("o[starts-with(@as, 'α')][@loc]")) {
-                args.add(arg.xpath("@loc").get(0));
-            }
-            found.put(application.xpath("@loc").get(0), args);
+            found.put(application.xpath("@loc").get(0), this.placed(application));
         }
         return found;
+    }
+
+    /**
+     * The arguments of one application, ordered by the place each one names.
+     * @param application The application
+     * @return The arguments, one per place, up to the highest place named
+     */
+    private List<String> placed(final XML application) {
+        final Map<Integer, String> byplace = new HashMap<>(1);
+        int highest = -1;
+        for (final XML arg : application.nodes("o[starts-with(@as, 'α')][@loc]")) {
+            final int place = Integer.parseInt(arg.xpath("@as").get(0).substring(1));
+            byplace.put(place, arg.xpath("@loc").get(0));
+            highest = Math.max(highest, place);
+        }
+        final List<String> args = new ArrayList<>(highest + 1);
+        for (int place = 0; place <= highest; place += 1) {
+            args.add(byplace.getOrDefault(place, ""));
+        }
+        return args;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Given.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Given.java
@@ -5,7 +5,6 @@
 package org.eolang.inference;
 
 import com.jcabi.xml.XML;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -46,28 +45,8 @@ final class Given {
     Map<String, List<String>> arguments() {
         final Map<String, List<String>> found = new HashMap<>(0);
         for (final XML application : this.all) {
-            found.put(application.xpath("@loc").get(0), this.placed(application));
+            found.put(application.xpath("@loc").get(0), new Placed(application).args());
         }
         return found;
-    }
-
-    /**
-     * The arguments of one application, ordered by the place each one names.
-     * @param application The application
-     * @return The arguments, one per place, up to the highest place named
-     */
-    private List<String> placed(final XML application) {
-        final Map<Integer, String> byplace = new HashMap<>(1);
-        int highest = -1;
-        for (final XML arg : application.nodes("o[starts-with(@as, 'α')][@loc]")) {
-            final int place = Integer.parseInt(arg.xpath("@as").get(0).substring(1));
-            byplace.put(place, arg.xpath("@loc").get(0));
-            highest = Math.max(highest, place);
-        }
-        final List<String> args = new ArrayList<>(highest + 1);
-        for (int place = 0; place <= highest; place += 1) {
-            args.add(byplace.getOrDefault(place, ""));
-        }
-        return args;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Placed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Placed.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The arguments of one application, ordered by the place each one names.
+ *
+ * <p>An inline binding {@code :N} says which place the argument goes to, so
+ * the order the arguments are written in is not the order they fill. A place
+ * nobody names comes back as an empty locator, since the list is read by
+ * position and a gap has to keep its own seat.</p>
+ *
+ * @since 0.69.0
+ */
+final class Placed {
+
+    /**
+     * The application.
+     */
+    private final XML application;
+
+    /**
+     * Ctor.
+     * @param app The application
+     */
+    Placed(final XML app) {
+        this.application = app;
+    }
+
+    /**
+     * The arguments, one per place, up to the highest place named.
+     * @return The locator of every argument, by its place
+     */
+    List<String> args() {
+        final Map<Integer, String> byplace = new HashMap<>(1);
+        int highest = -1;
+        for (final XML arg : this.application.nodes("o[starts-with(@as, 'α')][@loc]")) {
+            final int place = Integer.parseInt(arg.xpath("@as").get(0).substring(1));
+            byplace.put(place, arg.xpath("@loc").get(0));
+            highest = Math.max(highest, place);
+        }
+        final List<String> args = new ArrayList<>(highest + 1);
+        for (int place = 0; place <= highest; place += 1) {
+            args.add(byplace.getOrDefault(place, ""));
+        }
+        return args;
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/GivenTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/GivenTest.java
@@ -6,7 +6,6 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
-import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -19,38 +18,36 @@ final class GivenTest {
 
     @Test
     void placesAnInlineBindingByItsIndexNotItsPosition() {
-        final Map<String, List<String>> arguments = new Given(
-            List.of(
-                new XMLDocument(
-                    "<o loc='Φ.app.only'><o as='α1' loc='Φ.app.only.α1'/></o>"
-                ).nodes("/o").get(0)
-            )
-        ).arguments();
         MatcherAssert.assertThat(
             "an argument bound with :1 must land on the second void, not the first",
-            arguments.get("Φ.app.only"),
+            new Given(
+                List.of(
+                    new XMLDocument(
+                        "<o loc='Φ.app.only'><o as='α1' loc='Φ.app.only.α1'/></o>"
+                    ).nodes("/o").get(0)
+                )
+            ).arguments().get("Φ.app.only"),
             Matchers.equalTo(List.of("", "Φ.app.only.α1"))
         );
     }
 
     @Test
     void keepsPlainApplicationsInDocumentOrder() {
-        final Map<String, List<String>> arguments = new Given(
-            List.of(
-                new XMLDocument(
-                    String.join(
-                        "",
-                        "<o loc='Φ.app.pair'>",
-                        "<o as='α0' loc='Φ.app.pair.α0'/>",
-                        "<o as='α1' loc='Φ.app.pair.α1'/>",
-                        "</o>"
-                    )
-                ).nodes("/o").get(0)
-            )
-        ).arguments();
         MatcherAssert.assertThat(
             "two ordinary arguments must keep filling the voids in order",
-            arguments.get("Φ.app.pair"),
+            new Given(
+                List.of(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<o loc='Φ.app.pair'>",
+                            "<o as='α0' loc='Φ.app.pair.α0'/>",
+                            "<o as='α1' loc='Φ.app.pair.α1'/>",
+                            "</o>"
+                        )
+                    ).nodes("/o").get(0)
+                )
+            ).arguments().get("Φ.app.pair"),
             Matchers.equalTo(List.of("Φ.app.pair.α0", "Φ.app.pair.α1"))
         );
     }

--- a/eo-inference/src/test/java/org/eolang/inference/GivenTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/GivenTest.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Given}.
+ * @since 0.69.0
+ */
+final class GivenTest {
+
+    @Test
+    void placesAnInlineBindingByItsIndexNotItsPosition() {
+        final Map<String, List<String>> arguments = new Given(
+            List.of(
+                new XMLDocument(
+                    "<o loc='Φ.app.only'><o as='α1' loc='Φ.app.only.α1'/></o>"
+                ).nodes("/o").get(0)
+            )
+        ).arguments();
+        MatcherAssert.assertThat(
+            "an argument bound with :1 must land on the second void, not the first",
+            arguments.get("Φ.app.only"),
+            Matchers.equalTo(List.of("", "Φ.app.only.α1"))
+        );
+    }
+
+    @Test
+    void keepsPlainApplicationsInDocumentOrder() {
+        final Map<String, List<String>> arguments = new Given(
+            List.of(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<o loc='Φ.app.pair'>",
+                        "<o as='α0' loc='Φ.app.pair.α0'/>",
+                        "<o as='α1' loc='Φ.app.pair.α1'/>",
+                        "</o>"
+                    )
+                ).nodes("/o").get(0)
+            )
+        ).arguments();
+        MatcherAssert.assertThat(
+            "two ordinary arguments must keep filling the voids in order",
+            arguments.get("Φ.app.pair"),
+            Matchers.equalTo(List.of("Φ.app.pair.α0", "Φ.app.pair.α1"))
+        );
+    }
+}


### PR DESCRIPTION
Closes #7445

`Given.arguments()` listed an application's arguments in document order and used that
position as the void's place. For an inline binding like `pair 5:1`, the single argument
node carries `@as="α1"` but was the only element in the list, so it landed at list
position 0 and filled the first void instead of the second.

The fix reads the place from the numeric part of `@as` and builds the list so that
`list.get(place)` always matches the void at that place, leaving an empty locator for
any place an inline binding skipped. `Bound` and `Filled`, which both walk this list by
place, now skip an empty placeholder the same way they already skip an unknown void.

Added a unit test reproducing the exact case from the issue (a single `:1`-bound
argument landing on the second void) plus one confirming plain two-argument
applications still fill voids in order.
