### PR TITLE
fix(#7269): name the i64 with %s and as-scientific in the as-i32 error

### DIFF
--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -1,5 +1,12 @@
 # Signed 64-bit integer.
 # Here `as-bytes` must be a `bytes` object.
+#
+# The out-of-bounds message of `as-i32` names the receiver with `%s` and
+# `as-scientific`, not with `%d`, because `%d` would take a `number` and the
+# `i64` to `number` conversion is lossy at the top of the 64-bit range: the
+# nearest double of `9223372036854775807` is `2^63`, which is one past the
+# `long` range that `printf`'s own `%d` guard accepts, so the message itself
+# used to terminate instead of being printed.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -18,8 +25,9 @@
             ^.as-bytes.slice 4 4
       left
       cant-convert
-        "Can't convert i64 number %d to i32 because it's out of i32 bounds".printf
-          * ^.as-number
+        "Can't convert i64 number %s to i32 because it's out of i32 bounds".printf
+          *
+            string ^.as-number.as-scientific
     i32 > left
       ^.as-bytes.slice 4 4
   [^] > as-number
@@ -240,8 +248,14 @@
 
   42.as-i64.as-bytes.eq 00-00-00-00-00-00-00-2A ++> can-expose-valid-bytes
 
+  eq. ++> can-format-the-error-message-of-the-maximum-i64-when-converting-to-i32
+    "Can't convert i64 number 9.223372e18 to i32 because it's out of i32 bounds"
+    as-i32.
+      i64 7F-FF-FF-FF-FF-FF-FF-FF
+      I
+
   eq. ++> can-format-the-error-message-of-the-minimum-i64-when-converting-to-i32
-    "Can't convert i64 number -9223372036854775808 to i32 because it's out of i32 bounds"
+    "Can't convert i64 number -9.223372e18 to i32 because it's out of i32 bounds"
     as-i32.
       i64 80-00-00-00-00-00-00-00
       I


### PR DESCRIPTION
Closes #7269.

`i64.as-i32` built its out-of-bounds message with `%d` and `^.as-number`. The
`i64` to `number` conversion is lossy at the top of the 64-bit range: the
nearest double of `9223372036854775807` is exactly `2^63`, one past the `long`
range that `string.printf`'s own `%d` guard accepts. The message therefore
terminated with printf's range error instead of ever being printed — and did so
slowly enough to exceed the generated-test deadline, so a test reproducing it
reported as *skipped* rather than failed.

The fix is the one #7185 applied to `number/as-i64.eo`: the message names the
receiver with `%s` and a decimal string built by `as-scientific`, so nothing is
handed to a conversion that rejects it.

Changes:

* `eo-runtime/src/main/eo/i64.eo` — `as-i32` formats with `%s` and
  `string ^.as-number.as-scientific`; the file docblock records why `%d` is
  not used here.
* New regression `can-format-the-error-message-of-the-maximum-i64-when-converting-to-i32`
  alongside the existing minimum-value one, which now expects the same
  scientific form.

Verified locally with `mvn clean test -pl :eo-runtime -Deo.deadline=3600 -Dtest=EOi64Test`:
`Tests run: 60, Failures: 0, Errors: 0, Skipped: 0`.

Note: the message now reads `9.223372e18` rather than the exact digits. Naming
the exact integer would need an `i64`-to-decimal renderer that never goes
through a double; `number.as-decimal` cannot serve, since it refuses any
magnitude at or above `2^63`, which is exactly where the rounded value lands.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJQnABXpcZR2UVuaShRzuU)_