### PR TITLE
close unclosed doc paragraphs in Stack and Kind

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Kind.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Kind.java
@@ -26,7 +26,7 @@ package org.eolang.parser;
  * <p>The {@link #TOP_LEVEL} sentinel is not a real expression kind — it is
  * the {@code parent_kind} for entries pushed at indent 0 (R-5.2.11), used
  * by close-time checks to recognise top-level naming requirements
- * (R-5.3.1). *
+ * (R-5.3.1).</p>
  *
  * @since 0.1
  */

--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -22,7 +22,7 @@ import java.util.List;
  * {@link Closer} when a level is popped or replaced, so the same checks
  * fire whether closing happens mid-parse (a shallower or sibling line
  * arrived) or at end-of-stream (R-5.4 / §8). The stack itself is
- * structural; semantics live with the caller. *
+ * structural; semantics live with the caller.</p>
  *
  * @since 0.1
  */


### PR DESCRIPTION
Same defect as #7497, in two sibling files from the same commit: `Stack.java` and `Kind.java` each open a `<p>` in their class docblock and never close it, ending the paragraph with a stray trailing `*` instead of `</p>`.

`Stack.java:20-25` — the paragraph explaining that close-time semantic checks are dispatched to the `Closer` hook.

`Kind.java:26-29` — the paragraph explaining the `TOP_LEVEL` sentinel.

Both render as literal text in the generated Javadoc. This closes the tags to match the convention already used elsewhere in the same docblocks.

@yegor256 have a look