### PR TITLE
fix(#7384): dataize integral's partition width once per call

### DIFF
--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -36,7 +36,7 @@
                 false
               true > [^ i]
             sum
-          as-number. > step
+          as-number. > step!
             div.
               ^.b.minus ^.a
               ^.n


### PR DESCRIPTION
Closes #7384.

`step` in `number/integral.eo` was bound without the `!` const marker, so the
division computing the partition width was re-dataized on every read. The
`while` loop reads `^.step` twice per iteration, so one `integral` call paid
`2*n` divisions — plus the `^.b`/`^.a`/`^.n` attribute hops behind each — for a
value that never changes across the loop.

This is the one-character fix that #6651 applied to `number/power.eo`
(`half!`/`k!`) and #6868 to `string/regex.eo` (`group1!`/`group2!`);
`integral.eo` was missed when that convention was applied to its siblings.

Verified locally with `mvn clean test -pl :eo-runtime -Deo.deadline=3600 -Dtest=EOnumberTest`:
`Tests run: 502, Failures: 0, Errors: 0, Skipped: 0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJQnABXpcZR2UVuaShRzuU)_