### PR TITLE
fix(#7505): drop unreachable indent-step check from Stack.push

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -12,10 +12,10 @@ import java.util.List;
  *
  * <p>The stack carries one {@link Level} per occupied indent level. Indents
  * grow strictly bottom-to-top in steps of exactly two (R-5.1.1, R-5.1.2);
- * this class enforces the step at {@link #push(int, int, Kind, Openness)}.
- * The bottom entry's {@code parent} is always {@link Kind#TOP_LEVEL};
- * higher entries carry the kind of the entry directly below them as their
- * parent.</p>
+ * the caller enforces the step (R-5.1.3) before calling
+ * {@link #push(int, int, Kind, Openness)}. The bottom entry's
+ * {@code parent} is always {@link Kind#TOP_LEVEL}; higher entries carry the
+ * kind of the entry directly below them as their parent.</p>
  *
  * <p>This class manages structural transitions only. Close-time semantic
  * checks (R-5.3.1 through R-5.3.5) are dispatched to a caller-supplied
@@ -27,12 +27,6 @@ import java.util.List;
  * @since 0.1
  */
 final class Stack {
-
-    /**
-     * Indent step between adjacent stack entries — fixed at 2 spaces by
-     * R-2.2.1.
-     */
-    private static final int STEP = 2;
 
     /**
      * The levels, bottom-to-top.
@@ -222,14 +216,6 @@ final class Stack {
             owner = "";
         } else {
             final Level under = this.top();
-            if (indent != under.indent() + Stack.STEP) {
-                throw new IllegalStateException(
-                    String.format(
-                        "push at indent %d violates step rule from indent %d",
-                        indent, under.indent()
-                    )
-                );
-            }
             parent = under.kind();
             patom = under.atom();
             argues = under.argumentative();

--- a/eo-parser/src/test/java/org/eolang/parser/StackTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/StackTest.java
@@ -74,17 +74,6 @@ final class StackTest {
     }
 
     @Test
-    void rejectsPushWithIndentJumpGreaterThanTwo() {
-        final Stack stack = new Stack();
-        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
-        Assertions.assertThrows(
-            IllegalStateException.class,
-            () -> stack.push(4, 2, Kind.HEAD, Openness.OPEN),
-            "indent jump of more than one level cannot push"
-        );
-    }
-
-    @Test
     void readsParentKindFromEntryBelow() {
         final Stack stack = new Stack();
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);

--- a/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
@@ -54,6 +54,22 @@ final class TransitionTest {
     }
 
     @Test
+    void capturesCanonicalMessageOfIndentJumpViolation() {
+        final Stack stack = new Stack();
+        new Transition(stack, new Span("delta", 1))
+            .apply(Kind.BARE_FORMATION, Openness.OPEN, new Admission(null, false));
+        MatcherAssert.assertThat(
+            "the error message must name the indent-step requirement",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new Transition(stack, new Span("    epsilon", 2))
+                    .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false))
+            ).getMessage(),
+            Matchers.equalTo("indent increased by more than one level")
+        );
+    }
+
+    @Test
     void rejectsDeeperChildUnderHorizontallyCompletedParent() {
         final Stack stack = new Stack();
         new Transition(stack, new Span("zeta", 1))

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/indent-jumps-two-levels.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/indent-jumps-two-levels.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:0] error: 'indent increased by more than one level'
+      bar
+  ^
+input: |
+  [] > foo
+      bar


### PR DESCRIPTION
Stack.push carried an indent-step check that could never fire. Its only caller, Transition.pushed, already checks the same condition and throws a ParseError with the canonical "indent increased by more than one level" text before ever calling push — so the IllegalStateException branch inside push was dead.

This drops that branch, the now-unused STEP constant it referenced, and the test that exercised the dead branch by calling Stack.push directly. Stack's class docblock is updated to say the caller enforces the step, since the class itself no longer does.

R-5.1.3 is still enforced, just once, in Transition.pushed, where the canonical error text already lives.

Closes #7505