### PR TITLE
#7500: XMIR.xsd rejects rho as the name of a receiver void

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -64,7 +64,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="α[0-9]+|φ|[a-z+-]\S*|λ"/>
+      <xs:pattern value="α[0-9]+|φ|ρ|[a-z+-]\S*|λ"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="fqn">

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/rho-void-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/rho-void-name.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7500: a formation may declare its receiver as a void named "ρ" (R-3.4.11),
+# but the "attribute-name" pattern only listed "φ" and "λ" by name, so this
+# XMIR did not validate.
+errors: 0
+input: |
+  [] > size /Q.number
+    ? > ^


### PR DESCRIPTION
Fixes #7500. Since #7134 a formation may declare its receiver as a void named
rho, but the `attribute-name` pattern in `XMIR.xsd` only listed `phi` and
`lambda` by name, so the XMIR of such a formation did not validate against
the schema.

Added `rho` to the pattern, beside `phi`. Added a regression pack under
`xsd-mistakes/` using the exact input from #7500 and one of the existing
syntax packs (`eo-syntax/rho-void-written-vertically.yaml`), asserting
`errors: 0`.
