### PR TITLE
fix(#7481): admit XI in R-3.8.1's reversed-dispatch head list

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -407,7 +407,7 @@ This section number is reserved; the method-dispatch line continuation rules pre
 
 The trailing-dot prefix-notation form.
 
-R-3.8.1. The identifier ends with a trailing `.` followed by space or end-of-line. **The identifier preceding the trailing dot must be a single `NAME`, `PHI` (`@`), or `RHO` (`^`) token** — no dotted paths and no `ROOT`/`XI`/literal-rooted prefixes. Chained heads (`Q.x.foo.`) are not valid as the lead of a reversed dispatch — a trailing dot after `Q.x.foo` does not produce a reversed-dispatch line and is reported as a lexical/parse error.
+R-3.8.1. The identifier ends with a trailing `.` followed by space or end-of-line. **The identifier preceding the trailing dot must be a single `NAME`, `PHI` (`@`), `RHO` (`^`), or `XI` (`$`) token** — no dotted paths and no `ROOT`/literal-rooted prefixes. Chained heads (`Q.x.foo.`) are not valid as the lead of a reversed dispatch — a trailing dot after `Q.x.foo` does not produce a reversed-dispatch line and is reported as a lexical/parse error.
 R-3.8.2. **Horizontal form** — `name. arg1 arg2 …`:
   - `arg1` is the **receiver** (the dispatch target of `.name`).
   - `arg2…` are method arguments of `.name`.

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -35,9 +35,9 @@ import java.util.List;
  * For vertical form, deeper-indent lines (dispatched through
  * {@link LnApplication} etc.) attach as children automatically.</p>
  *
- * <p>R-3.8.1 restricts the receiver-identifier to a single {@code NAME}
- * token (or {@code @} / {@code ^}). This iteration accepts {@code NAME}
- * only; {@code @} and {@code ^} attach in a later round. *
+ * <p>R-3.8.1 restricts the head identifier to a single {@code NAME},
+ * {@code @}, {@code ^}, or {@code $} token — no dotted paths and no
+ * {@code ROOT}/literal-rooted prefixes.</p>
  *
  * @since 0.1
  */

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-dispatch-xi-rooted-path-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/reversed-dispatch-xi-rooted-path-is-rejected.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# #7481: R-3.8.1 admits a bare `$` head but excludes `$`-rooted dotted
+# paths, same as it excludes `Q`-rooted ones; only the bare form is a
+# reversed-dispatch head.
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+input: |
+  [] > main
+    $.x. 1 > z


### PR DESCRIPTION
Closes #7481

R-3.8.1 named only `NAME`, `PHI` (`@`) and `RHO` (`^`) as valid reversed-dispatch heads, while the parser (`LnReversed`) and an existing fixture (`reversed-dispatch-root-head-on-indented-line.yaml`) already accept `XI` (`$`) too. The spec text is what's out of sync here — the fixture's name calls out "root head" deliberately, and the parser's own `rootHead` check already lists `@`, `^` and `$` together.

This adds `XI` to R-3.8.1's list of admissible head tokens, so the rule matches what the parser actually does.

Along the way, `LnReversed`'s class docblock still claimed the receiver-identifier accepted `NAME` only, with `@`/`^` support "attaching in a later round" — stale from an earlier iteration, since all four tokens are already wired up. Updated it to describe the current behavior.

Also added a fixture pinning that a `$`-rooted dotted path (`$.x.`) still gets rejected, the same way a `Q`-rooted one does — the rule's exclusion of dotted and root-rooted prefixes applies to `$` exactly as it does to the other heads, and that boundary wasn't covered by an existing test.