### PR TITLE
fix(#7507): align emitted error texts with the §9.9 canonical table

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -46,7 +46,7 @@ final class Blanks {
         if (globals.pendingBlanks() > 0) {
             emit.error(
                 span.line(), span.indent(),
-                "blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line"
+                "blank line not allowed between non-master siblings"
             );
         }
     }
@@ -110,7 +110,7 @@ final class Blanks {
             if (globals.pendingBlanks() == 0) {
                 emit.error(
                     span.line(), span.indent(),
-                    "missing blank line between meta header and the first non-meta line (R-6.5.5); exactly one blank must separate them"
+                    "meta header must be followed by exactly one blank line"
                 );
             } else {
                 globals.clearBlanks();

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -113,7 +113,7 @@ final class LnFormation implements Line {
         if (suffix.atom() && !params.isEmpty()) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + 1,
-                "an atom must declare its void attributes vertically, as `? > name` lines"
+                "an atom must declare its void attributes vertically, as ? > name lines"
             );
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -226,7 +226,7 @@ final class LnVoid implements Line {
             if (end == idx) {
                 throw new ParseError(
                     span.line(), span.indent(),
-                    "types in a `/{…}` list must be separated by exactly one space"
+                    "types in a /{…} list must be separated by exactly one space"
                 );
             }
             final String member = inside.substring(idx, end);
@@ -244,7 +244,7 @@ final class LnVoid implements Line {
             if (idx == inside.length()) {
                 throw new ParseError(
                     span.line(), span.indent(),
-                    "types in a `/{…}` list must be separated by exactly one space"
+                    "types in a /{…} list must be separated by exactly one space"
                 );
             }
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -334,7 +334,7 @@ final class Suffix {
         } else {
             throw new ParseError(
                 span.line(), home + idx,
-                "trailing garbage after expression"
+                "unexpected content after name suffix"
             );
         }
         return result;
@@ -493,7 +493,7 @@ final class Suffix {
         if (idx < tail.length()) {
             throw new ParseError(
                 span.line(), home + idx,
-                "trailing garbage after name suffix"
+                "unexpected content after name suffix"
             );
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -60,7 +60,7 @@ final class Transition {
         if (level.patom() && !admission.permitted()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body"
+                "atom may contain only test attributes"
             );
         }
         if (admission.label() != null) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-misplace-ms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-misplace-ms.yaml
@@ -6,7 +6,7 @@ sheets: []
 asserts:
   - /object[@ms]
   - /object[not(.//o[@ms])]
-  - /object/errors/error[contains(text(),'garbage')]
+  - /object/errors/error[contains(text(),'unexpected content after name suffix')]
 input: |
   [] > app
     seq > s

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-trailing-garbage-after-bracket.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-trailing-garbage-after-bracket.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object/errors/error[contains(text(),'trailing garbage')]
+  - /object/errors/error[contains(text(),'unexpected content after name suffix')]
 input: |
   [] > main
     q.f (a > [x] this is garbage) > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-keeps-blank-before-next-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovery-keeps-blank-before-next-object.yaml
@@ -6,7 +6,7 @@ sheets: []
 asserts:
   - /object/errors[count(error)=2]
   - /object/errors/error[contains(text(),'expected identifier')]
-  - /object/errors/error[contains(text(),'R-6.5.4')]
+  - /object/errors/error[contains(text(),'blank line not allowed between non-master siblings')]
 input: |
   # Sample.
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-head.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:7] error: 'trailing garbage after name suffix'
+  [1:7] error: 'unexpected content after name suffix'
   [] > a [] > b [] > c [] > d hello world
          ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-void-args.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "types in a /{…} list must be separated by exactly one space"
+message: "types in a `/{…}` list must be separated by exactly one space"
 input: |
   [] > fopen /file
     ? > missing /{string  int}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-void-args.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "types in a /{…} list must be separated by exactly one space"
+input: |
+  [] > fopen /file
+    ? > missing /{string  int}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-application.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 4
 message: |-
-  [4:2] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [4:2] error: 'blank line not allowed between non-master siblings'
     x y > a
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-first-object.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-first-object.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:2] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [3:2] error: 'blank line not allowed between non-master siblings'
     "Hello" > @
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-method-2.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-method-2.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 13
 message: |-
-  [13:2] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [13:2] error: 'blank line not allowed between non-master siblings'
     o > b
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-method.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 4
 message: |-
-  [4:2] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [4:2] error: 'blank line not allowed between non-master siblings'
     x.y > a
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-ref-deep.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-ref-deep.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 8
 message: |-
-  [8:6] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [8:6] error: 'blank line not allowed between non-master siblings'
         a > c
         ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-ref.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-ref.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 4
 message: |-
-  [4:2] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [4:2] error: 'blank line not allowed between non-master siblings'
     x > a
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-in-vertical-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-in-vertical-application.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 5
 message: |-
-  [5:4] error: 'blank line before a plain object is forbidden (R-6.5.4); only master objects (formations, atoms, only-phi formations, +> tests) may be preceded by a blank line'
+  [5:4] error: 'blank line not allowed between non-master siblings'
       b
       ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/missing-empty-line-after-metas.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/missing-empty-line-after-metas.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:0] error: 'missing blank line between meta header and the first non-meta line (R-6.5.5); exactly one blank must separate them'
+  [3:0] error: 'meta header must be followed by exactly one blank line'
   [] > main
   ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application-second-child.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application-second-child.yaml
@@ -7,7 +7,7 @@
 # through unchecked.
 line: 4
 message: |-
-  [4:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
+  [4:2] error: 'atom may contain only test attributes'
     42 > bar
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms-application.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
+  [2:2] error: 'atom may contain only test attributes'
     42 > bar
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/not-empty-atoms.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:2] error: 'Atom cannot contain inner objects; only `+>` and `->` test attributes are allowed in an atom body'
+  [2:2] error: 'atom may contain only test attributes'
     [] > inner
     ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/scoped-application-after-suffix.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/scoped-application-after-suffix.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:8] error: 'trailing garbage after name suffix'
+  [2:8] error: 'unexpected content after name suffix'
     a > x (b > x)
           ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/space-in-tail.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/space-in-tail.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:6] error: 'trailing garbage after name suffix'
+  [1:6] error: 'unexpected content after name suffix'
   [] >  foo
         ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/suffix-with-dots.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/suffix-with-dots.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:8] error: 'trailing garbage after name suffix'
+  [1:8] error: 'unexpected content after name suffix'
   [] > foo.x.main
           ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-non-suffix-auto.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-non-suffix-auto.yaml
@@ -3,7 +3,7 @@
 ---
 line: 1
 message: |-
-  [1:9] error: 'trailing garbage after name suffix'
+  [1:9] error: 'unexpected content after name suffix'
   5 >> foo bar
            ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-non-suffix-test.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-non-suffix-test.yaml
@@ -3,7 +3,7 @@
 ---
 line: 1
 message: |-
-  [1:10] error: 'trailing garbage after name suffix'
+  [1:10] error: 'unexpected content after name suffix'
   [] +> foo garbage
             ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-non-suffix.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-non-suffix.yaml
@@ -3,7 +3,7 @@
 ---
 line: 1
 message: |-
-  [1:1] error: 'trailing garbage after expression'
+  [1:1] error: 'unexpected content after name suffix'
   5x
    ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "types in a `/{…}` list must be separated by exactly one space"
+message: "types in a /{…} list must be separated by exactly one space"
 input: |
   [] > fopen /file
     ? > missing /{string }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "types in a /{…} list must be separated by exactly one space"
+message: "types in a `/{…}` list must be separated by exactly one space"
 input: |
   [] > fopen /file
     ? > missing /{string }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/version-with-inline-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/version-with-inline-application.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 2
 message: |-
-  [2:8] error: 'trailing garbage after expression'
+  [2:8] error: 'unexpected content after name suffix'
     stdout|1.2.3 42
           ^
 input: |


### PR DESCRIPTION
Several parser error messages diverged from the exact canonical text that PARSER_SPEC.md §9.9 (R-9.9.1) requires, breaking the guarantee that two implementations report the same condition identically.

This brings each flagged site back to the table's wording: the two "trailing garbage" variants in Suffix.java become `unexpected content after name suffix`; the verbose blank-line-before-plain-object and meta-header messages in Blanks.java are trimmed to their canonical form; the atom-body message in Transition.java drops its rationale prose; and the backtick-wrapped void-attribute and `/{…}`-list messages in LnFormation.java and LnVoid.java lose the stray backticks so LnVoid is consistent with itself.

Golden-file fixtures under eo-typos and eo-syntax that asserted the old wording are updated to match.

Closes #7507