### PR TITLE
#7502: XMIR.xsd incorrectly rejects unrooted dotted names in atom signature

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -90,7 +90,7 @@
       </xs:documentation>
     </xs:annotation>
     <xs:restriction base="xs:string">
-      <xs:pattern value="[A-F]|⊥|∅|\.(ρ|φ|[a-z][^\s.]*|α[0-9]*)|([Φξ])(\.(ρ|φ|[a-z][^\s.]*|α[0-9]*))*"/>
+      <xs:pattern value="[A-F]|⊥|∅|\.(ρ|φ|[a-z][^\s.]*|α[0-9]*)|([Φξ])(\.(ρ|φ|[a-z][^\s.]*|α[0-9]*))*|[a-z][^\s.]*(\.[a-z][^\s.]*)*"/>
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="type-anno">

--- a/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/signature-unrooted-dotted-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/xsd-mistakes/signature-unrooted-dotted-name.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7502: an atom may name what it comes back with as a dotted chain with no
+# "Φ."/"Q." root ("/org.eolang.number", "/x.y.z"), and the parser keeps that
+# spelling verbatim, but the "signature" pattern only let a chain of names
+# follow "Φ" or "ξ", so neither validated.
+errors: 0
+input: |-
+  [] > parent
+    [] > dotted /org.eolang.number
+
+    [] > deep /x.y.z


### PR DESCRIPTION
Fixes #7502. An atom may name what it comes back with as a dotted chain
with no `Φ.`/`Q.` root, `/org.eolang.number` or `/x.y.z`, and the parser
keeps that spelling verbatim, but the `signature` pattern in `XMIR.xsd`
only let a chain of names follow `Φ` or `ξ`, so neither validated.

Added an alternative for a bare dotted chain of lower-case names, matching
the two spellings the parser accepts and keeps as-is.

Added a regression pack under `xsd-mistakes/` using the pack's own input
from the issue, asserting `errors: 0`.
