### PR TITLE
stop the fraction scale from carrying an unfloored accumulator across places

### DIFF
--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -122,6 +122,16 @@
         count.minus 1
       acc.concat "0".as-bytes
 
+  eq. ++> can-agree-with-fewer-places-on-their-shared-digits
+    "1.1000000000000000000"
+    string
+      1.1.as-fixed 19
+
+  eq. ++> can-agree-with-more-places-on-their-shared-digits
+    "1.100000000000000000000"
+    string
+      1.1.as-fixed 21
+
   eq. ++> can-carry-rounding-into-the-integer-part
     "1.000000"
     string
@@ -264,16 +274,6 @@
     "0.00"
     string
       0.as-fixed 2
-
-  eq. ++> can-agree-with-fewer-places-on-their-shared-digits
-    "1.1000000000000000000"
-    string
-      1.1.as-fixed 19
-
-  eq. ++> can-agree-with-more-places-on-their-shared-digits
-    "1.100000000000000000000"
-    string
-      1.1.as-fixed 21
 
   eq. ++> can-write-a-fraction-of-places-past-the-double-accumulator-range
     "123.45600000000000300000"

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -54,9 +54,7 @@
                 unit.as-decimal.concat ".".as-bytes
                 concat.
                   rec-pad rest ^.k --
-                  zeros
-                    ^.^.places.minus ^.k
-                    --
+                  zeros (^.^.places.minus ^.k) --
             | (whole.plus 1) 0
             written whole digits
           floor. > digits
@@ -65,11 +63,11 @@
                 a.minus whole
                 scale
               0.5
-          pow10 k > scale
           if. > k
             ^.places.gt 15
             15
             ^.places
+          pow10 k > scale
           a.floor > whole
         | 0
       if.

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -11,6 +11,13 @@
 # `as-decimal` writes exactly is written exactly here too. A magnitude of
 # 2^63 or larger is past what `as-decimal` can write, so it returns the
 # `cant-print` fallback as well, instead of terminating.
+#
+# The fraction is scaled by at most 10^15, the largest power of ten that
+# keeps the scaled value an exact integer below 2^53, and never by 10^places
+# directly. Only that many digits are peeled off; any place beyond them is a
+# trailing zero. This keeps the digits shared by two calls with different
+# `places` in agreement, instead of drifting as an unfloored accumulator was
+# carried through more divisions the larger `places` was.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -45,7 +52,11 @@
               unit.as-decimal
               concat.
                 unit.as-decimal.concat ".".as-bytes
-                rec-pad rest ^.^.places --
+                concat.
+                  rec-pad rest ^.k --
+                  zeros
+                    ^.^.places.minus ^.k
+                    --
             | (whole.plus 1) 0
             written whole digits
           floor. > digits
@@ -54,7 +65,11 @@
                 a.minus whole
                 scale
               0.5
-          pow10 ^.places > scale
+          pow10 k > scale
+          if. > k
+            ^.places.gt 15
+            15
+            ^.places
           a.floor > whole
         | 0
       if.
@@ -87,24 +102,25 @@
     count.eq 0
     acc
     ^.rec-pad
-      if.
-        value.gte 9007199254740992
+      floor.
         value.div 10
-        floor.
-          value.div 10
       as-number.
         count.minus 1
       concat.
         as-char.
           plus.
-            if.
-              value.gte 9007199254740992
-              0
-              floor.
-                value.minus
-                  times. (value.div 10).floor 10
+            floor.
+              value.minus
+                times. (value.div 10).floor 10
             48
         acc
+  if. > [^ count acc] >> zeros
+    count.eq 0
+    acc
+    ^.zeros
+      as-number.
+        count.minus 1
+      acc.concat "0".as-bytes
 
   eq. ++> can-carry-rounding-into-the-integer-part
     "1.000000"
@@ -248,6 +264,16 @@
     "0.00"
     string
       0.as-fixed 2
+
+  eq. ++> can-agree-with-fewer-places-on-their-shared-digits
+    "1.1000000000000000000"
+    string
+      1.1.as-fixed 19
+
+  eq. ++> can-agree-with-more-places-on-their-shared-digits
+    "1.100000000000000000000"
+    string
+      1.1.as-fixed 21
 
   eq. ++> can-write-a-fraction-of-places-past-the-double-accumulator-range
     "123.45600000000000300000"


### PR DESCRIPTION
`number.as-fixed` scaled the fraction by `10^places` directly, then peeled digits by repeatedly dividing that scaled value by ten. Once the accumulator went past 2^53, the code stopped flooring the division to avoid losing a digit, but that carried a fractional remainder through every further division. By the time the accumulator dropped back below 2^53, the remaining digits reflected accumulated drift rather than the true value, so the same digit position could read differently depending on how many places were asked for (`1.1.as-fixed 19` and `1.1.as-fixed 21` disagreed on digits they should share).

The fix scales the fraction by at most `10^15`, the largest power of ten that keeps the scaled value an exact integer below `2^53`. Those digits are peeled off exactly, the same way `as-decimal` does, and any place beyond the 15th is a trailing zero instead of a carried-forward accumulator. This also let the `rec-pad` recursion drop its now-unreachable overflow branch, since the value it peels digits from is always below `2^53`.

Closes #7470