### PR TITLE
#7449: map xi to $ on the printer's reversed-dispatch path

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -433,16 +433,20 @@ final class Node {
             } else {
                 dot = ".";
             }
-            result = this.children.get(0).braced().map(
-                glued -> new Node(
-                    String.join(
-                        dot, glued,
-                        this.base.substring(0, this.base.length() - dot.length())
-                    ),
-                    this.tail, this.abstractt, this.test, false, false,
-                    this.children.subList(1, this.children.size())
-                )
-            );
+            final String head = this.base.substring(0, this.base.length() - dot.length());
+            /*
+             "$" (xi) is not a real attribute, so "receiver.$" has no valid
+             surface spelling, unlike "@" (phi) and "^" (rho) (#7449).
+             */
+            if (!"$".equals(head)) {
+                result = this.children.get(0).braced().map(
+                    glued -> new Node(
+                        String.join(dot, glued, head),
+                        this.tail, this.abstractt, this.test, false, false,
+                        this.children.subList(1, this.children.size())
+                    )
+                );
+            }
         }
         return result;
     }

--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -434,10 +434,6 @@ final class Node {
                 dot = ".";
             }
             final String head = this.base.substring(0, this.base.length() - dot.length());
-            /*
-             "$" (xi) is not a real attribute, so "receiver.$" has no valid
-             surface spelling, unlike "@" (phi) and "^" (rho) (#7449).
-             */
             if (!"$".equals(head)) {
                 result = this.children.get(0).braced().map(
                     glued -> new Node(

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -19,10 +19,10 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:variable name="eol" select="'&#10;'"/>
   <xsl:output method="xml" encoding="UTF-8"/>
-  <!-- Translate a dotted path to EO surface form: ρ -> ^, φ -> @. -->
+  <!-- Translate a dotted path to EO surface form: ρ -> ^, φ -> @, ξ -> $. -->
   <xsl:function name="eo:translate-path" as="xs:string">
     <xsl:param name="path" as="xs:string"/>
-    <xsl:sequence select="string-join(for $seg in tokenize($path, '\.') return (if ($seg = $eo:rho) then '^' else if ($seg = $eo:phi) then '@' else if ($seg = $eo:bottom) then 'T' else $seg), '.')"/>
+    <xsl:sequence select="string-join(for $seg in tokenize($path, '\.') return (if ($seg = $eo:rho) then '^' else if ($seg = $eo:phi) then '@' else if ($seg = $eo:xi) then '$' else if ($seg = $eo:bottom) then 'T' else $seg), '.')"/>
   </xsl:function>
   <!--
   Render a base as an EO head: drop implicit ξ./Φ. roots, render a

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-dispatch-on-xi-uses-dollar.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/reversed-dispatch-on-xi-uses-dollar.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A reversed dispatch whose head is "$" (xi) must reprint with the "$"
+# surface spelling, the way "@" (phi) and "^" (rho) already do in a leading
+# reversed marker: "eo:translate-path" mapped rho and phi but not xi, so the
+# marker printed as the raw internal "xi" glyph instead and the result did
+# not reparse. Unlike "@" and "^", "$" is not a real attribute a chain can
+# dispatch through, so it also keeps its prefix ("$. receiver") shape rather
+# than folding into a "receiver.$" suffix the grammar does not accept (#7449).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    $. 1 > z


### PR DESCRIPTION
Closes #7449

A reversed dispatch whose head is xi printed with the internal xi glyph
instead of its surface spelling `$`, matching what already happens correctly
for phi (`@`) and rho (`^`) in the same position. `eo:translate-path` mapped
rho and phi but not xi, so the leading reversed marker printed as raw `ξ`
(`ξ. 1 > z`), which does not reparse.

Mapping xi to `$` in `eo:translate-path` fixes the marker itself. It also
uncovered a second problem: unlike `@` and `^`, which name real attributes
(the decoratee and the parent) and so can legally sit after a dot in a
dispatch chain, `$` (xi) is not a real attribute anywhere, so a plain
`receiver.$` chain has no valid surface spelling and the grammar rejects it
(confirmed against the parser directly). `Node#suffixed()`, the code that
folds a reversed dispatch into that receiver-first shape when it is shorter,
now skips that transformation when the head is `$`, so a xi-headed reversed
dispatch keeps its `$. receiver` prefix shape.

Added `print-packs/yaml/reversed-dispatch-on-xi-uses-dollar.yaml`
reproducing the issue's example. Confirmed it fails (prints raw `ξ`, does not
reparse) with the fix reverted, and passes with it applied.
