### PR TITLE
Give each /{…} member its own error column

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -206,13 +206,13 @@ final class LnVoid implements Line {
             );
         }
         LnVoid.endsClean(tail, close + 1, span);
-        return LnVoid.members(tail.substring(open + 1, close), span);
+        return LnVoid.members(tail.substring(open + 1, close), open + 1, span);
     }
 
-    private static String members(final String inside, final Span span) {
+    private static String members(final String inside, final int offset, final Span span) {
         if (inside.isEmpty()) {
             throw new ParseError(
-                span.line(), span.indent(),
+                span.line(), span.indent() + 1 + offset,
                 "a `/{…}` argument list must name at least one type"
             );
         }
@@ -225,25 +225,25 @@ final class LnVoid implements Line {
             }
             if (end == idx) {
                 throw new ParseError(
-                    span.line(), span.indent(),
+                    span.line(), span.indent() + 1 + offset + idx,
                     "types in a `/{…}` list must be separated by exactly one space"
                 );
             }
             final String member = inside.substring(idx, end);
             if (member.indexOf('?') >= 0) {
                 throw new ParseError(
-                    span.line(), span.indent(),
+                    span.line(), span.indent() + 1 + offset + idx,
                     "? is not allowed inside a /{…} argument list"
                 );
             }
             if (out.length() > 0) {
                 out.append(' ');
             }
-            out.append(Suffix.typeAtom(member, span, span.indent()));
+            out.append(Suffix.typeAtom(member, span, span.indent() + 1 + offset + idx));
             idx = end + 1;
             if (idx == inside.length()) {
                 throw new ParseError(
-                    span.line(), span.indent(),
+                    span.line(), span.indent() + 1 + offset + idx,
                     "types in a `/{…}` list must be separated by exactly one space"
                 );
             }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/args-double-space-position.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/args-double-space-position.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "[2:17] error: 'types in a `/{…}` list must be separated by exactly one space'"
+input: |
+  [] > atom /A
+    ? > x /{string  number}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/args-member-position.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/args-member-position.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "[2:17] error: 'type variable must be one of A-F'"
+input: |
+  [] > atom /A
+    ? > x /{string Zzz number}


### PR DESCRIPTION
Closes #7510

LnVoid.members passed span.indent() as the source column for every member of a /{…} argument list, so an error raised on any type in the list landed at the line's indent instead of at the offending type — the caret pointed at the wrong token.

args() now carries the list's own start offset (the position right after the opening brace) into members(), and members() adds that offset plus the running index to span.indent() + 1, matching the convention LnVoid.type already uses for its own annotation column. All four ParseErrors raised inside members(), plus the Suffix.typeAtom call, now use that column.

Added two eo-typos cases that assert the exact [line:col] in the error message: one for a bad type variable partway through a list, one for a double-space separator partway through a list.