### PR TITLE
fix(#7499): declare the fragile marker in XMIR.xsd

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -196,6 +196,18 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="fragile" type="empty">
+      <xs:annotation>
+        <xs:appinfo>The marker of a fragile dispatch "?." (R-3.5.3a)</xs:appinfo>
+        <xs:documentation>
+          Set on the dispatch node that a "?." link parses into, in a method
+          chain as well as in a reversed dispatch, and says that the receiver
+          may be ⊥ and the dispatch is to answer ⊥ rather than terminate.
+          A regular "." dispatch straight after such a link is reported by
+          the "fragile-dispatch" check.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="loc" type="locator"/>
     <xs:attribute name="atom" type="signature">
       <xs:annotation>

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/fragile-dispatch.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/fragile-dispatch.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7499: the parser marks a fragile `?.` dispatch with an empty `fragile`
+# attribute, and the schema has to know about it, or the XMIR of a program
+# the parser accepts does not validate.
+errors: 0
+document: |
+  <object author="eo-parser">
+    <o name="main">
+      <o base=".b" fragile="" name="x">
+        <o base="Φ.a"/>
+      </o>
+    </o>
+  </object>


### PR DESCRIPTION
Closes #7499.

The parser marks a fragile `?.` dispatch with an empty `fragile` attribute on
the dispatch node (R-3.5.3a, §9.4), and `XMIR.xsd` did not declare it, so the
XMIR of a program the parser accepts did not validate:

```
cvc-complex-type.3.2.2: Attribute 'fragile' is not allowed to appear in element 'o'.
```

Changes:

* `XMIR.xsd` — `fragile` is declared on `<o>`, next to the other markers, with
  the `empty` type it is emitted with.
* New pack `xsd-mistakes/fragile-dispatch.yaml`, so the marker stays covered
  by `EoSyntaxTest.checksXsdMistakes`. Against master that pack reports exactly
  the error above; with the declaration it reports none.

Verified locally: `mvn test -pl eo-parser` — `Tests run: 1326, Failures: 0,
Errors: 0, Skipped: 6`, and `mvn -PskipTests -Pqulice verify -pl eo-parser` is
clean.

Not in scope here: the issue also notes that seventeen packs under
`eo-parser/src/test/resources` and `eo-printer/src/test/resources` carry a `?.`
and are never validated against the schema at all, because only the files under
`xsd-mistakes/` are. Widening that validation is a separate change and is
likely to surface further gaps in the schema.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VJQnABXpcZR2UVuaShRzuU)_