### PR TITLE
#7447: keep an argument bound by name instead of dropping it

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -45,6 +45,11 @@ final class Bound {
     private final Map<String, List<String>> args;
 
     /**
+     * The arguments of every application bound by name, from {@link Given}.
+     */
+    private final Map<String, Map<String, String>> named;
+
+    /**
      * What every dispatch takes its attribute from, from {@link Xmirs}.
      */
     private final Map<String, String> receivers;
@@ -62,17 +67,20 @@ final class Bound {
     /**
      * Ctor.
      * @param arguments The arguments of every application, from {@link Given}
+     * @param bindings The arguments of every application bound by name
      * @param taken What every dispatch takes its attribute from
      * @param links The pairs, each name against the one it is a copy of
      * @param provided What the types certainly have
      */
     Bound(
         final Map<String, List<String>> arguments,
+        final Map<String, Map<String, String>> bindings,
         final Map<String, String> taken,
         final Map<String, String> links,
         final Provided provided
     ) {
         this.args = arguments;
+        this.named = bindings;
         this.receivers = taken;
         this.pairs = links;
         this.owned = provided;
@@ -109,6 +117,13 @@ final class Bound {
             final String hollow = this.owned.vacant(this.base(application), before, place);
             if (!hollow.isEmpty() && !given.get(place).isEmpty()) {
                 found.put(hollow, given.get(place));
+            }
+        }
+        for (final Map.Entry<String, String> bind
+            : this.named.getOrDefault(application, Collections.emptyMap()).entrySet()) {
+            final String hollow = this.owned.named(this.base(application), bind.getKey());
+            if (!hollow.isEmpty()) {
+                found.put(hollow, bind.getValue());
             }
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -48,6 +48,11 @@ final class Dispatched {
     private final Map<String, List<String>> args;
 
     /**
+     * The arguments of every application bound by name, from {@link Given}.
+     */
+    private final Map<String, Map<String, String>> named;
+
+    /**
      * What every dispatch takes its attribute from, from {@link Xmirs}.
      */
     private final Map<String, String> receivers;
@@ -62,6 +67,7 @@ final class Dispatched {
      * @param provides The provides table
      * @param dispatches Every dispatch of the program
      * @param arguments The arguments of every application, from {@link Given}
+     * @param bindings The arguments of every application bound by name
      * @param taken What every dispatch takes its attribute from
      * @param voids The locator of every void this pass may look into, empty
      *  when it may look into none
@@ -70,12 +76,14 @@ final class Dispatched {
         final XML provides,
         final Collection<XML> dispatches,
         final Map<String, List<String>> arguments,
+        final Map<String, Map<String, String>> bindings,
         final Map<String, String> taken,
         final Collection<String> voids
     ) {
         this.given = provides;
         this.all = dispatches;
         this.args = arguments;
+        this.named = bindings;
         this.receivers = taken;
         this.hollows = voids;
     }
@@ -90,7 +98,9 @@ final class Dispatched {
         final Map<String, String> names = new Ends(pairs).names();
         final Provided owned = new Provided(this.given, names, this.hollows);
         final Filled filled = new Filled(
-            pairs, owned, new Bound(this.args, this.receivers, pairs, owned).all()
+            pairs,
+            owned,
+            new Bound(this.args, this.named, this.receivers, pairs, owned).all()
         );
         final Map<String, String> found = new HashMap<>(0);
         for (final XML dispatch : this.all) {

--- a/eo-inference/src/main/java/org/eolang/inference/Given.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Given.java
@@ -16,9 +16,11 @@ import java.util.Map;
  * <p>An argument goes into a void by its place and not by its name, and the
  * place is what {@code @as} says, not where the argument sits among its
  * siblings: an inline binding such as {@code pair 5:1} names its void
- * directly and can leave an earlier one for whoever applies next. What the
- * argument is stays a locator here, since the type of it is a question for
- * the links table and the answer changes as the passes go on.</p>
+ * directly and can leave an earlier one for whoever applies next. A binding
+ * may name the void itself rather than its place, and is kept apart for that
+ * reason (R-3.12.1). What the argument is stays a locator here, since the
+ * type of it is a question for the links table and the answer changes as the
+ * passes go on.</p>
  *
  * @since 0.69.0
  */
@@ -46,6 +48,25 @@ final class Given {
         final Map<String, List<String>> found = new HashMap<>(0);
         for (final XML application : this.all) {
             found.put(application.xpath("@loc").get(0), new Placed(application).args());
+        }
+        return found;
+    }
+
+    /**
+     * The arguments of every application bound by name, by the locator of the
+     * application.
+     * @return The arguments, by the name of the void each names
+     */
+    Map<String, Map<String, String>> named() {
+        final Map<String, Map<String, String>> found = new HashMap<>(0);
+        for (final XML application : this.all) {
+            final Map<String, String> args = new HashMap<>(0);
+            for (final XML arg : application.nodes(
+                "o[@as][not(starts-with(@as, 'α'))][@loc]"
+            )) {
+                args.put(arg.xpath("@as").get(0), arg.xpath("@loc").get(0));
+            }
+            found.put(application.xpath("@loc").get(0), args);
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -180,6 +180,24 @@ final class Provided {
         return this.bound(type, "φ");
     }
 
+    /**
+     * The void this type keeps under the given name.
+     * @param type The name the type goes by
+     * @param name The name of the void
+     * @return The locator of the void, or an empty string when this type keeps
+     *  no void of that name
+     */
+    String named(final String type, final String name) {
+        String found = "";
+        for (final Map<String, String> row : this.own(type)) {
+            if ("true".equals(row.get("void")) && name.equals(row.getOrDefault("name", ""))) {
+                found = row.getOrDefault("type", "");
+                break;
+            }
+        }
+        return found;
+    }
+
     private boolean hollow(final String type) {
         boolean found = false;
         String walked = type;

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -72,23 +72,25 @@ public final class Resolved implements Clue {
         final Xmirs world = new Xmirs(xmirs);
         final XML given = new XMLDocument(tables.resolve("provides.xml"));
         final Collection<XML> dispatches = world.dispatches();
-        final Map<String, List<String>> args = new Given(world.applications()).arguments();
+        final Given applied = new Given(world.applications());
+        final Map<String, List<String>> args = applied.arguments();
+        final Map<String, Map<String, String>> named = applied.named();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final XML table = new XMLDocument(links);
         final Pairs written = new Pairs(table);
         final Map<String, String> pairs = new Settled(
-            new Dispatched(given, dispatches, args, world.receivers(), voids)
+            new Dispatched(given, dispatches, args, named, world.receivers(), voids)
         ).from(
             new Settled(
                 new Dispatched(
-                    given, dispatches, args, world.receivers(), Collections.emptyList()
+                    given, dispatches, args, named, world.receivers(), Collections.emptyList()
                 )
             ).from(written.all())
         );
         final Map<String, Type> rows = new Refs(
             pairs,
             new Bound(
-                args, world.receivers(), pairs,
+                args, named, world.receivers(), pairs,
                 new Provided(given, new Ends(pairs).names(), voids)
             ).all()
         ).all();

--- a/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
@@ -38,7 +38,7 @@ final class BoundTest {
         MatcherAssert.assertThat(
             "the second application of a chain must fill the void the first one left empty",
             new Bound(
-                args, Collections.emptyMap(), pairs,
+                args, Collections.emptyMap(), Collections.emptyMap(), pairs,
                 new Provided(
                     rows, Collections.emptyMap(),
                     Collections.emptyList(), Collections.emptyMap()
@@ -50,6 +50,32 @@ final class BoundTest {
                     "Φ.app.full", Map.of("Φ.app.pair.y", "Φ.app.two")
                 )
             )
+        );
+    }
+
+    @Test
+    void namesBothVoidsOfAnApplicationBoundEntirelyByName() {
+        MatcherAssert.assertThat(
+            "both voids named inline must show up, keyed by the void they were bound to",
+            new Bound(
+                Map.of("only", List.of()),
+                Map.of("only", Map.of("y", "only.y", "x", "only.x")),
+                Collections.emptyMap(),
+                Map.of("only", "pair"),
+                new Provided(
+                    Map.of(
+                        "pair",
+                        List.of(
+                            Map.of("void", "true", "name", "x", "type", "pair.x"),
+                            Map.of("void", "true", "name", "y", "type", "pair.y")
+                        )
+                    ),
+                    Collections.emptyMap(),
+                    Collections.emptyList(),
+                    Collections.emptyMap()
+                )
+            ).all().get("only"),
+            Matchers.equalTo(Map.of("pair.y", "only.y", "pair.x", "only.x"))
         );
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
@@ -39,7 +39,8 @@ final class FilledTest {
                 owned,
                 new Bound(
                     Map.of("app", List.of("value-x", "value-foo")),
-                    Collections.emptyMap(), Map.of("app", "form"), owned
+                    Collections.emptyMap(), Collections.emptyMap(),
+                    Map.of("app", "form"), owned
                 ).all()
             ).instead("Φ.node.x", "app"),
             Matchers.equalTo("value-x")
@@ -67,7 +68,8 @@ final class FilledTest {
                 owned,
                 new Bound(
                     Map.of("app", List.of("short-fill", "long-fill")),
-                    Collections.emptyMap(), Map.of("app", "form"), owned
+                    Collections.emptyMap(), Collections.emptyMap(),
+                    Map.of("app", "form"), owned
                 ).all()
             ).instead("Φ.node.x.y", "app"),
             Matchers.equalTo("Φ.result")

--- a/eo-inference/src/test/java/org/eolang/inference/GivenTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/GivenTest.java
@@ -6,6 +6,7 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XMLDocument;
 import java.util.List;
+import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,27 @@ final class GivenTest {
                 )
             ).arguments().get("Φ.app.pair"),
             Matchers.equalTo(List.of("Φ.app.pair.α0", "Φ.app.pair.α1"))
+        );
+    }
+
+    @Test
+    void keepsAnArgumentBoundByNameApartFromThePositionalOnes() {
+        MatcherAssert.assertThat(
+            "an argument bound by name must be kept, not thrown away by the α filter",
+            new Given(
+                List.of(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<o loc='Φ.app.only'>",
+                            "<o as='y' loc='Φ.app.only.y'/>",
+                            "<o as='x' loc='Φ.app.only.x'/>",
+                            "</o>"
+                        )
+                    ).nodes("/o").get(0)
+                )
+            ).named().get("Φ.app.only"),
+            Matchers.equalTo(Map.of("y", "Φ.app.only.y", "x", "Φ.app.only.x"))
         );
     }
 }


### PR DESCRIPTION
Closes #7447

`Given.arguments()` picked up an application's arguments with
`o[starts-with(@as, 'α')][@loc]`. An inline binding by name (R-3.12.1) puts
the void's name into `@as` instead of an `α` index, so the filter passed it by
and the application ended up with no argument at all, positional or named.

`Given` now also has `named()`, which picks up exactly the nodes the old
filter skipped (`@as` present, not starting with `α`), keyed by the name the
void was bound to. `Provided` gets a matching `named(type, name)` lookup
alongside the existing `slot(type, place)`, and `Bound`/`Filled` each take the
named-argument map and fold it into what they already compute for a
positional one, using `named` instead of `slot` to find the void.

Added a `GivenTest` covering both halves (a name-bound argument is kept, and
it does not leak into the positional list) and a `BoundTest` reproducing the
issue's exact case: an application bound entirely by name (`pair 9:y 7:x`)
must name both voids.
