### PR TITLE
fix(#7475): scale a subnormal into the normal range before taking its mantissa

### DIFF
--- a/eo-runtime/src/main/eo/number/as-scientific.eo
+++ b/eo-runtime/src/main/eo/number/as-scientific.eo
@@ -6,6 +6,9 @@
 # digit, and a non-finite number becomes `nan`, `infinity` or `-infinity`,
 # having no digits at all. The mantissa is always normalized to `[1, 10)`, so
 # a magnitude below one carries a negative power, as `5.000000e-1` for `0.5`.
+# A magnitude below the normal range of a `double` is brought up into that range
+# before the mantissa is taken, since the power of ten that would scale it in
+# one step is itself subnormal and carries too few bits to divide by.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -36,19 +39,23 @@
         mantissa.concat "e".as-bytes
         as-decimal.
           number exponent
+  10.power 300 > boost!
   mantissa.eq "-10.000000".as-bytes > carried!
-  rec-exponent > exponent!
-    n.abs
-    0
+  minus. > exponent!
+    number raw
+    number shift
   as-fixed. > mantissa
-    n.div
+    scaled.div
       10.power
-        number exponent
+        number raw
     6
   ^ > n
   carried.as-bool.if > normalized!
     "-1.000000".as-bytes
     "1.000000".as-bytes
+  rec-exponent > raw!
+    scaled.abs
+    0
   if. > [^ m count] >> rec-exponent
     or.
       m.eq 0
@@ -66,6 +73,17 @@
         m.div 10
         as-number.
           count.plus 1
+  tiny.as-bool.if > scaled
+    n.times boost
+    n
+  tiny.as-bool.if > shift!
+    300
+    0
+  and. > tiny!
+    n.abs.lt
+      1.div boost
+    not.
+      n.eq 0
 
   eq. ++> can-carry-a-rounded-mantissa-into-the-next-power-of-ten
     "1.000000e1"
@@ -83,6 +101,10 @@
     "-1.000000e20"
     string -9.9999996e19.as-scientific
 
+  eq. ++> can-name-a-magnitude-at-the-bottom-of-the-subnormal-range
+    "4.940656e-324"
+    string 4.9e-324.as-scientific
+
   eq. ++> can-name-a-magnitude-past-the-long-range
     "1.000000e19"
     string 1.0e19.as-scientific
@@ -98,6 +120,14 @@
   eq. ++> can-name-a-small-magnitude-with-a-negative-power
     "1.000000e-7"
     string 1.0e-7.as-scientific
+
+  eq. ++> can-name-a-subnormal-magnitude
+    "9.999889e-321"
+    string 1.0e-320.as-scientific
+
+  eq. ++> can-name-a-subnormal-magnitude-with-few-significant-bits
+    "9.980126e-322"
+    string 1.0e-321.as-scientific
 
   eq. ++> can-name-nan
     "nan"


### PR DESCRIPTION
Fixes #7475.

The mantissa was taken by dividing through `10^exponent` built in one step. Past `1e-308` that power is itself subnormal, where a `double` keeps only a handful of significant bits, so the quotient came back skewed and could land at or above ten; at the very bottom the power underflowed to zero, the division gave an infinity, and `as-fixed` then described a finite input as non-finite and terminated.

A magnitude below the normal range is now multiplied by `10^300` first, the exponent is found on the scaled value, and the shift is subtracted from the exponent that gets printed. Everything at `1e-300` and above takes the same path as before, so only the subnormals move.

Measured against the transpiled runtime, one core, with `java.lang.String.format("%.6e")` as the reference:

| input | before | after | `%.6e` |
| --- | --- | --- | --- |
| `1e-318` | `10.000099e-319` | `9.999987e-319` | `1.000000e-318` |
| `1e-320` | `10.019802e-321` | `9.999889e-321` | `1.000000e-320` |
| `1e-321` | `10.100000e-322` | `9.980126e-322` | `1.000000e-321` |
| `5e-322` | `5.050000e-322` | `4.990063e-322` | `5.000000e-322` |
| `1e-323` | terminates: not finite | `9.881313e-324` | `9.900000e-324` |
| `4.9e-324` | terminates: not finite | `4.940656e-324` | `4.900000e-324` |

Every finite input across the sweep now carries a mantissa inside `[1, 10)` and no finite input terminates. Reading the output back with `Double.parseDouble` gives the input double exactly, in all 30 cases of the sweep, subnormals included.

The remaining column difference is not an error. `%.6e` prints the shortest decimal that round-trips to the double, so it shows `1.000000e-320` for a double whose stated value is `9.99988867e-321`; this object spells out the value it actually holds. The issue's expected column was written from the `%.6e` reading, so the numbers here are the honest ones — `9.999889e-321` and `1.000000e-320` name the same double.

Three `++>` cases pin the range: the bottom of it (`4.9e-324`, which used to terminate) and two magnitudes that used to print a mantissa of ten or more. `EOnumberTest`: 505 run, 0 failures.
