### PR TITLE
stop repeating all-or-nothing error after Stack.seal

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -462,7 +462,6 @@ final class Level {
         this.bindings = 0;
         this.argpending = false;
         this.argbound = false;
-        this.argspan = null;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -459,6 +459,10 @@ final class Level {
         this.tupled = false;
         this.children = 0;
         this.count = 0;
+        this.bindings = 0;
+        this.argpending = false;
+        this.argbound = false;
+        this.argspan = null;
     }
 
     /**
@@ -519,6 +523,7 @@ final class Level {
             if (this.bindings == 0) {
                 this.bindings = code;
             } else if (this.bindings != code) {
+                this.argpending = false;
                 throw new ParseError(
                     this.argspan.line(), this.argspan.indent(),
                     "argument bindings must be all-or-nothing"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-bound-group-with-method-continuation-is-accepted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-bound-group-with-method-continuation-is-accepted.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7503: Level.sealed() resets the all-or-nothing tracking fields, so a
+# legitimately all-bound argument group followed by a same-indent
+# `.method` continuation must not be flagged as a violation.
+sheets: []
+asserts:
+  - /object[not(errors/error[contains(text(),'argument bindings must be all-or-nothing')])]
+input: |
+  [] > main
+    foo > app
+      a:x
+      b:y
+    .bar > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-reported-once-after-chained-method-continuations.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-reported-once-after-chained-method-continuations.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7503: chaining several same-indent `.method` continuations onto the
+# sealed entry must still surface the all-or-nothing violation only once.
+sheets: []
+asserts:
+  - /object[count(errors/error[contains(text(),'argument bindings must be all-or-nothing')])=1]
+input: |
+  [] > main
+    foo > app
+      a:x
+      b
+    .bar > z
+    .baz > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-reported-once-after-method-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/all-or-nothing-reported-once-after-method-continuation.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7503: a same-indent `.method` continuation reuses the sealed stack entry,
+# so the all-or-nothing violation caught by `Stack.seal` must not be reported
+# again when the entry is finally popped at EOF.
+sheets: []
+asserts:
+  - /object[count(errors/error[contains(text(),'argument bindings must be all-or-nothing')])=1]
+input: |
+  [] > main
+    foo > app
+      a:x
+      b
+    .bar > z


### PR DESCRIPTION
Closes #7503

`Level.commitArg` cleared `argpending` only on the happy path, so when the all-or-nothing check rejected an argument the flag stayed `true` along with the rejected argument's `argbound`/`argspan`. `Stack.seal` runs the closer on the top entry and then leaves that entry on the stack for a same-indent `.method` continuation to reuse, so the same argument got committed and rejected a second time when the entry was finally popped at EOF, producing two identical `argument bindings must be all-or-nothing` errors for one mistake.

This clears `argpending` before the `throw`, and has `Level.sealed()` also reset `bindings`, `argbound` and `argspan`, matching what its own docblock already promises the caller.

Two `eo-syntax` yaml cases lock this down: one with a single `.method` continuation after the offending group, and one with a chain of two, both asserting exactly one `error` element.