### PR TITLE
#7450: map an argument's :as label back to its surface glyph

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -454,7 +454,7 @@
           <xsl:value-of select="substring-after(@as, $eo:alpha)"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="@as"/>
+          <xsl:value-of select="eo:translate-path(@as)"/>
         </xsl:otherwise>
       </xsl:choose>
     </xsl:if>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/argument-bound-to-receiver-uses-caret.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/argument-bound-to-receiver-uses-caret.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An argument bound to a named void with ":^" (R-3.12.2a rho) must reprint
+# with its surface spelling, the way the base of an object already does:
+# the TAIL template's "@as" branch printed the raw internal "rho" glyph
+# instead of "^", and the result did not reparse (#7450).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > user
+    lt x:0 y:^ > @
+
+printed: |
+  [] > user
+    lt > @
+      x:0
+      y:^


### PR DESCRIPTION
Closes #7450

An argument bound to a named void with `:^` (rho, R-3.12.2a) printed as `:ρ`,
the raw internal glyph, which does not reparse. The TAIL template's `@as`
branch handled a numeric index (`α0` etc) but printed any other `@as` value
verbatim, with no glyph mapping.

Routed the non-numeric case through `eo:translate-path`, the same function
`eo:surface` already uses to turn `ρ`/`φ`/`ξ` into `^`/`@`/`$` elsewhere, so
`:ρ` becomes `:^` and `:φ` becomes `:@` consistently.

Added `print-packs/yaml/argument-bound-to-receiver-uses-caret.yaml`
reproducing the issue's example. Confirmed it fails (prints raw `ρ`, does not
reparse) with the fix reverted, and passes with it applied.
