### PR TITLE
fix(#7513): move remaining kind()-driven branches onto Value as named predicates

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -133,16 +133,16 @@ final class Emissions {
     static void openValue(
         final Emit emit, final String name, final Value value, final int line
     ) {
-        if (value.kind() == Value.Kind.INTEGER || value.kind() == Value.Kind.FLOAT) {
+        if (value.number()) {
             Emissions.number(emit, name, value, line);
-        } else if (value.kind() == Value.Kind.HEX) {
+        } else if (value.hex()) {
             Emissions.hex(emit, name, value, line);
-        } else if (value.kind() == Value.Kind.BYTES) {
+        } else if (value.bytes()) {
             emit.object(name, "Φ.bytes", line, value.pos());
             emit.object(null, null, line, value.pos());
             emit.set(value.raw());
             emit.close();
-        } else if (value.kind() == Value.Kind.STRING) {
+        } else if (value.string()) {
             Emissions.string(emit, name, value, line);
         } else {
             Emissions.openBase(emit, name, value, line);
@@ -238,12 +238,12 @@ final class Emissions {
     private static void openBase(
         final Emit emit, final String name, final Value value, final int line
     ) {
-        if (value.kind() == Value.Kind.STAR) {
+        if (value.star()) {
             emit.object(name, "Φ.tuple", line, value.pos());
             emit.star();
         } else if (value.kind() == Value.Kind.ROOT) {
             emit.object(name, value.rootSymbol(), line, value.pos());
-        } else if (value.kind() == Value.Kind.TERM) {
+        } else if (value.term()) {
             emit.object(name, "⊥", line, value.pos());
         } else if (value.identity()) {
             Emissions.identity(emit, name, value, line);

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -195,6 +195,54 @@ final class Value {
     }
 
     /**
+     * A numeric literal — {@code INT} or {@code FLOAT} (§9.0.3)?
+     * @return True for {@link Kind#INTEGER} or {@link Kind#FLOAT}
+     */
+    boolean number() {
+        return this.kind == Kind.INTEGER || this.kind == Kind.FLOAT;
+    }
+
+    /**
+     * A {@code HEX} numeric literal — {@code 0xFF} form (§9.0.3)?
+     * @return True for {@link Kind#HEX}
+     */
+    boolean hex() {
+        return this.kind == Kind.HEX;
+    }
+
+    /**
+     * A {@code BYTES} literal (§3.13.1)?
+     * @return True for {@link Kind#BYTES}
+     */
+    boolean bytes() {
+        return this.kind == Kind.BYTES;
+    }
+
+    /**
+     * A {@code STRING} literal (§9.0.3)?
+     * @return True for {@link Kind#STRING}
+     */
+    boolean string() {
+        return this.kind == Kind.STRING;
+    }
+
+    /**
+     * The {@code STAR} tuple marker (§9.0.3)?
+     * @return True for {@link Kind#STAR}
+     */
+    boolean star() {
+        return this.kind == Kind.STAR;
+    }
+
+    /**
+     * The {@code T} terminator term (§9.3)?
+     * @return True for {@link Kind#TERM}
+     */
+    boolean term() {
+        return this.kind == Kind.TERM;
+    }
+
+    /**
      * The {@code I} identity object (§3.16)?
      * @return True for {@link Kind#IDENTITY}
      */
@@ -272,11 +320,6 @@ final class Value {
         return found;
     }
 
-    // @todo #7379:30min Move the remaining kind()-driven branches in
-    //  Emissions#openValue and Emissions#openBase (INTEGER/FLOAT, HEX,
-    //  BYTES, STRING, STAR, TERM) onto Value as named predicates, the
-    //  way reversible() and rootSymbol() already replaced the
-    //  IDENTIFIER/ROOT and ROOT-glyph decisions.
     /**
      * The kinds of value recognised by the parser. Further kinds
      * (HEX, BYTES, paren groups) attach as the corresponding line

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -222,46 +222,10 @@ final class ValueTest {
     }
 
     @Test
-    void marksStringNotNumber() {
-        MatcherAssert.assertThat(
-            "number() must be false for a STRING value",
-            new Value(Value.Kind.STRING, "\"hi\"", 0).number(),
-            Matchers.equalTo(false)
-        );
-    }
-
-    @Test
     void marksHexAsHex() {
         MatcherAssert.assertThat(
             "hex() must be true for a HEX value",
             new Value(Value.Kind.HEX, "0xFF", 0).hex(),
-            Matchers.equalTo(true)
-        );
-    }
-
-    @Test
-    void marksBytesAsBytes() {
-        MatcherAssert.assertThat(
-            "bytes() must be true for a BYTES value",
-            new Value(Value.Kind.BYTES, "CA-FE", 0).bytes(),
-            Matchers.equalTo(true)
-        );
-    }
-
-    @Test
-    void marksStringAsString() {
-        MatcherAssert.assertThat(
-            "string() must be true for a STRING value",
-            new Value(Value.Kind.STRING, "\"hi\"", 0).string(),
-            Matchers.equalTo(true)
-        );
-    }
-
-    @Test
-    void marksStarAsStar() {
-        MatcherAssert.assertThat(
-            "star() must be true for a STAR value",
-            new Value(Value.Kind.STAR, "*", 0).star(),
             Matchers.equalTo(true)
         );
     }
@@ -272,15 +236,6 @@ final class ValueTest {
             "term() must be true for a TERM value",
             new Value(Value.Kind.TERM, "T", 0).term(),
             Matchers.equalTo(true)
-        );
-    }
-
-    @Test
-    void marksIdentifierNotStar() {
-        MatcherAssert.assertThat(
-            "star() must be false for an IDENTIFIER value",
-            new Value(Value.Kind.IDENTIFIER, "foo", 0).star(),
-            Matchers.equalTo(false)
         );
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -211,4 +211,76 @@ final class ValueTest {
             Matchers.equalTo("ρ")
         );
     }
+
+    @Test
+    void marksFloatAsNumber() {
+        MatcherAssert.assertThat(
+            "number() must be true for a FLOAT value",
+            new Value(Value.Kind.FLOAT, "3.14", 0).number(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void marksStringNotNumber() {
+        MatcherAssert.assertThat(
+            "number() must be false for a STRING value",
+            new Value(Value.Kind.STRING, "\"hi\"", 0).number(),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void marksHexAsHex() {
+        MatcherAssert.assertThat(
+            "hex() must be true for a HEX value",
+            new Value(Value.Kind.HEX, "0xFF", 0).hex(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void marksBytesAsBytes() {
+        MatcherAssert.assertThat(
+            "bytes() must be true for a BYTES value",
+            new Value(Value.Kind.BYTES, "CA-FE", 0).bytes(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void marksStringAsString() {
+        MatcherAssert.assertThat(
+            "string() must be true for a STRING value",
+            new Value(Value.Kind.STRING, "\"hi\"", 0).string(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void marksStarAsStar() {
+        MatcherAssert.assertThat(
+            "star() must be true for a STAR value",
+            new Value(Value.Kind.STAR, "*", 0).star(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void marksTermAsTerm() {
+        MatcherAssert.assertThat(
+            "term() must be true for a TERM value",
+            new Value(Value.Kind.TERM, "T", 0).term(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void marksIdentifierNotStar() {
+        MatcherAssert.assertThat(
+            "star() must be false for an IDENTIFIER value",
+            new Value(Value.Kind.IDENTIFIER, "foo", 0).star(),
+            Matchers.equalTo(false)
+        );
+    }
 }


### PR DESCRIPTION
Value already had reversible() and rootSymbol() replacing the IDENTIFIER/ROOT and ROOT-glyph kind() checks in Emissions. The remaining branches in Emissions#openValue and Emissions#openBase — INTEGER/FLOAT, HEX, BYTES, STRING, STAR, TERM — still switched on value.kind() directly.

This adds number(), hex(), bytes(), string(), star() and term() as named predicates on Value, and switches those two Emissions methods to call them instead of comparing kind() against Value.Kind constants. The ROOT check and the INTEGER-vs-FLOAT distinction inside the private number() formatting helper are untouched, since the puzzle scoped this to openValue/openBase only.

Closes #7513