### PR TITLE
#7453: drop an argument's :label when the same node is also its own body line

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -447,7 +447,18 @@
   </xsl:template>
   <!-- TAIL: SUFFIX, NAME, CONST, ATOM -->
   <xsl:template match="o" mode="tail">
-    <xsl:if test="@as">
+    <!--
+    "@as" labels the void this object fills when it stands as an
+    argument (R-3.12). The same node keeps that stale "@as" when it is
+    also bound to a real, written-out name and printed as its own body
+    line, "then.baz > z" (#7453): a label only means something at the
+    call site, so it is dropped whenever "@name" shows this node is
+    defined there instead - unless "@name" is only the auto-generated
+    cactus placeholder of an anonymous inline handle ("[f]:1 &gt;&gt;"),
+    which is itself the argument the label belongs to, not a separate
+    definition.
+    -->
+    <xsl:if test="@as and (not(@name) or starts-with(@name, concat('a', $eo:cactoos)))">
       <xsl:text>:</xsl:text>
       <xsl:choose>
         <xsl:when test="starts-with(@as, $eo:alpha)">

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/argument-label-dropped-on-its-own-body-line.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/argument-label-dropped-on-its-own-body-line.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An object bound by an inline argument label (".baz:x > z") keeps "@as"
+# on its own XMIR node alongside the "@name" that binds it, since the
+# reference using that label ("z:x" inside the application) is a separate
+# node. The TAIL template printed "@as" unconditionally, so "z"'s own
+# body line kept the label it has no use for ("then.baz:x > z"), which a
+# body line may not carry ("binding allowed only in argument position",
+# #7453).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    if. > first
+      cond
+      then
+      .baz:x > z
+
+printed: |
+  [] > main
+    cond.if > first
+      z:x
+    then.baz > z


### PR DESCRIPTION
Closes #7453

An object bound with an inline argument label (`.baz:x > z`) keeps `@as="x"`
on its own XMIR node alongside the `@name="z"` that names it, since the
reference actually using that label is a separate node elsewhere. The TAIL
template printed `@as` unconditionally, so `z`'s own body line kept the
label it has no use for (`then.baz:x > z`), which does not reparse
(`binding allowed only in argument position`).

The label is now dropped whenever `@name` shows this node is defined as its
own body line, unless `@name` is only the auto-generated cactus placeholder
of an anonymous inline handle (`[f]:1 >>`), which genuinely is the argument
the label belongs to and needs to keep it.

Added `print-packs/yaml/argument-label-dropped-on-its-own-body-line.yaml`
reproducing the issue's example. Confirmed it fails (keeps `:x` on the body
line, does not reparse) with the fix reverted, and passes with it applied.
