### PR TITLE
fix(#7479): derive the dirname text once instead of on every reference

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -64,6 +64,7 @@
                     0
                     text.last-index-of ^.separator >> len!
       tail.index-of ^.separator > first!
+      ^.stripped ^.driveless > pth!
       and. > root
         text.length.gt 2
         and.
@@ -76,8 +77,7 @@
           text.slice
             2
             text.length.minus 2
-      string > text
-        ^.stripped ^.driveless
+      string pth > text
     sys.drive uri > drive
     if. > driveless
       drive.size.eq 0
@@ -718,6 +718,11 @@
           "html"
     path.joined
       * "var" "www"
+
+  eq. ++> can-return-the-dirname-of-a-long-win32-path
+    dirname.
+      path.win32 "C:\\aaaaaaaaaaaa\\aaaaaaaaaaaa\\aaaaaaaaaaaa"
+    "C:\\aaaaaaaaaaaa\\aaaaaaaaaaaa"
 
   eq. ++> can-return-the-dirname-of-a-win32-path-with-a-drive
     dirname.


### PR DESCRIPTION
Fixes #7479.

`dirname` built its text as a plain object,

```eo
string > text
  ^.stripped ^.driveless
```

and then read it from six places: `text.slice`, `text.last-index-of`, `text.length`, and through `tail` and `root`, which read it again. Every one of those re-ran `stripped` over `driveless`, and `driveless` re-ran the drive regex, so the work multiplied with the number of references and with the length of the path. `basename` next door does not have the problem because it derives the same text once into a const.

The text is now derived once, the way `basename` derives it. Measured against the transpiled runtime, one core:

| path | length | before | after |
| --- | --- | --- | --- |
| `C:\ab\cd\ef` | 11 | 2244 ms | 695 ms |
| `C:\abcd\efgh\ij` | 15 | 3831 ms | 402 ms |
| `C:\abcdef\ghijkl\mn` | 19 | 4437 ms | 487 ms |
| `C:\abcdefgh\ijklmnop\qr` | 23 | 6782 ms | 679 ms |
| `C:\a×12\a×12\a×12` | 41 | ExFailure after 196 s | 967 ms |
| `C:\Users\…\Temp\eo-made-360271972531604741` | 66 | did not finish in 5 min | 940 ms |

The cost no longer grows with the length. `directory.made`, which walks up the tree one `dirname` at a time, completes on a real temp path again: creating `%TEMP%\eo-probe-<n>\deep\deeper` takes 3.9 s where it used to hang.

`tail` is deliberately left as it was. Making it a const too gives no further speedup and breaks `can-return-the-dirname-of-a-win32-unc-share-subfolder`, so the change is confined to the one binding that pays.

The new `++>` case pins the 41-character path, which is the shortest length that failed outright rather than merely crawling. `EOpathTest`: 90 run, 0 failures.
