### PR TITLE
fix(#7477): say the identity object takes no horizontal arguments

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -687,13 +687,13 @@ An `I` token is *the one-character spelling of the identity object* `x > [x]` �
 "hello".at 1.5 I                      ← the error branch hands the message back
 ```
 
-R-3.16.1. `I` is a value: it is recognised wherever a value is expected — as a line head, as a horizontal argument, as a vertical one, and inside a paren group — and takes a `.method` chain with the ordinary application shape (§3.6). It takes **no horizontal arguments**: an argument is given on a deeper-indent line, or inside a paren group where the identity is applied to it.
+R-3.16.1. `I` is a value: it is recognised wherever a value is expected — as a line head, as a horizontal argument, as a vertical one, and inside a paren group — and takes a `.method` chain with the ordinary application shape (§3.6). It takes **no horizontal arguments**, in any position: an argument is given on a deeper-indent line.
 
 ```
 I 5 > r                               ← rejected: the identity takes no horizontal arguments
+foo (I 5) > r                         ← rejected: the same application, inside a group
 I > r                                 ← the vertical form of the same
   5
-foo (I 5) > r                         ← accepted: the application is inside the group
 ```
 
 R-3.16.2. **The void.** The void `I` binds is always named `x`, since nothing but the φ ever reads it. A same-named attribute of an enclosing formation does not capture that φ: the void is the nearest declaration of `x`, so scope resolution binds to it.

--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -170,7 +170,7 @@ The parser recognises the following lexical tokens:
 | `ROOT` | `Q` |
 | `XI` | `$` |
 | `TERM` | `T` — the terminator term (§9.3), similar to `⊥` in 𝜑-calculus. A value: it may carry arguments, horizontal (`T 42`) or vertical, which are the cause of the terminator, the way `T "why it failed"` is used across the runtime, and a `.method` chain (`T.foo` parses as `⊥.foo`), like any other head. |
-| `IDENTITY` | `I` — the identity object (§3.16), the one-character spelling of `x > [x]`. A value: it may carry arguments (`I 5`) and a `.method` chain, like any other head. |
+| `IDENTITY` | `I` — the identity object (§3.16), the one-character spelling of `x > [x]`. A value: it may carry vertical arguments and a `.method` chain, like any other head, but no horizontal ones (R-3.16.1). |
 | `VOID` | `?` — the vertical-void marker (§3.4). A `? > name` body line declares a void attribute, equivalent to listing `name` in `[…]`. |
 | `QDOT` | `?.` — the fragile-dispatch operator (§3.5). Accepted in every position the plain `.` dispatch is, recorded as `@fragile` in XMIR. A `?` immediately followed by `.` is `QDOT`; a `?` followed by space (`? > name`) is `VOID`. |
 | `INT` | optional sign, then `0` or non-zero digit string. |
@@ -687,13 +687,20 @@ An `I` token is *the one-character spelling of the identity object* `x > [x]` �
 "hello".at 1.5 I                      ← the error branch hands the message back
 ```
 
-R-3.16.1. `I` is a value: it is recognised wherever a value is expected — as a line head, as a horizontal argument, as a vertical one, and inside a paren group — and takes horizontal arguments (`I 5`) and a `.method` chain with the ordinary application shape (§3.6).
+R-3.16.1. `I` is a value: it is recognised wherever a value is expected — as a line head, as a horizontal argument, as a vertical one, and inside a paren group — and takes a `.method` chain with the ordinary application shape (§3.6). It takes **no horizontal arguments**: an argument is given on a deeper-indent line, or inside a paren group where the identity is applied to it.
+
+```
+I 5 > r                               ← rejected: the identity takes no horizontal arguments
+I > r                                 ← the vertical form of the same
+  5
+foo (I 5) > r                         ← accepted: the application is inside the group
+```
 
 R-3.16.2. **The void.** The void `I` binds is always named `x`, since nothing but the φ ever reads it. A same-named attribute of an enclosing formation does not capture that φ: the void is the nearest declaration of `x`, so scope resolution binds to it.
 
 R-3.16.3. **Emission / XMIR.** The parser emits a base-less `<o>` with two children in this order — the void `<o name='x' base='∅'/>` and the decoratee `<o name='φ' base='x'/>` — which is exactly what the spelled-out `x > [x]` emits.
 
-R-3.16.4. **Outer kind.** A bare `I` line is an `identity-object` (Appendix A): a pipe may apply arguments to it (R-3.14.2), because `I` names a formation, while its own deeper-indent children stay arguments, not bindings, as under any other head. An `I` carrying a chain or horizontal args takes the outer kind of the underlying application (§3.6).
+R-3.16.4. **Outer kind.** A bare `I` line is an `identity-object` (Appendix A): a pipe may apply arguments to it (R-3.14.2), because `I` names a formation, while its own deeper-indent children stay arguments, not bindings, as under any other head. An `I` carrying a chain takes the outer kind of the underlying application (§3.6).
 
 ---
 

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -29,6 +29,19 @@ import java.util.regex.Pattern;
 final class Emissions {
 
     /**
+     * What the parser says when the identity object is applied to
+     * arguments (R-3.16.1). Shared by every position an application may
+     * be written in — a line head ({@link LnApplication}), a paren
+     * group, an inline φ, and the φ of an only-phi line — so the writer
+     * gets the same instruction wherever the glyph carries arguments.
+     */
+    static final String NO_IDENTITY_ARGS = String.join(
+        " ",
+        "the identity object takes no horizontal arguments;",
+        "put the argument on a deeper-indent line"
+    );
+
+    /**
      * Bits an IEEE-754 double keeps below the leading one of its
      * significand.
      */
@@ -94,6 +107,9 @@ final class Emissions {
         final List<MethodChain> chain = tokens.readChain();
         final List<Value> args = tokens.readArgs();
         Bindings.checkAllOrNothing(args, span);
+        if (head.identity() && !args.isEmpty()) {
+            throw new ParseError(line, head.pos(), Emissions.NO_IDENTITY_ARGS);
+        }
         ChainEmission.link(emit, line, head, chain, name);
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, line);

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -149,10 +149,17 @@ final class LnApplication implements Line {
             );
         }
         if (!args.isEmpty() && head.opensFormationBody()) {
-            throw new ParseError(
-                this.span.line(), head.pos(),
-                "horizontal formation not allowed as argument"
-            );
+            final String reason;
+            if (head.identity()) {
+                reason = String.join(
+                    " ",
+                    "the identity object takes no horizontal arguments;",
+                    "put the argument on the next line, or apply it inside parentheses"
+                );
+            } else {
+                reason = "horizontal formation not allowed as argument";
+            }
+            throw new ParseError(this.span.line(), head.pos(), reason);
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -151,11 +151,7 @@ final class LnApplication implements Line {
         if (!args.isEmpty() && head.opensFormationBody()) {
             final String reason;
             if (head.identity()) {
-                reason = String.join(
-                    " ",
-                    "the identity object takes no horizontal arguments;",
-                    "put the argument on the next line, or apply it inside parentheses"
-                );
+                reason = Emissions.NO_IDENTITY_ARGS;
             } else {
                 reason = "horizontal formation not allowed as argument";
             }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/identity-glyph-with-arg-in-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/identity-glyph-with-arg-in-group.yaml
@@ -6,4 +6,4 @@ line: 2
 message: "the identity object takes no horizontal arguments; put the argument on a deeper-indent line"
 input: |
   [] > app
-    I 5 > y
+    foo (I 5) > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/identity-glyph-with-horizontal-arg.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/identity-glyph-with-horizontal-arg.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "horizontal formation not allowed as argument"
+message: "the identity object takes no horizontal arguments; put the argument on the next line, or apply it inside parentheses"
 input: |
   [] > app
     I 5 > y


### PR DESCRIPTION
Fixes #7477.

R-3.16.1 promised that the identity object takes horizontal arguments and spelled the form out as `I 5`, while the parser has rejected it since #6929, where `I 5 > y` was found to emit a formation child with neither `@name` nor `@as` (#6918). The rule now says what the parser does: no horizontal arguments, an argument goes on a deeper-indent line or inside a paren group where the identity is applied to it. The three lines the rule allows are given as examples, and the two other places that repeated the promise (the `IDENTITY` token row in the appendix and R-3.16.4's "chain or horizontal args") follow.

The message the parser gives for that line named a position the writer is not in: on `I 5 > r` the identity is the line head, not an argument, so `horizontal formation not allowed as argument` sends them looking for an argument to fix. With an identity head it now says what to write instead. Every other head that opens a formation body keeps the old wording, and the existing typo fixture pins the new message.
