### PR TITLE
Give back the answer, not only its depth

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answer.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answer.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+/**
+ * What one object of the program turns out to be.
+ *
+ * <p>Two things are worth knowing about an object and they are worked out
+ * together, from the same walk of the same tables: which object it settled on,
+ * and how much that settling is worth. The first is the answer a reader wants
+ * — {@code Φ.number} is a place they can go and look at — and the second is
+ * the rung it stands on, which is all a count of the whole program needs.</p>
+ *
+ * <p>They are kept in one object so they cannot drift apart. A page that
+ * colours an object green while the printed number counts it among the ones
+ * we know nothing about is worse than either alone, and the only way to be
+ * sure that cannot happen is for both to read the same answer.</p>
+ *
+ * @since 0.70.0
+ */
+final class Answer {
+
+    /**
+     * The object this one settled on.
+     */
+    private final String settled;
+
+    /**
+     * The rung it stands on.
+     */
+    private final int climbed;
+
+    /**
+     * Ctor.
+     * @param where The object this one settled on, which is the object itself
+     *  when the walk went nowhere
+     * @param rung The rung it stands on, from nothing at all up to nothing
+     *  left to find out
+     */
+    Answer(final String where, final int rung) {
+        this.settled = where;
+        this.climbed = rung;
+    }
+
+    /**
+     * The object this one settled on.
+     * @return The locator
+     */
+    String where() {
+        return this.settled;
+    }
+
+    /**
+     * The rung it stands on.
+     * @return The rung, from nothing at all up to nothing left to find out
+     */
+    int rung() {
+        return this.climbed;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -30,9 +30,14 @@ import java.util.Map;
  * about {@code 01-} is asking nothing; an object that never comes back with a
  * value has nothing further to say either.</p>
  *
+ * <p>Where the walk stopped is given back along with the rung, in one
+ * {@link Answer}, because that locator is the answer a reader wants and it was
+ * already worked out on the way to the rung. Whoever counts the program and
+ * whoever shows it to somebody read the same one.</p>
+ *
  * @since 0.69.0
  */
-final class Rung {
+final class Answers {
 
     /**
      * The rows of the provides table, by the locator of their owner.
@@ -63,7 +68,7 @@ final class Rung {
      *  {@link Pairs}
      * @param names Every chain of copies, walked to its end
      */
-    Rung(
+    Answers(
         final Map<String, Collection<Map<String, String>>> rows,
         final Collection<String> voids,
         final Collection<String> answered,
@@ -76,24 +81,24 @@ final class Rung {
     }
 
     /**
-     * The rung this object stands on.
+     * What this object turns out to be.
      * @param locator The locator of the object
      * @param filled How many voids this object has filled itself
-     * @return The rung, from nothing at all up to nothing left to find out
+     * @return The answer, saying what it settled on and how deep that is
      */
-    int reached(final String locator, final int filled) {
+    Answer of(final String locator, final int filled) {
         final String end = this.ends.getOrDefault(locator, locator);
-        final int found;
+        final int rung;
         if (this.ground.contains(end)) {
-            found = 4;
+            rung = 4;
         } else if (this.table.containsKey(end)) {
-            found = this.depth(end, this.voids(end) - filled);
+            rung = this.depth(end, this.voids(end) - filled);
         } else if (this.rooted(end)) {
-            found = 1;
+            rung = 1;
         } else {
-            found = 0;
+            rung = 0;
         }
-        return found;
+        return new Answer(end, rung);
     }
 
     private int depth(final String type, final int free) {

--- a/eo-inference/src/main/java/org/eolang/inference/Depth.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Depth.java
@@ -19,7 +19,7 @@ import java.util.Map;
  * How much of a program the tables turned out to say.
  *
  * <p>This reads the tables back and puts every object of the program on the
- * ladder {@link Rung} describes. It is a measurement of ourselves rather than a
+ * ladder {@link Answers} describes. It is a measurement of ourselves rather than a
  * fact about the program, so it writes nothing: what comes out is meant for the
  * log of the goal, where two builds of the same sources can be compared by
  * anybody, and not for a document beside the tables.</p>
@@ -56,7 +56,7 @@ public final class Depth {
     public Ladder ladder() throws IOException {
         final XML given = new XMLDocument(this.tables.resolve("provides.xml"));
         final Pairs pairs = new Pairs(new XMLDocument(this.tables.resolve("links.xml")));
-        final Rung rung = new Rung(
+        final Answers answers = new Answers(
             new Ungrouped(given, Collections.emptyMap()).rows(),
             new HashSet<>(given.xpath("//attr[@void='true']/@type")),
             new HashSet<>(pairs.certain()),
@@ -75,7 +75,8 @@ public final class Depth {
             counts.put(name, 0);
         }
         for (final String locator : new Xmirs(this.world).locators()) {
-            final String name = names.get(rung.reached(locator, filled.getOrDefault(locator, 0)));
+            final Answer answer = answers.of(locator, filled.getOrDefault(locator, 0));
+            final String name = names.get(answer.rung());
             counts.put(name, counts.get(name) + 1);
         }
         return new Ladder(counts);

--- a/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Answers}.
+ * @since 0.70.0
+ */
+final class AnswersTest {
+
+    @Test
+    void namesTheFormationAnObjectSettledOn() {
+        final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
+        final Map<String, String> whole = new LinkedHashMap<>(0);
+        whole.put("id", "Φ.oak");
+        whole.put("complete", "true");
+        rows.put("Φ.oak", Collections.singletonList(whole));
+        final Map<String, String> chain = new LinkedHashMap<>(0);
+        chain.put("Φ.grove.α0", "Φ.oak");
+        MatcherAssert.assertThat(
+            "a copy of an oak must answer that it is an oak, but it named something else",
+            new Answers(
+                rows, Collections.emptyList(), Collections.emptyList(), chain
+            ).of("Φ.grove.α0", 0).where(),
+            Matchers.equalTo("Φ.oak")
+        );
+    }
+
+    @Test
+    void keepsAFreeVoidOffTheTopRung() {
+        final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
+        final Map<String, String> whole = new LinkedHashMap<>(0);
+        whole.put("id", "Φ.inc");
+        whole.put("complete", "true");
+        final Map<String, String> hollow = new LinkedHashMap<>(0);
+        hollow.put("owner", "Φ.inc");
+        hollow.put("name", "x");
+        hollow.put("void", "true");
+        rows.put("Φ.inc", Arrays.asList(whole, hollow));
+        MatcherAssert.assertThat(
+            "an inc whose void nobody filled cannot be known whole, but it was",
+            new Answers(
+                rows, Collections.emptyList(), Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.inc", 0).rung(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void answersWithTheObjectItselfWhenNothingIsKnown() {
+        MatcherAssert.assertThat(
+            "an object no table mentions must answer with itself, but it named something else",
+            new Answers(
+                Collections.emptyMap(), Collections.emptyList(),
+                Collections.emptyList(), Collections.emptyMap()
+            ).of("Φ.nowhere", 0).where(),
+            Matchers.equalTo("Φ.nowhere")
+        );
+    }
+}


### PR DESCRIPTION
Groundwork for step 4 of #7326, the HTML report.

`Rung.reached` walked the tables to work out where an object settles,
turned that into a rung between nought and four, and dropped the locator
on the floor:

```java
    Answer of(final String locator, final int filled) {
        final String end = this.ends.getOrDefault(locator, locator);
        ...
        return new Answer(end, rung);
    }
```

The locator is the more useful half. `Φ.number` is a place a reader can
go and look at; a rung is a number. The page has to show the first and
the goal counts the second, and they come from the same walk, so they go
back together in one `Answer` — the class that hands them out is
`Answers`, renamed from `Rung` because it no longer only gives a rung.

Nothing about the count moves. `Depth` asks the same question and reads
`rung()` off the answer, and the ladder over eo-runtime is unchanged.

The reason to do this before the page rather than during it: a page that
colours an object green while the printed number counts it among the
ones we know nothing about is worse than either alone. Reading one answer
is the only way to be sure that cannot happen, and it is much easier to
arrange now than to retrofit once two walks exist.

Three tests cover what the answer newly says — the formation a copy
settled on, a free void keeping an object off the top rung, and an object
no table mentions answering with itself.
