### PR TITLE
close Level's unclosed doc paragraph

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -19,7 +19,7 @@ package org.eolang.parser;
  * copy-on-write would allocate a new object on every line transition,
  * pushing the parser's per-line cost from O(1) to O(D). Mutation is
  * confined to the {@link Stack} that owns this entry; no other class
- * keeps a reference. *
+ * keeps a reference.</p>
  *
  * @since 0.1
  */


### PR DESCRIPTION
The class docblock in `Level.java` opens a `<p>` for the paragraph explaining why the class deliberately breaks the four-field / immutability rules, but never closes it — the paragraph ends with a stray trailing `*` instead of `</p>`. It renders as literal text in the generated Javadoc.

This closes the tag to match the convention already used a few lines above in the same docblock.

@yegor256 take a look