### PR TITLE
#7451: only collapse a test attribute's doubled marker for an abstract head

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -470,11 +470,15 @@
           <xsl:variable name="marker" select="substring(@name, 1, 1)"/>
           <xsl:choose>
             <!--
-            No void params: collapse the empty `[]` head into the
-            single doubled-marker head-of-line shorthand (the head
-            template emits nothing in this case).
+            An abstract formation with no void params: collapse its
+            empty `[]` head into the single doubled-marker head-of-line
+            shorthand (the head template emits nothing in this case).
+            A non-abstract object (a plain reference or application,
+            "true +&gt; works") has a rendered head of its own, so the
+            doubled marker would glue onto it instead (#7451); that
+            case falls through to the single-marker branch below.
             -->
-            <xsl:when test="empty(o[eo:void(.)])">
+            <xsl:when test="eo:abstract(.) and empty(o[eo:void(.)])">
               <xsl:value-of select="$marker"/>
               <xsl:value-of select="$marker"/>
               <xsl:text>&gt; </xsl:text>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute-marker-keeps-space-before-non-abstract-head.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/test-attribute-marker-keeps-space-before-non-abstract-head.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A "+>" test attribute on a plain reference ("true +> works", XMIR
+# <o base="Phi.true" name="+works"/>) must keep the single-marker, spaced
+# " +> " form. The TAIL template's doubled-marker head-of-line shorthand
+# ("++> works", used to collapse an EMPTY anonymous formation's own bracket
+# head, "[] +> works") was firing here too, since it only checked for the
+# absence of void children and not for the object actually being such a
+# formation - the doubled marker then glued straight onto "true"'s own
+# rendered head instead of standing in for the (nonexistent) bracket (#7451).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > foo
+
+    true +> works


### PR DESCRIPTION
Closes #7451

A `+>` test attribute on a plain reference (`true +> works`, XMIR
`<o base="Φ.true" name="+works"/>`) printed as `true++> works`: the TAIL
template's doubled-marker head-of-line shorthand, meant to collapse an empty
anonymous formation's own bracket head (`[] +> works` -> `++> works`), only
checked for the absence of void children. A plain object also has no void
children, so the same branch fired for it and glued the doubled marker onto
its own rendered head instead of standing in for a bracket that was never
there.

Added `eo:abstract(.)` to the branch's condition, so the doubled-marker
shorthand only applies to an actual formation; a non-abstract object now
falls through to the existing single-marker, spaced `+> ` branch.

Added `print-packs/yaml/test-attribute-marker-keeps-space-before-non-abstract-head.yaml`
reproducing the issue's example. Confirmed it fails (prints `true++> works`,
does not reparse) with the fix reverted, and passes with it applied.
