### PR TITLE
move the reversed-dispatch and root-symbol decisions off Emissions and LnOnlyPhi

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -242,12 +242,12 @@ final class Emissions {
             emit.object(name, "Φ.tuple", line, value.pos());
             emit.star();
         } else if (value.kind() == Value.Kind.ROOT) {
-            emit.object(name, Emissions.rootBase(value.raw()), line, value.pos());
+            emit.object(name, value.rootSymbol(), line, value.pos());
         } else if (value.kind() == Value.Kind.TERM) {
             emit.object(name, "⊥", line, value.pos());
-        } else if (value.kind() == Value.Kind.IDENTITY) {
+        } else if (value.identity()) {
             Emissions.identity(emit, name, value, line);
-        } else if (value.kind() == Value.Kind.GROUP) {
+        } else if (value.group()) {
             Emissions.group(emit, name, value, line);
         } else {
             emit.object(name, value.raw(), line, value.pos());
@@ -406,26 +406,9 @@ final class Emissions {
         }
     }
 
-    private static String rootBase(final String raw) {
-        final String mapped;
-        if ("Q".equals(raw)) {
-            mapped = "Φ";
-        } else if ("@".equals(raw)) {
-            mapped = "φ";
-        } else if ("^".equals(raw)) {
-            mapped = "ρ";
-        } else if ("$".equals(raw)) {
-            mapped = "ξ";
-        } else {
-            mapped = raw;
-        }
-        return mapped;
-    }
-
     private static boolean reversedDispatch(final Tokens tokens, final Value head) {
         final boolean reversed;
-        if ((head.kind() == Value.Kind.IDENTIFIER || head.kind() == Value.Kind.ROOT)
-            && !tokens.atEnd() && tokens.dispatchAhead()) {
+        if (head.reversible() && !tokens.atEnd() && tokens.dispatchAhead()) {
             final int skip;
             if (tokens.current() == '?') {
                 skip = 2;

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -204,8 +204,7 @@ final class LnOnlyPhi implements Line {
 
     private static boolean reversedAhead(final Tokens tokens, final Value head) {
         final boolean result;
-        if ((head.kind() == Value.Kind.IDENTIFIER || head.kind() == Value.Kind.ROOT)
-            && !tokens.atEnd() && tokens.dispatchAhead()) {
+        if (head.reversible() && !tokens.atEnd() && tokens.dispatchAhead()) {
             final int skip;
             if (tokens.current() == '?') {
                 skip = 2;

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -211,6 +211,37 @@ final class Value {
     }
 
     /**
+     * May this value open a reversed dispatch as the line's head — a
+     * bare identifier or a root glyph, the only kinds R-9.0.3 allows in
+     * that position?
+     * @return True for {@link Kind#IDENTIFIER} or {@link Kind#ROOT}
+     */
+    boolean reversible() {
+        return this.kind == Kind.IDENTIFIER || this.kind == Kind.ROOT;
+    }
+
+    /**
+     * The XMIR symbol a {@link Kind#ROOT} glyph maps to per §9.3 —
+     * {@code Q} to {@code Φ}, {@code @} to {@code φ}, {@code ^} to
+     * {@code ρ}, {@code $} to {@code ξ}. Call only when {@link #kind()}
+     * is {@link Kind#ROOT}.
+     * @return The mapped symbol
+     */
+    String rootSymbol() {
+        final String mapped;
+        if ("Q".equals(this.raw)) {
+            mapped = "Φ";
+        } else if ("@".equals(this.raw)) {
+            mapped = "φ";
+        } else if ("^".equals(this.raw)) {
+            mapped = "ρ";
+        } else {
+            mapped = "ξ";
+        }
+        return mapped;
+    }
+
+    /**
      * Does this head open a formation body?
      * @return True for identity, or a group wrapping inline {@code > [...]}
      */
@@ -241,9 +272,11 @@ final class Value {
         return found;
     }
 
-    // @todo #7281:30min Move the remaining kind()/raw()-driven decisions out
-    //  of Emissions and LnOnlyPhi onto Value, then drop the kind()/raw()
-    //  accessors it no longer needs.
+    // @todo #7379:30min Move the remaining kind()-driven branches in
+    //  Emissions#openValue and Emissions#openBase (INTEGER/FLOAT, HEX,
+    //  BYTES, STRING, STAR, TERM) onto Value as named predicates, the
+    //  way reversible() and rootSymbol() already replaced the
+    //  IDENTIFIER/ROOT and ROOT-glyph decisions.
     /**
      * The kinds of value recognised by the parser. Further kinds
      * (HEX, BYTES, paren groups) attach as the corresponding line

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -184,4 +184,31 @@ final class ValueTest {
             Matchers.equalTo(false)
         );
     }
+
+    @Test
+    void marksIdentifierReversible() {
+        MatcherAssert.assertThat(
+            "an IDENTIFIER value must be allowed as a reversed-dispatch head",
+            new Value(Value.Kind.IDENTIFIER, "foo", 0).reversible(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void mapsRootGlyphQToUpperPhi() {
+        MatcherAssert.assertThat(
+            "rootSymbol() must map Q to the top-level Φ per §9.3",
+            new Value(Value.Kind.ROOT, "Q", 0).rootSymbol(),
+            Matchers.equalTo("Φ")
+        );
+    }
+
+    @Test
+    void mapsRootGlyphCaretToRho() {
+        MatcherAssert.assertThat(
+            "rootSymbol() must map ^ to ρ per §9.3",
+            new Value(Value.Kind.ROOT, "^", 0).rootSymbol(),
+            Matchers.equalTo("ρ")
+        );
+    }
 }


### PR DESCRIPTION
Resolves the #7281 puzzle in Value.java. Emissions#reversedDispatch and LnOnlyPhi#reversedAhead both branched on `head.kind() == IDENTIFIER || head.kind() == ROOT` to decide whether a value may open a reversed dispatch, and Emissions carried a private `rootBase(raw)` helper mapping the Q/@/^/$ glyphs to their XMIR symbols. Both are decisions that belong on Value, not on its callers.

Value now exposes `reversible()` (true for IDENTIFIER/ROOT, the only kinds R-9.0.3 allows in a reversed-dispatch head) and `rootSymbol()` (the Q/@/^/$ to Φ/φ/ρ/ξ mapping per §9.3). Emissions and LnOnlyPhi call these instead of repeating the kind check, and the now-dead `rootBase` static helper is gone. While in there, two existing IDENTITY/GROUP `kind()` comparisons in Emissions#openBase were switched to the identity()/group() predicates Value already had, for consistency with the rest of the method.

The remaining kind()-driven branches in Emissions#openValue and #openBase (INTEGER/FLOAT, HEX, BYTES, STRING, STAR, TERM) are left as a puzzle — moving all of them onto Value in one PR would run well past this repo's size band, so it's scoped as a follow-up `@todo #7379:30min` in Value.java.

Closes #7379