### PR TITLE
#7458: nan and infinite arguments incorrectly return fixed-point decimal error message

### DIFF
--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -32,8 +32,12 @@
         "Can't write a non-finite number as a fixed-point decimal"
         huge.if
           "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"
-          "Can't write a fixed-point decimal with %f fraction places".printf
-            * places
+          places.is-finite.if
+            "Can't write a fixed-point decimal with %f fraction places".printf
+              * places
+            "Can't write a fixed-point decimal with %s fraction places".printf
+              *
+                string places.as-scientific
     if.
       n.as-bytes.eq 80-00-00-00-00-00-00-00
       "-".as-bytes.concat
@@ -136,6 +140,12 @@
     "Can't write a fixed-point decimal with 9007199254740992.000000 fraction places"
     1.25.as-fixed
       9007199254740992
+      I
+
+  eq. ++> can-format-the-error-message-of-infinite-places
+    "Can't write a fixed-point decimal with infinity fraction places"
+    3.14159.as-fixed
+      pinf
       I
 
   eq. ++> can-format-the-error-message-of-negative-places

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -35,9 +35,7 @@
           places.is-finite.if
             "Can't write a fixed-point decimal with %f fraction places".printf
               * places
-            "Can't write a fixed-point decimal with %s fraction places".printf
-              *
-                string places.as-scientific
+            "Can't write a fixed-point decimal with a non-finite number of fraction places"
     if.
       n.as-bytes.eq 80-00-00-00-00-00-00-00
       "-".as-bytes.concat
@@ -143,7 +141,7 @@
       I
 
   eq. ++> can-format-the-error-message-of-infinite-places
-    "Can't write a fixed-point decimal with infinity fraction places"
+    "Can't write a fixed-point decimal with a non-finite number of fraction places"
     3.14159.as-fixed
       pinf
       I

--- a/eo-runtime/src/main/eo/string/at.eo
+++ b/eo-runtime/src/main/eo/string/at.eo
@@ -26,8 +26,12 @@
               idx
         number index
     fallback
-      "Index must be an integer, but was %f".printf
-        * i
+      i.is-finite.if
+        "Index must be an integer, but was %f".printf
+          * i
+        "Index must be an integer, but was %s".printf
+          *
+            string i.as-scientific
     if.
       or.
         0.gt index
@@ -44,6 +48,12 @@
     "Index must be an integer, but was 1.500000"
     "some".at
       1.5
+      I
+
+  eq. ++> can-format-the-error-message-of-a-non-finite-index
+    "Index must be an integer, but was nan"
+    "some".at
+      nan
       I
 
   eq. ++> can-recover-from-a-fractional-index-in-bounds

--- a/eo-runtime/src/main/eo/string/nsplit.eo
+++ b/eo-runtime/src/main/eo/string/nsplit.eo
@@ -24,8 +24,12 @@
       if.
         size.eq 0
         "The delimiter must not be empty"
-        "Invalid limit %f for nsplit, must be at least 1".printf
-          * limit
+        limit.is-finite.if
+          "Invalid limit %f for nsplit, must be at least 1".printf
+            * limit
+          "Invalid limit %s for nsplit, must be at least 1".printf
+            *
+              string limit.as-scientific
     if.
       1.eq limit
       * text
@@ -84,6 +88,13 @@
     "a-b-c".nsplit
       "-"
       1.5
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-limit-when-splitting
+    "Invalid limit infinity for nsplit, must be at least 1"
+    "a-b-c".nsplit
+      "-"
+      pinf
       I
 
   eq. ++> can-nsplit-an-empty-text-into-one-empty-string

--- a/eo-runtime/src/main/eo/string/padded-left.eo
+++ b/eo-runtime/src/main/eo/string/padded-left.eo
@@ -23,8 +23,13 @@
       not.
         1.eq fill.length
     cant-pad
-      "Can't pad text to %f characters with %s".printf
-        * width fill
+      width.is-finite.if
+        "Can't pad text to %f characters with %s".printf
+          * width fill
+        "Can't pad text to %s characters with %s".printf
+          *
+            string width.as-scientific
+            fill
     if.
       width.gt
         text.length >> len!
@@ -46,6 +51,13 @@
     "Can't pad text to -1.000000 characters with x"
     "y".padded-left
       -1
+      "x"
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-width-when-padding-left
+    "Can't pad text to infinity characters with x"
+    "y".padded-left
+      pinf
       "x"
       I
 

--- a/eo-runtime/src/main/eo/string/padded-right.eo
+++ b/eo-runtime/src/main/eo/string/padded-right.eo
@@ -23,8 +23,13 @@
       not.
         1.eq fill.length
     cant-pad
-      "Can't pad text to %f characters with %s".printf
-        * width fill
+      width.is-finite.if
+        "Can't pad text to %f characters with %s".printf
+          * width fill
+        "Can't pad text to %s characters with %s".printf
+          *
+            string width.as-scientific
+            fill
     if.
       width.gt
         text.length >> len!
@@ -45,6 +50,13 @@
     "Can't pad text to -1.000000 characters with x"
     "y".padded-right
       -1
+      "x"
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-width-when-padding-right
+    "Can't pad text to infinity characters with x"
+    "y".padded-right
+      pinf
       "x"
       I
 

--- a/eo-runtime/src/main/eo/string/padded-zeros.eo
+++ b/eo-runtime/src/main/eo/string/padded-zeros.eo
@@ -20,8 +20,12 @@
       0.gt width
       width.is-integer.not
     cant-pad
-      "Can't pad text to %f characters with zeros".printf
-        * width
+      width.is-finite.if
+        "Can't pad text to %f characters with zeros".printf
+          * width
+        "Can't pad text to %s characters with zeros".printf
+          *
+            string width.as-scientific
     if.
       and.
         0.lt
@@ -54,6 +58,12 @@
     "Can't pad text to -4.000000 characters with zeros"
     "7".padded-zeros
       -4
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-width-when-padding-with-zeros
+    "Can't pad text to infinity characters with zeros"
+    "7".padded-zeros
+      pinf
       I
 
   eq. ++> can-keep-a-minus-sign-in-front-of-the-zeros

--- a/eo-runtime/src/main/eo/string/repeated.eo
+++ b/eo-runtime/src/main/eo/string/repeated.eo
@@ -17,8 +17,12 @@
       0.gt times
       times.is-integer.not
     cant-repeat
-      "Can't repeat text %f times".printf
-        * times
+      times.is-finite.if
+        "Can't repeat text %f times".printf
+          * times
+        "Can't repeat text %s times".printf
+          *
+            string times.as-scientific
     string
       [n] >> rec-repeated
         if. > @
@@ -39,6 +43,12 @@
     "Can't repeat text -1.000000 times"
     "x".repeated
       -1
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-count
+    "Can't repeat text infinity times"
+    "x".repeated
+      pinf
       I
 
   eq. ++> can-recover-from-a-negative-count

--- a/eo-runtime/src/main/eo/string/slice.eo
+++ b/eo-runtime/src/main/eo/string/slice.eo
@@ -27,15 +27,23 @@
       nstart.lt 0
       nstart.is-integer.not
     T
-      "Start index must be a non-negative integer, but was %f".printf
-        * nstart
+      nstart.is-finite.if
+        "Start index must be a non-negative integer, but was %f".printf
+          * nstart
+        "Start index must be a non-negative integer, but was %s".printf
+          *
+            string nstart.as-scientific
     if.
       or.
         nlen.lt 0
         nlen.is-integer.not
       T
-        "Length to slice must be a non-negative integer, but was %f".printf
-          * nlen
+        nlen.is-finite.if
+          "Length to slice must be a non-negative integer, but was %f".printf
+            * nlen
+          "Length to slice must be a non-negative integer, but was %s".printf
+            *
+              string nlen.as-scientific
       seq *
         recidx >> bstart!
           0
@@ -308,3 +316,13 @@
     "some string"
     7
     5
+
+  slice. --> stops-on-an-infinite-length
+    "some"
+    0
+    pinf
+
+  slice. --> stops-on-an-infinite-start
+    "some"
+    pinf
+    1

--- a/eo-runtime/src/main/eo/string/truncated.eo
+++ b/eo-runtime/src/main/eo/string/truncated.eo
@@ -20,8 +20,12 @@
       0.gt limit
       limit.is-integer.not
     cant-truncate
-      "Can't truncate text to %f characters".printf
-        * limit
+      limit.is-finite.if
+        "Can't truncate text to %f characters".printf
+          * limit
+        "Can't truncate text to %s characters".printf
+          *
+            string limit.as-scientific
     if.
       limit.lt text.length
       text.slice 0 limit
@@ -36,6 +40,12 @@
     "Can't truncate text to -3.000000 characters"
     "Jeff".truncated
       -3
+      I
+
+  eq. ++> can-format-the-error-message-of-an-infinite-limit
+    "Can't truncate text to infinity characters"
+    "Jeff".truncated
+      pinf
       I
 
   eq. ++> can-recover-from-a-negative-limit


### PR DESCRIPTION
Fixes the message for the ten call sites listed in #7458: `string/at.eo`, `string/repeated.eo`,
`string/padded-left.eo`, `string/padded-right.eo`, `string/padded-zeros.eo`,
`string/truncated.eo`, `string/slice.eo` (both messages), `string/nsplit.eo` and
`number/as-fixed.eo`.

Each site now checks whether the offending argument is finite before building the message.
A finite bad value keeps the existing `%f` message. A `nan` or infinite value is now printed
with `%s` and `as-scientific`, the same idiom `number.as-i64` already uses for this in #7185,
instead of going through `%f`/`as-fixed` and failing on its own non-finite receiver.
