### PR TITLE
validate write and send size through Natural

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
@@ -7,6 +7,8 @@ package org.eolang.posix;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
+import org.eolang.Expect;
+import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,8 +35,10 @@ public final class SendSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
-        final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size < 0 || size > buf.length) {
+        final int size = new Natural(
+            new Expect<>("the 'size' argument of send", () -> params[2])
+        ).it();
+        if (size > buf.length) {
             throw new ExFailure(
                 "Can't send %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
@@ -7,6 +7,8 @@ package org.eolang.posix;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
+import org.eolang.Expect;
+import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,8 +35,10 @@ public final class WriteSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
-        final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size < 0 || size > buf.length) {
+        final int size = new Natural(
+            new Expect<>("the 'size' argument of write", () -> params[2])
+        ).it();
+        if (size > buf.length) {
             throw new ExFailure(
                 "Can't write %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -7,6 +7,8 @@ package org.eolang.win32;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
+import org.eolang.Expect;
+import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -34,8 +36,10 @@ public final class SendFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
-        final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size < 0 || size > buf.length) {
+        final int size = new Natural(
+            new Expect<>("the 'size' argument of send", () -> params[2])
+        ).it();
+        if (size > buf.length) {
             throw new ExFailure(
                 "Can't send %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
@@ -7,6 +7,8 @@ package org.eolang.win32;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
+import org.eolang.Expect;
+import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,8 +35,10 @@ public final class WriteFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final byte[] buf = new Dataized(params[1]).take();
-        final int size = new Dataized(params[2]).asNumber().intValue();
-        if (size < 0 || size > buf.length) {
+        final int size = new Natural(
+            new Expect<>("the 'size' argument of write", () -> params[2])
+        ).it();
+        if (size > buf.length) {
             throw new ExFailure(
                 "Can't write %d bytes from a buffer of only %d bytes",
                 size, buf.length

--- a/eo-runtime/src/test/java/org/eolang/posix/SendSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/SendSyscallTest.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link SendSyscall}.
+ * @since 0.57.0
+ */
+final class SendSyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsNegativeFractionalSizeOnPosixSend() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new SendSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(new byte[]{1, 2}),
+                new Data.ToPhi(-0.5), new Data.ToPhi(0)
+            ),
+            "A negative fractional posix send size must fail with ExFailure, not report a false zero send"
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/posix/WriteSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/WriteSyscallTest.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link WriteSyscall}.
+ * @since 0.57.0
+ */
+final class WriteSyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsNegativeFractionalSizeOnPosixWrite() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new WriteSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(new byte[]{1, 2}), new Data.ToPhi(-0.5)
+            ),
+            "A negative fractional posix write size must fail with ExFailure, not report a false zero write"
+        );
+    }
+}


### PR DESCRIPTION
posix.write and posix.send (and their win32 counterparts, _write and WriteFile/send)
read the size argument with `Dataized(params[2]).asNumber().intValue()`, which
truncates toward zero. A fractional size like `3.999` silently writes three
bytes, and a negative fraction like `-0.5` truncates to `0`, slips past the
`size < 0` guard, and reports a successful zero-byte write that EO cannot tell
apart from a real one.

read and recv already guard against this by putting size through Natural and
Expect, which reject anything that isn't a whole number at or above zero. This
change puts write, send, WriteFuncCall and SendFuncCall through the same
Natural/Expect check, so all four now agree with read and recv instead of
disagreeing with them.

The buffer-length check (`size > buf.length`) stays, since Natural only knows
about the size argument itself; the redundant `size < 0` half of that check is
gone because Natural already rejects negative values, with a clearer message
naming the offending argument.

Closes #7509