### PR TITLE
#7455: normalize the mantissa without dividing by a subnormal power of ten

### DIFF
--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -41,9 +41,18 @@
     n.abs
     0
   as-fixed. > mantissa
-    n.div
-      10.power
-        number exponent
+    if. > [v e] >> scaled
+      e.eq 0
+      v
+      if.
+        e.lt 0
+        ^.scaled
+          v.times 10
+          e.plus 1
+        ^.scaled
+          v.div 10
+          e.minus 1
+    | n (number exponent)
     6
   ^ > n
   carried.as-bool.if > normalized!
@@ -99,6 +108,10 @@
     "1.000000e-7"
     string 1.0e-7.as-scientific
 
+  eq. ++> can-name-a-subnormal-magnitude
+    "1.000000e-320"
+    string 1.0e-320.as-scientific
+
   eq. ++> can-name-nan
     "nan"
     string nan.as-scientific
@@ -110,3 +123,7 @@
   eq. ++> can-name-positive-infinity
     "infinity"
     string pinf.as-scientific
+
+  eq. ++> can-name-the-smallest-positive-subnormal
+    "4.900000e-324"
+    string 4.9e-324.as-scientific


### PR DESCRIPTION
Closes #7455

The mantissa was computed as `as-fixed (n.div (10.power exponent)) 6`. In the
subnormal range `10.power exponent` is itself subnormal (or flushes to zero
past `-323`), so the division lands outside `[1, 10)` or produces infinity:
`1e-320.as-scientific` gave `10.019802e-321` instead of `1.000000e-320`, and
`4.9e-324.as-scientific` (the smallest positive double) threw
`Can't write a non-finite number as a fixed-point decimal`.

`rec-exponent`, which finds the exponent, never has this problem: it scales
`n.abs` toward `[1, 10)` one factor of ten at a time (`m.times 10` /
`m.div 10`), never computing a power of ten directly. The mantissa now goes
through the same kind of divisor-free scaling, applied to the signed `n`
over `exponent` steps, instead of dividing by a separately computed power of
ten.

Added two EO tests matching the issue's own examples (a mid-range subnormal
and the smallest positive double), plus the existing suite's normal-range
cases, and ran them (`EOnumberTest`) to confirm they pass.
