### PR TITLE
#7457: correct the documented precision boundary of sine's range reduction

### DIFF
--- a/eo-runtime/src/main/eo/number/sine.eo
+++ b/eo-runtime/src/main/eo/number/sine.eo
@@ -1,12 +1,11 @@
 # Sine of `num` radians as `org.eolang.number`.
 # The argument is reduced into the [-pi, pi] range with a Cody-Waite style
 # two-part reduction constant, and the Taylor series is summed through
-# Horner's scheme. The reduction is exact to within a few ULPs for
-# |num| up to about 1e10, and stays noticeably better than a plain
-# single-double reduction up to about 1e15, but beyond that consecutive
-# `double` values are already spaced further apart than a full turn, so
-# no reduction algorithm can meaningfully recover sub-turn precision.
-# Non-finite arguments collapse to nan.
+# Horner's scheme. The high part of that constant has 26 trailing zero
+# mantissa bits, so `k times tau_hi` stays exact only while `k` is under
+# `2^26`, which puts the reduction's few-ULP accuracy at |num| up to about
+# 4e8; past that point the product itself rounds and the error lands
+# straight in the reduced angle. Non-finite arguments collapse to nan.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -43,6 +42,11 @@
           ^.factor
             depth.plus 1
     | 1
+
+  lt. ++> can-be-accurate-near-the-documented-four-hundred-million-boundary
+    abs.
+      400000000.sine.minus 0.9965407850188008
+    1.0e-9
 
   lt. ++> can-behave-as-an-odd-function-when-taking-sine
     abs.


### PR DESCRIPTION
Closes #7457

`sine.eo`'s header claimed the Cody-Waite reduction stays accurate to a few
ULPs for `|num|` up to about 1e10. The high part of the reduction constant
(`tau_hi = 6.283185303211212`) has 26 trailing zero mantissa bits, so
`k times tau_hi` is exact only while `k < 2^26`, which puts the real
few-ULP boundary at about 4e8 (`|num| < 2^26 * 2*pi`), not 1e10:
`sine 1e9` is already off in the 7th digit against `Math.sin`, and `sine
1e10` is off by about 4.5e8 ULPs.

Corrected the header to describe the boundary the current constant actually
delivers, and added a test pinning `sine 4e8` against `Math.sin(4e8)` within
`1e-9`, so the documented boundary is enforced rather than just claimed.

No behavior changed; this is the documentation-fix path the issue itself
names as one of two acceptable resolutions (the other being to widen the
constant, a larger, riskier change to a shared reduction used by several
trig functions).
