### PR TITLE
#7448: use only the first +package meta when shortening a self-reference

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -332,7 +332,7 @@
     self-reference to a same-file object carries after being homed
     into the package (add-default-package / build-fqns).
     -->
-    <xsl:variable name="package" select="string(/object/metas/meta[head='package']/part[1])"/>
+    <xsl:variable name="package" select="string((/object/metas/meta[head='package'])[1]/part[1])"/>
     <xsl:variable name="self-prefix" select="concat($eo:program, '.', $package, '.')"/>
     <xsl:variable name="self-rest" select="substring-after(@base, $self-prefix)"/>
     <xsl:variable name="self-first" select="if (contains($self-rest, '.')) then substring-before($self-rest, '.') else $self-rest"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/two-package-metas-do-not-crash.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/two-package-metas-do-not-crash.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A file may carry more than one "+package" meta (the parser accepts it,
+# eo-syntax/multiple-package-metas-do-not-crash.yaml), and the printer must
+# not crash on it either: to-eo-tree.xsl reads the "package" variable while
+# shortening a self-reference, and picking `part[1]` of every matching meta
+# instead of the first meta gave Saxon two nodes for `string()` (#7448). Only
+# the first "+package" is used to build the self-reference prefix.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package a
+  +package b
+
+  [] > main
+    (stdout "hi").print > @
+
+printed: |
+  +package a
+  +package b
+
+  print. > [] > main
+    stdout "hi"


### PR DESCRIPTION
Closes #7448

`to-eo-tree.xsl:335` read the file's package as
`/object/metas/meta[head='package']/part[1]`. The `[1]` picks the first
`part` of every matching `meta`, not the first `meta`, so with two
`+package` metas `string()` got two nodes and Saxon threw. A file with one
`+package` meta was unaffected, which is why this only shows up once a file
carries two of them (the parser already accepts that, see
`eo-syntax/multiple-package-metas-do-not-crash.yaml`).

Changed the XPath to `(/object/metas/meta[head='package'])[1]/part[1]`, so
the first `[1]` selects the first meta and the printer uses that one's
package the way it already does for a file with a single meta.

Added `print-packs/yaml/two-package-metas-do-not-crash.yaml`, reproducing
the exact program from the issue. Confirmed it fails with the original
crash when the fix is reverted, and passes with it applied.
