### PR TITLE
Let every formation declare its receiver

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -64,7 +64,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="α[0-9]+|φ|[a-z+-]\S*|λ"/>
+      <xs:pattern value="α[0-9]+|φ|ρ|[a-z+-]\S*|λ"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="fqn">

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -319,6 +319,39 @@
                 'tuple.empty', looks unused to it (objectionary/lints#1276).
                 -->
                 <lint>redundant-object</lint>
+                <!--
+                @todo #6985:30min Stop skipping 'anemic-getter' here. Every
+                formation now declares its receiver, so a '^ &gt; name' binding
+                reads to the lint as a getter that renames 'ρ' and adds
+                nothing. It does add something: a name that survives nesting,
+                where the alternative '^.^' spelling counts hops and silently
+                retargets when a block is re-indented. Drop this entry once
+                objectionary/lints#1300 stops reporting a getter whose source
+                is the receiver, and check that no genuine anemic getter crept
+                in behind the suppression meanwhile.
+                -->
+                <lint>anemic-getter</lint>
+                <!--
+                @todo #6985:30min Stop skipping 'redundant-attachment' here. A
+                declared 'ρ' counts as one of the object's own voids, so
+                'outer-refs' comes back empty for formations that do reach into
+                the enclosing scope, and their '&gt;&gt;' names look
+                unreferenced. Dropping those names made the formatter reshape
+                the call sites and broke 'map', 'while', 'range' and 'input'.
+                Remove this entry once objectionary/lints#1301 treats the
+                receiver as reaching outward even when the head declares it.
+                -->
+                <lint>redundant-attachment</lint>
+                <!--
+                @todo #6985:30min Stop skipping 'many-void-attributes' here.
+                The rule caps a formation at five voids to keep it callable,
+                but it counts 'ρ' among them, and 'string.regex.matched' has
+                five real ones. Writing the receiver down did not add an
+                argument, so the cap now bites any head honest enough to
+                declare what it already had. Remove this entry once
+                objectionary/lints#1299 leaves the receiver out of the count.
+                -->
+                <lint>many-void-attributes</lint>
               </skipSourceLints>
               <!--
               Objects with an optional fallback argument, like 'string.as-fixed'

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -11,17 +11,17 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[if] > bool
+[^ if] > bool
   if > @
     01-
     00-
-  ^.if > [x] > and
+  ^.if > [^ x] > and
     01-.eq x
     false
   if > not
     false
     true
-  ^.if > [x] > or
+  ^.if > [^ x] > or
     true
     01-.eq x
 
@@ -39,12 +39,12 @@
 
   ++> can-call-a-function-from-an-app
     app.eq 2 > @
-    [] > app
+    [^] > app
       f * > @
         1
         2
         3
-      [args] > f
+      [^ args] > f
         2 > @
         1 > a
 
@@ -79,11 +79,11 @@
 
   ++> can-compile-deeply-duplicated-names
     true > @
-    [] > long-object-name
-      [] > long-object-name
-        [] > long-object-name
-          [] > long-object-name
-            [] > long-object-name
+    [^] > long-object-name
+      [^] > long-object-name
+        [^] > long-object-name
+          [^] > long-object-name
+            [^] > long-object-name
               42 > x
 
   not. ++> can-conjoin-true-with-false
@@ -95,9 +95,9 @@
 
   ++> can-extract-an-attribute-from-a-decoratee
     a.foo.eq 43 > @
-    ^.return > [] > a
+    ^.return > [^] > a
       42.plus 1
-    [foo] > return
+    [^ foo] > return
 
   eq. ++> can-fork-on-a-false-condition
     if.
@@ -125,90 +125,90 @@
     eq. > @
       blah0 0
       39
-    [x] > blah0
+    [^ x] > blah0
       blah1 > @
         x.plus 1
-      [x] > blah1
+      [^ x] > blah1
         blah2 > @
           x.plus 1
-        [x] > blah2
+        [^ x] > blah2
           blah3 > @
             x.plus 1
-          [x] > blah3
+          [^ x] > blah3
             blah4 > @
               x.plus 1
-            [x] > blah4
+            [^ x] > blah4
               blah5 > @
                 x.plus 1
-              [x] > blah5
+              [^ x] > blah5
                 blah6 > @
                   x.plus 1
-                [x] > blah6
+                [^ x] > blah6
                   blah7 > @
                     x.plus 1
-                  [x] > blah7
+                  [^ x] > blah7
                     blah8 (x.plus 1) > @
-                    [x] > blah8
+                    [^ x] > blah8
                       blah9 (x.plus 1) > @
-                      [x] > blah9
+                      [^ x] > blah9
                         blah10 (x.plus 1) > @
-                        [x] > blah10
+                        [^ x] > blah10
                           blah11 (x.plus 1) > @
-                          [x] > blah11
+                          [^ x] > blah11
                             blah12 (x.plus 1) > @
-                            [x] > blah12
+                            [^ x] > blah12
                               blah13 (x.plus 1) > @
-                              [x] > blah13
+                              [^ x] > blah13
                                 blah14 (x.plus 1) > @
-                                [x] > blah14
+                                [^ x] > blah14
                                   blah15 (x.plus 1) > @
-                                  [x] > blah15
+                                  [^ x] > blah15
                                     blah16 (x.plus 1) > @
-                                    [x] > blah16
+                                    [^ x] > blah16
                                       blah17 (x.plus 1) > @
-                                      [x] > blah17
+                                      [^ x] > blah17
                                         blah18 (x.plus 1) > @
-                                        [x] > blah18
+                                        [^ x] > blah18
                                           blah19 (x.plus 1) > @
-                                          [x] > blah19
+                                          [^ x] > blah19
                                             blah20 (x.plus 1) > @
-                                            [x] > blah20
+                                            [^ x] > blah20
                                               blah21 (x.plus 1) > @
-                                              [x] > blah21
+                                              [^ x] > blah21
                                                 blah22 (x.plus 1) > @
-                                                [x] > blah22
+                                                [^ x] > blah22
                                                   blah23 (x.plus 1) > @
-                                                  [x] > blah23
+                                                  [^ x] > blah23
                                                     blah24 (x.plus 1) > @
-                                                    [x] > blah24
+                                                    [^ x] > blah24
                                                       blah25 (x.plus 1) > @
-                                                      [x] > blah25
+                                                      [^ x] > blah25
                                                         blah26 (x.plus 1) > @
-                                                        [x] > blah26
+                                                        [^ x] > blah26
                                                           blah27 (x.plus 1) > @
-                                                          [x] > blah27
+                                                          [^ x] > blah27
                                                             blah28 (x.plus 1) > @
-                                                            [x] > blah28
+                                                            [^ x] > blah28
                                                               blah29 (x.plus 1) > @
-                                                              [x] > blah29
+                                                              [^ x] > blah29
                                                                 blah30 (x.plus 1) > @
-                                                                [x] > blah30
+                                                                [^ x] > blah30
                                                                   blah31 (x.plus 1) > @
-                                                                  [x] > blah31
+                                                                  [^ x] > blah31
                                                                     blah32 (x.plus 1) > @
-                                                                    [x] > blah32
+                                                                    [^ x] > blah32
                                                                       blah33 (x.plus 1) > @
-                                                                      [x] > blah33
+                                                                      [^ x] > blah33
                                                                         blah34 (x.plus 1) > @
-                                                                        [x] > blah34
+                                                                        [^ x] > blah34
                                                                           blah35 (x.plus 1) > @
-                                                                          [x] > blah35
+                                                                          [^ x] > blah35
                                                                             blah36 (x.plus 1) > @
-                                                                            [x] > blah36
+                                                                            [^ x] > blah36
                                                                               blah37 (x.plus 1) > @
-                                                                              [x] > blah37
+                                                                              [^ x] > blah37
                                                                                 blah38 (x.plus 1) > @
-                                                                                [x] > blah38
+                                                                                [^ x] > blah38
                                                                                   blah39 (x.plus 1) > @
                                                                                   I > blah39
 
@@ -216,9 +216,9 @@
     eq. > @
       a 42
       42
-    [x] > a
+    [^ x] > a
       take > @
-      ^.x > [] > take
+      ^.x > [^] > take
 
   not. ++> can-tell-false-does-not-disjoin-with-itself
     false.or false

--- a/eo-runtime/src/main/eo/buffer.eo
+++ b/eo-runtime/src/main/eo/buffer.eo
@@ -6,9 +6,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[buf] > buffer
+[^ buf] > buffer
   buf > @
-  buffer > [str] > with
+  buffer > [^ str] > with
     string
       ^.buf.as-bytes.concat str.as-bytes
 

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -20,20 +20,28 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[@] > bytes
+[^ @] > bytes
   [] > and /Q.bytes
+    ? > ^
     ? > b /Q.bytes
   [] > concat /Q.bytes
+    ? > ^
     ? > b
   [] > eq /Q.bool
+    ? > ^
     ? > b
   [] > not /Q.bytes
+    ? > ^
   [] > or /Q.bytes
+    ? > ^
     ? > b /Q.bytes
   [] > right /Q.bytes
+    ? > ^
     ? > x /Q.number
   [] > size /Q.number
+    ? > ^
   [] > slice /Q.bytes
+    ? > ^
     ? > start /Q.number
     ? > len /Q.number
     ? > cant-slice /{Q.string}
@@ -165,14 +173,14 @@
     20-1F-EE-B5-90.slice
       2000000000
       2000000000
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-out-of-bounds-slice
     "recovered"
     20-1F-EE-B5-90.slice
       3
       10
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-shift-right-an-even-negative
     -38.as-bytes.right 1

--- a/eo-runtime/src/main/eo/bytes/array.eo
+++ b/eo-runtime/src/main/eo/bytes/array.eo
@@ -9,11 +9,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > array
+[^] > array
   ^ > b
   size. >> len!
     b >> data!
-  if. > [tup index] >> slice-byte
+  if. > [^ tup index] >> slice-byte
     index.lt len
     ^.slice-byte
       tup.with

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-bool
+[^] > as-bool
   ^.eq 01- > @
 
   not. ++> can-convert-bytes-to-a-bool

--- a/eo-runtime/src/main/eo/bytes/as-bytes.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bytes.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-bytes
+[^] > as-bytes
   ^ > @
 
   20-1F-EE.as-bytes.eq 20-1F-EE ++> can-return-itself

--- a/eo-runtime/src/main/eo/bytes/as-hex.eo
+++ b/eo-runtime/src/main/eo/bytes/as-hex.eo
@@ -8,15 +8,15 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-hex
+[^] > as-hex
   ^ > b
-  if. > [h] >> hex-digit
+  if. > [^ h] >> hex-digit
     h.lt 10
     as-char.
       h.plus 48
     as-char.
       h.plus 55
-  [index acc] >> rec-hex
+  [^ index acc] >> rec-hex
     if. > @
       index.eq ^.b.size
       acc

--- a/eo-runtime/src/main/eo/bytes/as-i16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i16.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-i16
+[^ cant-convert] > as-i16
   if. > @
     b.size.eq 2
     i16 b

--- a/eo-runtime/src/main/eo/bytes/as-i32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i32.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-i32
+[^ cant-convert] > as-i32
   if. > @
     b.size.eq 4
     i32 b

--- a/eo-runtime/src/main/eo/bytes/as-i64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i64.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-i64
+[^ cant-convert] > as-i64
   if. > @
     b.size.eq 8
     i64 b
@@ -27,7 +27,7 @@
   eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-i64
     "recovered"
     01-01-01-01.as-i64
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   not. ++> can-tell-it-does-not-match-the-bytes-of-the-same-number
     00-00-00-00-00-00-00-2A.as-i64.as-bytes.eq 42.as-bytes

--- a/eo-runtime/src/main/eo/bytes/as-i8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-i8.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-i8
+[^ cant-convert] > as-i8
   if. > @
     b.size.eq 1
     i8 b

--- a/eo-runtime/src/main/eo/bytes/as-input.eo
+++ b/eo-runtime/src/main/eo/bytes/as-input.eo
@@ -28,16 +28,16 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-input
+[^] > as-input
   ^ > b
-  [size] > read
+  [^ size] > read
     @. > @
       read.
         input-block ^.b --
         size
-    [data buffer] > input-block
+    [^ data buffer] > input-block
       buffer > @
-      [size] > read
+      [^ size] > read
         if. > @
           size.is-finite.not.or
             size.is-integer.not.or

--- a/eo-runtime/src/main/eo/bytes/as-number.eo
+++ b/eo-runtime/src/main/eo/bytes/as-number.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-number
+[^ cant-convert] > as-number
   if. > @
     b.size.eq 8
     if.
@@ -31,7 +31,7 @@
   eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-a-number
     "recovered"
     01-01-01-01.as-number
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   is-nan. ++> can-route-non-canonical-nan-bytes-to-nan
     FF-F8-00-00-00-00-00-00.as-number

--- a/eo-runtime/src/main/eo/bytes/as-u16.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u16.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-u16
+[^ cant-convert] > as-u16
   if. > @
     b.size.eq 2
     u16 b

--- a/eo-runtime/src/main/eo/bytes/as-u32.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u32.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-u32
+[^ cant-convert] > as-u32
   if. > @
     b.size.eq 4
     u32 b

--- a/eo-runtime/src/main/eo/bytes/as-u64.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u64.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-u64
+[^ cant-convert] > as-u64
   if. > @
     b.size.eq 8
     u64 b
@@ -25,6 +25,6 @@
   eq. ++> can-recover-from-bytes-of-wrong-size-when-converting-to-u64
     "recovered"
     01-01-01-01.as-u64
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   01-01-01-01.as-u64 --> stops-on-bytes-of-wrong-size-when-converting-to-u64

--- a/eo-runtime/src/main/eo/bytes/as-u8.eo
+++ b/eo-runtime/src/main/eo/bytes/as-u8.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-u8
+[^ cant-convert] > as-u8
   if. > @
     b.size.eq 1
     u8 b

--- a/eo-runtime/src/main/eo/bytes/hash.eo
+++ b/eo-runtime/src/main/eo/bytes/hash.eo
@@ -11,9 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > hash
+[^] > hash
   ^.as-bytes >> b!
-  [acc index] >> rec-hash-code
+  [^ acc index] >> rec-hash-code
     if. > @
       index.eq b.size!
       acc.as-number

--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > left
+[^ x] > left
   ^.right x.neg > @
 
   eq. ++> can-shift-left-an-even-negative

--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > xor
+[^ x] > xor
   or. > @
     b.and x.not
     b.not.and x

--- a/eo-runtime/src/main/eo/chunk.eo
+++ b/eo-runtime/src/main/eo/chunk.eo
@@ -27,9 +27,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[id] > chunk
+[^ id] > chunk
   get > @
-  [source target length] > copy
+  [^ source target length] > copy
     seq * > @
       ^.read source length >> data!
       if.
@@ -45,7 +45,7 @@
   read > get
     0
     size
-  if. > [object] > put
+  if. > [^ object] > put
     and.
       ^.size.gt 0
       object.size.gt ^.size
@@ -64,20 +64,24 @@
         ^.write 0 object
         ^.get
   [] > read /Q.bytes
+    ? > ^
     ? > offset /Q.number
     ? > length /Q.number
     ? > cant-read /{Q.string}
   [] > resized /Q.chunk
+    ? > ^
     ? > capacity /Q.number
   [] > size /Q.number
+    ? > ^
   [] > write /Q.bool
+    ? > ^
     ? > offset /Q.number
     ? > data
 
   eq. ++> can-get-what-was-put
     malloc.of
       8
-      seq * > [c]
+      seq * > [^ c]
         c.put 42
         c.get
     42.as-bytes
@@ -85,13 +89,13 @@
   eq. ++> can-know-its-size
     malloc.of
       3
-      c.size > [c]
+      c.size > [^ c]
     3
 
   eq. ++> can-read-a-slice-of-what-was-written
     malloc.of
       5
-      seq * > [c]
+      seq * > [^ c]
         c.write 0 "hello"
         c.read 1 3
     "ell".as-bytes

--- a/eo-runtime/src/main/eo/chunk/to-output.eo
+++ b/eo-runtime/src/main/eo/chunk/to-output.eo
@@ -19,13 +19,13 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > to-output
+[^] > to-output
   ^ > allocated
-  [buffer] > write
+  [^ buffer] > write
     write. > @
-      [offset] >> output-block
+      [^ offset] >> output-block
         true > @
-        seq * > [buffer] > write
+        seq * > [^ buffer] > write
           if.
             gt.
               ^.offset.plus buffer.size
@@ -44,7 +44,7 @@
   eq. ++> can-make-an-output-from-malloc-and-write-to-it
     malloc.of
       10
-      seq * > [mem]
+      seq * > [^ mem]
         write.
           write.
             mem.to-output.write 01-02-03
@@ -56,7 +56,7 @@
   eq. ++> can-make-an-output-via-a-chunk-extension
     malloc.of
       3
-      seq * > [mem]
+      seq * > [^ mem]
         mem.to-output.write 01-02-03
         mem
     01-02-03
@@ -64,7 +64,7 @@
   eq. ++> can-write-data-larger-than-the-block
     malloc.of
       2
-      seq * > [mem]
+      seq * > [^ mem]
         mem.to-output.write 01-02-03
         mem
     01-02-03

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > clock
+[^] > clock
   as-i64. > @
     os.is-windows.if
       plus.

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -62,15 +62,15 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > console
+[^] > console
   os.is-windows.if > @
-    [] >>
-      [size] > read
+    [^] >>
+      [^ size] > read
         @. > @
           read.
-            [buffer] >> input-block
+            [^ buffer] >> input-block
               buffer > @
-              [size] > read
+              [^ size] > read
                 seq * > @
                   if. >> chunk!
                     received.code.eq -1
@@ -86,12 +86,12 @@
                     size
             | --
             size
-      [buffer] > write
+      [^ buffer] > write
         @. > @
           write.
-            [] >> output-block
+            [^] >> output-block
               true > @
-              [buffer] > write
+              [^ buffer] > write
                 seq * > @
                   if. >>!
                     code.eq -1
@@ -112,13 +112,13 @@
                     buffer.slice code (buffer.size.minus code)
                   ^.^.output-block
             buffer
-    [] >>
-      [size] > read
+    [^] >>
+      [^ size] > read
         @. > @
           read.
-            [buffer] >> input-block
+            [^ buffer] >> input-block
               buffer > @
-              [size] > read
+              [^ size] > read
                 seq * > @
                   if. >> chunk!
                     received.code.eq -1
@@ -134,12 +134,12 @@
                     size
             | --
             size
-      [buffer] > write
+      [^ buffer] > write
         @. > @
           write.
-            [] >> output-block
+            [^] >> output-block
               true > @
-              [buffer] > write
+              [^ buffer] > write
                 seq * > @
                   if. >>!
                     code.eq -1

--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -38,20 +38,21 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > dataized /Q.bytes
+  ? > ^
   ? > target
 
   ++> can-avoid-recalculation
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           seq * > @
             as-number.
               func >> cached!
             cached.as-bytes
             cached.as-bool
             m
-          ^.m.put > [] > func
+          ^.m.put > [^] > func
             ^.m.as-number.plus 1
       1
 
@@ -66,7 +67,7 @@
         1.eq cached1
     malloc.for > func
       0
-      seq * > [m]
+      seq * > [^ m]
         true
         m.put
           m.as-number.plus 1
@@ -76,9 +77,9 @@
       as-number.
         dataized foo
       5
-    [] > foo
+    [^] > foo
       inner.five > @
-      [] > inner
+      [^] > inner
         5 > five
 
   ++> can-dataize-a-number-to-the-same-bytes-as-as-bytes

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -14,11 +14,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[file] > directory
+[^ file] > directory
   file > @
   [] > listed /Q.tuple
-  [dir time process random] > retried
-    [index] >> attempted
+    ? > ^
+  [^ dir time process random] > retried
+    [^ index] >> attempted
       if. > @
         descriptor.eq -1
         if.
@@ -43,7 +44,7 @@
             *
       ^.candidate index > path!
     | 0 > @
-    [index] > candidate
+    [^ index] > candidate
       path.separator.joined > @
         * ^.dir name
       "%d-%d-%d-%f".printf > name!
@@ -52,7 +53,7 @@
           ^.process
           index
           ^.random
-    code. > [descriptor] > closed
+    code. > [^ descriptor] > closed
       os.is-windows.if
         win32 *1
           "_close"
@@ -60,7 +61,7 @@
         posix *1
           "close"
           descriptor
-    code. > [name] > opened
+    code. > [^ name] > opened
       os.is-windows.if
         win32 *1
           "_open"
@@ -76,13 +77,13 @@
             posix.rdonly.plus posix.creat
             posix.exclusive
           posix.mode
-  [] > tmpfile
+  [^] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
       T
         "Directory %s does not exist, can't create temporary file".printf
           * ^.file
-    ^.^.retried > [] > touch
+    ^.^.retried > [^] > touch
       ^.^.path
       clock.as-number
       code.
@@ -94,9 +95,9 @@
             "getpid"
             *
       clock.as-number.random
-  [glob] > walk
-    [accum prefix dir] >> walked
-      [rest] >> stepped
+  [^ glob] > walk
+    [^ accum prefix dir] >> walked
+      [^ rest] >> stepped
         if. > @
           rest.length.eq 0
           picked ^.accum ^.prefix
@@ -121,18 +122,18 @@
       *
       ""
       ^
-    if. > [accum rel] >> picked
+    if. > [^ accum rel] >> picked
       matched rel
       accum.with
         Q.file (base.resolved rel).as-bytes
       accum
     ^.as-path >> base
-    if. > [char] >> escaped
+    if. > [^ char] >> escaped
       ".+()|^$[]\\".contains char
       "".joined
         * "\\" char
       char
-    [text] >> matched
+    [^ text] >> matched
       as-bool. > @
         exists.
           next.
@@ -146,7 +147,7 @@
                           "/^"
                           translated 0 "" false false
                           "$/"
-                T > [message] >>
+                T > [^ message] >>
                   "Can't parse '%s' as a glob pattern, %s".printf
                     * ^.glob message
               text
@@ -155,24 +156,24 @@
         "[^"
         escaped path.separator >> literal
         "]"
-    if. > [char] >> classified
+    if. > [^ char] >> classified
       "\\[&".contains char
       "".joined
         * "\\" char
       char
-    if. > [from] >> closes
+    if. > [^ from] >> closes
       from.gte ^.glob.length
       false
       if.
         eq.
           ^.glob.at
             from
-            "" > [absent]
+            "" > [^ absent]
           "]"
         true
         ^.closes
           from.plus 1
-    [index acc braced classed] >> translated
+    [^ index acc braced classed] >> translated
       if. > @
         index.gte ^.glob.length
         acc
@@ -215,13 +216,13 @@
           eq.
             ^.glob.at
               index.plus 1
-              "" > [message]
+              "" > [^ message]
             "*"
       opening.and > negated
         eq.
           ^.glob.at
             index.plus 1
-            "" > [missing]
+            "" > [^ missing]
           "!"
       classed.not.and > opening
         and.
@@ -232,7 +233,7 @@
         eq.
           ^.glob.at
             index.plus 2
-            "" > [space]
+            "" > [^ space]
           "/"
       classed.if > token
         if.

--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -8,9 +8,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > deleted
+[^] > deleted
   seq * > @
-    if. > [tup] >> r
+    if. > [^ tup] >> r
       tup.length.eq 0
       true
       seq *
@@ -19,7 +19,7 @@
     | entries
     d
   ^ > d
-  recovered > [] > entries
+  recovered > [^] > entries
     ^.d.walk "**"
     ^.d.exists.if
       ^.d.walk "**"

--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -19,7 +19,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > made
+[^] > made
   d.exists.if > @
     d.is-directory.if
       d

--- a/eo-runtime/src/main/eo/directory/open.eo
+++ b/eo-runtime/src/main/eo/directory/open.eo
@@ -9,11 +9,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[mode scope] > open
+[^ mode scope] > open
   T > @
     "The file %s is a directory, can't open for I/O operations".printf
       * ^
 
   mktemp.open --> stops-on-opening-a-directory
     "w"
-    true > [x]
+    true > [^ x]

--- a/eo-runtime/src/main/eo/eol.eo
+++ b/eo-runtime/src/main/eo/eol.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > eol
+[^] > eol
   string > @
     as-bytes.
       os.is-windows.if "\r\n" "\n"

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 bool > false
-  []
+  [^]
     ? >> left
     ? >> right
     right > @

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -6,11 +6,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[path] > file
+[^ path] > file
   path > @
   @. > as-path
     Q.path path
-  or. > [] > exists
+  or. > [^] > exists
     eq.
       code.
         os.is-windows.if
@@ -24,7 +24,7 @@
             0
       0
     ^.is-symlink false
-  [cant-check] > is-directory
+  [^ cant-check] > is-directory
     if. > @
       info.code.eq 0
       eq.
@@ -40,7 +40,7 @@
         posix *1
           "stat"
           ^.path
-  [cant-check] > is-symlink
+  [^ cant-check] > is-symlink
     os.is-windows.if > @
       if.
         attributes.eq win32.invalid
@@ -64,7 +64,7 @@
       posix *1
         "lstat"
         ^.path
-  [mode scope cant-open] > open
+  [^ mode scope cant-open] > open
     known.not.if > @
       T
         "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
@@ -90,23 +90,23 @@
     or. > known
       existing.or truncate
       appending
-    [] > open-file
+    [^] > open-file
       os.is-windows.if > @
         open-through
-          []
+          [^]
             win32 > @
             win32 "_close" > close
             win32 "_open" > open
             win32 "_read" > read
             win32 "_write" > write
         open-through
-          []
+          [^]
             posix > @
             posix "close" > close
             posix "open" > open
             posix "read" > read
             posix "write" > write
-      [syscall] > open-through
+      [^ syscall] > open-through
         if. > @
           descriptor.eq -1
           ^.^.cant-open
@@ -146,14 +146,14 @@
         called. > opened
           syscall.open
             * ^.^.^.path flags syscall.mode
-        [descriptor] > stream
-          [size] > read
+        [^ descriptor] > stream
+          [^ size] > read
             read. > @
               input-block --
               size
-            [buffer] > input-block
+            [^ buffer] > input-block
               buffer > @
-              [size] > read
+              [^ size] > read
                 ^.^.^.^.^.^.readable.not.if > @
                   T
                     "Can't read from file with provided access mode '%s'".printf
@@ -169,11 +169,11 @@
                 called. > received
                   ^.^.^.^.syscall.read
                     * ^.^.^.descriptor size
-          [buffer] > write
+          [^ buffer] > write
             output-block.write buffer > @
-            [] > output-block
+            [^] > output-block
               true > @
-              [buffer] > write
+              [^ buffer] > write
                 ^.^.^.^.^.^.writable.not.if > @
                   T
                     "Can't write to file with provided access mode '%s'".printf
@@ -216,9 +216,9 @@
       open.
         mktemp.tmpfile.open
           "w"
-          f.write "Hello, world" > [f]
+          f.write "Hello, world" > [^ f]
         "a"
-        f.write "!" > [f]
+        f.write "!" > [^ f]
     13
 
   ++> can-close-a-descriptor-when-the-scope-fails
@@ -227,14 +227,14 @@
       true
       drain
       tmp
-    if. > [n] > drain
+    if. > [^ n] > drain
       n.lte 0
       true
       seq *
         recovered
           ^.tmp.open
             "r"
-            T "boom" > [f]
+            T "boom" > [^ f]
           true
         ^.drain
           n.minus 1
@@ -251,7 +251,7 @@
             link
         link.as-file.open
           "w"
-          f.write "created" > [f]
+          f.write "created" > [^ f]
     target.resolved "dangling-link" > link
     mktemp.tmpfile.deleted.as-path > target
 
@@ -260,9 +260,9 @@
       open.
         mktemp.tmpfile.open
           "w"
-          f.write "Hello, world" > [f]
+          f.write "Hello, world" > [^ f]
         "a"
-        true > [f]
+        true > [^ f]
     12
 
   eq. ++> can-keep-the-size-of-a-file-opened-for-reading
@@ -270,9 +270,9 @@
       open.
         mktemp.tmpfile.open
           "w"
-          f.write "Hello, world" > [f]
+          f.write "Hello, world" > [^ f]
         "r"
-        true > [f]
+        true > [^ f]
     12
 
   eq. ++> can-keep-the-size-of-a-file-opened-for-reading-or-appending
@@ -280,23 +280,23 @@
       open.
         mktemp.tmpfile.open
           "w"
-          f.write "Hello, world" > [f]
+          f.write "Hello, world" > [^ f]
         "a+"
-        true > [f]
+        true > [^ f]
     12
 
   ++> can-read-from-a-file
     eq. > @
       malloc.of
         12
-        [m]
+        [^ m]
           seq * > @
             open.
               mktemp.tmpfile.open
                 "w"
-                f.write "Hello, world" > [f]
+                f.write "Hello, world" > [^ f]
               "r"
-              ^.m.put > [f] >>
+              ^.m.put > [^ f] >>
                 f.read 12
             m
       "Hello, world"
@@ -305,14 +305,14 @@
     eq. > @
       malloc.of
         5
-        [m]
+        [^ m]
           seq * > @
             open.
               mktemp.tmpfile.open
                 "w"
-                f.write "Hello, world" > [f]
+                f.write "Hello, world" > [^ f]
               "r"
-              ^.m.put > [f] >>
+              ^.m.put > [^ f] >>
                 read.
                   f.read 7
                   5
@@ -323,17 +323,17 @@
     seq * > @
       temp.open
         "w"
-        f.write > [f]
+        f.write > [^ f]
           "Shrek is love"
       "Shrek is love".eq
         malloc.of
           13
-          [m] >>
+          [^ m] >>
             seq * > @
               open.
                 file ^.source
                 "r"
-                ^.m.put > [f] >>
+                ^.m.put > [^ f] >>
                   f.read 13
               m
     temp.path > source
@@ -350,7 +350,7 @@
     mktemp.tmpfile.deleted.open
       "r"
       I
-      "recovered" > [reason]
+      "recovered" > [^ reason]
 
   ++> can-resolve-a-path-and-touch-it
     resolved.as-dir.made.tmpfile.exists.and > @
@@ -396,31 +396,31 @@
   exists. ++> can-touch-an-absent-file-on-opening-for-appending
     mktemp.tmpfile.deleted.open
       "a"
-      true > [f]
+      true > [^ f]
 
   exists. ++> can-touch-an-absent-file-on-opening-for-reading-or-appending
     mktemp.tmpfile.deleted.open
       "a+"
-      true > [f]
+      true > [^ f]
 
   exists. ++> can-touch-an-absent-file-on-opening-for-writing
     mktemp.tmpfile.deleted.open
       "w"
-      true > [f]
+      true > [^ f]
 
   exists. ++> can-touch-an-absent-file-on-opening-for-writing-or-reading
     mktemp.tmpfile.deleted.open
       "w+"
-      true > [f]
+      true > [^ f]
 
   eq. ++> can-truncate-a-file-opened-for-writing
     size.
       open.
         mktemp.tmpfile.open
           "w"
-          f.write "Hello, world" > [f]
+          f.write "Hello, world" > [^ f]
         "w"
-        true > [f]
+        true > [^ f]
     0
 
   eq. ++> can-truncate-a-file-opened-for-writing-or-reading
@@ -428,16 +428,16 @@
       open.
         mktemp.tmpfile.open
           "w"
-          f.write "Hello, world" > [f]
+          f.write "Hello, world" > [^ f]
         "w+"
-        true > [f]
+        true > [^ f]
     0
 
   eq. ++> can-write-data-to-a-file
     size.
       mktemp.tmpfile.open
         "w"
-        f.write > [f]
+        f.write > [^ f]
           "Hello, world"
     12
 
@@ -445,7 +445,7 @@
     size.
       mktemp.tmpfile.open
         "a+"
-        write. > [f]
+        write. > [^ f]
           f.write "Hello, world"
           "!"
     13
@@ -454,21 +454,21 @@
     seq * > @
       temp.open
         "w"
-        f.write > [f]
+        f.write > [^ f]
           "Shrek is love"
       open.
         file source
         "a"
-        f.write "!" > [f]
+        f.write "!" > [^ f]
       eq.
         malloc.of
           14
-          [m] >>
+          [^ m] >>
             seq * > @
               open.
                 file ^.source
                 "r"
-                ^.m.put > [f] >>
+                ^.m.put > [^ f] >>
                   f.read 14
               m
         "Shrek is love!"
@@ -480,16 +480,16 @@
   seq * --> stops-on-opening-with-a-wrong-mode
     mktemp.tmpfile.open
       "x"
-      true > [f]
+      true > [^ f]
     true
 
   mktemp.tmpfile.open --> stops-on-reading-a-negative-size-from-a-file
     "r"
-    f.read -5 > [f]
+    f.read -5 > [^ f]
 
   mktemp.tmpfile.open --> stops-on-reading-from-a-file-with-a-wrong-mode
     "w"
-    f.read 12 > [f]
+    f.read 12 > [^ f]
 
   mktemp.tmpfile.deleted.open --> stops-on-reading-from-a-missing-file
     "r"
@@ -505,4 +505,4 @@
 
   mktemp.tmpfile.open --> stops-on-writing-with-a-wrong-mode
     "r"
-    f.write "Hello" > [f]
+    f.write "Hello" > [^ f]

--- a/eo-runtime/src/main/eo/file/deleted.eo
+++ b/eo-runtime/src/main/eo/file/deleted.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > deleted
+[^] > deleted
   f.exists.if > @
     if.
       or.

--- a/eo-runtime/src/main/eo/file/moved.eo
+++ b/eo-runtime/src/main/eo/file/moved.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[target] > moved
+[^ target] > moved
   if. > @
     renamed.code.eq 0
     file target

--- a/eo-runtime/src/main/eo/file/size.eo
+++ b/eo-runtime/src/main/eo/file/size.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-measure] > size
+[^ cant-measure] > size
   if. > @
     info.code.eq 0
     info.output.size

--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -27,7 +27,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > touched
+[^] > touched
   reachable.if > @
     f
     if.

--- a/eo-runtime/src/main/eo/getenv.eo
+++ b/eo-runtime/src/main/eo/getenv.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[name cant-get] > getenv
+[^ name cant-get] > getenv
   result.code.if > @
     result.output
     cant-get

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -7,9 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > i16
+[^ as-bytes] > i16
   as-bytes > @
-  [] > as-i32
+  [^] > as-i32
     i32 > @
       concat.
         if. >>
@@ -21,7 +21,7 @@
         ^.as-bytes
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-i16 >> other
@@ -46,13 +46,13 @@
             b.slice 0 2
           i16
             b.slice 2 2
-  ^.as-i32.gt x.as-i16.as-i32 > [x] > gt
-  ^.as-i32.gte x.as-i16.as-i32 > [x] > gte
-  ^.as-i32.lt x.as-i16.as-i32 > [x] > lt
-  ^.as-i32.lte x.as-i16.as-i32 > [x] > lte
-  ^.plus x.as-i16.neg > [x] > minus
+  ^.as-i32.gt x.as-i16.as-i32 > [^ x] > gt
+  ^.as-i32.gte x.as-i16.as-i32 > [^ x] > gte
+  ^.as-i32.lt x.as-i16.as-i32 > [^ x] > lt
+  ^.as-i32.lte x.as-i16.as-i32 > [^ x] > lte
+  ^.plus x.as-i16.neg > [^ x] > minus
   times -1.as-i64.as-i32.as-i16 > neg
-  [x] > plus
+  [^ x] > plus
     if. > @
       or.
         eq.
@@ -70,7 +70,7 @@
           b.slice 0 2
         i16
           b.slice 2 2
-  i16 > [x] > times
+  i16 > [^ x] > times
     slice.
       as-bytes.
         ^.as-i32.times x.as-i16.as-i32
@@ -145,7 +145,7 @@
     "recovered"
     2.as-i64.as-i32.as-i16.div
       0.as-i64.as-i32.as-i16
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-subtract-one-from-one
     1.as-i64.as-i32.as-i16.minus 1.as-i64.as-i32.as-i16

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -7,9 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > i32
+[^ as-bytes] > i32
   as-bytes > @
-  [cant-convert] > as-i16
+  [^ cant-convert] > as-i16
     if. > @
       ^.eq left.as-i32
       left
@@ -18,7 +18,7 @@
           * ^.as-i64.as-number
     i16 > left
       ^.as-bytes.slice 2 2
-  [] > as-i64
+  [^] > as-i64
     i64 > @
       concat.
         if. >>
@@ -29,7 +29,7 @@
           FF-FF-FF-FF
         ^.as-bytes
   as-i64.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-i32 >> other
@@ -54,13 +54,13 @@
             b.slice 0 4
           i32
             b.slice 4 4
-  ^.as-i64.gt x.as-i32.as-i64 > [x] > gt
-  ^.as-i64.gte x.as-i32.as-i64 > [x] > gte
-  ^.as-i64.lt x.as-i32.as-i64 > [x] > lt
-  ^.as-i64.lte x.as-i32.as-i64 > [x] > lte
-  ^.plus x.as-i32.neg > [x] > minus
+  ^.as-i64.gt x.as-i32.as-i64 > [^ x] > gt
+  ^.as-i64.gte x.as-i32.as-i64 > [^ x] > gte
+  ^.as-i64.lt x.as-i32.as-i64 > [^ x] > lt
+  ^.as-i64.lte x.as-i32.as-i64 > [^ x] > lte
+  ^.plus x.as-i32.neg > [^ x] > minus
   times -1.as-i64.as-i32 > neg
-  [x] > plus
+  [^ x] > plus
     if. > @
       or.
         eq.
@@ -78,7 +78,7 @@
           b.slice 0 4
         i32
           b.slice 4 4
-  i32 > [x] > times
+  i32 > [^ x] > times
     slice.
       as-bytes.
         ^.as-i64.times x.as-i32.as-i64
@@ -156,13 +156,13 @@
   eq. ++> can-recover-from-an-out-of-bounds-conversion-to-i16
     "recovered"
     247483647.as-i64.as-i32.as-i16
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-division-by-zero
     "recovered"
     2.as-i64.as-i32.div
       0.as-i64.as-i32
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-subtract-one-from-one
     1.as-i64.as-i32.minus 1.as-i64.as-i32

--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > i64
+[^ as-bytes] > i64
   as-bytes > @
   as-i32.as-i16 > as-i16
-  [cant-convert] > as-i32
+  [^ cant-convert] > as-i32
     if. > @
       ^.eq
         as-i64.
@@ -22,7 +22,7 @@
           * ^.as-number
     i32 > left
       ^.as-bytes.slice 4 4
-  [] > as-number
+  [^] > as-number
     if. > @
       ^.as-bytes.eq 00-00-00-00-00-00-00-00
       0
@@ -76,7 +76,7 @@
       kept
     guard.and > roundup
       sticky.or odd
-    [m acc step bit] > scan
+    [^ m acc step bit] > scan
       if. > @
         step.lt 1
         acc
@@ -100,7 +100,7 @@
         magnitude.left
           117.minus highest
         00-00-00-00-00-00-00-00
-  [x] > gt
+  [^ x] > gt
     if. > @
       not.
         eq.
@@ -116,23 +116,23 @@
           00-00-00-00-00-00-00-00
         not.
           difference.as-bytes.eq 00-00-00-00-00-00-00-00
-  [x] > gte
+  [^ x] > gte
     or. > @
       ^.gt
         x >> value!
       ^.eq value
-  gt. > [x] > lt
+  gt. > [^ x] > lt
     i64 x.as-bytes
     ^
-  [x] > lte
+  [^ x] > lte
     or. > @
       ^.lt
         x >> value!
       ^.eq value
-  ^.plus (i64 x!).neg > [x] > minus
+  ^.plus (i64 x!).neg > [^ x] > minus
   times -1.as-i64 > neg
-  [x] > plus
-    if. > [a b] >> carried
+  [^ x] > plus
+    if. > [^ a b] >> carried
       b.eq 00-00-00-00-00-00-00-00
       i64 a
       ^.carried
@@ -143,8 +143,8 @@
     | > @
       ^.as-bytes
       x.as-bytes
-  [x] > times
-    if. > [acc a b] > looped
+  [^ x] > times
+    if. > [^ acc a b] > looped
       b.eq 00-00-00-00-00-00-00-00
       i64 acc
       ^.looped
@@ -265,7 +265,7 @@
   eq. ++> can-recover-from-an-out-of-bounds-conversion-to-i32
     "recovered"
     3147483647.as-i64.as-i32
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-round-a-tie-to-even-when-converting-to-a-number
     as-number.

--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x cant-divide] > div
+[^ x cant-divide] > div
   if. > @
     x.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
@@ -28,8 +28,8 @@
               looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
           i64 00-00-00-00-00-00-00-01
       i64 quotient
-  00-00-00-00-00-00-00-01.left i > [i] >> bit
-  [index remainder quot] >> looped
+  00-00-00-00-00-00-00-01.left i > [^ i] >> bit
+  [^ index remainder quot] >> looped
     if. > @
       index.lt 0
       quot
@@ -66,7 +66,7 @@
     plus.
       i64
         not.
-          if. > [b] >> magnitude
+          if. > [^ b] >> magnitude
             eq.
               b.and 80-00-00-00-00-00-00-00
               80-00-00-00-00-00-00-00
@@ -110,7 +110,7 @@
     "recovered"
     2.as-i64.div
       0.as-i64
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-truncate-toward-zero
     -13.as-i64.div 5.as-i64

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -8,9 +8,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > i8
+[^ as-bytes] > i8
   as-bytes > @
-  [] > as-i16
+  [^] > as-i16
     i16 > @
       concat.
         if. >>
@@ -21,7 +21,7 @@
           FF-
         ^.as-bytes
   as-i16.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-i8 >> other
@@ -35,24 +35,24 @@
             ^.as-i16.div other.as-i16
           1
           1
-  ^.as-i16.gt x.as-i8.as-i16 > [x] > gt
-  ^.as-i16.gte x.as-i8.as-i16 > [x] > gte
-  ^.as-i16.lt x.as-i8.as-i16 > [x] > lt
-  ^.as-i16.lte x.as-i8.as-i16 > [x] > lte
-  i8 > [x] > minus
+  ^.as-i16.gt x.as-i8.as-i16 > [^ x] > gt
+  ^.as-i16.gte x.as-i8.as-i16 > [^ x] > gte
+  ^.as-i16.lt x.as-i8.as-i16 > [^ x] > lt
+  ^.as-i16.lte x.as-i8.as-i16 > [^ x] > lte
+  i8 > [^ x] > minus
     slice.
       as-bytes.
         ^.as-i16.minus x.as-i8.as-i16
       1
       1
   times FF-.as-i8 > neg
-  i8 > [x] > plus
+  i8 > [^ x] > plus
     slice.
       as-bytes.
         ^.as-i16.plus x.as-i8.as-i16
       1
       1
-  i8 > [x] > times
+  i8 > [^ x] > times
     slice.
       as-bytes.
         ^.as-i16.times x.as-i8.as-i16
@@ -111,7 +111,7 @@
     "recovered"
     02-.as-i8.div
       00-.as-i8
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-subtract-one-from-one
     01-.as-i8.minus 01-.as-i8

--- a/eo-runtime/src/main/eo/input.eo
+++ b/eo-runtime/src/main/eo/input.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[@] > input
+[^ @] > input
 
   eq. ++> can-decorate-a-source-of-bytes
     as-bytes.

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -15,10 +15,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-bytes
+[^] > as-bytes
   malloc.of > @
     0
-    seq * > [m] >>
+    seq * > [^ m] >>
       ^.origin.copied m.to-output
       m
   ^ > origin

--- a/eo-runtime/src/main/eo/input/copied.eo
+++ b/eo-runtime/src/main/eo/input/copied.eo
@@ -18,7 +18,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[output] > copied
+[^ output] > copied
   length. > @
     input
       ^.tee output
@@ -26,7 +26,7 @@
   eq. ++> can-copy-all-bytes-and-return-the-length
     malloc.of
       5
-      seq * > [m]
+      seq * > [^ m]
         copied.
           input 01-02-03-04-05.as-input
           m.to-output
@@ -42,7 +42,7 @@
   eq. ++> can-handle-an-empty-input
     malloc.of
       0
-      seq * > [m]
+      seq * > [^ m]
         copied.
           input --.as-input
           m.to-output
@@ -53,14 +53,14 @@
     20
     malloc.of
       20
-      copied. > [m]
+      copied. > [^ m]
         input 01-02-03-04-05-06-07-08-09-0A-0B-0C-0D-0E-0F-10-11-12-13-14.as-input
         m.to-output
 
   eq. ++> can-return-the-byte-count
     malloc.of
       10
-      copied. > [m]
+      copied. > [^ m]
         input 01-02-03-04-05-06-07-08-09-10.as-input
         m.to-output
     10
@@ -68,7 +68,7 @@
   eq. ++> can-return-zero-for-an-empty-input
     malloc.of
       0
-      copied. > [m]
+      copied. > [^ m]
         input --.as-input
         m.to-output
     0

--- a/eo-runtime/src/main/eo/input/dead.eo
+++ b/eo-runtime/src/main/eo/input/dead.eo
@@ -10,11 +10,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > dead
-  [size] > read
-    [] >> input-block
+[^] > dead
+  [^ size] > read
+    [^] >> input-block
       -- > @
-      ^.^.input-block > [size] > read
+      ^.^.input-block > [^ size] > read
     | > @
 
   eq. ++> can-be-taken-off-any-input

--- a/eo-runtime/src/main/eo/input/length.eo
+++ b/eo-runtime/src/main/eo/input/length.eo
@@ -11,8 +11,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > length
-  [input length] >> rec-read
+[^] > length
+  [^ input length] >> rec-read
     if. > @
       chunk.size.eq 0
       length
@@ -35,7 +35,7 @@
   eq. ++> can-copy-all-bytes-to-an-output-and-return-the-length
     malloc.of
       10
-      seq * > [m]
+      seq * > [^ m]
         length.
           input
             tee.

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -22,18 +22,18 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[output] > tee
+[^ output] > tee
   ^ > origin
-  [size] > read
+  [^ size] > read
     read. > @
       input-block
         ^.origin
         ^.output
         --
       size
-    [input output buffer] > input-block
+    [^ input output buffer] > input-block
       buffer > @
-      [size] > read
+      [^ size] > read
         seq * > @
           written
           ^.^.input-block chunk written chunk.as-bytes
@@ -43,7 +43,7 @@
   eq. ++> can-read-from-bytes-and-write-to-memory
     malloc.of
       5
-      read. > [mem]
+      read. > [^ mem]
         tee.
           input 01-02-03-04-05.as-input
           mem.to-output
@@ -53,7 +53,7 @@
   eq. ++> can-read-from-bytes-and-write-to-memory-by-portions
     malloc.of
       5
-      seq * > [m]
+      seq * > [^ m]
         read.
           read.
             read.
@@ -70,10 +70,10 @@
     eq. > @
       malloc.of
         6
-        [m1]
+        [^ m1]
           malloc.of > @
             5
-            seq * > [m2] >>
+            seq * > [^ m2] >>
               read.
                 tee.
                   input ((input 01-02-03-04-05.as-input).tee m2.to-output)

--- a/eo-runtime/src/main/eo/malloc.eo
+++ b/eo-runtime/src/main/eo/malloc.eo
@@ -60,48 +60,49 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > malloc
-  malloc.of > [scope] > empty
+[^] > malloc
+  malloc.of > [^ scope] > empty
     0
     scope
-  [object scope] > for
+  [^ object scope] > for
     malloc.of > @
       size.
         object >> bts!
-      seq * > [m] >>
+      seq * > [^ m] >>
         m.write 0 bts
         ^.scope m
   [] > of /Q.bytes
+    ? > ^
     ? > size /Q.number
     ? > scope /{Q.chunk}
 
   ++> can-allocate-a-block-of-the-right-size
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.of > @
           10
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             m.size.eq 10
 
   malloc.empty ++> can-allocate-an-empty-block
-    m.size.eq 0 > [m]
+    m.size.eq 0 > [^ m]
 
   eq. ++> can-allocate-zero-bytes
     0
     malloc.of
       0
-      m.size > [m]
+      m.size > [^ m]
 
   ++> can-calculate-only-once
     eq. > @
       malloc.for 0 x
       1
-    [m] > x
+    [^ m] > x
       seq * > @
         a.neg.neg.neg.neg.eq 42
         m
-      seq * > [] > a
+      seq * > [^] > a
         ^.m.put
           ^.m.as-number.plus 1
         42
@@ -109,10 +110,10 @@
   ++> can-concat-strings-with-an-offset
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.of > @
           3
-          seq * > [m] >>
+          seq * > [^ m] >>
             m.write 0 "XXX"
             m.write 1 "Y"
             ^.b.put
@@ -122,7 +123,7 @@
 
   malloc.for ++> can-copy-and-resize-to-a-target
     0
-    seq * > [m]
+    seq * > [^ m]
       m.copy
         3
         9
@@ -131,7 +132,7 @@
 
   malloc.for ++> can-copy-data-from-start-to-end
     01-02-03-04-05-06
-    and. > [m]
+    and. > [^ m]
       m.copy
         0
         3
@@ -140,7 +141,7 @@
 
   malloc.for ++> can-copy-data-inside-itself
     01-02-03-04-05
-    and. > [m]
+    and. > [^ m]
       m.copy
         1
         2
@@ -151,21 +152,21 @@
     2.eq > @
       malloc.for
         0
-        [f]
+        [^ f]
           seq > @
             * second second
           malloc.of > second
             1
-            ^.f.put > [s] >>
+            ^.f.put > [^ s] >>
               ^.f.as-number.plus 1
 
   ++> can-decrease-the-block-size
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           01-02-03-04-05
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             and.
               eq. (m.resized 3).size 3
               m.get.eq 01-02-03
@@ -174,64 +175,64 @@
     eq. > @
       malloc.for
         7
-        [m] >>
+        [^ m] >>
           m.put > @
             num.times num
           number (^.inc m)! > num
       64
-    seq * > [x] > inc
+    seq * > [^ x] > inc
       x.put
         x.as-number.plus 1
       x.as-number
 
   malloc.of ++> can-give-an-id-to-an-allocated-block
     1
-    m.put > [m]
+    m.put > [^ m]
       m.id.gt 0
 
   eq. ++> can-grow-an-empty-block-on-the-first-put
     malloc.empty
-      m.put 42 > [m]
+      m.put 42 > [^ m]
     42
 
   ++> can-increase-the-block-size
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           01-02-03-04
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             and.
               eq. (m.resized 6).size 6
               m.get.eq 01-02-03-04-00-00
 
   malloc.for ++> can-keep-the-size-of-a-bool-block
     false
-    m.put true > [m]
+    m.put true > [^ m]
 
   eq. ++> can-keep-the-size-of-a-float-block
     malloc.for
       245.88
-      m.put 82.22 > [m]
+      m.put 82.22 > [^ m]
     82.22
 
   eq. ++> can-keep-the-size-of-a-string-block
     malloc.for
       "Hello"
-      m.put "Prot" > [m]
+      m.put "Prot" > [^ m]
     "Proto"
 
   eq. ++> can-keep-the-size-of-an-integer-block
     malloc.for
       12248
-      m.put 2556 > [m]
+      m.put 2556 > [^ m]
     2556
 
   ++> can-put-into-a-block-made-by-for
     mem.eq 10 > @
     malloc.for > mem
       0
-      m.put 10 > [m]
+      m.put 10 > [^ m]
 
   ++> can-put-over-the-previous-data
     eq. > @
@@ -239,7 +240,7 @@
       mem
     malloc.of > mem
       13
-      seq * > [m]
+      seq * > [^ m]
         m.put
           "Hello, world!"
         m.put 42
@@ -247,10 +248,10 @@
   ++> can-read-with-an-offset-and-a-length
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.of > @
           10
-          seq * > [m] >>
+          seq * > [^ m] >>
             m.write 2 "Hello"
             ^.b.put
               eq.
@@ -261,18 +262,18 @@
     01-02
     malloc.of
       1
-      m.read > [m]
+      m.read > [^ m]
         0
         10
-        01-02 > [ex]
+        01-02 > [^ ex]
 
   ++> can-recurse-without-arguments
     eq. > @
       malloc.for
         4
-        func m > [m] >>
+        func m > [^ m] >>
       0
-    if. > [n] >> func
+    if. > [^ n] >> func
       n.as-number.gt 0
       seq *
         n.put
@@ -283,14 +284,14 @@
   eq. ++> can-return-the-size-from-a-scope
     malloc.of
       5
-      m.size > [m]
+      m.size > [^ m]
     5
 
   ++> can-rewrite-and-increment-itself
     mem.eq 6 > @
     malloc.of > mem
       8
-      seq * > [m]
+      seq * > [^ m]
         m.write 0 1
         m.put
           m.as-number.plus 5
@@ -298,10 +299,10 @@
   ++> can-write-and-read
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.of > @
           12
-          seq * > [m] >>
+          seq * > [^ m] >>
             m.write
               0
               "Hello, "
@@ -315,7 +316,7 @@
     mem.eq 10 > @
     malloc.of > mem
       8
-      seq * > [m]
+      seq * > [^ m]
         m.write 0 10
         m
 
@@ -323,12 +324,12 @@
     eq.
       malloc.of
         8
-        m.put 10 > [m]
+        m.put 10 > [^ m]
       10
     eq.
       malloc.of
         8
-        m.put 20 > [m]
+        m.put 20 > [^ m]
       20
 
   eq. ++> can-write-the-initial-value
@@ -339,43 +340,43 @@
 
   malloc.of --> stops-on-changing-the-size-to-a-fraction
     1
-    m.resized 1.5 > [m]
+    m.resized 1.5 > [^ m]
 
   malloc.of --> stops-on-changing-the-size-to-a-negative
     1
-    m.resized -1 > [m]
+    m.resized -1 > [^ m]
 
   malloc.for --> stops-on-copying-with-a-wrong-length
     0
-    m.copy > [m]
+    m.copy > [^ m]
       3
       1
       9
 
   malloc.for --> stops-on-copying-with-a-wrong-source
     0
-    m.copy > [m]
+    m.copy > [^ m]
       9
       1
       1
 
   malloc.for --> stops-on-overflowing-a-bool-block
     false
-    m.put 8.612486788e7 > [m]
+    m.put 8.612486788e7 > [^ m]
 
   malloc.for --> stops-on-overflowing-a-string-block
     "Hello"
-    m.put > [m]
+    m.put > [^ m]
       "Much longer string!"
 
   malloc.for --> stops-on-reading-over-the-limit
     10
-    m.read > [m]
+    m.read > [^ m]
       0
       100
 
   malloc.of --> stops-on-writing-beyond-an-offset
     1
-    m.write > [m]
+    m.write > [^ m]
       1
       true

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -15,18 +15,18 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[pairs] > map
+[^ pairs] > map
   ctor > @
     if.
       pairs.length.eq 0
       *
       @.
-        [tup] >> rec-rebuild
+        [^ tup] >> rec-rebuild
           if. > @
             tup.length.eq 0
             *
             others.with
-              [] >>
+              [^] >>
                 ^.hash > hash
                 ^.kbts > kbts
                 ^.tup.head.key > key
@@ -34,19 +34,19 @@
           hash. >> hash!
             tup.head.key.as-bytes >> kbts!
           prev.filtered > others
-            not. > [ent] >>
+            not. > [^ ent] >>
               and.
                 ent.hash.eq hash
                 ent.kbts.eq kbts
           @. > prev
             ^.rec-rebuild tup.tail
         | pairs
-  [entries] > ctor
-    [key] > found
+  [^ entries] > ctor
+    [^ key] > found
       if. > @
         ^.size.eq 0
         not-found
-        [tup] >> rec-key-search
+        [^ tup] >> rec-key-search
           if. > @
             tup.length.eq 0
             ^.not-found
@@ -56,52 +56,52 @@
                 and.
                   tup.head.hash.eq hash
                   tup.head.kbts.eq kbts
-                [] >>
+                [^] >>
                   true > exists
-                  ^.^.tup.head.value > [cant-get] > get
+                  ^.^.tup.head.value > [^ cant-get] > get
                 ^.not-found
           @. > prev
             ^.rec-key-search tup.tail
         | ^.entries
       hash. >> hash!
         key.as-bytes >> kbts!
-      [] > not-found
+      [^] > not-found
         false > exists
-        cant-get > [cant-get] > get
+        cant-get > [^ cant-get] > get
           "Object by hash code %d from given key does not exists".printf
             * hash
-    exists. > [key] > has
+    exists. > [^ key] > has
       ^.found key
     entries.mapped > keys
-      entry.key > [entry]
+      entry.key > [^ entry]
     entries.length > size
     entries.mapped > values
-      entry.value > [entry]
-    [key value] > with
+      entry.value > [^ entry]
+    [^ key value] > with
       map.ctor > @
         with.
           ^.entries.filtered
-            not. > [entry] >>
+            not. > [^ entry] >>
               and.
                 hash.eq entry.hash
                 kbts.eq entry.kbts
-          [] >>
+          [^] >>
             ^.hash > hash
             ^.kbts > kbts
             ^.key > key
             ^.value > value
       hash. >> hash!
         key.as-bytes >> kbts!
-    [key] > without
+    [^ key] > without
       map.ctor > @
         ^.entries.filtered
-          not. > [entry] >>
+          not. > [^ entry] >>
             and.
               hash.eq entry.hash
               kbts.eq entry.kbts
       hash. >> hash!
         key.as-bytes >> kbts!
-  [key value] > entry
+  [^ key value] > entry
 
   ++> can-add-a-key-colliding-with-an-existing-one
     and. > @
@@ -180,7 +180,7 @@
     2.eq > @
       get.
         mp.found 1
-        "unreachable" > [message]
+        "unreachable" > [^ message]
     map * > mp
       map.entry 1 1
       map.entry 1 2
@@ -197,7 +197,7 @@
     1.eq > @
       malloc.for
         0
-        [m]
+        [^ m]
           seq * > @
             exists.
               mp.found 1
@@ -217,13 +217,13 @@
         map *
           map.entry "Aa" 1
         "BB"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   ++> can-recover-from-getting-a-missing-key
     "recovered".eq > @
       get.
         mp.found "absent"
-        "recovered" > [message]
+        "recovered" > [^ message]
     map * > mp
       map.entry "one" 1
 

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -13,11 +13,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > mktemp
+[^] > mktemp
   directory > @
     file
       string
-        [] >>!
+        [^] >>!
           os.is-windows.if > @
             if.
               tmp.eq empty

--- a/eo-runtime/src/main/eo/nop.eo
+++ b/eo-runtime/src/main/eo/nop.eo
@@ -18,7 +18,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > nop
+[^ x] > nop
   true > @
 
   nop 42 ++> accepts-a-number-argument

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -9,17 +9,21 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > number
+[^ as-bytes] > number
   as-bytes > @
   as-i32.as-i16 > as-i16
   $.as-i64.as-i32 > as-i32
   [] > div /Q.number
+    ? > ^
     ? > x /Q.number
   [] > gt /Q.bool
+    ? > ^
     ? > x /Q.number
   [] > plus /Q.number
+    ? > ^
     ? > x /Q.number
   [] > times /Q.number
+    ? > ^
     ? > x /Q.number
 
   eq. ++> can-add-a-negative-float-to-negative-infinity
@@ -87,11 +91,11 @@
     eq. > @
       fibonacci 4
       3
-    [n] > fibonacci
+    [^ n] > fibonacci
       if. > @
         n.lt 3
         small n
-        if. > [n minus1 minus2] >> rec
+        if. > [^ n minus1 minus2] >> rec
           n.eq 3
           minus1.plus minus2
           ^.rec
@@ -99,7 +103,7 @@
             minus1.plus minus2
             minus1
         | n 1 1
-      if. > [n] > small
+      if. > [^ n] > small
         n.eq 2
         1
         n
@@ -108,7 +112,7 @@
     eq. > @
       fibo 4
       3
-    if. > [n] > fibo
+    if. > [^ n] > fibo
       n.lt 3
       1
       plus.

--- a/eo-runtime/src/main/eo/number/abs.eo
+++ b/eo-runtime/src/main/eo/number/abs.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > abs
+[^] > abs
   if. > @
     gte.
       number ^.as-bytes >> value

--- a/eo-runtime/src/main/eo/number/arc-cosine.eo
+++ b/eo-runtime/src/main/eo/number/arc-cosine.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > arc-cosine
+[^] > arc-cosine
   minus. > @
     pi.div 2
     ^.arc-sine

--- a/eo-runtime/src/main/eo/number/arc-sine.eo
+++ b/eo-runtime/src/main/eo/number/arc-sine.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > arc-sine
+[^] > arc-sine
   if. > @
     arg.as-bytes.eq 80-00-00-00-00-00-00-00
     arg
@@ -23,12 +23,12 @@
           minus.
             pi.div 2
             2.times
-              [point] >> series
+              [^ point] >> series
                 times. > @
                   number
                     point >> bts!
                   poly 1
-                if. > [depth] > poly
+                if. > [^ depth] > poly
                   depth.gt 30
                   1
                   1.plus

--- a/eo-runtime/src/main/eo/number/as-char.eo
+++ b/eo-runtime/src/main/eo/number/as-char.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-char
+[^] > as-char
   if. > @
     or.
       or.

--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -12,7 +12,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-decimal
+[^] > as-decimal
   n.is-finite.not.if > @
     T
       "Can't write a non-finite number as decimal"
@@ -26,7 +26,7 @@
           "Can't write this number as decimal digits: its magnitude is 2^63 or larger, past the range of a signed 64-bit integer"
         if.
           n.lt 0
-          if. > [m] >> negative
+          if. > [^ m] >> negative
             m.as-number.eq 0
             digits m
             "-".as-bytes.concat
@@ -34,8 +34,8 @@
           |
             as-i64.
               n.times -1
-              T message > [message] >> failure
-          [n] >> digits
+              T message > [^ message] >> failure
+          [^ n] >> digits
             if. > @
               n.lt ^.ten
               as-char.

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -19,7 +19,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[places cant-print] > as-fixed
+[^ places cant-print] > as-fixed
   if. > @
     n.is-finite.not.or
       huge.or
@@ -37,10 +37,10 @@
     if.
       n.as-bytes.eq 80-00-00-00-00-00-00-00
       "-".as-bytes.concat
-        [a] >> positive
+        [^ a] >> positive
           if. > @
             digits.eq scale
-            if. > [unit rest] >> written
+            if. > [^ unit rest] >> written
               ^.^.places.eq 0
               unit.as-decimal
               concat.
@@ -59,7 +59,7 @@
         | 0
       if.
         n.lt 0
-        if. > [a] >> signed
+        if. > [^ a] >> signed
           eq.
             floor.
               plus.
@@ -75,7 +75,7 @@
   n.abs.gte > huge
     2.power 63
   ^ > n
-  if. > [p] >> pow10
+  if. > [^ p] >> pow10
     p.eq 0
     1
     times.
@@ -83,7 +83,7 @@
         as-number.
           p.minus 1
       10
-  if. > [value count acc] >> rec-pad
+  if. > [^ value count acc] >> rec-pad
     count.eq 0
     acc
     ^.rec-pad
@@ -173,61 +173,61 @@
     "recovered"
     9.223372036854776e18.as-fixed
       2
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-negative-number-with-a-non-decrementable-precision
     "recovered"
     -1.25.as-fixed
       9007199254740992
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-non-finite-number
     "recovered"
     nan.as-fixed
       2
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-precision-far-above-the-non-decrementable-bound
     "recovered"
     1.25.as-fixed
       18014398509481984
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-precision-just-above-the-non-decrementable-bound
     "recovered"
     1.25.as-fixed
       9007199254740994
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-precision-that-cannot-be-decremented
     "recovered"
     1.25.as-fixed
       9007199254740992
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-number
     "recovered"
     pinf.as-fixed
       2
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-infinite-places
     "recovered"
     1.25.as-fixed
       pinf
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-negative-places
     "recovered"
     3.14159.as-fixed
       -2
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-non-integer-places
     "recovered"
     3.14159.as-fixed
       2.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-round-to-the-last-place
     "0.123457"

--- a/eo-runtime/src/main/eo/number/as-i64.eo
+++ b/eo-runtime/src/main/eo/number/as-i64.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-convert] > as-i64
+[^ cant-convert] > as-i64
   if. > @
     or.
       eq.
@@ -81,7 +81,7 @@
   eq. ++> can-recover-from-an-out-of-range-number
     "recovered"
     1.0e30.as-i64
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-truncate-a-negative-toward-zero
     -3.7.as-i64.as-bytes

--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > as-scientific
+[^] > as-scientific
   n.is-finite.not.if > @
     n.is-nan.if
       "nan".as-bytes
@@ -49,7 +49,7 @@
   carried.as-bool.if > normalized!
     "-1.000000".as-bytes
     "1.000000".as-bytes
-  if. > [m count] >> rec-exponent
+  if. > [^ m count] >> rec-exponent
     or.
       m.eq 0
       and.

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > cosine
+[^] > cosine
   if. > @
     num.eq 0
     1

--- a/eo-runtime/src/main/eo/number/degrees.eo
+++ b/eo-runtime/src/main/eo/number/degrees.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > degrees
+[^] > degrees
   times. > @
     div.
       number ^.as-bytes

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > eq
+[^ x] > eq
   if. > @
     n.is-nan.or
       is-nan.

--- a/eo-runtime/src/main/eo/number/exp.eo
+++ b/eo-runtime/src/main/eo/number/exp.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > exp
+[^] > exp
   e.power ^ > @
 
   lt. ++> can-exponentiate-five

--- a/eo-runtime/src/main/eo/number/floor.eo
+++ b/eo-runtime/src/main/eo/number/floor.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > floor
+[^] > floor
   if. > @
     n.as-bytes.eq 80-00-00-00-00-00-00-00
     n

--- a/eo-runtime/src/main/eo/number/gte.eo
+++ b/eo-runtime/src/main/eo/number/gte.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > gte
+[^ x] > gte
   or. > @
     n.gt
       x >> value!

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[fun a b n] > integral
+[^ fun a b n] > integral
   if. > @
     and.
       n.is-finite.and
@@ -21,10 +21,10 @@
     as-number.
       malloc.of
         8
-        [sum] >>
+        [^ sum] >>
           seq * > @
             while
-              if. > [i] >>
+              if. > [^ i] >>
                 i.lt ^.^.n
                 seq *
                   ^.sum.put
@@ -34,7 +34,7 @@
                         ^.^.a.plus ((i.plus 1).times ^.step)
                   true
                 false
-              true > [i]
+              true > [^ i]
             sum
           as-number. > step
             div.
@@ -43,7 +43,7 @@
     T
       "the number of partitions must be a finite positive integer smaller than 2^53"
   9007199254740992 > safe
-  times. > [a b] >> subsection
+  times. > [^ a b] >> subsection
     div.
       b.minus a
       6
@@ -60,7 +60,7 @@
     close-to > @
       as-number.
         integral
-          times. > [x]
+          times. > [^ x]
             x.times x
             x
           1
@@ -68,14 +68,14 @@
           100
       2499.75
       1.0e-7
-    [value operand err] > close-to
+    [^ value operand err] > close-to
       lte. > @
         minus.
           abs.
             value.minus operand
           err
         0
-      if. > [value] > abs
+      if. > [^ value] > abs
         value.gte 0
         value
         value.neg
@@ -90,14 +90,14 @@
           15
       49.5
       1.0e-7
-    [value operand err] > close-to
+    [^ value operand err] > close-to
       lte. > @
         minus.
           abs.
             value.minus operand
           err
         0
-      if. > [value] > abs
+      if. > [^ value] > abs
         value.gte 0
         value
         value.neg
@@ -106,20 +106,20 @@
     close-to > @
       as-number.
         integral
-          x.times x > [x]
+          x.times x > [^ x]
           1
           10
           100
       333
       1.0e-7
-    [value operand err] > close-to
+    [^ value operand err] > close-to
       lte. > @
         minus.
           abs.
             value.minus operand
           err
         0
-      if. > [value] > abs
+      if. > [^ value] > abs
         value.gte 0
         value
         value.neg
@@ -134,14 +134,14 @@
           1
       0.5
       1.0e-7
-    [value operand err] > close-to
+    [^ value operand err] > close-to
       lte. > @
         minus.
           abs.
             value.minus operand
           err
         0
-      if. > [value] > abs
+      if. > [^ value] > abs
         value.gte 0
         value
         value.neg
@@ -156,14 +156,14 @@
           10
       50
       1.0e-7
-    [value operand err] > close-to
+    [^ value operand err] > close-to
       lte. > @
         minus.
           abs.
             value.minus operand
           err
         0
-      if. > [value] > abs
+      if. > [^ value] > abs
         value.gte 0
         value
         value.neg

--- a/eo-runtime/src/main/eo/number/is-finite.eo
+++ b/eo-runtime/src/main/eo/number/is-finite.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-finite
+[^] > is-finite
   and. > @
     n.as-bytes.size.eq 8
     n.is-nan.not.and

--- a/eo-runtime/src/main/eo/number/is-integer.eo
+++ b/eo-runtime/src/main/eo/number/is-integer.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-integer
+[^] > is-integer
   n.is-finite.and > @
     n.eq n.floor
   ^ > n

--- a/eo-runtime/src/main/eo/number/is-nan.eo
+++ b/eo-runtime/src/main/eo/number/is-nan.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-nan
+[^] > is-nan
   if. > @
     and.
       bts.size.gt 7

--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -13,7 +13,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > ln
+[^] > ln
   n.is-nan.if > @
     nan
     if.
@@ -25,7 +25,7 @@
         n.is-finite.if
           lnp n
           pinf
-  [p] > lnp
+  [^ p] > lnp
     if. > @
       p.gte e
       climb 9 p
@@ -34,7 +34,7 @@
           1.div e
         descend 9 p
         series p
-    if. > [level p] > climb
+    if. > [^ level p] > climb
       level.lt 0
       ^.series p
       if.
@@ -49,7 +49,7 @@
         ^.climb
           level.minus 1
           p
-    if. > [level p] > descend
+    if. > [^ level p] > descend
       level.lt 0
       ^.series p
       if.
@@ -65,18 +65,18 @@
         ^.descend
           level.minus 1
           p
-    [level] > epow
+    [^ level] > epow
       if. > @
         level.eq 0
         e
         prev.times prev
       ^.epow > prev
         level.minus 1
-    [m] > series
+    [^ m] > series
       2.times > @
         t.times
           horner 0
-      if. > [k] > horner
+      if. > [^ k] > horner
         k.gt 40
         0
         plus.
@@ -91,7 +91,7 @@
       div. > t
         m.minus 1
         m.plus 1
-    [level] > step
+    [^ level] > step
       if. > @
         level.eq 0
         1

--- a/eo-runtime/src/main/eo/number/lt.eo
+++ b/eo-runtime/src/main/eo/number/lt.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > lt
+[^ x] > lt
   0.gt > @
     ^.minus
       number x!

--- a/eo-runtime/src/main/eo/number/lte.eo
+++ b/eo-runtime/src/main/eo/number/lte.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > lte
+[^ x] > lte
   or. > @
     n.lt
       x >> value!

--- a/eo-runtime/src/main/eo/number/minus.eo
+++ b/eo-runtime/src/main/eo/number/minus.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > minus
+[^ x] > minus
   ^.plus > @
     neg.
       number x!

--- a/eo-runtime/src/main/eo/number/mod.eo
+++ b/eo-runtime/src/main/eo/number/mod.eo
@@ -18,7 +18,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[y cant-mod] > mod
+[^ y cant-mod] > mod
   if. > @
     eq.
       number y.as-bytes >> divisor
@@ -36,18 +36,18 @@
             gte.
               number x.as-bytes >> dividend
               0
-            [] >> abs-mod
+            [^] >> abs-mod
               shrink > @
                 grow divisor.abs
                 dividend.abs
-              if. > [chunk] > grow
+              if. > [^ chunk] > grow
                 or.
                   chunk.gte dividend.abs
                   not. (chunk.plus chunk).is-finite
                 chunk
                 ^.grow
                   chunk.plus chunk
-              if. > [chunk rest] > shrink
+              if. > [^ chunk rest] > shrink
                 chunk.lt divisor.abs
                 rest
                 ^.shrink
@@ -63,7 +63,7 @@
     "recovered"
     5.mod
       0
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   is-nan. ++> can-return-nan-when-the-dividend-is-infinite
     pinf.mod 5

--- a/eo-runtime/src/main/eo/number/neg.eo
+++ b/eo-runtime/src/main/eo/number/neg.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > neg
+[^] > neg
   ^.times -1 > @
 
   ninf.neg.eq pinf ++> can-negate-negative-infinity

--- a/eo-runtime/src/main/eo/number/power.eo
+++ b/eo-runtime/src/main/eo/number/power.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x] > power
+[^ x] > power
   if. > @
     eq.
       number x.as-bytes >> expo
@@ -42,7 +42,7 @@
               expo.is-integer.if
                 if.
                   expo.lt 0
-                  [b n] >> ipow
+                  [^ b n] >> ipow
                     if. > @
                       n.eq 0
                       1
@@ -58,7 +58,7 @@
                   ipow base expo.abs
                 if.
                   base.gt 0
-                  [y] >> expon
+                  [^ y] >> expon
                     times. > @
                       if.
                         lt. (number k) 0
@@ -67,7 +67,7 @@
                         ipow e (number k).abs
                       fraction 1
                     y > arg!
-                    if. > [j] > fraction
+                    if. > [^ j] > fraction
                       j.gt 20
                       1
                       1.plus

--- a/eo-runtime/src/main/eo/number/radians.eo
+++ b/eo-runtime/src/main/eo/number/radians.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > radians
+[^] > radians
   times. > @
     div.
       number ^.as-bytes

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -7,9 +7,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > random
+[^] > random
   seed.as-number.div 00-20-00-00-00-00-00-00.as-i64.as-number > @
-  [clock] > clocked
+  [^ clock] > clocked
     random. > @
       as-number.
         plus.

--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -15,7 +15,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > sine
+[^] > sine
   times. > @
     minus. >> reduced
       arg.minus
@@ -28,7 +28,7 @@
               0.5
           6.283185303211212
       k.times 3.968374318722162e-9
-    if. > [depth] >> factor
+    if. > [^ depth] >> factor
       depth.gt 15
       1
       1.minus

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > sqrt
+[^] > sqrt
   if. > @
     arg.lt 0
     nan

--- a/eo-runtime/src/main/eo/os.eo
+++ b/eo-runtime/src/main/eo/os.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > os
+[^] > os
   name > @
   as-bool. > is-linux
     exists.
@@ -23,6 +23,7 @@
       next.
         "/windows/i".regex.match name
   [] > name /Q.string
+    ? > ^
 
   or. ++> can-check-the-os-family
     os.is-windows.or os.is-macos

--- a/eo-runtime/src/main/eo/output.eo
+++ b/eo-runtime/src/main/eo/output.eo
@@ -10,12 +10,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[@] > output
+[^ @] > output
 
   eq. ++> can-decorate-a-destination-of-bytes
     malloc.of
       3
-      seq * > [m]
+      seq * > [^ m]
         write.
           output m.to-output
           01-02-03

--- a/eo-runtime/src/main/eo/output/dead.eo
+++ b/eo-runtime/src/main/eo/output/dead.eo
@@ -9,16 +9,16 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > dead
-  [buffer] > write
-    [] >> output-block
+[^] > dead
+  [^ buffer] > write
+    [^] >> output-block
       true > @
-      ^.^.output-block > [buffer] > write
+      ^.^.output-block > [^ buffer] > write
     | > @
 
   malloc.of ++> can-be-taken-off-any-output
     3
-    write. > [m]
+    write. > [^ m]
       dead.
         output m.to-output
       01-02-03

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -7,18 +7,18 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[uri] > path
+[^ uri] > path
   os.is-windows.if > @
     win32
       string uri.as-bytes
     posix
       string uri.as-bytes
-  [sys uri] > impl
+  [^ sys uri] > impl
     uri > @
     directory > as-dir
       file uri
     file uri > as-file
-    [] > basename
+    [^] > basename
       string > @
         if.
           or.
@@ -44,7 +44,7 @@
           eq.
             driveless.slice 2 1
             "?"
-    [] > dirname
+    [^] > dirname
       string > @
         if.
           ^.unc.and root
@@ -85,7 +85,7 @@
       uri.slice
         drive.length
         uri.length.minus drive.length
-    [] > extname
+    [^] > extname
       if. > @
         or.
           or.
@@ -108,7 +108,7 @@
       eq.
         driveless.slice 0 1
         separator
-    [] > normalized
+    [^] > normalized
       ^.^.impl > @
         ^.sys
         if.
@@ -130,7 +130,7 @@
           reduced.
             ^.driveless.split ^.separator
             *
-            if. > [accum segment] >>
+            if. > [^ accum segment] >>
               segment.eq ".."
               if.
                 and.
@@ -201,7 +201,7 @@
             ubts.size.plus -1
             1
           ^.separator
-    [other] > resolved
+    [^ other] > resolved
       normalized. > @
         ^.^.impl
           ^.sys
@@ -238,7 +238,7 @@
         separator.concat
           chunks.at 3
       uri
-    if. > [tail] > stripped
+    if. > [^ tail] > stripped
       or.
         tail.size.eq 0
         tail.eq ^.separator
@@ -252,7 +252,7 @@
                 0
                 tail.length.minus ^.separator.length
         tail
-    string > [] > trimmed
+    string > [^] > trimmed
       ^.stripped ^.uri
     and. > unc
       separator.eq "\\"
@@ -260,7 +260,7 @@
         driveless.size.gt 1
         driveless.starts-with
           separator.concat separator
-  [paths] > joined
+  [^ paths] > joined
     normalized. > @
       os.is-windows.if
         ^.win32 jpath
@@ -268,29 +268,29 @@
     string > jpath
       as-bytes.
         ^.separator.joined paths
-  [uri] > posix
+  [^ uri] > posix
     ^.impl > @
       sys
       uri
     "/" > separator
-    [] > sys
-      -- > [uri] > drive
+    [^] > sys
+      -- > [^ uri] > drive
       I > sanitized
       ^.separator > separator
   os.is-windows.if > separator
     win32.separator
     posix.separator
-  [uri] > win32
+  [^ uri] > win32
     ^.impl > @
       sys
       sys.sanitized uri
     "\\" > separator
-    [] > sys
-      if. > [uri] > drive
+    [^] > sys
+      if. > [^ uri] > drive
         as-bool. ("/^[a-zA-Z]:/".regex.match uri).next.exists
         uri.slice 0 2
         --
-      [uri] > sanitized
+      [^ uri] > sanitized
         if. > @
           eq.
             pth.index-of path.posix.separator

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -11,8 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[name args] > posix
+[^ name args] > posix
   [] > @ /Q.posix.return
+    ? > ^
   os.is-macos.if > append
     8
     1024
@@ -29,25 +30,25 @@
   511 > permissions
   0 > rdonly
   2 > rdwr
-  [code output] > return
+  [^ code output] > return
     output > @
     ^.return > called
       code
       output
-  [family port address] > sockaddr-in
+  [^ family port address] > sockaddr-in
     00-00-00-00-00-00-00-00 > padding
     plus. > size
       plus.
         family.size.plus port.size
         address.size
       padding.size
-  [mode size] > stat
+  [^ mode size] > stat
   2 > stderr
   0 > stdin
   1 > stdout
   1 > stream
   6 > tcp
-  [seconds micros] > timeval
+  [^ seconds micros] > timeval
   os.is-macos.if > trunc
     1024
     512

--- a/eo-runtime/src/main/eo/range.eo
+++ b/eo-runtime/src/main/eo/range.eo
@@ -26,10 +26,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[start end] > range
+[^ start end] > range
   if. > @
     start.lt end
-    if. > [acc current] >> appended
+    if. > [^ acc current] >> appended
       current.lt ^.end
       ^.appended
         acc.with current
@@ -53,9 +53,9 @@
         8
         9
     range > rng
-      []
+      [^]
         build 1 > @
-        [i] > build
+        [^ i] > build
           i > @
           ^.build > next
             1.plus @
@@ -73,9 +73,9 @@
         4
         4.5
     range > rng
-      []
+      [^]
         x 1 > @
-        [i] > x
+        [^ i] > x
           i > @
           ^.x > next
             0.5.plus @
@@ -85,9 +85,9 @@
     rng.eq > @
       * 1 6
     range > rng
-      []
+      [^]
         b 1 > @
-        [num] > b
+        [^ num] > b
           num > @
           ^.b > next
             5.plus @
@@ -96,10 +96,10 @@
   ++> can-build-an-empty-range-from-wrong-items
     rng.is-empty > @
     range > rng
-      []
+      [^]
         y 10 > @
-        [num] > y
+        [^ num] > y
           num > @
-          [] > next
+          [^] > next
             42 > nothing
       1

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -13,7 +13,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > naturals
+[^] > naturals
   if. > @
     and.
       r.start.is-integer.and r.end.is-integer
@@ -21,9 +21,9 @@
         r.start.abs.lt safe
         r.end.abs.lt safe
     range
-      [] >>
+      [^] >>
         build ^.r.start > @
-        [num] > build
+        [^ num] > build
           num > @
           ^.build > next
             1.plus @

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -12,6 +12,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > recovered /A
+  ? > ^
   ? > value /A?
   ? > alternative /A
 
@@ -53,7 +54,7 @@
     recovered
       2.as-i64.div
         0.as-i64
-        T > [message]
+        T > [^ message]
           "cannot divide"
       42
     42

--- a/eo-runtime/src/main/eo/seq.eo
+++ b/eo-runtime/src/main/eo/seq.eo
@@ -17,7 +17,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[steps] > seq
+[^ steps] > seq
   if. > @
     steps.length.eq 0
     true
@@ -46,10 +46,10 @@
   ++> can-dataize-a-float-once-when-greater
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           0
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             gt.
               seq *
                 m.put
@@ -60,10 +60,10 @@
   ++> can-dataize-a-float-once-when-less
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           0
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             lt.
               seq *
                 m.put
@@ -74,10 +74,10 @@
   ++> can-dataize-an-integer-once-when-equal
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           0
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             eq.
               seq *
                 m.put 0
@@ -89,10 +89,10 @@
   ++> can-dataize-an-integer-once-when-equal-and-cached
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           0
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             eq.
               seq *
                 at.
@@ -106,10 +106,10 @@
   ++> can-dataize-an-integer-once-when-less
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           0
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             lt.
               seq *
                 m.put
@@ -120,10 +120,10 @@
   ++> can-dataize-an-integer-once-when-less-or-equal
     malloc.of > @
       1
-      [b]
+      [^ b]
         malloc.for > @
           0
-          ^.b.put > [m] >>
+          ^.b.put > [^ m] >>
             lte.
               seq *
                 m.put

--- a/eo-runtime/src/main/eo/set.eo
+++ b/eo-runtime/src/main/eo/set.eo
@@ -6,19 +6,19 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[lst] > set
-  [mp] >> ctor
+[^ lst] > set
+  [^ mp] >> ctor
     mp.keys > @
-    ^.mp.has item > [item] > has
+    ^.mp.has item > [^ item] > has
     mp.size > size
-    set.ctor > [item] > with
+    set.ctor > [^ item] > with
       ^.mp.with item true
-    set.ctor > [item] > without
+    set.ctor > [^ item] > without
       ^.mp.without item
   | > @
     map
       lst.mapped
-        map.entry item true > [item]
+        map.entry item true > [^ item]
 
   has. ++> can-append-a-new-item
     with.

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -48,15 +48,15 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[address port] > socket
+[^ address port] > socket
   os.is-windows.if > @
-    [sys] >> impl
+    [^ sys] >> impl
       code. > addr
         sys.raw *1
           "inet_addr"
           ^.address
       addr.as-i32 > addrint
-      [descriptor] > closed-socket
+      [^ descriptor] > closed-socket
         if. > @
           closed.eq -1
           T
@@ -67,9 +67,9 @@
           ^.sys.raw *1
             ^.sys.close
             descriptor
-      [scope cant-connect] > connect
+      [^ scope cant-connect] > connect
         ^.safe-socket > @
-          [] >>
+          [^] >>
             if. > @
               connected.eq -1
               ^.cant-connect
@@ -85,9 +85,9 @@
                 sock.sockaddr.size
             ^.^.^ > sock
           cant-connect
-      [scope cant-listen] > listen
+      [^ scope cant-listen] > listen
         ^.safe-socket > @
-          [] >>
+          [^] >>
             if. > @
               bound.eq -1
               ^.cant-listen
@@ -99,9 +99,9 @@
                   "Failed to listen to %s:%d on the socket #%d because %s".printf
                     * sock.address sock.port sock.sd sock.sys.message
                 ^.scope
-                  [] >>
+                  [^] >>
                     ^.sock.scoped-socket ^.sock.sd > @
-                    [scope cant-accept] > accept
+                    [^ scope cant-accept] > accept
                       if. > @
                         client.eq -1
                         cant-accept
@@ -129,7 +129,7 @@
                 2048
             ^.^.^ > sock
           cant-listen
-      [scope cant] > safe-socket
+      [^ scope cant] > safe-socket
         if. > @
           not.
             ^.sys.startup.eq 0
@@ -154,10 +154,10 @@
           ^.^.guarded
             converted
             ^.closed-socket ^.sd
-      [descriptor] > scoped-socket
+      [^ descriptor] > scoped-socket
         ^.^.as-input recv > as-input
         ^.^.as-output send > as-output
-        [size cant-receive] > recv
+        [^ size cant-receive] > recv
           if. > @
             received.code.eq -1
             cant-receive
@@ -170,7 +170,7 @@
               ^.descriptor
               size
               0
-        [buffer cant-send] > send
+        [^ buffer cant-send] > send
           if. > @
             sent.eq -1
             cant-send
@@ -195,7 +195,7 @@
         ^.htons ^.checked-port
         addrint
     |
-      []
+      [^]
         raw > @
         if. > cleanup
           eq.
@@ -220,7 +220,7 @@
             "WSAStartup"
             win32.version
     impl
-      []
+      [^]
         raw > @
         true > cleanup
         "close" > close
@@ -233,27 +233,27 @@
                 *
         posix > raw
         0 > startup
-  [recv] > as-input
-    [size] > read
+  [^ recv] > as-input
+    [^ size] > read
       @. > @
         read.
           input-block --
           size
-      [buffer] > input-block
+      [^ buffer] > input-block
         buffer > @
-        [size] > read
+        [^ size] > read
           seq * > @
             chunk
             ^.^.input-block chunk
           as-bytes. > chunk
             ^.^.^.recv size
-  [send] > as-output
-    [buffer] > write
+  [^ send] > as-output
+    [^ buffer] > write
       @. > @
         output-block.write buffer
-      [] > output-block
+      [^] > output-block
         true > @
-        [buffer] > write
+        [^ buffer] > write
           seq > @
             * sent remainder
           if. > remainder
@@ -264,7 +264,7 @@
                 buffer.size.minus sent
             ^.^.output-block
           ^.^.^.send buffer > sent
-  ^.port.is-integer.not.if > [] > checked-port
+  ^.port.is-integer.not.if > [^] > checked-port
     T
       "Port must be an integer in 0 to 65535, but was %f".printf
         * ^.port
@@ -276,13 +276,13 @@
         "Port %d is out of range; it must be 0 to 65535".printf
           * ^.port
       ^.port
-  [scope cleanup] > guarded
+  [^ scope cleanup] > guarded
     seq * > @
       recovered value true
       cleanup
       value
     scope > value!
-  [port] > htons
+  [^ port] > htons
     as-i16. > @
       or.
         left.
@@ -302,7 +302,7 @@
   eq. ++> can-dataize-a-guarded-scope-once
     malloc.for
       0
-      seq * > [m]
+      seq * > [^ m]
         socket.guarded
           m.put
             m.as-number.plus 1
@@ -320,14 +320,14 @@
     eq. > @
       malloc.of
         2
-        [c]
+        [^ c]
           seq * > @
             write.
               socket.as-output
                 partial-send c
               01-02
             c.get
-          seq * > [acc buffer] > partial-send
+          seq * > [^ acc buffer] > partial-send
             acc.write
               2.minus buffer.size
               buffer.slice 0 1
@@ -337,7 +337,7 @@
   eq. ++> can-run-a-guard-cleanup-after-a-successful-scope
     malloc.for
       0
-      seq * > [m]
+      seq * > [^ m]
         socket.guarded
           42
           m.put
@@ -348,7 +348,7 @@
   eq. ++> can-run-a-guard-cleanup-after-a-terminated-scope
     malloc.for
       0
-      seq * > [m]
+      seq * > [^ m]
         recovered
           socket.guarded
             2.as-i64.div 0.as-i64

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -18,17 +18,17 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > stderr
+[^ text] > stderr
   seq * > @
     write.
       os.is-windows.if
-        [] >>
-          [buffer] > write
+        [^] >>
+          [^ buffer] > write
             @. > @
               output-block.write buffer
-            [] > output-block
+            [^] > output-block
               true > @
-              [buffer] > write
+              [^ buffer] > write
                 seq * > @
                   if. >>!
                     code.eq -1
@@ -48,13 +48,13 @@
                   ^.^.output-block.write
                     buffer.slice code (buffer.size.minus code)
                   ^.^.output-block
-        [] >>
-          [buffer] > write
+        [^] >>
+          [^ buffer] > write
             @. > @
               output-block.write buffer
-            [] > output-block
+            [^] > output-block
               true > @
-              [buffer] > write
+              [^ buffer] > write
                 seq * > @
                   if. >>!
                     code.eq -1

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -20,10 +20,10 @@
 +spdx SPDX-License-Identifier: MIT
 +unlint unit-test-missing
 
-[] > stdin
+[^] > stdin
   all-lines > @
-  [] > all-lines
-    [scan buffer is-first] >> rec-read
+  [^] > all-lines
+    [^ scan buffer is-first] >> rec-read
       scan.eof.if > @
         string buffer
         ^.rec-read
@@ -38,13 +38,13 @@
       ^.line-or-eof
       ""
       true
-  [] > line-or-eof
+  [^] > line-or-eof
     first.as-bytes.size.eq 0 > eof
     @. > first
       console.read 1
     eof.if > line
       ""
-      [input buffer] >> rec-read
+      [^ input buffer] >> rec-read
         if. > @
           or.
             char.eq --
@@ -61,4 +61,4 @@
         @. > next
           input.read 1
       | first --
-  ^.line-or-eof.line > [] > next-line
+  ^.line-or-eof.line > [^] > next-line

--- a/eo-runtime/src/main/eo/stdout.eo
+++ b/eo-runtime/src/main/eo/stdout.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > stdout
+[^ text] > stdout
   seq * > @
     console.write text
     true

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -23,7 +23,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > string
+[^ as-bytes] > string
   as-bytes > @
 
   not. ++> can-compare-a-string-with-nan

--- a/eo-runtime/src/main/eo/string/as-ascii.eo
+++ b/eo-runtime/src/main/eo/string/as-ascii.eo
@@ -12,7 +12,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-read] > as-ascii
+[^ cant-read] > as-ascii
   if. > @
     char.as-bytes.size.eq 1
     as-number.
@@ -46,12 +46,12 @@
   eq. ++> can-recover-from-a-multi-byte-character
     "recovered"
     "Ж".as-ascii
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-empty-string
     "recovered"
     "".as-ascii
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   "Ж".as-ascii --> stops-on-a-multi-byte-character
 

--- a/eo-runtime/src/main/eo/string/as-number.eo
+++ b/eo-runtime/src/main/eo/string/as-number.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-parse] > as-number
+[^ cant-parse] > as-number
   if. > @
     not.
       "/^[+-]?\\d+(?:\\.\\d+)?(?:[eE][+-]?\\d+)?$/".regex.compiled.matches text
@@ -41,36 +41,36 @@
   eq. ++> can-recover-from-a-bare-exponent-marker
     42
     "1e".as-number
-      42 > [message]
+      42 > [^ message]
 
   eq. ++> can-recover-from-an-exponent-without-a-mantissa
     42
     "e3".as-number
-      42 > [message]
+      42 > [^ message]
 
   eq. ++> can-recover-from-currency-prefixed-text
     42
     "$100".as-number
-      42 > [message]
+      42 > [^ message]
 
   eq. ++> can-recover-from-non-numeric-text
     42
     "Hello".as-number
-      42 > [message]
+      42 > [^ message]
 
   eq. ++> can-recover-from-space-separated-numbers
     42
     "1 2 3".as-number
-      42 > [message]
+      42 > [^ message]
 
   eq. ++> can-recover-from-text-with-an-embedded-number
     42
     "abc5".as-number
-      42 > [message]
+      42 > [^ message]
 
   eq. ++> can-recover-from-text-with-multiple-dots
     42
     "12.34.56".as-number
-      42 > [message]
+      42 > [^ message]
 
   "Hello".as-number --> stops-on-converting-non-numeric-text

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[i fallback] > at
+[^ i fallback] > at
   if. > @
     not.
       eq.
@@ -50,19 +50,19 @@
     "recovered"
     "some".at
       1.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-negative-fractional-index-in-bounds
     "recovered"
     "some".at
       -1.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-out-of-bounds-index
     "recovered"
     "some".at
       10
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-return-a-character-at-a-negative-index
     "m"

--- a/eo-runtime/src/main/eo/string/chained.eo
+++ b/eo-runtime/src/main/eo/string/chained.eo
@@ -8,14 +8,14 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[others] > chained
+[^ others] > chained
   if. > @
     0.eq others.length
     text
     string
       others.reduced
         text.as-bytes
-        accum.concat str.as-bytes > [accum str]
+        accum.concat str.as-bytes > [^ accum str]
   ^ > text
 
   eq. ++> can-chain-with-other-strings

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -7,12 +7,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substrings] > contains-all
+[^ substrings] > contains-all
   reduced. > @
     substrings.mapped
-      ^.text.contains x > [x] >>
+      ^.text.contains x > [^ x] >>
     true
-    x.and a > [a x]
+    x.and a > [^ a x]
   ^ > text
 
   contains-all. ++> can-contain-all-of-no-substrings

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -7,12 +7,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substrings] > contains-any
+[^ substrings] > contains-any
   reduced. > @
     substrings.mapped
-      ^.text.contains x > [x] >>
+      ^.text.contains x > [^ x] >>
     false
-    x.or a > [a x]
+    x.or a > [^ a x]
   ^ > text
 
   contains-any. ++> can-contain-any-substring

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substring] > contains
+[^ substring] > contains
   and. > @
     gte.
       number
@@ -19,7 +19,7 @@
         eq.
           text >> txt!
           substring >> part!
-      [index] >> rec-contains
+      [^ index] >> rec-contains
         if. > @
           end.eq index
           includes

--- a/eo-runtime/src/main/eo/string/ends-with.eo
+++ b/eo-runtime/src/main/eo/string/ends-with.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substring] > ends-with
+[^ substring] > ends-with
   and. > @
     lte.
       number

--- a/eo-runtime/src/main/eo/string/english.eo
+++ b/eo-runtime/src/main/eo/string/english.eo
@@ -17,13 +17,13 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > english
+[^] > english
   s > @
-  [] > lower
+  [^] > lower
     string > @
       ^.s.as-bytes.array.reduced
         --
-        [accum byte] >>
+        [^ accum byte] >>
           accum.concat > @
             if.
               and.
@@ -41,11 +41,11 @@
             string byte
     "A".as-ascii >> mincode!
   ^ > s
-  [] > upper
+  [^] > upper
     string > @
       ^.s.as-bytes.array.reduced
         --
-        [accum byte] >>
+        [^ accum byte] >>
           accum.concat > @
             if.
               and.

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substring] > index-of
+[^ substring] > index-of
   if. > @
     or.
       or.
@@ -32,7 +32,7 @@
   minus. >> end!
     number tlen
     size
-  [idx] >> rec-index-of
+  [^ idx] >> rec-index-of
     if. > @
       end.eq idx
       includes.if idx -1

--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-alpha
+[^] > is-alpha
   "/^[a-zA-Z]+$/".regex.matches text > @
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-alphanumeric
+[^] > is-alphanumeric
   "/^[A-Za-z0-9]+$/".regex.matches text > @
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-ascii
+[^] > is-ascii
   "/^[\\x00-\\x7F]+$/".regex.matches text > @
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-digit
+[^] > is-digit
   "/^[0-9]+$/".regex.matches text > @
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/joined.eo
+++ b/eo-runtime/src/main/eo/string/joined.eo
@@ -8,12 +8,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[items] > joined
+[^ items] > joined
   string > @
     if. >>!
       items.length.eq 0
       --
-      [acc tup] >> with-delimiter
+      [^ acc tup] >> with-delimiter
         if. > @
           tup.length.eq 0
           acc

--- a/eo-runtime/src/main/eo/string/last-index-of.eo
+++ b/eo-runtime/src/main/eo/string/last-index-of.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substring] > last-index-of
+[^ substring] > last-index-of
   if. > @
     or.
       or.
@@ -32,7 +32,7 @@
             minus.
               number tlen
               size
-  [idx] >> rec-index-of
+  [^ idx] >> rec-index-of
     if. > @
       0.eq idx
       includes.if idx -1

--- a/eo-runtime/src/main/eo/string/length.eo
+++ b/eo-runtime/src/main/eo/string/length.eo
@@ -17,13 +17,13 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > length
+[^] > length
   if. > @
     eq.
       text.as-bytes.size >> size!
       0
     0
-    [index accum] >> reclen
+    [^ index accum] >> reclen
       if. > @
         index.eq size
         accum
@@ -116,7 +116,7 @@
       b2cont.and second3 > threevalid
       leadc0c1.not.and b1cont > twovalid
     | 0 0
-  if. > [idx csize valid accum] >> step
+  if. > [^ idx csize valid accum] >> step
     gt.
       idx.plus csize
       size

--- a/eo-runtime/src/main/eo/string/lower.eo
+++ b/eo-runtime/src/main/eo/string/lower.eo
@@ -13,7 +13,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > lower
+[^] > lower
   text.english.lower > @
   ^ > text
 

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[delimiter limit cant-split] > nsplit
+[^ delimiter limit cant-split] > nsplit
   if. > @
     or.
       eq.
@@ -29,7 +29,7 @@
     if.
       1.eq limit
       * text
-      [accum start current count] >> rec-nsplit
+      [^ accum start current count] >> rec-nsplit
         if. > @
           ^.text.size.eq current
           appended
@@ -97,28 +97,28 @@
     "a-b-c".nsplit
       "-"
       1.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-empty-delimiter-when-nsplitting
     "recovered"
     "abc".nsplit
       ""
       3
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-limit-when-splitting
     "recovered"
     "a-b-c".nsplit
       "-"
       pinf
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-invalid-limit
     "fallback"
     "text".nsplit
       "-"
       0
-      "fallback" > [message]
+      "fallback" > [^ message]
 
   eq. ++> can-split-into-empty-strings
     "-a-b-c".nsplit

--- a/eo-runtime/src/main/eo/string/padded-left.eo
+++ b/eo-runtime/src/main/eo/string/padded-left.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[width fill cant-pad] > padded-left
+[^ width fill cant-pad] > padded-left
   if. > @
     or.
       or.
@@ -66,28 +66,28 @@
     "y".padded-left
       5
       "ab"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-negative-width-when-padding-left
     "recovered"
     "y".padded-left
       -1
       "x"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-non-integer-width-when-padding-left
     "recovered"
     "y".padded-left
       2.5
       "x"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-width-when-padding-left
     "recovered"
     "y".padded-left
       pinf
       "x"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-return-a-longer-text-unchanged-when-padding-left
     "hello"

--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[width fill cant-pad] > padded-right
+[^ width fill cant-pad] > padded-right
   if. > @
     or.
       or.
@@ -65,28 +65,28 @@
     "y".padded-right
       5
       "ab"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-negative-width-when-padding-right
     "recovered"
     "y".padded-right
       -1
       "x"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-non-integer-width-when-padding-right
     "recovered"
     "y".padded-right
       2.5
       "x"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-width-when-padding-right
     "recovered"
     "y".padded-right
       pinf
       "x"
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-return-a-longer-text-unchanged-when-padding-right
     "hello"

--- a/eo-runtime/src/main/eo/string/padded-zeros.eo
+++ b/eo-runtime/src/main/eo/string/padded-zeros.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[width cant-pad] > padded-zeros
+[^ width cant-pad] > padded-zeros
   if. > @
     or.
       0.gt width
@@ -72,19 +72,19 @@
     "recovered"
     "7".padded-zeros
       -4
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-non-integer-width-when-padding-with-zeros
     "recovered"
     "7".padded-zeros
       3.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-width-when-padding-with-zeros
     "recovered"
     "7".padded-zeros
       pinf
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-return-a-longer-text-unchanged-when-padding-with-zeros
     "12345"

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -50,9 +50,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[args] > printf
+[^ args] > printf
   string > @
-    [index auto acc] >> walk
+    [^ index auto acc] >> walk
       if. > @
         gte.
           number cursor
@@ -77,14 +77,14 @@
         1
       index > cursor!
     | 0 0 --
-  slice. > [i] >> byte
+  slice. > [^ i] >> byte
     bytes raw
     i
     1
-  as-ascii. > [i] >> code
+  as-ascii. > [^ i] >> code
     string
       byte i
-  if. > [i] >> digits-end
+  if. > [^ i] >> digits-end
     i.gte
       number span
     i
@@ -98,7 +98,7 @@
         as-number.
           i.plus 1
       i
-  if. > [from to acc] >> digits-value
+  if. > [^ from to acc] >> digits-value
     from.gte to
     acc
     ^.digits-value
@@ -111,8 +111,8 @@
           minus.
             code from
             48
-  T message > [message] >> failure
-  if. > [i] >> flags-end
+  T message > [^ message] >> failure
+  if. > [^ i] >> flags-end
     i.gte
       number span
     i
@@ -131,7 +131,7 @@
   size. >> span!
     bytes
       format.as-bytes >> raw!
-  [index auto acc] >> spec
+  [^ index auto acc] >> spec
     if. > @
       gte.
         number end
@@ -174,7 +174,7 @@
       number end
     if. > converted!
       73-.eq conv
-      as-bytes. > [text] >> capped
+      as-bytes. > [^ text] >> capped
         ^.precise.as-bool.if
           truncated.
             string text
@@ -262,7 +262,7 @@
       auto
     number arg > numeric!
     if. > padded!
-      if. > [i c] >> flagged
+      if. > [^ i c] >> flagged
         i.gte
           number ^.digits
         false

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -23,18 +23,19 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > regex
+[^] > regex
   compile > @
   [] > compile /Q.string.regex.pattern
+    ? > ^
     ? > cant-compile /{Q.string}
   ^ > expression
-  [serialized] > pattern
+  [^ serialized] > pattern
     ^.pattern serialized > compiled
-    [txt] > match
-      [position start from to groups] > matched
+    [^ txt] > match
+      [^ position start from to groups] > matched
         groups.length > count
         start.gte 0 > exists
-        ^.groups.at index > [index] > group
+        ^.groups.at index > [^ index] > group
         $ > matched
         exists.if > next
           if.
@@ -56,15 +57,16 @@
           T
             "Matched block does not exist, can't get text"
       [] > matched-from-index /Q.string.regex.pattern.match.matched
+        ? > ^
         ? > position /Q.number
         ? > start /Q.number
-      [] > missing
+      [^] > missing
         T > count
           "Matched block does not exist, can't get count"
         start.gte 0 > exists
         T > from
           "Matched block does not exist, can't get 'from' position"
-        T > [index] > group
+        T > [^ index] > group
           "Matched block does not exist, can't get group"
         T > groups
           "Matched block does not exist, can't get groups"
@@ -78,7 +80,7 @@
           "Matched block does not exist, can't get 'to' position"
       matched. > next
         matched-from-index 1 0
-    [txt] > matches
+    [^ txt] > matches
       found.exists.and > @
         and.
           found.to.eq txt.length
@@ -97,8 +99,8 @@
         "/^\\/([\\s\\S]*)\\/([dimsux]*)$/".regex.compiled.match ^.^.expression
       "/(?:%s\\E)(?![\\s\\S])/%s".printf > quoted
         * group1 group2
-      ^.commented.regex.compile ^.retry-quoted > [message] > retry-commented
-      ^.quoted.regex.compile > [message] > retry-quoted
+      ^.commented.regex.compile ^.retry-quoted > [^ message] > retry-commented
+      ^.quoted.regex.compile > [^ message] > retry-quoted
 
   eq. ++> can-advance-after-a-zero-width-match
     1
@@ -179,12 +181,12 @@
   eq. ++> can-recover-from-a-pattern-with-a-missing-slash
     "no-slash"
     "(.)+".regex.compile
-      "no-slash" > [message]
+      "no-slash" > [^ message]
 
   eq. ++> can-recover-from-invalid-regex-syntax
     "recovered"
     "/[a-z/".regex.compile
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   ++> can-report-the-border-indexes-of-a-match
     and. > @

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[times cant-repeat] > repeated
+[^ times cant-repeat] > repeated
   if. > @
     or.
       0.gt times
@@ -20,7 +20,7 @@
       "Can't repeat text %f times".printf
         * times
     string
-      [n] >> rec-repeated
+      [^ n] >> rec-repeated
         if. > @
           0.eq n
           --
@@ -45,19 +45,19 @@
     "recovered"
     "x".repeated
       -1
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-non-integer-count
     "recovered"
     "x".repeated
       2.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-count
     "recovered"
     "x".repeated
       pinf
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-repeat-a-text-five-times
     "heyheyheyheyhey"

--- a/eo-runtime/src/main/eo/string/replaced.eo
+++ b/eo-runtime/src/main/eo/string/replaced.eo
@@ -10,10 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[target replacement] > replaced
+[^ target replacement] > replaced
   matched.exists.not.if > @
     string text! >> reinit
-    block.exists.if > [block accum start] >> rec-replaced
+    block.exists.if > [^ block accum start] >> rec-replaced
       ^.rec-replaced
         block.next
         concat.

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -25,15 +25,15 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[read] > scanf
+[^ read] > scanf
   ^ > format
-  [pattern specifiers] >>
-    [text] > as-float
+  [^ pattern specifiers] >>
+    [^ text] > as-float
       negative.if negated scaled > @
       mantissa.index-of "." > dot
       esign.index-of "e" > eloc
       unsigned.replaced "/[eE]/".regex "e" > esign
-      [txt] > exp-value
+      [^ txt] > exp-value
         if. > @
           eq.
             txt.slice 0 1
@@ -66,7 +66,7 @@
             eloc.plus 1
             esign.length.minus
               eloc.plus 1
-      if. > [value power] > lowered
+      if. > [^ value power] > lowered
         and.
           power.gt 300
           ^.scalable value
@@ -99,7 +99,7 @@
         "-"
       mantissa.length.minus > places
         dot.plus 1
-      if. > [value power] > raised
+      if. > [^ value power] > raised
         and.
           power.gt 300
           ^.scalable value
@@ -109,7 +109,7 @@
           power.minus 300
         value.times
           10.power power
-      and. > [value] > scalable
+      and. > [^ value] > scalable
         not.
           value.eq 0
         value.is-finite
@@ -131,7 +131,7 @@
           1
           text.length.minus 1
         text
-    [text] > as-integer
+    [^ text] > as-integer
       if. > @
         or.
           normalized.length.gt 19
@@ -145,8 +145,8 @@
           "The number doesn't fit into long range for the '%%d' conversion".printf
             *
         negative.if negated folded
-      [a b] > digits-lte
-        if. > [index] >> rec
+      [^ a b] > digits-lte
+        if. > [^ index] >> rec
           index.eq ^.a.length
           true
           if.
@@ -187,7 +187,7 @@
           text
         "/^0+/".regex
         ""
-    [group acc] >> convert
+    [^ group acc] >> convert
       ^.matched.exists.not.if > @
         *
         if.
@@ -205,15 +205,15 @@
     | > @
       1
       *
-    if. > [spec text] > converted
+    if. > [^ spec text] > converted
       spec.eq "s"
       text
       if.
         spec.eq "d"
         ^.as-integer text
         ^.as-float text
-    [text] > fold-digits
-      [index acc] >> rec
+    [^ text] > fold-digits
+      [^ index acc] >> rec
         if. > @
           index.eq ^.text.length
           acc
@@ -240,7 +240,7 @@
     tokens.at
       1
       T
-  if. > [ch] >> escaped
+  if. > [^ ch] >> escaped
     contains.
       *
         "\\"
@@ -262,7 +262,7 @@
     "\\".chained
       * ch
     ch
-  [position accumulated found pending] >> tokenize
+  [^ position accumulated found pending] >> tokenize
     if. > @
       position.gte ^.format.length
       pending.if *1

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -21,7 +21,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[start len] > slice
+[^ start len] > slice
   if. > @
     or.
       nstart.lt 0
@@ -50,7 +50,7 @@
           string
             text.as-bytes.slice bstart blen
   minus. > blen
-    [index accum result cause] >> recidx
+    [^ index accum result cause] >> recidx
       if. > @
         accum.eq result
         index
@@ -161,7 +161,7 @@
         *
           nstart.plus nlen
     bstart
-  if. > [index csize valid] > increase
+  if. > [^ index csize valid] > increase
     gt.
       index.plus csize
       size

--- a/eo-runtime/src/main/eo/string/split.eo
+++ b/eo-runtime/src/main/eo/string/split.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[delimiter cant-split] > split
+[^ delimiter cant-split] > split
   if. > @
     delimiter.size.eq 0
     cant-split
@@ -20,7 +20,7 @@
           text >> bts!
         0
       * ""
-      [accum start current] >> rec-split
+      [^ accum start current] >> rec-split
         if. > @
           len.eq current
           appended
@@ -62,7 +62,7 @@
     "recovered"
     "abc".split
       ""
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-split-a-text-into-empty-strings
     "-a-b-".split "-"

--- a/eo-runtime/src/main/eo/string/starts-with.eo
+++ b/eo-runtime/src/main/eo/string/starts-with.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[substring] > starts-with
+[^ substring] > starts-with
   and. > @
     lte.
       number

--- a/eo-runtime/src/main/eo/string/trimmed-left.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-left.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > trimmed-left
+[^] > trimmed-left
   if. > @
     0.eq
       b.size >> len!
@@ -23,7 +23,7 @@
         minus.
           number len
           idx
-  [index] >> first-non-ws-index
+  [^ index] >> first-non-ws-index
     if. > @
       len.eq index
       index
@@ -31,7 +31,7 @@
         is-ws (b.slice index 1)!
         ^.first-non-ws-index (index.plus 1).as-number
         index
-  or. > [c] >> is-ws
+  or. > [^ c] >> is-ws
     c.eq 20-
     or.
       c.eq 09-

--- a/eo-runtime/src/main/eo/string/trimmed-right.eo
+++ b/eo-runtime/src/main/eo/string/trimmed-right.eo
@@ -11,7 +11,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > trimmed-right
+[^] > trimmed-right
   if. > @
     0.eq
       b.size >> len!
@@ -20,7 +20,7 @@
       slice.
         text >> b!
         0
-        [index] >> first-non-ws-index
+        [^ index] >> first-non-ws-index
           if. > @
             -1.eq index
             0
@@ -29,7 +29,7 @@
               ^.first-non-ws-index (index.plus -1).as-number
               index.plus 1
         | ((number len).plus -1)
-  or. > [c] >> is-ws
+  or. > [^ c] >> is-ws
     c.eq 20-
     or.
       c.eq 09-

--- a/eo-runtime/src/main/eo/string/trimmed.eo
+++ b/eo-runtime/src/main/eo/string/trimmed.eo
@@ -12,7 +12,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > trimmed
+[^] > trimmed
   if. > @
     0.eq text.as-bytes.size
     text

--- a/eo-runtime/src/main/eo/string/truncated.eo
+++ b/eo-runtime/src/main/eo/string/truncated.eo
@@ -14,7 +14,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[limit cant-truncate] > truncated
+[^ limit cant-truncate] > truncated
   if. > @
     or.
       0.gt limit
@@ -42,19 +42,19 @@
     "recovered"
     "Jeff".truncated
       -3
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-a-non-integer-limit
     "recovered"
     "Jeff".truncated
       1.75
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-infinite-limit-when-truncating
     "recovered"
     "Jeff".truncated
       pinf
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-return-a-shorter-text-unchanged
     "hi"

--- a/eo-runtime/src/main/eo/string/turkish.eo
+++ b/eo-runtime/src/main/eo/string/turkish.eo
@@ -19,16 +19,16 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > turkish
+[^] > turkish
   s > @
-  lower. > [] > lower
+  lower. > [^] > lower
     english.
       replaced.
         ^.s.replaced "/I/".regex "ı"
         "/İ/".regex
         "i"
   ^ > s
-  upper. > [] > upper
+  upper. > [^] > upper
     english.
       replaced.
         ^.s.replaced "/i/".regex "İ"

--- a/eo-runtime/src/main/eo/string/upper.eo
+++ b/eo-runtime/src/main/eo/string/upper.eo
@@ -13,7 +13,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > upper
+[^] > upper
   text.english.upper > @
   ^ > text
 

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -24,7 +24,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cases fallback] > switch
+[^ cases fallback] > switch
   if. > @
     cases.length.eq 0
     fallback
@@ -33,13 +33,13 @@
       true.eq
         match.
           @. >> found
-            [tup] >> rec-case
+            [^ tup] >> rec-case
               if. > @
                 and.
                   tup.length.gt 1
                   previous.match
                 previous
-                [] >>
+                [^] >>
                   ^.tup.head.head > head
                   ^.tup.head.tail.head > match!
               @. > previous
@@ -53,19 +53,19 @@
     "recovered"
     switch
       *
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   ++> can-switch-on-a-complex-case
     eq. > @
       switch *
         *
-          ^.c1 > [] >>
+          ^.c1 > [^] >>
           22
         *
-          ^.c2 > [] >>
+          ^.c2 > [^] >>
           0
         *
-          ^.c3 > [] >>
+          ^.c3 > [^] >>
           "true case"
       "true case"
     false > c1
@@ -84,7 +84,7 @@
       *
         * false "false1"
         * false "false2"
-      "fallback" > [message]
+      "fallback" > [^ message]
 
   ++> can-switch-on-strings
     eq. > @

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -9,7 +9,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 bool > true
-  []
+  [^]
     ? >> left
     ? >> right
     left > @

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -7,8 +7,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[tail head length] > tuple
-  [i fallback] > at
+[^ tail head length] > tuple
+  [^ i fallback] > at
     if. > @
       or.
         0.gt
@@ -20,7 +20,7 @@
         ^.length.lte index
       fallback
         "Given index is out of tuple bounds"
-      if. > [tup] >> at-fast
+      if. > [^ tup] >> at-fast
         0.eq tup.length
         ^.fallback
           "Given index is out of tuple bounds"
@@ -37,17 +37,17 @@
     T
       "Can't get head from the empty tuple"
     0
-  [other] > eq
+  [^ other] > eq
     and. > @
       ^.length.eq other.length
-      if. > [first second] >> receq
+      if. > [^ first second] >> receq
         first.length.eq 0
         true
         and.
           first.head.eq second.head
           ^.receq first.tail second.tail
       | ^ other
-  tuple > [x] > with
+  tuple > [^ x] > with
     ^
     x
     as-number.
@@ -211,7 +211,7 @@
         "one"
         "two"
       1.5
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-recover-from-an-out-of-bounds-index
     "recovered"
@@ -222,7 +222,7 @@
         3
         4
       20
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   ++> can-report-the-length-of-a-non-empty-tuple
     eq. > @
@@ -235,7 +235,7 @@
             "d"
             "e"
       5
-    [elements] > array
+    [^ elements] > array
 
   ++> can-report-the-length-of-an-empty-tuple
     eq. > @
@@ -244,7 +244,7 @@
           array
             *
       0
-    [elements] > array
+    [^ elements] > array
 
   ++> can-take-the-first-item-by-a-negative-index
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/back.eo
+++ b/eo-runtime/src/main/eo/tuple/back.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[index] > back
+[^ index] > back
   index.is-integer.if > @
     if.
       0.gt
@@ -16,7 +16,7 @@
       list
       list.reducedi
         *
-        if. > [accum item idx] >>
+        if. > [^ accum item idx] >>
           idx.gte start
           accum.with item
           accum

--- a/eo-runtime/src/main/eo/tuple/concat.eo
+++ b/eo-runtime/src/main/eo/tuple/concat.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[passed] > concat
+[^ passed] > concat
   passed.reducedi > @
     ^
-    accum.with item > [accum item index]
+    accum.with item > [^ accum item index]
 
   ++> can-concat-two-lists
     and. > @

--- a/eo-runtime/src/main/eo/tuple/contains.eo
+++ b/eo-runtime/src/main/eo/tuple/contains.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[element] > contains
+[^ element] > contains
   not. > @
     -1.eq
       ^.index-of element

--- a/eo-runtime/src/main/eo/tuple/each.eo
+++ b/eo-runtime/src/main/eo/tuple/each.eo
@@ -9,18 +9,18 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[func] > each
+[^ func] > each
   ^.eachi > @
-    ^.func item > [item index] >>
+    ^.func item > [^ item index] >>
 
   ++> can-iterate-over-a-list
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           each. > @
             * 1 2 3
-            ^.m.put > [i] >>
+            ^.m.put > [^ i] >>
               ^.m.as-number.plus i
       6
 
@@ -37,10 +37,10 @@
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           each. > @
             * 10 20 30
-            ^.m.put > [i] >>
+            ^.m.put > [^ i] >>
               ^.m.as-number.plus i
       60
 
@@ -48,12 +48,12 @@
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           each. > @
             * 7
-            ^.m.put > [i] >>
+            ^.m.put > [^ i] >>
               ^.m.as-number.plus i
       7
 
   tuple.empty.each ++> can-walk-an-empty-list
-    false > [x]
+    false > [^ x]

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -11,10 +11,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[func] > eachi
+[^ func] > eachi
   ^.reducedi > @
     true
-    seq * > [acc item index] >>
+    seq * > [^ acc item index] >>
       acc
       ^.func item index
 
@@ -22,10 +22,10 @@
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           eachi. > @
             * 1 2 3
-            ^.m.put > [item index] >>
+            ^.m.put > [^ item index] >>
               plus.
                 ^.m.as-number.plus item
                 index

--- a/eo-runtime/src/main/eo/tuple/filtered.eo
+++ b/eo-runtime/src/main/eo/tuple/filtered.eo
@@ -11,9 +11,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[func] > filtered
+[^ func] > filtered
   ^.filteredi > @
-    ^.func item > [item index] >>
+    ^.func item > [^ item index] >>
 
   eq. ++> can-filter-a-list
     filtered.
@@ -23,7 +23,7 @@
         4
         2
         5
-      v.gt 2 > [v]
+      v.gt 2 > [^ v]
     *
       3
       4
@@ -35,5 +35,5 @@
         true
         false
         true
-      v.not > [v]
+      v.not > [^ v]
     * false

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -12,8 +12,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[func] > filteredi
-  [tup] >> recfilter
+[^ func] > filteredi
+  [^ tup] >> recfilter
     if. > @
       tup.length.eq 0
       *
@@ -32,7 +32,7 @@
         4
         2
         5
-      v.lt 3 > [v i]
+      v.lt 3 > [^ v i]
     *
       1
       2
@@ -44,12 +44,12 @@
         "Name"
         "EO"
         "List"
-      v.length.gt 4 > [v i]
+      v.length.gt 4 > [^ v i]
     * "Hello"
 
   is-empty. ++> can-filter-an-empty-list
     tuple.empty.filteredi
-      v.lt 3 > [v i]
+      v.lt 3 > [^ v i]
 
   eq. ++> can-filter-by-index
     filteredi.
@@ -57,7 +57,7 @@
         3
         1
         4
-      i.gt 0 > [v i]
+      i.gt 0 > [^ v i]
     *
       1
       4
@@ -68,5 +68,5 @@
         true
         false
         true
-      v.not > [v i]
+      v.not > [^ v i]
     * false

--- a/eo-runtime/src/main/eo/tuple/front.eo
+++ b/eo-runtime/src/main/eo/tuple/front.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[index] > front
+[^ index] > front
   index.is-integer.if > @
     if.
       idx.eq 0
@@ -21,7 +21,7 @@
             number idx
             list.length
           list
-          if. > [tup] >> rechead
+          if. > [^ tup] >> rechead
             tup.length.eq idx
             tup
             ^.rechead tup.tail

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -8,9 +8,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[wanted] > index-of
+[^ wanted] > index-of
   number > @
-    [tup] >> recidx
+    [^ tup] >> recidx
       if. > @
         tup.length.eq 0
         -1

--- a/eo-runtime/src/main/eo/tuple/is-empty.eo
+++ b/eo-runtime/src/main/eo/tuple/is-empty.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[] > is-empty
+[^] > is-empty
   0.eq ^.length > @
 
   tuple.empty.is-empty ++> can-be-empty-when-built-empty
@@ -15,7 +15,7 @@
   ++> can-tell-it-is-not-empty-with-one-anonymous-object
     xs.is-empty.not > @
     * > xs
-      [f]
+      [^ f]
 
   not. ++> can-tell-it-is-not-empty-with-one-item
     is-empty.
@@ -24,6 +24,6 @@
   ++> can-tell-it-is-not-empty-with-three-objects
     xs.is-empty.not > @
     * > xs
-      [x]
-      [y]
-      [z]
+      [^ x]
+      [^ y]
+      [^ z]

--- a/eo-runtime/src/main/eo/tuple/last-index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/last-index-of.eo
@@ -8,8 +8,8 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[wanted] > last-index-of
-  if. > [t] >> rec
+[^ wanted] > last-index-of
+  if. > [^ t] >> rec
     t.length.eq 0
     -1
     if.

--- a/eo-runtime/src/main/eo/tuple/mapped.eo
+++ b/eo-runtime/src/main/eo/tuple/mapped.eo
@@ -9,9 +9,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[func] > mapped
+[^ func] > mapped
   ^.mappedi > @
-    ^.func item > [item idx] >>
+    ^.func item > [^ item idx] >>
 
   eq. ++> can-map-a-list
     mapped.
@@ -19,7 +19,7 @@
         1
         2
         3
-      x.times 2 > [x]
+      x.times 2 > [^ x]
     *
       2
       4

--- a/eo-runtime/src/main/eo/tuple/mappedi.eo
+++ b/eo-runtime/src/main/eo/tuple/mappedi.eo
@@ -10,10 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[func] > mappedi
+[^ func] > mappedi
   ^.reducedi > @
     *
-    accum.with > [accum item idx] >>
+    accum.with > [^ accum item idx] >>
       ^.func item idx
 
   eq. ++> can-map-a-list-with-indexes
@@ -23,7 +23,7 @@
         2
         3
         4
-      i.times x > [x i]
+      i.times x > [^ x i]
     *
       0
       2

--- a/eo-runtime/src/main/eo/tuple/maximum.eo
+++ b/eo-runtime/src/main/eo/tuple/maximum.eo
@@ -9,13 +9,13 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-max] > maximum
+[^ cant-max] > maximum
   sequence.is-empty.if > @
     cant-max
       "cannot get the maximum number from an empty sequence"
     sequence.reduced
       ninf
-      if. > [max item]
+      if. > [^ max item]
         item.as-number.is-nan.or
           item.as-number.gt max
         item
@@ -36,7 +36,7 @@
   eq. ++> can-recover-from-an-empty-list-when-taking-the-maximum
     "recovered"
     tuple.empty.maximum
-      "recovered" > [msg]
+      "recovered" > [^ msg]
 
   eq. ++> can-take-a-maximum-of-one-item
     maximum.

--- a/eo-runtime/src/main/eo/tuple/minimum.eo
+++ b/eo-runtime/src/main/eo/tuple/minimum.eo
@@ -9,13 +9,13 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[cant-min] > minimum
+[^ cant-min] > minimum
   sequence.is-empty.if > @
     cant-min
       "cannot get the minimum number from an empty sequence"
     sequence.reduced
       pinf
-      if. > [min item]
+      if. > [^ min item]
         item.as-number.is-nan.or
           min.gt item.as-number
         item
@@ -36,7 +36,7 @@
   eq. ++> can-recover-from-an-empty-list-when-taking-the-minimum
     "recovered"
     tuple.empty.minimum
-      "recovered" > [msg]
+      "recovered" > [^ msg]
 
   eq. ++> can-take-a-minimum-of-one-item
     minimum.

--- a/eo-runtime/src/main/eo/tuple/reduced.eo
+++ b/eo-runtime/src/main/eo/tuple/reduced.eo
@@ -10,10 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[start func] > reduced
+[^ start func] > reduced
   ^.reducedi > @
     start
-    ^.func > [accum item index] >>
+    ^.func > [^ accum item index] >>
       accum
       item
 
@@ -25,14 +25,14 @@
         3
         4
       -1
-      a.times x > [a x]
+      a.times x > [^ a x]
     -24
 
   eq. ++> can-reduce-a-list-into-a-string
     reduced.
       * 0 1
       ""
-      acc.concat > [acc item]
+      acc.concat > [^ acc item]
         "%d".printf
           * item
     "01"

--- a/eo-runtime/src/main/eo/tuple/reducedi.eo
+++ b/eo-runtime/src/main/eo/tuple/reducedi.eo
@@ -10,10 +10,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[start func] > reducedi
+[^ start func] > reducedi
   list.is-empty.if > @
     start
-    if. > [tup] >> rec-reducedi
+    if. > [^ tup] >> rec-reducedi
       tup.length.eq 1
       ^.func
         ^.start
@@ -31,7 +31,7 @@
     reducedi.
       * 1 1
       0
-      x.plus > [a x i]
+      x.plus > [^ a x i]
         a.plus
           at.
             * 2 2
@@ -86,7 +86,7 @@
         0
         1
       0
-      x.plus a > [a x i]
+      x.plus a > [^ a x i]
     1
 
   not. ++> can-reduce-bools-with-indexes
@@ -96,16 +96,16 @@
         true
         false
       true
-      x.and a > [a x i]
+      x.and a > [^ a x i]
 
   ++> can-reduce-with-nested-functions
     eq. > @
       reducedi.
         * 10 500
         0
-        [acc x i]
+        [^ acc x i]
           check x > @
-          if. > [el] > check
+          if. > [^ el] > check
             ^.x.lt 100
             ^.acc.plus ^.x
             ^.acc.minus ^.x

--- a/eo-runtime/src/main/eo/tuple/shifted.eo
+++ b/eo-runtime/src/main/eo/tuple/shifted.eo
@@ -7,7 +7,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[shift] > shifted
+[^ shift] > shifted
   shift.is-integer.if > @
     list.slice
       if.

--- a/eo-runtime/src/main/eo/tuple/slice.eo
+++ b/eo-runtime/src/main/eo/tuple/slice.eo
@@ -8,7 +8,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[start end] > slice
+[^ start end] > slice
   if. > @
     start.is-integer.and end.is-integer
     if.
@@ -37,7 +37,7 @@
       *
       list.reducedi
         *
-        if. > [accum item index] >>
+        if. > [^ accum item index] >>
           and.
             index.gte s
             index.lt e

--- a/eo-runtime/src/main/eo/tuple/withi.eo
+++ b/eo-runtime/src/main/eo/tuple/withi.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[index item] > withi
+[^ index item] > withi
   index.is-integer.if > @
     concat.
       with.

--- a/eo-runtime/src/main/eo/tuple/without.eo
+++ b/eo-runtime/src/main/eo/tuple/without.eo
@@ -7,10 +7,10 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[element] > without
+[^ element] > without
   ^.reduced > @
     *
-    if. > [accum item] >>
+    if. > [^ accum item] >>
       ^.element.eq item
       accum
       accum.with item

--- a/eo-runtime/src/main/eo/tuple/withouti.eo
+++ b/eo-runtime/src/main/eo/tuple/withouti.eo
@@ -7,11 +7,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[i] > withouti
+[^ i] > withouti
   i.is-integer.if > @
     ^.reducedi
       *
-      if. > [accum item index] >>
+      if. > [^ accum item index] >>
         ^.i.eq index
         accum
         accum.with item
@@ -36,7 +36,7 @@
         "text"
         "f"
       * "text" "f"
-    a.withouti 0 > [a] > foo
+    a.withouti 0 > [^ a] > foo
 
   eq. ++> can-drop-an-item-by-index-in-a-nested-list
     withouti.

--- a/eo-runtime/src/main/eo/u16.eo
+++ b/eo-runtime/src/main/eo/u16.eo
@@ -8,12 +8,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > u16
+[^ as-bytes] > u16
   as-bytes > @
-  i32 > [] > as-i32
+  i32 > [^] > as-i32
     00-00.concat ^.as-bytes
   as-i32.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-u16 >> other
@@ -27,23 +27,23 @@
             ^.as-i32.div other.as-i32
           2
           2
-  ^.as-i32.gt x.as-u16.as-i32 > [x] > gt
-  ^.as-i32.gte x.as-u16.as-i32 > [x] > gte
-  ^.as-i32.lt x.as-u16.as-i32 > [x] > lt
-  ^.as-i32.lte x.as-u16.as-i32 > [x] > lte
-  u16 > [x] > minus
+  ^.as-i32.gt x.as-u16.as-i32 > [^ x] > gt
+  ^.as-i32.gte x.as-u16.as-i32 > [^ x] > gte
+  ^.as-i32.lt x.as-u16.as-i32 > [^ x] > lt
+  ^.as-i32.lte x.as-u16.as-i32 > [^ x] > lte
+  u16 > [^ x] > minus
     slice.
       as-bytes.
         ^.as-i32.minus x.as-u16.as-i32
       2
       2
-  u16 > [x] > plus
+  u16 > [^ x] > plus
     slice.
       as-bytes.
         ^.as-i32.plus x.as-u16.as-i32
       2
       2
-  u16 > [x] > times
+  u16 > [^ x] > times
     slice.
       as-bytes.
         ^.as-i32.times x.as-u16.as-i32
@@ -88,7 +88,7 @@
     "recovered"
     00-02.as-u16.div
       00-00.as-u16
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-subtract
     00-05.as-u16.minus 00-03.as-u16

--- a/eo-runtime/src/main/eo/u32.eo
+++ b/eo-runtime/src/main/eo/u32.eo
@@ -8,12 +8,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > u32
+[^ as-bytes] > u32
   as-bytes > @
-  i64 > [] > as-i64
+  i64 > [^] > as-i64
     00-00-00-00.concat ^.as-bytes
   as-i64.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-u32 >> other
@@ -27,23 +27,23 @@
             ^.as-i64.div other.as-i64
           4
           4
-  ^.as-i64.gt x.as-u32.as-i64 > [x] > gt
-  ^.as-i64.gte x.as-u32.as-i64 > [x] > gte
-  ^.as-i64.lt x.as-u32.as-i64 > [x] > lt
-  ^.as-i64.lte x.as-u32.as-i64 > [x] > lte
-  u32 > [x] > minus
+  ^.as-i64.gt x.as-u32.as-i64 > [^ x] > gt
+  ^.as-i64.gte x.as-u32.as-i64 > [^ x] > gte
+  ^.as-i64.lt x.as-u32.as-i64 > [^ x] > lt
+  ^.as-i64.lte x.as-u32.as-i64 > [^ x] > lte
+  u32 > [^ x] > minus
     slice.
       as-bytes.
         ^.as-i64.minus x.as-u32.as-i64
       4
       4
-  u32 > [x] > plus
+  u32 > [^ x] > plus
     slice.
       as-bytes.
         ^.as-i64.plus x.as-u32.as-i64
       4
       4
-  u32 > [x] > times
+  u32 > [^ x] > times
     slice.
       as-bytes.
         ^.as-i64.times x.as-u32.as-i64
@@ -94,7 +94,7 @@
     "recovered"
     00-00-00-02.as-u32.div
       00-00-00-00.as-u32
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-subtract
     00-00-00-05.as-u32.minus 00-00-00-03.as-u32

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -10,9 +10,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > u64
+[^ as-bytes] > u64
   as-bytes > @
-  plus. > [] > as-number
+  plus. > [^] > as-number
     as-number.
       i64 ^.as-bytes
     if.
@@ -22,31 +22,31 @@
       1.8446744073709552e19
       0
   as-bytes.xor 80-00-00-00-00-00-00-00 > flip
-  gt. > [x] > gt
+  gt. > [^ x] > gt
     i64 ^.flip
     i64 x.as-u64.flip
-  gte. > [x] > gte
+  gte. > [^ x] > gte
     i64 ^.flip
     i64 x.as-u64.flip
-  lt. > [x] > lt
+  lt. > [^ x] > lt
     i64 ^.flip
     i64 x.as-u64.flip
-  lte. > [x] > lte
+  lte. > [^ x] > lte
     i64 ^.flip
     i64 x.as-u64.flip
-  [x] > minus
+  [^ x] > minus
     u64 > @
       as-bytes.
         minus. >>
           i64 ^.as-bytes
           i64 x.as-u64.as-bytes
-  [x] > plus
+  [^ x] > plus
     u64 > @
       as-bytes.
         plus. >>
           i64 ^.as-bytes
           i64 x.as-u64.as-bytes
-  [x] > times
+  [^ x] > times
     u64 > @
       as-bytes.
         times. >>

--- a/eo-runtime/src/main/eo/u64/div.eo
+++ b/eo-runtime/src/main/eo/u64/div.eo
@@ -10,7 +10,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[x cant-divide] > div
+[^ x cant-divide] > div
   if. > @
     d.as-bytes.eq 00-00-00-00-00-00-00-00
     cant-divide
@@ -69,7 +69,7 @@
     "recovered"
     00-00-00-00-00-00-00-02.as-u64.div
       00-00-00-00-00-00-00-00.as-u64
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   div. --> stops-on-division-by-zero
     00-00-00-00-00-00-00-02.as-u64

--- a/eo-runtime/src/main/eo/u8.eo
+++ b/eo-runtime/src/main/eo/u8.eo
@@ -8,12 +8,12 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > u8
+[^ as-bytes] > u8
   as-bytes > @
-  i16 > [] > as-i16
+  i16 > [^] > as-i16
     00-.concat ^.as-bytes
   as-i16.as-number > as-number
-  [x cant-divide] > div
+  [^ x cant-divide] > div
     if. > @
       eq.
         x.as-u8 >> other
@@ -27,23 +27,23 @@
             ^.as-i16.div other.as-i16
           1
           1
-  ^.as-i16.gt x.as-u8.as-i16 > [x] > gt
-  ^.as-i16.gte x.as-u8.as-i16 > [x] > gte
-  ^.as-i16.lt x.as-u8.as-i16 > [x] > lt
-  ^.as-i16.lte x.as-u8.as-i16 > [x] > lte
-  u8 > [x] > minus
+  ^.as-i16.gt x.as-u8.as-i16 > [^ x] > gt
+  ^.as-i16.gte x.as-u8.as-i16 > [^ x] > gte
+  ^.as-i16.lt x.as-u8.as-i16 > [^ x] > lt
+  ^.as-i16.lte x.as-u8.as-i16 > [^ x] > lte
+  u8 > [^ x] > minus
     slice.
       as-bytes.
         ^.as-i16.minus x.as-u8.as-i16
       1
       1
-  u8 > [x] > plus
+  u8 > [^ x] > plus
     slice.
       as-bytes.
         ^.as-i16.plus x.as-u8.as-i16
       1
       1
-  u8 > [x] > times
+  u8 > [^ x] > times
     slice.
       as-bytes.
         ^.as-i16.times x.as-u8.as-i16
@@ -92,7 +92,7 @@
     "recovered"
     02-.as-u8.div
       00-.as-u8
-      "recovered" > [message]
+      "recovered" > [^ message]
 
   eq. ++> can-subtract
     05-.as-u8.minus 03-.as-u8

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -23,7 +23,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[text] > uri
+[^ text] > uri
   text > @
   string > authority
     has-authority.if >> authority-bytes!

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -2,7 +2,7 @@
 # Here's how you can use it:
 # ```
 # while > last
-#   i.lt 5 > [i]
+#   i.lt 5 > [^ i]
 #   [i]
 #     "Iteration %d\n".printf > @
 #       * i
@@ -29,11 +29,11 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[condition body] > while
+[^ condition body] > while
   if. > @
     as-bool.
       condition 0
-    [index] >> loop
+    [^ index] >> loop
       if. > @
         as-bool.
           ^.condition
@@ -51,10 +51,10 @@
     0.eq > @
       malloc.for
         42
-        [m]
+        [^ m]
           while > @
-            i.eq 0 > [i]
-            ^.m.put i > [i] >>
+            i.eq 0 > [^ i]
+            ^.m.put i > [^ i] >>
 
   ++> can-iterate-a-tuple-with-an-external-iterator
     data.eq array.length > @
@@ -65,13 +65,13 @@
       1
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             while > @
-              ^.^.^.max.gt ^.iter > [i] >>
-              seq * > [i] >>
+              ^.^.^.max.gt ^.iter > [^ i] >>
+              seq * > [^ i] >>
                 ^.^.acc.put
                   ^.^.acc.as-number.plus
                     ^.^.^.array.at ^.iter
@@ -88,18 +88,18 @@
       1
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             if. > @
               ^.^.max.eq 0
               ^.acc.put
                 ^.acc.as-number.plus
                   ^.^.array.at 0
               while
-                ^.^.^.max.gt ^.iter > [i] >>
-                seq * > [i] >>
+                ^.^.^.max.gt ^.iter > [^ i] >>
+                seq * > [^ i] >>
                   ^.^.acc.put
                     ^.^.acc.as-number.plus (^.^.^.array.at i)
                   ^.iter.put
@@ -114,13 +114,13 @@
       1
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             seq * > @
               while
-                if. > [i] >>
+                if. > [^ i] >>
                   ^.^.^.max.gt ^.iter
                   seq *
                     ^.^.acc.put
@@ -128,7 +128,7 @@
                     ^.iter.put (^.iter.as-number.plus 1)
                     true
                   false
-                true > [i]
+                true > [^ i]
               ^.acc
     array.length > max
 
@@ -137,13 +137,13 @@
     * 1 > array
     malloc.for > data
       0
-      [acc] >>
+      [^ acc] >>
         malloc.for > @
           0
-          [iter] >>
+          [^ iter] >>
             seq * > @
               while
-                if. > [i] >>
+                if. > [^ i] >>
                   ^.^.^.max.gt ^.iter
                   seq *
                     ^.^.acc.put
@@ -151,7 +151,7 @@
                     ^.iter.put (^.iter.as-number.plus 1)
                     true
                   false
-                true > [i]
+                true > [^ i]
               ^.acc
     array.length > max
 
@@ -159,39 +159,39 @@
     eq. > @
       malloc.for
         true
-        [m]
+        [^ m]
           while > @
-            ^.m > [i] >>
-            ^.m.put false > [i] >>
+            ^.m > [^ i] >>
+            ^.m.put false > [^ i] >>
       false
 
   ++> can-loop-over-a-simple-iteration
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           while > @
-            i.lt 10 > [i]
-            ^.m.put i > [i] >>
+            i.lt 10 > [^ i]
+            ^.m.put i > [^ i] >>
       9
 
   not. ++> can-loop-when-the-condition-is-false-first
     while
-      false > [i]
-      true > [i]
+      false > [^ i]
+      true > [^ i]
 
   ++> can-return-the-last-dataized-object
     eq. > @
       malloc.for
         0
-        [m]
+        [^ m]
           while > @
-            2.gt ^.m > [i] >>
-            ^.m.put > [i] >>
+            2.gt ^.m > [^ i] >>
+            ^.m.put > [^ i] >>
               ^.m.as-number.plus 1
       3
 
   not. ++> can-return-the-last-dataized-object-with-a-false-condition
     while
-      1.gt 2 > [i]
-      true > [i]
+      1.gt 2 > [^ i]
+      true > [^ i]

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -16,8 +16,9 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[name args] > win32
+[^ name args] > win32
   [] > @ /Q.win32.return
+    ? > ^
   8 > append
   256 > creat
   17 > eexist
@@ -30,25 +31,25 @@
   32768 > rdonly
   32770 > rdwr
   00-00-00-00-00-00-04-00 > reparse
-  [code output] > return
+  [^ code output] > return
     output > @
     ^.return > called
       code
       output
-  [family port address] > sockaddr-in
+  [^ family port address] > sockaddr-in
     00-00-00-00-00-00-00-00 > padding
     plus. > size
       plus.
         family.size.plus port.size
         address.size
       padding.size
-  [mode size] > stat64
+  [^ mode size] > stat64
   2 > stderr
   0 > stdin
   1 > stdout
   1 > stream
   6 > tcp
-  [time millitm] > timeb
+  [^ time millitm] > timeb
   512 > trunc
   02-02 > version
   32769 > wronly


### PR DESCRIPTION
A member like `number.eq` reads its receiver through `^`, but nothing in its head said so. The receiver arrived through a side channel — every attribute wrapped in `AtWithRho` at load time, each read of a ρ-less value copying the object just to stamp ρ on it. This declares `^` as a void on every formation in `eo-runtime`, so the receiver becomes an ordinary attribute that dispatch fills.

Bracket heads take the glyph directly. The twenty-five atoms declare it vertically, since an atom must write its voids one per line:

```
[] > div /Q.number
  ? > ^
  ? > x /Q.number
```

Putting `^` first cannot disturb positional filling: `PhDefault.SORTABLE` is `^([a-z].*)|φ$`, and Greek `ρ` is not ASCII `[a-z]`, so ρ never enters `order`.

The eighty-five `^ > name` aliases are gone. Once ρ is a declared void such a binding is a literal rename, which `anemic-getter` rejects, so each is inlined to `^` — or to `^.^` where an inner formation reached it through the enclosing one.

Two knock-on effects deserve a look, both from lints that do not treat ρ as special:

A declared ρ makes a formation look self-contained to `outer-refs`, so sixteen `>>` auto-names stopped being referenced and `redundant-attachment` flagged them. Dropping the suffix satisfies it, but the formatter then rewrites those call sites into vertical-argument form, which is most of the churn in `while.eo`.

`string.regex`'s `matched` would reach six voids against `many-void-attributes`' cap of five, so it keeps its implicit receiver. That one formation is the single exception to "every formation" here.

`AtRho` seeding in `PhDefault.defaults()` stays for now, so this change is behaviour-preserving on its own; removing it is the next step.