### PR TITLE
#7501: XMIR.xsd fqn pattern fails to validate a dispatch on bottom term and reversed dispatch on $

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -77,7 +77,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="⊥|∅|\.(ρ|φ|[a-z][^\s.]*|α[0-9]*)|([Φξ])(\.(ρ|φ|[a-z][^\s.]*|α[0-9]*))*"/>
+      <xs:pattern value="∅|\.(ρ|φ|ξ|[a-z][^\s.]*|α[0-9]*)|([Φξ⊥])(\.(ρ|φ|[a-z][^\s.]*|α[0-9]*))*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="signature">

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/fqn-bottom-term-dispatch.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/fqn-bottom-term-dispatch.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7501: the "fqn" pattern let the bottom term "⊥" stand alone but not head
+# a dispatch chain, so an attribute of "T" did not validate.
+errors: 0
+input: |
+  [] > main
+    T.foo > x

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/fqn-reversed-dispatch-on-xi.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/fqn-reversed-dispatch-on-xi.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7501: after a leading dot, the "fqn" pattern accepted "ρ", "φ", a
+# lower-case name or an "α" index, but not "ξ", so a reversed dispatch on
+# "$" did not validate.
+errors: 0
+input: |
+  [] > main
+    $. 1 > z


### PR DESCRIPTION
Fixes #7501. The `fqn` pattern in `XMIR.xsd` had two holes:

1. The bottom term `⊥` could stand alone but not head a dispatch chain, so
   an attribute of `T` (`T.foo > x`) did not validate.
2. After a leading dot, the pattern accepted `ρ`, `φ`, a lower-case name or
   an `α` index, but not `ξ`, so a reversed dispatch on `$` (`$. 1 > z`)
   did not validate either.

Moved `⊥` into the same alternation as `Φ`/`ξ` so it can head a chain the
same way they do, and added `ξ` to the leading-dot alternatives.

Added regression packs under `xsd-mistakes/` using the exact inputs from
the issue, asserting `errors: 0`.
