### PR TITLE
Make a receiver an ordinary attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,10 +156,10 @@ This is how you iterate:
 [args] > app
   malloc.for > @
     2
-    [x] >>
+    [^ x] >>
       while > @
-        ^.x.as-number.lt 6 > [i] >>
-        seq * > [i] >>
+        ^.x.as-number.lt 6 > [^ i] >>
+        seq * > [^ i] >>
           stdout
             "%d x %1$d = %d\n".printf
               *

--- a/eo-integration-tests/src/it/fibonacci/src/main/eo/examples/fibonacci.eo
+++ b/eo-integration-tests/src/it/fibonacci/src/main/eo/examples/fibonacci.eo
@@ -6,7 +6,7 @@
 +package examples
 +architect yegor256@gmail.com
 
-[n] > fibonacci
+[^ n] > fibonacci
   if. > @
     lt.
       n

--- a/eo-integration-tests/src/test/resources/snippets/fibo.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/fibo.yaml
@@ -10,7 +10,7 @@ eo: |
   +package snippets
 
   [] > fibo
-    [n] > f
+    [^ n] > f
       if. > @
         n.lt 2
         n

--- a/eo-runtime/src/main/java/org/eolang/AtRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtRho.java
@@ -11,7 +11,9 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Special attribute for \rho.
  *
- * <p>The attribute can be set only once, and it ignores all other puts.</p>
+ * <p>The attribute behaves like a void one, except that it keeps the
+ * receiver by reference: copying an object must not clone the chain
+ * above it.</p>
  *
  * @since 0.36.0
  */
@@ -44,18 +46,29 @@ public final class AtRho implements Attribute {
 
     @Override
     public Phi get() {
-        if (this.rho.get() == null) {
-            throw new ExUnset(
-                String.format("The \"%s\" attribute is not set", Phi.RHO)
+        final Phi phi = this.rho.get();
+        final Phi result;
+        if (phi == null) {
+            result = new PhTerminator(
+                String.format("the attribute \"%s\" is not set", Phi.RHO)
             );
+        } else {
+            result = phi;
         }
-        return this.rho.get();
+        return result;
     }
 
     @Override
     public void put(final Phi phi) {
         Objects.requireNonNull(phi, "Attribute value can't be null");
-        this.rho.compareAndSet(null, phi);
+        if (!this.rho.compareAndSet(null, phi)) {
+            throw new ExReadOnly(
+                String.format(
+                    "This void attribute \"%s\" is already set, can't reset",
+                    Phi.RHO
+                )
+            );
+        }
     }
 
     @Override
@@ -65,6 +78,13 @@ public final class AtRho implements Attribute {
 
     @Override
     public String φTerm() {
-        return "^";
+        final Phi phi = this.rho.get();
+        final String term;
+        if (phi == null) {
+            term = "?";
+        } else {
+            term = "^";
+        }
+        return term;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/AtWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtWithRho.java
@@ -6,14 +6,15 @@
 package org.eolang;
 
 /**
- * The attribute that tries to copy object and set \rho to it if it has not already set.
+ * The attribute that copies the object and binds itself as its \rho, but
+ * only when the object declares a \rho and has not been bound to one yet.
  * The terminator ({@link PhTerminator}) silently ignores this \rho itself, so no container
  * leaks into it and its cause is not masked as it propagates.
  * This attribute is NOT thread safe!
  * @since 0.36.0
  * @todo #4673:30min The {@link AtWithRho#get()} is not thread safe. If multiple threads
  *  call get() concurrently when the underlying object lacks RHO, each thread will:
- *  1. Pass the !ret.hasRho() check
+ *  1. Pass the ret.needsRho() check
  *  2. Create its own copy via ret.copy()
  *  3. Attempt to set RHO on its copy
  *  This results in different threads receiving different copies, violating the expectation
@@ -52,7 +53,7 @@ final class AtWithRho implements Attribute {
     @Override
     public Phi get() {
         Phi ret = this.original.get();
-        if (!ret.hasRho()) {
+        if (ret.needsRho()) {
             ret = ret.copy();
             ret.put(Phi.RHO, this.rho);
         }

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -81,8 +81,8 @@ public interface Data {
         }
 
         @Override
-        public boolean hasRho() {
-            return this.object.hasRho();
+        public boolean needsRho() {
+            return this.object.needsRho();
         }
 
         @Override

--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -35,6 +35,10 @@ public interface Data {
      * return applied;
      * }
      *
+     * <p>It never needs a receiver: data becomes one of the root objects — a
+     * number, a string, a bytes, a tuple — and every one of them takes its
+     * receiver from the package that handed it out.</p>
+     *
      * @since 0.1
      */
     final class ToPhi implements Phi {
@@ -82,7 +86,7 @@ public interface Data {
 
         @Override
         public boolean needsRho() {
-            return this.object.needsRho();
+            return false;
         }
 
         @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOand.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOand.java
@@ -19,7 +19,7 @@ public final class EObytes$EOand extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOand() {
-        super(new Attrs(new Attr("b", new AtVoid("b"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("b", new AtVoid("b"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOconcat.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOconcat.java
@@ -19,7 +19,7 @@ public final class EObytes$EOconcat extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOconcat() {
-        super(new Attrs(new Attr("b", new AtVoid("b"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("b", new AtVoid("b"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOeq.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOeq.java
@@ -21,7 +21,7 @@ public final class EObytes$EOeq extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOeq() {
-        super(new Attrs(new Attr("b", new AtVoid("b"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("b", new AtVoid("b"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOnot.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOnot.java
@@ -20,6 +20,7 @@ public final class EObytes$EOnot extends PhDefault implements Atom {
      */
     public EObytes$EOnot() {
         // nothing
+        super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOnot.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOnot.java
@@ -19,7 +19,6 @@ public final class EObytes$EOnot extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOnot() {
-        // nothing
         super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOor.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOor.java
@@ -19,7 +19,7 @@ public final class EObytes$EOor extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOor() {
-        super(new Attrs(new Attr("b", new AtVoid("b"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("b", new AtVoid("b"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOright.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOright.java
@@ -19,7 +19,7 @@ public final class EObytes$EOright extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOright() {
-        super(new Attrs(new Attr("x", new AtVoid("x"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOsize.java
@@ -20,6 +20,7 @@ public final class EObytes$EOsize extends PhDefault implements Atom {
      */
     public EObytes$EOsize() {
         // nothing
+        super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOsize.java
@@ -19,7 +19,6 @@ public final class EObytes$EOsize extends PhDefault implements Atom {
      * Ctor.
      */
     public EObytes$EOsize() {
-        // nothing
         super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
+++ b/eo-runtime/src/main/java/org/eolang/EObytes$EOslice.java
@@ -27,6 +27,7 @@ public final class EObytes$EOslice extends PhDefault implements Atom {
      */
     public EObytes$EOslice() {
         super(new Attrs(
+            new Attr(Phi.RHO, new AtRho()),
             new Attr("start", new AtVoid("start")),
             new Attr("len", new AtVoid("len")),
             new Attr(EObytes$EOslice.FALLBACK, new AtVoid(EObytes$EOslice.FALLBACK))

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOread.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOread.java
@@ -25,6 +25,7 @@ public final class EOchunk$EOread extends PhDefault implements Atom {
      */
     public EOchunk$EOread() {
         super(new Attrs(
+            new Attr(Phi.RHO, new AtRho()),
             new Attr("offset", new AtVoid("offset")),
             new Attr("length", new AtVoid("length")),
             new Attr(

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOresized.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOresized.java
@@ -26,6 +26,7 @@ public final class EOchunk$EOresized extends PhDefault implements Atom {
     public EOchunk$EOresized() {
         super(
             new Attrs(
+                new Attr(Phi.RHO, new AtRho()),
                 new Attr(
                     EOchunk$EOresized.CAPACITY,
                     new AtVoid(EOchunk$EOresized.CAPACITY)

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOsize.java
@@ -20,6 +20,7 @@ public final class EOchunk$EOsize extends PhDefault implements Atom {
      */
     public EOchunk$EOsize() {
         // nothing
+        super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOsize.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOsize.java
@@ -19,7 +19,6 @@ public final class EOchunk$EOsize extends PhDefault implements Atom {
      * Ctor.
      */
     public EOchunk$EOsize() {
-        // nothing
         super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOwrite.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOwrite.java
@@ -20,6 +20,7 @@ public final class EOchunk$EOwrite extends PhDefault implements Atom {
      */
     public EOchunk$EOwrite() {
         super(new Attrs(
+            new Attr(Phi.RHO, new AtRho()),
             new Attr("offset", new AtVoid("offset")),
             new Attr("data", new AtVoid("data"))
         ));

--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOlisted.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOlisted.java
@@ -26,7 +26,6 @@ public final class EOdirectory$EOlisted extends PhDefault implements Atom {
      * Ctor.
      */
     public EOdirectory$EOlisted() {
-        // nothing
         super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/EOdirectory$EOlisted.java
+++ b/eo-runtime/src/main/java/org/eolang/EOdirectory$EOlisted.java
@@ -27,6 +27,7 @@ public final class EOdirectory$EOlisted extends PhDefault implements Atom {
      */
     public EOdirectory$EOlisted() {
         // nothing
+        super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOnumber$EOdiv.java
+++ b/eo-runtime/src/main/java/org/eolang/EOnumber$EOdiv.java
@@ -19,7 +19,7 @@ public final class EOnumber$EOdiv extends PhDefault implements Atom {
      * Ctor.
      */
     public EOnumber$EOdiv() {
-        super(new Attrs(new Attr("x", new AtVoid("x"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOnumber$EOgt.java
+++ b/eo-runtime/src/main/java/org/eolang/EOnumber$EOgt.java
@@ -19,7 +19,7 @@ public final class EOnumber$EOgt extends PhDefault implements Atom {
      * Ctor.
      */
     public EOnumber$EOgt() {
-        super(new Attrs(new Attr("x", new AtVoid("x"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOnumber$EOplus.java
+++ b/eo-runtime/src/main/java/org/eolang/EOnumber$EOplus.java
@@ -19,7 +19,7 @@ public final class EOnumber$EOplus extends PhDefault implements Atom {
      * Ctor.
      */
     public EOnumber$EOplus() {
-        super(new Attrs(new Attr("x", new AtVoid("x"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOnumber$EOtimes.java
+++ b/eo-runtime/src/main/java/org/eolang/EOnumber$EOtimes.java
@@ -19,7 +19,7 @@ public final class EOnumber$EOtimes extends PhDefault implements Atom {
      * Ctor.
      */
     public EOnumber$EOtimes() {
-        super(new Attrs(new Attr("x", new AtVoid("x"))));
+        super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x"))));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOposix$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOposix$EOφ.java
@@ -21,6 +21,7 @@ public final class EOposix$EOφ extends PhDefault implements Atom {
      */
     public EOposix$EOφ() {
         // nothing
+        super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOposix$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOposix$EOφ.java
@@ -20,7 +20,6 @@ public final class EOposix$EOφ extends PhDefault implements Atom {
      * Ctor.
      */
     public EOposix$EOφ() {
-        // nothing
         super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
@@ -31,6 +31,7 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
      */
     public EOstring$EOregex$EOcompile() {
         super(new Attrs(
+            new Attr(Phi.RHO, new AtRho()),
             new Attr(
                 EOstring$EOregex$EOcompile.FALLBACK,
                 new AtVoid(EOstring$EOregex$EOcompile.FALLBACK)

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -39,6 +39,7 @@ public final class EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index exten
     public EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index() {
         super(
             new Attrs(
+                new Attr(Phi.RHO, new AtRho()),
                 new Attr(
                     EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.POSITION,
                     new AtVoid(EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.POSITION)

--- a/eo-runtime/src/main/java/org/eolang/EOwin32$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOwin32$EOφ.java
@@ -21,6 +21,7 @@ public final class EOwin32$EOφ extends PhDefault implements Atom {
      */
     public EOwin32$EOφ() {
         // nothing
+        super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/EOwin32$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOwin32$EOφ.java
@@ -20,7 +20,6 @@ public final class EOwin32$EOφ extends PhDefault implements Atom {
      * Ctor.
      */
     public EOwin32$EOφ() {
-        // nothing
         super(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 

--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -92,8 +92,8 @@ public final class PhCoverage implements Phi {
     }
 
     @Override
-    public boolean hasRho() {
-        return this.origin.hasRho();
+    public boolean needsRho() {
+        return this.origin.needsRho();
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -192,8 +192,9 @@ public class PhDefault implements Phi, Cloneable {
     }
 
     @Override
-    public boolean hasRho() {
-        return !this.loaded().get(Phi.RHO).vacant();
+    public boolean needsRho() {
+        final Attribute attr = this.loaded().get(Phi.RHO);
+        return attr != null && attr.vacant();
     }
 
     @Override
@@ -372,7 +373,11 @@ public class PhDefault implements Phi, Cloneable {
 
     private Phi absent(final String name) {
         final Phi object;
-        if (this instanceof Atom) {
+        if (Phi.RHO.equals(name)) {
+            object = new PhTerminator(
+                String.format("the object %s declares no receiver", this.forma())
+            );
+        } else if (this instanceof Atom) {
             object = this.take(Phi.LAMBDA).take(name);
         } else if (this.loaded().containsKey(Phi.PHI)) {
             object = this.take(Phi.PHI).take(name);
@@ -452,7 +457,7 @@ public class PhDefault implements Phi, Cloneable {
         this.lock.lock();
         try {
             if (this.attrs == null) {
-                this.attrs = PhDefault.defaults();
+                this.attrs = new Bindings();
                 for (final Map.Entry<String, Attribute> ent : this.initial.entrySet()) {
                     this.add(ent.getKey(), ent.getValue());
                 }
@@ -511,11 +516,6 @@ public class PhDefault implements Phi, Cloneable {
         return result;
     }
 
-    private static Map<String, Attribute> defaults() {
-        final Map<String, Attribute> attrs = new Bindings();
-        attrs.put(Phi.RHO, new AtRho());
-        return attrs;
-    }
 
     private static AtomTypes atoms() {
         final Map<String, String> table;

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -516,7 +516,6 @@ public class PhDefault implements Phi, Cloneable {
         return result;
     }
 
-
     private static AtomTypes atoms() {
         final Map<String, String> table;
         final InputStream source = PhDefault.class.getResourceAsStream("atoms.csv");

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -39,7 +39,10 @@ public final class PhLogged implements Phi {
 
     @Override
     public boolean needsRho() {
-        return this.origin.needsRho();
+        System.out.printf("%d.needsRho()...%n", this.hashCode());
+        final boolean ret = this.origin.needsRho();
+        System.out.printf("%d.needsRho()! -> %b%n", this.hashCode(), ret);
+        return ret;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -38,11 +38,8 @@ public final class PhLogged implements Phi {
     }
 
     @Override
-    public boolean hasRho() {
-        System.out.printf("%d.hasRho()...%n", this.hashCode());
-        final boolean ret = this.origin.hasRho();
-        System.out.printf("%d.hasRho()! -> %b%n", this.hashCode(), ret);
-        return ret;
+    public boolean needsRho() {
+        return this.origin.needsRho();
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -75,9 +75,16 @@ public class PhOnce implements Phi {
         );
     }
 
+    /**
+     * A receiver is bound onto a formation, never onto the result of an
+     * expression: the dispatch that produced this object has already given
+     * it the receiver it deserves. Answering without forcing the wrapped
+     * object keeps a lazy expression lazy while it is dispatched over.
+     * @return Always FALSE
+     */
     @Override
-    public boolean hasRho() {
-        return this.object.get().hasRho();
+    public boolean needsRho() {
+        return false;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -12,6 +12,13 @@ import java.util.function.Supplier;
 
 /**
  * An object wrapping another one.
+ *
+ * <p>It never needs a receiver. A receiver is bound onto a formation, never
+ * onto the result of an expression: the dispatch that produced this object
+ * has already given it the receiver it deserves. Saying so without forcing
+ * the wrapped object keeps a lazy expression lazy while it is dispatched
+ * over.</p>
+ *
  * @since 0.1
  * @checkstyle DesignForExtensionCheck (200 lines)
  */
@@ -75,13 +82,6 @@ public class PhOnce implements Phi {
         );
     }
 
-    /**
-     * A receiver is bound onto a formation, never onto the result of an
-     * expression: the dispatch that produced this object has already given
-     * it the receiver it deserves. Answering without forcing the wrapped
-     * object keeps a lazy expression lazy while it is dispatched over.
-     * @return Always FALSE
-     */
     @Override
     public boolean needsRho() {
         return false;

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -117,16 +117,6 @@ final class PhPackage implements Phi {
         return this.pkg;
     }
 
-    /**
-     * Load the object and bind this package as its receiver.
-     *
-     * <p>A package does not overwrite a receiver that is already bound: a
-     * decorated top-level object gets its \rho from the dispatch that
-     * resolved its decoratee, and that binding stays.</p>
-     *
-     * @param fqn Fully qualified name of the object
-     * @return The object, with its receiver in place
-     */
     private Phi bound(final String fqn) {
         final Phi loaded = this.loadPhi(fqn);
         if (loaded.needsRho()) {

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -55,8 +55,8 @@ final class PhPackage implements Phi {
     }
 
     @Override
-    public boolean hasRho() {
-        return this.objects.containsKey(Phi.RHO);
+    public boolean needsRho() {
+        return false;
     }
 
     @Override
@@ -84,9 +84,7 @@ final class PhPackage implements Phi {
             }
             taken = next;
         } else {
-            final Phi loaded = this.loadPhi(fqn);
-            loaded.put(Phi.RHO, this);
-            this.put(fqn, loaded);
+            this.put(fqn, this.bound(fqn));
             taken = this.take(name);
         }
         return taken;
@@ -117,6 +115,24 @@ final class PhPackage implements Phi {
     @Override
     public String φTerm() {
         return this.pkg;
+    }
+
+    /**
+     * Load the object and bind this package as its receiver.
+     *
+     * <p>A package does not overwrite a receiver that is already bound: a
+     * decorated top-level object gets its \rho from the dispatch that
+     * resolved its decoratee, and that binding stays.</p>
+     *
+     * @param fqn Fully qualified name of the object
+     * @return The object, with its receiver in place
+     */
+    private Phi bound(final String fqn) {
+        final Phi loaded = this.loadPhi(fqn);
+        if (loaded.needsRho()) {
+            loaded.put(Phi.RHO, this);
+        }
+        return loaded;
     }
 
     private Phi loadPhi(final String fqn) {

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -127,8 +127,8 @@ public final class PhSafe implements Phi, Atom {
     }
 
     @Override
-    public boolean hasRho() {
-        return this.through(this.origin::hasRho);
+    public boolean needsRho() {
+        return this.through(this.origin::needsRho);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -103,7 +103,7 @@ public final class PhTerminator implements Phi {
     }
 
     @Override
-    public boolean hasRho() {
+    public boolean needsRho() {
         return false;
     }
 

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -49,10 +49,16 @@ public interface Phi extends Data, Term {
     Phi copy();
 
     /**
-     * Returns true if object has bound rho attribute.
-     * @return True if object has rho bound attribute
+     * Does this object still await a receiver?
+     *
+     * <p>True only when the object carries a rho attribute that nothing has
+     * filled yet. An object that declares no rho wants no receiver, and one
+     * whose rho is already bound must keep it, so both answer FALSE and a
+     * dispatch leaves them alone.</p>
+     *
+     * @return TRUE if a rho attribute is present and empty
      */
-    boolean hasRho();
+    boolean needsRho();
 
     /**
      * Take object by name of the attribute.

--- a/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtRhoTest.java
@@ -16,20 +16,31 @@ import org.junit.jupiter.api.Test;
 final class AtRhoTest {
 
     @Test
-    void printsCaretAsTerm() {
+    void printsQuestionMarkAsTermWhenUnset() {
         MatcherAssert.assertThat(
-            "AtRho must render as caret in φ-term, but it didnt",
+            "AtRho must render as question mark in φ-term while unset, but it didnt",
             new AtRho().φTerm(),
+            Matchers.equalTo("?")
+        );
+    }
+
+    @Test
+    void printsCaretAsTermWhenSet() {
+        final Attribute rho = new AtRho();
+        rho.put(new PhDefault());
+        MatcherAssert.assertThat(
+            "AtRho must render as caret in φ-term once set, but it didnt",
+            rho.φTerm(),
             Matchers.equalTo("^")
         );
     }
 
     @Test
-    void throwsOnEmptyRho() {
-        Assertions.assertThrows(
-            ExUnset.class,
-            new AtRho()::get,
-            "AtRho must throw an exception if attribute is not set"
+    void terminatesOnEmptyRho() {
+        MatcherAssert.assertThat(
+            "AtRho must terminate, not throw, while the attribute is not set",
+            new AtRho().get(),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 
@@ -58,15 +69,16 @@ final class AtRhoTest {
     }
 
     @Test
-    void doesNotResetObject() {
+    void rejectsSecondPut() {
         final Attribute rho = new AtRho();
-        final Phi obj = new PhDefault();
-        rho.put(obj);
         rho.put(new PhDefault());
         MatcherAssert.assertThat(
-            "AtRho must not change state after put()",
-            rho.get(),
-            Matchers.equalTo(obj)
+            "AtRho must reject the second put instead of dropping it silently",
+            Assertions.assertThrows(
+                ExReadOnly.class,
+                () -> rho.put(new PhDefault())
+            ).getMessage(),
+            Matchers.containsString("already set")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
@@ -143,10 +143,6 @@ final class AtWithRhoTest {
         );
     }
 
-    /**
-     * Make an object that declares a receiver, the way a formation does.
-     * @return The object
-     */
     private Phi formation() {
         return new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }

--- a/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AtWithRhoTest.java
@@ -29,14 +29,15 @@ final class AtWithRhoTest {
         final Phi rho = new PhDefault();
         MatcherAssert.assertThat(
             "AtWithRho must set RHO if it is not set before",
-            new AtWithRho(new AtComposite(new PhDefault(), phi -> phi), rho).get().take(Phi.RHO),
+            new AtWithRho(new AtComposite(this.formation(), phi -> phi), rho)
+                .get().take(Phi.RHO),
             Matchers.is(rho)
         );
     }
 
     @Test
     void copiesAndSetsRhoIfNotSetMustCopyOriginal() {
-        final Phi obj = new PhDefault();
+        final Phi obj = this.formation();
         final Phi phi = new AtWithRho(new AtComposite(obj, p -> p), new PhDefault()).get();
         phi.take(Phi.RHO);
         MatcherAssert.assertThat(
@@ -61,7 +62,7 @@ final class AtWithRhoTest {
 
     @Test
     void doesNotCopyAndSetRhoIfAlreadySetMustNotResetRho() {
-        final Phi obj = new PhDefault();
+        final Phi obj = this.formation();
         final Phi rho = new PhDefault();
         obj.put(Phi.RHO, rho);
         MatcherAssert.assertThat(
@@ -73,7 +74,7 @@ final class AtWithRhoTest {
 
     @Test
     void doesNotCopyAndSetRhoIfAlreadySetMustCopyOriginalIfRhoIsSet() {
-        final Phi obj = new PhDefault();
+        final Phi obj = this.formation();
         obj.put(Phi.RHO, new PhDefault());
         final Phi res = new AtWithRho(new AtComposite(obj, phi -> phi), new PhDefault()).get();
         res.take(Phi.RHO);
@@ -86,18 +87,18 @@ final class AtWithRhoTest {
 
     @Test
     void copiesWithNewRhoMustSetNewPhoOnCopy() {
-        final Phi self = new PhDefault();
+        final Phi self = this.formation();
         MatcherAssert.assertThat(
             "AtWithRho must set new RHO on copy() operation",
-            new AtWithRho(new AtComposite(new PhDefault(), phi -> phi), new PhDefault()).copy(self)
-                .get().take(Phi.RHO),
+            new AtWithRho(new AtComposite(this.formation(), phi -> phi), new PhDefault())
+                .copy(self).get().take(Phi.RHO),
             Matchers.is(self)
         );
     }
 
     @Test
     void copiesWithNewRhoMustCallCopyOnOriginal() {
-        final Phi obj = new PhDefault();
+        final Phi obj = this.formation();
         final Phi res = new AtWithRho(new AtComposite(obj, phi -> phi), new PhDefault()).copy(
             new PhDefault()
         ).get();
@@ -134,14 +135,19 @@ final class AtWithRhoTest {
     @Test
     void leavesADeclaredReceiverUnwrapped() {
         final PhDefault host = new PhDefault();
-        host.add(
-            "kid",
-            new AtComposite(host, rho -> new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho()))))
-        );
+        host.add("kid", new AtComposite(host, rho -> this.formation()));
         MatcherAssert.assertThat(
             "a declared receiver must hand out the host itself, but it didnt",
             host.take("kid").take(Phi.RHO),
             Matchers.is(host)
         );
+    }
+
+    /**
+     * Make an object that declares a receiver, the way a formation does.
+     * @return The object
+     */
+    private Phi formation() {
+        return new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/DataTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataTest.java
@@ -29,6 +29,15 @@ final class DataTest {
     }
 
     @Test
+    void doesNotNeedRho() {
+        MatcherAssert.assertThat(
+            "Data must arrive with its receiver in place, but it didnt",
+            new Data.ToPhi("hello").needsRho(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void failsWhenObjectTypeIsUnknown() {
         Assertions.assertThrows(
             ExFailure.class,

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -377,10 +377,6 @@ final class ExpectTest {
         );
     }
 
-    /**
-     * Make an object that declares a receiver, the way a formation does.
-     * @return The object
-     */
     private Phi formation() {
         return new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }

--- a/eo-runtime/src/test/java/org/eolang/ExpectTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ExpectTest.java
@@ -152,7 +152,7 @@ final class ExpectTest {
                 () -> new Numeric(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(true)
                         ),
@@ -174,7 +174,7 @@ final class ExpectTest {
                 () -> new Int(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(true)
                         ),
@@ -196,7 +196,7 @@ final class ExpectTest {
                 () -> new Int(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(42.23)
                         ),
@@ -218,7 +218,7 @@ final class ExpectTest {
                 () -> new Natural(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(true)
                         ),
@@ -240,7 +240,7 @@ final class ExpectTest {
                 () -> new Natural(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(42.23)
                         ),
@@ -262,7 +262,7 @@ final class ExpectTest {
                 () -> new Natural(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(-42)
                         ),
@@ -284,7 +284,7 @@ final class ExpectTest {
                 () -> new Int(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(1.0e15)
                         ),
@@ -306,7 +306,7 @@ final class ExpectTest {
                 () -> new Natural(
                     Expect.at(
                         new PhApplication(
-                            new PhDefault(),
+                            this.formation(),
                             Phi.RHO,
                             new Data.ToPhi(1.0e15)
                         ),
@@ -375,5 +375,13 @@ final class ExpectTest {
             ).getMessage(),
             Matchers.equalTo("the 'ρ' attribute must be a number")
         );
+    }
+
+    /**
+     * Make an object that declares a receiver, the way a formation does.
+     * @return The object
+     */
+    private Phi formation() {
+        return new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())));
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -95,10 +95,10 @@ final class PhDefaultTest {
 
     @Test
     void doesNotHaveRhoWhenFormed() {
-        Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new PhSafe(PhDefaultTest.Int.made()).take(Phi.RHO),
-            String.format("Object should not have %s attribute when it's just formed", Phi.RHO)
+        MatcherAssert.assertThat(
+            String.format("Object should not have %s attribute when it's just formed", Phi.RHO),
+            PhDefaultTest.Int.made().take(Phi.RHO),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 
@@ -112,25 +112,27 @@ final class PhDefaultTest {
 
     @Test
     void doesNotHaveRhoAfterCopying() {
-        Assertions.assertThrows(
-            ExAbstract.class,
-            () -> new PhSafe(PhDefaultTest.Int.made().copy()).take(Phi.RHO),
-            String.format("Object should not give %s attribute after copying", Phi.RHO)
+        MatcherAssert.assertThat(
+            String.format("Object should not give %s attribute after copying", Phi.RHO),
+            PhDefaultTest.Int.made().copy().take(Phi.RHO),
+            Matchers.instanceOf(PhTerminator.class)
         );
     }
 
     @Test
-    void doesNotHaveRhoWhenItIsDeclaredAsVoid() {
+    void needsRhoWhenItIsDeclaredAsVoid() {
         MatcherAssert.assertThat(
-            String.format("Object with %s declared as void must not report it as set", Phi.RHO),
-            new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO)))).hasRho(),
-            Matchers.is(false)
+            String.format("Object with %s declared as void must await a receiver", Phi.RHO),
+            new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO)))).needsRho(),
+            Matchers.is(true)
         );
     }
 
     @Test
     void bindsHostToRhoDeclaredAsVoid() {
-        final Phi host = new PhDefault(new Attrs(new Attr("x", new AtVoid("x"))));
+        final Phi host = new PhDefault(
+            new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x")))
+        );
         host.put(Phi.RHO, Phi.Φ);
         host.put("x", new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO)))));
         MatcherAssert.assertThat(
@@ -747,8 +749,15 @@ final class PhDefaultTest {
          */
         static Phi made() {
             final PhDefaultTest.Int made = new PhDefaultTest.Int();
+            made.add(Phi.RHO, new AtRho());
             made.add("void", new AtVoid("void"));
-            made.add("plus", new AtComposite(made, rho -> new PhDefault()));
+            made.add(
+                "plus",
+                new AtComposite(
+                    made,
+                    rho -> new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())))
+                )
+            );
             made.add(
                 Phi.PHI,
                 new AtOnce(

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -104,9 +104,11 @@ final class PhDefaultTest {
 
     @Test
     void setsRhoAfterDispatch() {
-        Assertions.assertDoesNotThrow(
-            () -> PhDefaultTest.Int.made().take(this.plus()).take(Phi.RHO),
-            String.format("Kid of should have %s attribute after dispatch", Phi.RHO)
+        final Phi phi = PhDefaultTest.Int.made();
+        MatcherAssert.assertThat(
+            String.format("Kid should have %s attribute after dispatch", Phi.RHO),
+            phi.take(this.plus()).take(Phi.RHO),
+            Matchers.equalTo(phi)
         );
     }
 
@@ -130,14 +132,12 @@ final class PhDefaultTest {
 
     @Test
     void bindsHostToRhoDeclaredAsVoid() {
-        final Phi host = new PhDefault(
-            new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("x", new AtVoid("x")))
-        );
+        final Phi host = PhDefaultTest.Int.made();
         host.put(Phi.RHO, Phi.Φ);
-        host.put("x", new PhDefault(new Attrs(new Attr(Phi.RHO, new AtVoid(Phi.RHO)))));
+        host.put(this.getVoid(), PhDefaultTest.Int.formation());
         MatcherAssert.assertThat(
             String.format("Dispatch must bind the host to %s declared as void", Phi.RHO),
-            host.take("x").take(Phi.RHO),
+            host.take(this.getVoid()).take(Phi.RHO),
             Matchers.equalTo(host)
         );
     }
@@ -162,17 +162,6 @@ final class PhDefaultTest {
             phi.take(this.plus()),
             Matchers.not(
                 Matchers.equalTo(phi.take(this.plus()))
-            )
-        );
-    }
-
-    @Test
-    void hasKidWithSetRhoAfterCopyingShouldGetAfttribute() {
-        Assertions.assertDoesNotThrow(
-            () -> PhDefaultTest.Int.made().copy().take(this.plus()).take(Phi.RHO),
-            String.format(
-                "Child object should get %s attribute after copying main object",
-                Phi.RHO
             )
         );
     }
@@ -751,13 +740,7 @@ final class PhDefaultTest {
             final PhDefaultTest.Int made = new PhDefaultTest.Int();
             made.add(Phi.RHO, new AtRho());
             made.add("void", new AtVoid("void"));
-            made.add(
-                "plus",
-                new AtComposite(
-                    made,
-                    rho -> new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())))
-                )
-            );
+            made.add("plus", new AtComposite(made, rho -> PhDefaultTest.Int.formation()));
             made.add(
                 Phi.PHI,
                 new AtOnce(
@@ -783,6 +766,10 @@ final class PhDefaultTest {
                 )
             );
             return made;
+        }
+
+        static Phi formation() {
+            return new PhDefault(new Attrs(new Attr(Phi.RHO, new AtRho())));
         }
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
@@ -42,6 +42,19 @@ final class PhOnceTest {
     }
 
     @Test
+    void neverNeedsRhoWithoutEvaluatingWrappedObject() {
+        MatcherAssert.assertThat(
+            "PhOnce must never ask for a receiver, and must not evaluate itself to say so",
+            new PhOnce(
+                () -> {
+                    throw new IllegalStateException("must not be evaluated");
+                }
+            ).needsRho(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void doesNotEvaluateWrappedObjectForTerm() {
         MatcherAssert.assertThat(
             "PhOnce with explicit term must render it without evaluating the wrapped object, but it didnt",

--- a/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhOnceTest.java
@@ -42,7 +42,7 @@ final class PhOnceTest {
     }
 
     @Test
-    void neverNeedsRhoWithoutEvaluatingWrappedObject() {
+    void doesNotNeedRhoWithoutEvaluatingWrappedObject() {
         MatcherAssert.assertThat(
             "PhOnce must never ask for a receiver, and must not evaluate itself to say so",
             new PhOnce(

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -55,7 +55,7 @@ final class PhPackageTest {
     }
 
     @Test
-    void neverNeedsRho() {
+    void doesNotNeedRho() {
         MatcherAssert.assertThat(
             "The global object must never ask a dispatch for a receiver",
             Phi.Φ.needsRho(),

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -55,22 +55,22 @@ final class PhPackageTest {
     }
 
     @Test
-    void reportsNoRhoOnGlobalObject() {
+    void neverNeedsRho() {
         MatcherAssert.assertThat(
-            "hasRho() must agree with take(RHO) and report the global object as lacking ρ",
-            Phi.Φ.hasRho(),
+            "The global object must never ask a dispatch for a receiver",
+            Phi.Φ.needsRho(),
             Matchers.is(false)
         );
     }
 
     @Test
-    void reportsRhoOnceBound() {
+    void keepsRhoOnceBound() {
         final Phi pckg = new PhPackage("test-rho");
         pckg.put(Phi.RHO, Phi.Φ);
         MatcherAssert.assertThat(
-            "hasRho() must turn true as soon as ρ is bound into the package",
-            pckg.hasRho(),
-            Matchers.is(true)
+            String.format("A package must hand back the %s bound into it", Phi.RHO),
+            pckg.take(Phi.RHO),
+            Matchers.equalTo(Phi.Φ)
         );
     }
 
@@ -88,26 +88,14 @@ final class PhPackageTest {
     }
 
     @Test
-    void hasRhoReportsAbsenceOnGlobalObject() {
+    void stopsNeedingRhoAfterDispatch() {
         MatcherAssert.assertThat(
             String.format(
-                "hasRho() must agree with take(%s) and report the global object as unset",
+                "A package member must not still await %s once dispatch has bound it",
                 Phi.RHO
             ),
-            Phi.Φ.hasRho(),
+            Phi.Φ.take("nop").needsRho(),
             Matchers.is(false)
-        );
-    }
-
-    @Test
-    void hasRhoReportsPresenceAfterDispatch() {
-        MatcherAssert.assertThat(
-            String.format(
-                "hasRho() must report %s as set once dispatch has bound it",
-                Phi.RHO
-            ),
-            Phi.Φ.take("nop").hasRho(),
-            Matchers.is(true)
         );
     }
 


### PR DESCRIPTION
Closes #7327.

`PhDefault` used to seed an `AtRho` into every object it built, so every object had a receiver slot whether or not it wanted one. Now that `.eo` formations declare `^` themselves and the transpiler emits `this.add("ρ", new AtRho())` for them, that seeding is dead weight — and it is what let a receiver be bound onto things that were never formations. It is gone, so a receiver slot exists only where the object declares one.

`hasRho()` and `needsRho()` were two versions of the same question, so only one survives:

```java
@Override
public boolean needsRho() {
    final Attribute attr = this.loaded().get(Phi.RHO);
    return attr != null && attr.vacant();
}
```

`AtWithRho.get()` and `PhPackage.take()` both gate on it. `PhOnce` answers it `false` outright: a receiver is bound onto a formation, never onto the result of an expression, and the dispatch that produced a `PhDispatch` or a `PhApplication` has already given it whatever receiver it deserves. Answering without consulting the wrapped object also stops a dispatch from forcing a lazy expression just to ask.

`AtRho` now differs from `AtVoid` only where it must, by holding the receiver by reference so a copy does not clone the chain above it. Reading it unset yields a terminator instead of throwing, a second put is rejected rather than dropped on the floor, and `φTerm` prints `?` until something is bound.

The 21 hand-written atoms that read `Phi.RHO` leaned entirely on the old seeding, so each one declares its receiver now. Next in the epic is walking the code for places where a receiver is not needed at all.