### PR TITLE
fix(#7480): stop the parent walk at a path that is its own dirname

### DIFF
--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -8,6 +8,11 @@
 # so a `mkdir` coming back with `EEXIST` over a directory is taken for the
 # directory it names rather than for a failure. `EOdirectoryEOmadeRaceTest`
 # holds the interleaving that reaches that branch.
+#
+# The walk up to the missing parents stops at a path that is its own dirname,
+# like the root of a volume: without that stop the walk asks the same path for
+# its parent forever. A path whose parent is itself and which does not exist
+# cannot be made, so the computation terminates instead.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -24,9 +29,13 @@
         "Cant make the directory '%s': a file already occupies that path".printf
           * ^.path
     seq *
-      made.
-        directory
-          file ^.as-path.dirname
+      if.
+        above.path.eq ^.path
+        T
+          "Cant make the directory '%s': it has no parent".printf
+            * ^.path
+        made.
+          directory above
       if.
         or.
           created.code.eq 0
@@ -37,6 +46,7 @@
         T
           "Cant make the directory '%s': %s".printf
             * ^.path created.output
+  file ^.as-path.dirname > above
   called. > created
     os.is-windows.if
       win32 *1


### PR DESCRIPTION
Fixes #7480.

`made` walked up the tree by taking the `dirname` of each level and stopped when it met a directory that exists. A path whose `dirname` is the path itself has no such level above it, so the walk never ended: `Q:\` with no drive behind it, and `\srv\share` with the server down, both come back from `dirname` unchanged and both report `exists` as false, so the recursion ran until the heap was gone.

The parent is now bound once as `parent` and compared with the path it came from before recursing. A path that is its own parent ends the walk with the same shape of message the neighbouring failure already uses:

```
Cant make the directory 'Q:\': it has no parent
```

Measured against the transpiled runtime, one core: `Q:\` now terminates in 878 ms and `\srv\share` in 12 s (the remaining seconds there are the `exists` syscall on an unreachable host plus the `dirname` cost of #7479), where both exhausted a 1 GB heap before.

No `++>` regression comes with it, because the case cannot be written portably: on POSIX every fixed point of `dirname` is a directory that exists (`/` and `.`), so the walk terminates there for the ordinary reason and the guard is never the thing under test. `EOdirectoryTest` stays green: 43 run, 0 failures.
