### PR TITLE
fix(#7508): report blank line before the first meta directive

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -56,6 +56,13 @@ final class LnMeta implements Line {
                 "blank line between meta directives is forbidden (R-6.5.5); the meta header is a single contiguous block"
             );
         }
+        if (!globals.inMetaHeader() && globals.pendingBlanks() > 0
+            && globals.pendingComments().isEmpty()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "meta header must appear at the top of the file"
+            );
+        }
         final String body = this.span.body();
         final int space = body.indexOf(' ');
         final String head;

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -129,8 +129,9 @@ final class LnMetaTest {
     @Test
     void clearsPendingBlanksOnEmission() {
         final Globals globals = new Globals();
+        globals.addComment(new Span("# doc", 1));
         globals.blank();
-        new LnMeta(new Span("+foo", 2)).into(new Stack(), globals, new Emit());
+        new LnMeta(new Span("+foo", 3)).into(new Stack(), globals, new Emit());
         MatcherAssert.assertThat(
             "a meta line is non-blank so it must reset pendingBlanks to zero",
             globals.pendingBlanks(),

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-meta-header.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-meta-header.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:0] error: 'meta header must appear at the top of the file'
+  +package foo
+  ^
+input: |
+
+  +package foo
+
+  [] > main
+    [] > @
+      hello > test

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-lines-before-meta-header.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-lines-before-meta-header.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  [3:0] error: 'meta header must appear at the top of the file'
+  +package foo
+  ^
+input: |
+
+
+  +package foo
+
+  [] > main
+    [] > @
+      hello > test


### PR DESCRIPTION
LnMeta.into guarded the blank-line check with globals.inMetaHeader(), but that flag only flips true once markMeta() runs at the end of the very same call — so the first meta directive in a file always saw inMetaHeader() as false and skipped the check entirely. A file opening with a blank line followed by +package foo parsed clean, even though the same leading blank in front of a plain object is rejected by Blanks.checkPlain.

The fix reads pendingBlanks() unconditionally for the first meta too, but only when there is no pending top comment block. A blank line separating a comment block from the first meta is required by R-6.5.2 and is validated separately by Comments.seal, so that case is left alone; without the guard, the existing top-comment-reports-its-own-line.yaml fixture would start failing.

Added two eo-syntax fixtures under eo-typos/empty-lines covering one and two leading blank lines before the meta header, both asserting the canonical message from PARSER_SPEC.md §9.9: "meta header must appear at the top of the file".

Closes #7508