### PR TITLE
Cache dataization of pure formations in PhSticky

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -539,13 +539,9 @@
   <!--
   Abstract object as attribute. A formation that purify.xsl marked with
   @pure is returned wrapped in PhSticky, so that at run time it remembers
-  the results of its own dataization (see #5165).
-  @todo #5165:60min Wrap the pure top-level classes and the anonymous
-   formations in PhSticky too. Today only a named formation nested in
-   another one (an "abstract" element) is decorated when purify.xsl marks
-   it with @pure: a top-level "class" is instantiated by PhPackage through
-   reflection and an anonymous formation by the "o" template in mode
-   "object", and neither site knows about the label yet.
+  the results of its own dataization (see #5165). A pure top-level class
+  and a pure anonymous formation are not wrapped yet (see the puzzle in
+  PhSticky.java).
   -->
   <xsl:template match="abstract">
     <xsl:param name="parent"/>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -536,7 +536,17 @@
     <xsl:value-of select="eo:eol($indent)"/>
     <xsl:text>}))</xsl:text>
   </xsl:template>
-  <!-- Abstract object as attribute -->
+  <!--
+  Abstract object as attribute. A formation that purify.xsl marked with
+  @pure is returned wrapped in PhSticky, so that at run time it remembers
+  the results of its own dataization (see #5165).
+  @todo #5165:60min Wrap the pure top-level classes and the anonymous
+   formations in PhSticky too. Today only a named formation nested in
+   another one (an "abstract" element) is decorated when purify.xsl marks
+   it with @pure: a top-level "class" is instantiated by PhPackage through
+   reflection and an anonymous formation by the "o" template in mode
+   "object", and neither site knows about the label yet.
+  -->
   <xsl:template match="abstract">
     <xsl:param name="parent"/>
     <xsl:param name="name"/>
@@ -578,7 +588,16 @@
     </xsl:apply-templates>
     <xsl:value-of select="eo:eol($indent + 2)"/>
     <xsl:text>return </xsl:text>
-    <xsl:value-of select="$ctx"/>
+    <xsl:choose>
+      <xsl:when test="@pure='true'">
+        <xsl:text>new PhSticky(</xsl:text>
+        <xsl:value-of select="$ctx"/>
+        <xsl:text>)</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$ctx"/>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:text>;</xsl:text>
     <xsl:value-of select="eo:eol($indent + 1)"/>
     <xsl:text>}</xsl:text>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -132,6 +132,61 @@ final class MjTranspileTest {
     }
 
     @Test
+    void wrapsSafeToCacheFormationInPhSticky(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a formation marked as safe to cache must be wrapped in PhSticky in the generated Java, but it wasnt",
+            new TextOf(
+                new FakeMaven(temp).withProgram(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package examples",
+                        "",
+                        "# Outer.",
+                        "[] > x",
+                        "  inner > @",
+                        "  # Inner.",
+                        "  [] > inner",
+                        "    42 > @"
+                    )
+                )
+                .execute(MjParse.class)
+                .execute(MjInference.class)
+                .execute(MjTranspile.class)
+                .result()
+                .get("target/generated/org/eolang/EO_examples/EOx.java")
+            ).asString(),
+            Matchers.containsString("new PhSticky(")
+        );
+    }
+
+    @Test
+    void leavesUnmarkedFormationBare(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a formation nobody marked as safe to cache must not be wrapped in PhSticky, but it was",
+            new TextOf(
+                new FakeMaven(temp).withProgram(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package examples",
+                        "",
+                        "# Outer.",
+                        "[] > x",
+                        "  inner > @",
+                        "  # Inner.",
+                        "  [] > inner",
+                        "    42 > @"
+                    )
+                )
+                .execute(MjParse.class)
+                .execute(MjTranspile.class)
+                .result()
+                .get("target/generated/org/eolang/EO_examples/EOx.java")
+            ).asString(),
+            Matchers.not(Matchers.containsString("new PhSticky("))
+        );
+    }
+
+    @Test
     void transpilesSecondObjectOfProgramWhileTrackingSteps(@Mktmp final Path temp)
         throws IOException {
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -136,24 +136,12 @@ final class MjTranspileTest {
         MatcherAssert.assertThat(
             "a formation marked as safe to cache must be wrapped in PhSticky in the generated Java, but it wasnt",
             new TextOf(
-                new FakeMaven(temp).withProgram(
-                    String.join(
-                        System.lineSeparator(),
-                        "+package examples",
-                        "",
-                        "# Outer.",
-                        "[] > x",
-                        "  inner > @",
-                        "  # Inner.",
-                        "  [] > inner",
-                        "    42 > @"
-                    )
-                )
-                .execute(MjParse.class)
-                .execute(MjInference.class)
-                .execute(MjTranspile.class)
-                .result()
-                .get("target/generated/org/eolang/EO_examples/EOx.java")
+                MjTranspileTest.pure(temp)
+                    .execute(MjParse.class)
+                    .execute(MjInference.class)
+                    .execute(MjTranspile.class)
+                    .result()
+                    .get("target/generated/org/eolang/EO_examples/EOx.java")
             ).asString(),
             Matchers.containsString("new PhSticky(")
         );
@@ -164,23 +152,11 @@ final class MjTranspileTest {
         MatcherAssert.assertThat(
             "a formation nobody marked as safe to cache must not be wrapped in PhSticky, but it was",
             new TextOf(
-                new FakeMaven(temp).withProgram(
-                    String.join(
-                        System.lineSeparator(),
-                        "+package examples",
-                        "",
-                        "# Outer.",
-                        "[] > x",
-                        "  inner > @",
-                        "  # Inner.",
-                        "  [] > inner",
-                        "    42 > @"
-                    )
-                )
-                .execute(MjParse.class)
-                .execute(MjTranspile.class)
-                .result()
-                .get("target/generated/org/eolang/EO_examples/EOx.java")
+                MjTranspileTest.pure(temp)
+                    .execute(MjParse.class)
+                    .execute(MjTranspile.class)
+                    .result()
+                    .get("target/generated/org/eolang/EO_examples/EOx.java")
             ).asString(),
             Matchers.not(Matchers.containsString("new PhSticky("))
         );
@@ -774,5 +750,21 @@ final class MjTranspileTest {
             }
         }
         return valid && depth == 0;
+    }
+
+    private static FakeMaven pure(final Path temp) throws IOException {
+        return new FakeMaven(temp).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "+package examples",
+                "",
+                "# Outer.",
+                "[] > x",
+                "  inner > @",
+                "  # Inner.",
+                "  [] > inner",
+                "    42 > @"
+            )
+        );
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/Lru.java
+++ b/eo-runtime/src/main/java/org/eolang/Lru.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * A map that holds no more than the given number of entries, letting
+ * the entry asked for longest ago go first.
+ *
+ * <p>{@link LinkedHashMap} in access order is the one map the JDK lets
+ * evict by age of use, and the extension point it offers for that is an
+ * override, not an argument. The map is not thread-safe on its own —
+ * wrap it in {@link java.util.Collections#synchronizedMap(Map)} when
+ * several threads share it.</p>
+ *
+ * @since 0.75
+ */
+final class Lru extends LinkedHashMap<String, byte[]> {
+
+    /**
+     * Serialization marker, demanded by the parent.
+     */
+    private static final long serialVersionUID = 5165L;
+
+    /**
+     * How many entries to keep.
+     */
+    private final int capacity;
+
+    /**
+     * Ctor.
+     * @param cap How many entries to keep
+     */
+    Lru(final int cap) {
+        super(16, 0.75f, true);
+        this.capacity = cap;
+    }
+
+    @Override
+    protected boolean removeEldestEntry(final Map.Entry<String, byte[]> eldest) {
+        return this.size() > this.capacity;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/Lru.java
+++ b/eo-runtime/src/main/java/org/eolang/Lru.java
@@ -5,27 +5,28 @@
 
 package org.eolang;
 
+import java.util.Collection;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * A map that holds no more than the given number of entries, letting
  * the entry asked for longest ago go first.
  *
- * <p>{@link LinkedHashMap} in access order is the one map the JDK lets
- * evict by age of use, and the extension point it offers for that is an
- * override, not an argument. The map is not thread-safe on its own —
- * wrap it in {@link java.util.Collections#synchronizedMap(Map)} when
- * several threads share it.</p>
+ * <p>The map is not thread-safe on its own — wrap it in
+ * {@link java.util.Collections#synchronizedMap(Map)} when several
+ * threads share it.</p>
  *
  * @since 0.75
  */
-final class Lru extends LinkedHashMap<String, byte[]> {
+final class Lru implements Map<String, byte[]> {
 
     /**
-     * Serialization marker, demanded by the parent.
+     * The entries, in the order of access.
      */
-    private static final long serialVersionUID = 5165L;
+    private final Map<String, byte[]> origin;
 
     /**
      * How many entries to keep.
@@ -37,12 +38,74 @@ final class Lru extends LinkedHashMap<String, byte[]> {
      * @param cap How many entries to keep
      */
     Lru(final int cap) {
-        super(16, 0.75f, true);
+        this.origin = new LinkedHashMap<>(16, 0.75f, true);
         this.capacity = cap;
     }
 
     @Override
-    protected boolean removeEldestEntry(final Map.Entry<String, byte[]> eldest) {
-        return this.size() > this.capacity;
+    public int size() {
+        return this.origin.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return this.origin.isEmpty();
+    }
+
+    @Override
+    public boolean containsKey(final Object key) {
+        return this.origin.containsKey(key);
+    }
+
+    @Override
+    public boolean containsValue(final Object value) {
+        return this.origin.containsValue(value);
+    }
+
+    @Override
+    public byte[] get(final Object key) {
+        return this.origin.get(key);
+    }
+
+    @Override
+    public byte[] put(final String key, final byte[] value) {
+        if (this.origin.size() >= this.capacity && !this.origin.containsKey(key)) {
+            final Iterator<String> eldest = this.origin.keySet().iterator();
+            eldest.next();
+            eldest.remove();
+        }
+        return this.origin.put(key, value);
+    }
+
+    @Override
+    public byte[] remove(final Object key) {
+        return this.origin.remove(key);
+    }
+
+    @Override
+    public void putAll(final Map<? extends String, ? extends byte[]> map) {
+        for (final Map.Entry<? extends String, ? extends byte[]> entry : map.entrySet()) {
+            this.put(entry.getKey(), entry.getValue());
+        }
+    }
+
+    @Override
+    public void clear() {
+        this.origin.clear();
+    }
+
+    @Override
+    public Set<String> keySet() {
+        return this.origin.keySet();
+    }
+
+    @Override
+    public Collection<byte[]> values() {
+        return this.origin.values();
+    }
+
+    @Override
+    public Set<Map.Entry<String, byte[]>> entrySet() {
+        return this.origin.entrySet();
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -9,7 +9,6 @@ import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -81,7 +80,7 @@ public final class PhSticky implements Phi {
     public PhSticky(final Phi obj, final int capacity) {
         this(
             obj,
-            PhSticky.bounded(capacity),
+            Collections.synchronizedMap(new Lru(capacity)),
             Collections.synchronizedList(new ArrayList<>(0))
         );
     }
@@ -212,49 +211,5 @@ public final class PhSticky implements Phi {
             key = Optional.of(out.toString());
         }
         return key;
-    }
-
-    /**
-     * A thread-safe map that holds no more than the given number of entries,
-     * letting the entry asked for longest ago go first.
-     * @param capacity How many entries to keep
-     * @return The map
-     */
-    private static Map<String, byte[]> bounded(final int capacity) {
-        return Collections.synchronizedMap(new PhSticky.Lru(capacity));
-    }
-
-    /**
-     * The map under the bound: {@link LinkedHashMap} in access order is the
-     * one map the JDK lets evict by age of use, and the extension point it
-     * offers for that is an override, not an argument.
-     *
-     * @since 0.75
-     */
-    private static final class Lru extends LinkedHashMap<String, byte[]> {
-
-        /**
-         * Serialization marker, demanded by the parent.
-         */
-        private static final long serialVersionUID = 5165L;
-
-        /**
-         * How many entries to keep.
-         */
-        private final int capacity;
-
-        /**
-         * Ctor.
-         * @param cap How many entries to keep
-         */
-        Lru(final int cap) {
-            super(16, 0.75f, true);
-            this.capacity = cap;
-        }
-
-        @Override
-        protected boolean removeEldestEntry(final Map.Entry<String, byte[]> eldest) {
-            return this.size() > this.capacity;
-        }
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -1,0 +1,260 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * An object remembering the results of its own dataization (see #5165).
+ *
+ * <p>The transpiler puts this decorator on a formation that {@code purify.xsl}
+ * marked with {@code @pure}: one whose answer is decided by the bytes of its
+ * inputs and by nothing else. The cache belongs to the decorated object alone
+ * and holds only what is its own — there is no table shared between objects
+ * and no name under which a stranger could find an entry. A copy shares the
+ * cache of its origin, because an application copies the formation before
+ * filling it, and a cache that died with every copy would never answer
+ * anything.</p>
+ *
+ * <p>The inputs are whatever is put into the object — a void, a receiver, it
+ * makes no difference — and the key is those puts in the order they came,
+ * each reduced to the bytes of its object. The label of the transpiler is a
+ * promise about the callers of yesterday and not about those of tomorrow, so
+ * before trusting an input the decorator resolves it and looks at what it is:
+ * anything that is not a number or a string makes the whole dataization pass
+ * through, computed and not remembered.</p>
+ *
+ * <p>Only dataization is remembered. Taking an attribute, putting one,
+ * copying, normalizing — all of it reaches the decorated object untouched,
+ * and the cache is bounded, letting the entry asked for longest ago go first.</p>
+ *
+ * @since 0.75
+ */
+public final class PhSticky implements Phi {
+
+    /**
+     * The formae whose objects are decided by their bytes alone.
+     */
+    private static final List<String> DATA = List.of(
+        String.join(".", PhPackage.GLOBAL, "number"),
+        String.join(".", PhPackage.GLOBAL, "string")
+    );
+
+    /**
+     * The object decorated.
+     */
+    private final Phi origin;
+
+    /**
+     * The answers remembered so far, shared with every copy.
+     */
+    private final Map<String, byte[]> cache;
+
+    /**
+     * The puts this copy has received, in order.
+     */
+    private final List<Map.Entry<String, Phi>> inputs;
+
+    /**
+     * Ctor.
+     * @param obj The object to decorate
+     */
+    public PhSticky(final Phi obj) {
+        this(obj, 256);
+    }
+
+    /**
+     * Ctor.
+     * @param obj The object to decorate
+     * @param capacity How many answers to keep before evicting
+     */
+    public PhSticky(final Phi obj, final int capacity) {
+        this(
+            obj,
+            PhSticky.bounded(capacity),
+            Collections.synchronizedList(new ArrayList<>(0))
+        );
+    }
+
+    /**
+     * Primary ctor.
+     * @param obj The object to decorate
+     * @param map The answers remembered so far
+     * @param puts The puts received so far
+     */
+    private PhSticky(
+        final Phi obj,
+        final Map<String, byte[]> map,
+        final List<Map.Entry<String, Phi>> puts
+    ) {
+        this.origin = obj;
+        this.cache = map;
+        this.inputs = puts;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this.origin.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.origin.hashCode();
+    }
+
+    @Override
+    public Phi copy() {
+        final List<Map.Entry<String, Phi>> puts;
+        synchronized (this.inputs) {
+            puts = Collections.synchronizedList(new ArrayList<>(this.inputs));
+        }
+        return new PhSticky(this.origin.copy(), this.cache, puts);
+    }
+
+    @Override
+    public boolean needsRho() {
+        return this.origin.needsRho();
+    }
+
+    @Override
+    public Phi take(final String name) {
+        return this.origin.take(name);
+    }
+
+    @Override
+    public void put(final int pos, final Phi object) {
+        this.origin.put(pos, object);
+        this.inputs.add(new AbstractMap.SimpleImmutableEntry<>(String.valueOf(pos), object));
+    }
+
+    @Override
+    public void put(final String name, final Phi object) {
+        this.origin.put(name, object);
+        this.inputs.add(new AbstractMap.SimpleImmutableEntry<>(name, object));
+    }
+
+    @Override
+    public String locator() {
+        return this.origin.locator();
+    }
+
+    @Override
+    public String forma() {
+        return this.origin.forma();
+    }
+
+    @Override
+    public byte[] delta() {
+        final byte[] result;
+        final Optional<String> key = this.key();
+        if (key.isPresent()) {
+            final byte[] found = this.cache.get(key.get());
+            if (found == null) {
+                result = this.origin.delta();
+                this.cache.put(key.get(), result.clone());
+            } else {
+                result = found.clone();
+            }
+        } else {
+            result = this.origin.delta();
+        }
+        return result;
+    }
+
+    @Override
+    public Phi normalized() {
+        Phi result = this.origin.normalized();
+        if (result.equals(this.origin)) {
+            result = this;
+        }
+        return result;
+    }
+
+    @Override
+    public String φTerm() {
+        return this.origin.φTerm();
+    }
+
+    /**
+     * The key of this copy in the cache, or nothing when some input
+     * is not data and the cache must stay out of the way.
+     * @return The key, or empty
+     */
+    private Optional<String> key() {
+        final List<Map.Entry<String, Phi>> puts;
+        synchronized (this.inputs) {
+            puts = new ArrayList<>(this.inputs);
+        }
+        final StringBuilder out = new StringBuilder(0);
+        Optional<String> key = Optional.empty();
+        boolean data = true;
+        for (final Map.Entry<String, Phi> put : puts) {
+            final Phi norm = put.getValue().normalized();
+            if (!PhSticky.DATA.contains(norm.forma())) {
+                data = false;
+                break;
+            }
+            out.append(put.getKey()).append('=')
+                .append(Base64.getEncoder().encodeToString(new Dataized(norm).take()))
+                .append('|');
+        }
+        if (data) {
+            key = Optional.of(out.toString());
+        }
+        return key;
+    }
+
+    /**
+     * A thread-safe map that holds no more than the given number of entries,
+     * letting the entry asked for longest ago go first.
+     * @param capacity How many entries to keep
+     * @return The map
+     */
+    private static Map<String, byte[]> bounded(final int capacity) {
+        return Collections.synchronizedMap(new PhSticky.Lru(capacity));
+    }
+
+    /**
+     * The map under the bound: {@link LinkedHashMap} in access order is the
+     * one map the JDK lets evict by age of use, and the extension point it
+     * offers for that is an override, not an argument.
+     *
+     * @since 0.75
+     */
+    private static final class Lru extends LinkedHashMap<String, byte[]> {
+
+        /**
+         * Serialization marker, demanded by the parent.
+         */
+        private static final long serialVersionUID = 5165L;
+
+        /**
+         * How many entries to keep.
+         */
+        private final int capacity;
+
+        /**
+         * Ctor.
+         * @param cap How many entries to keep
+         */
+        Lru(final int cap) {
+            super(16, 0.75f, true);
+            this.capacity = cap;
+        }
+
+        @Override
+        protected boolean removeEldestEntry(final Map.Entry<String, byte[]> eldest) {
+            return this.size() > this.capacity;
+        }
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -5,19 +5,19 @@
 
 package org.eolang;
 
-import java.util.AbstractMap;
-import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 
 /**
  * An object remembering the results of its own dataization (see #5165).
  *
  * <p>The transpiler puts this decorator on a formation that {@code purify.xsl}
- * marked with {@code @pure}: one whose answer is decided by the bytes of its
+ * marked as pure: one whose answer is decided by the bytes of its
  * inputs and by nothing else. The cache belongs to the decorated object alone
  * and holds only what is its own — there is no table shared between objects
  * and no name under which a stranger could find an entry. A copy shares the
@@ -27,19 +27,34 @@ import java.util.Optional;
  *
  * <p>The inputs are whatever is put into the object — a void, a receiver, it
  * makes no difference — and the key is those puts in the order they came,
- * each reduced to the bytes of its object. The label of the transpiler is a
- * promise about the callers of yesterday and not about those of tomorrow, so
- * before trusting an input the decorator resolves it and looks at what it is:
- * anything that is not a number or a string makes the whole dataization pass
- * through, computed and not remembered.</p>
+ * each reduced to the bytes of its object. A put is remembered under the slot
+ * it came through, so the same void filled by position once and by name later
+ * makes two entries: a second computation, never a wrong answer. The label of
+ * the transpiler is a promise about the callers of yesterday and not about
+ * those of tomorrow, so before trusting an input the decorator resolves it
+ * and looks at what it is: anything that is not a number or a string makes
+ * the whole dataization pass through, computed and not remembered.</p>
  *
  * <p>Only dataization is remembered. Taking an attribute, putting one,
  * copying, normalizing — all of it reaches the decorated object untouched,
- * and the cache is bounded, letting the entry asked for longest ago go first.</p>
+ * and the cache is bounded, letting the entry asked for longest ago go
+ * first.</p>
  *
  * @since 0.75
+ * @todo #5165:60min Wrap the pure top-level classes and the anonymous
+ *  formations in PhSticky too. Today only a named formation nested in
+ *  another one (an "abstract" XMIR element) is decorated when purify.xsl
+ *  marks it as pure: a top-level "class" is instantiated by PhPackage
+ *  through reflection and an anonymous formation by the "o" template in
+ *  mode "object", and neither site in to-java.xsl knows about the label
+ *  yet.
  */
 public final class PhSticky implements Phi {
+
+    /**
+     * How many answers a decorated object keeps before evicting.
+     */
+    private static final int CAPACITY = 256;
 
     /**
      * The formae whose objects are decided by their bytes alone.
@@ -69,7 +84,7 @@ public final class PhSticky implements Phi {
      * @param obj The object to decorate
      */
     public PhSticky(final Phi obj) {
-        this(obj, 256);
+        this(obj, PhSticky.CAPACITY);
     }
 
     /**
@@ -81,7 +96,7 @@ public final class PhSticky implements Phi {
         this(
             obj,
             Collections.synchronizedMap(new Lru(capacity)),
-            Collections.synchronizedList(new ArrayList<>(0))
+            new CopyOnWriteArrayList<>()
         );
     }
 
@@ -113,11 +128,11 @@ public final class PhSticky implements Phi {
 
     @Override
     public Phi copy() {
-        final List<Map.Entry<String, Phi>> puts;
-        synchronized (this.inputs) {
-            puts = Collections.synchronizedList(new ArrayList<>(this.inputs));
-        }
-        return new PhSticky(this.origin.copy(), this.cache, puts);
+        return new PhSticky(
+            this.origin.copy(),
+            this.cache,
+            new CopyOnWriteArrayList<>(this.inputs)
+        );
     }
 
     @Override
@@ -133,13 +148,13 @@ public final class PhSticky implements Phi {
     @Override
     public void put(final int pos, final Phi object) {
         this.origin.put(pos, object);
-        this.inputs.add(new AbstractMap.SimpleImmutableEntry<>(String.valueOf(pos), object));
+        this.inputs.add(Map.entry(String.valueOf(pos), object));
     }
 
     @Override
     public void put(final String name, final Phi object) {
         this.origin.put(name, object);
-        this.inputs.add(new AbstractMap.SimpleImmutableEntry<>(name, object));
+        this.inputs.add(Map.entry(name, object));
     }
 
     @Override
@@ -184,32 +199,26 @@ public final class PhSticky implements Phi {
         return this.origin.φTerm();
     }
 
-    /**
-     * The key of this copy in the cache, or nothing when some input
-     * is not data and the cache must stay out of the way.
-     * @return The key, or empty
-     */
     private Optional<String> key() {
-        final List<Map.Entry<String, Phi>> puts;
-        synchronized (this.inputs) {
-            puts = new ArrayList<>(this.inputs);
+        final Optional<String> result;
+        final List<Map.Entry<String, Phi>> normal = this.inputs.stream()
+            .map(put -> Map.entry(put.getKey(), put.getValue().normalized()))
+            .collect(Collectors.toList());
+        if (normal.stream().allMatch(put -> PhSticky.DATA.contains(put.getValue().forma()))) {
+            result = Optional.of(
+                normal.stream().map(
+                    put -> String.format(
+                        "%s=%s",
+                        put.getKey(),
+                        Base64.getEncoder().encodeToString(
+                            new Dataized(put.getValue()).take()
+                        )
+                    )
+                ).collect(Collectors.joining("|"))
+            );
+        } else {
+            result = Optional.empty();
         }
-        final StringBuilder out = new StringBuilder(0);
-        Optional<String> key = Optional.empty();
-        boolean data = true;
-        for (final Map.Entry<String, Phi> put : puts) {
-            final Phi norm = put.getValue().normalized();
-            if (!PhSticky.DATA.contains(norm.forma())) {
-                data = false;
-                break;
-            }
-            out.append(put.getKey()).append('=')
-                .append(Base64.getEncoder().encodeToString(new Dataized(norm).take()))
-                .append('|');
-        }
-        if (data) {
-            key = Optional.of(out.toString());
-        }
-        return key;
+        return result;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
@@ -6,12 +6,8 @@ package org.eolang;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -26,11 +22,13 @@ final class PhStickyTest {
 
     @Test
     void computesThroughTheDecorator() {
-        final Phi twice = new PhSticky(PhStickyTest.doubler(new AtomicInteger()));
         MatcherAssert.assertThat(
             "the decorated formation must dataize to the doubled input, but it didnt",
             new Dataized(
-                new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))
+                new PhApplication(
+                    new PhSticky(PhStickyTest.doubler(new AtomicInteger())),
+                    new Bind(0, new Data.ToPhi(21.0d))
+                )
             ).asNumber(),
             Matchers.equalTo(42.0d)
         );
@@ -150,40 +148,32 @@ final class PhStickyTest {
     @Timeout(20L)
     void staysCorrectUnderConcurrentDataization() throws Exception {
         final Phi twice = new PhSticky(PhStickyTest.doubler(new AtomicInteger()));
-        final int threads = 8;
-        final ExecutorService pool = Executors.newFixedThreadPool(threads);
-        try {
-            final Collection<Callable<Double>> tasks = new ArrayList<>(threads);
-            for (int idx = 0; idx < threads; ++idx) {
-                tasks.add(
-                    () -> new Dataized(
-                        new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))
-                    ).asNumber()
-                );
-            }
-            final List<Future<Double>> answers = pool.invokeAll(
-                tasks, 10L, TimeUnit.SECONDS
+        final List<Double> results = Collections.synchronizedList(new ArrayList<>(8));
+        final Collection<Thread> threads = new ArrayList<>(8);
+        for (int idx = 0; idx < 8; ++idx) {
+            threads.add(
+                new Thread(
+                    () -> results.add(
+                        new Dataized(
+                            new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))
+                        ).asNumber()
+                    )
+                )
             );
-            final Collection<Double> results = new ArrayList<>(threads);
-            for (final Future<Double> answer : answers) {
-                results.add(answer.get());
-            }
-            MatcherAssert.assertThat(
-                "every concurrent dataization must answer the same doubled input, but some didnt",
-                results,
-                Matchers.everyItem(Matchers.equalTo(42.0d))
-            );
-        } finally {
-            pool.shutdownNow();
         }
+        for (final Thread thread : threads) {
+            thread.start();
+        }
+        for (final Thread thread : threads) {
+            thread.join(10_000L);
+        }
+        MatcherAssert.assertThat(
+            "every concurrent dataization must answer the same doubled input, but some didnt",
+            results,
+            Matchers.equalTo(Collections.nCopies(8, 42.0d))
+        );
     }
 
-    /**
-     * A formation like {@code [x] > twice} with {@code x.times 2 > @},
-     * counting how many times its body runs.
-     * @param count The counter of body evaluations
-     * @return The formation
-     */
     private static Phi doubler(final AtomicInteger count) {
         final PhDefault twice = new PhDefault();
         twice.add("x", new AtVoid("x"));
@@ -204,12 +194,6 @@ final class PhStickyTest {
         return twice;
     }
 
-    /**
-     * A formation like {@code [x] > length} answering the size of the
-     * bytes of its input, counting how many times its body runs.
-     * @param count The counter of body evaluations
-     * @return The formation
-     */
     private static Phi measurer(final AtomicInteger count) {
         final PhDefault length = new PhDefault();
         length.add("x", new AtVoid("x"));
@@ -230,12 +214,6 @@ final class PhStickyTest {
         return length;
     }
 
-    /**
-     * A formation like {@code [^] > halver} with {@code ^.div 2 > @},
-     * counting how many times its body runs.
-     * @param count The counter of body evaluations
-     * @return The formation
-     */
     private static Phi receiver(final AtomicInteger count) {
         final PhDefault halver = new PhDefault();
         halver.add(Phi.RHO, new AtRho());

--- a/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
@@ -1,0 +1,258 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Test case for {@link PhSticky}.
+ * @since 0.75
+ */
+final class PhStickyTest {
+
+    @Test
+    void computesThroughTheDecorator() {
+        final Phi twice = new PhSticky(PhStickyTest.doubler(new AtomicInteger()));
+        MatcherAssert.assertThat(
+            "the decorated formation must dataize to the doubled input, but it didnt",
+            new Dataized(
+                new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))
+            ).asNumber(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @Test
+    void dataizesBodyOnceForEqualInputs() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi twice = new PhSticky(PhStickyTest.doubler(count));
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))).take();
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))).take();
+        MatcherAssert.assertThat(
+            "the body must not be recomputed for an input already seen, but it was",
+            count.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void answersTheSameBytesFromTheCache() {
+        final Phi twice = new PhSticky(PhStickyTest.doubler(new AtomicInteger()));
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))).take();
+        MatcherAssert.assertThat(
+            "the cached answer must equal the computed one, but it didnt",
+            new Dataized(
+                new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))
+            ).asNumber(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @Test
+    void recomputesForDifferentInput() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi twice = new PhSticky(PhStickyTest.doubler(count));
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))).take();
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(7.0d)))).take();
+        MatcherAssert.assertThat(
+            "a fresh input must reach the body, but it didnt",
+            count.get(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void treatsStringInputAsData() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi length = new PhSticky(PhStickyTest.measurer(count));
+        new Dataized(new PhApplication(length, new Bind(0, new Data.ToPhi("kettle")))).take();
+        new Dataized(new PhApplication(length, new Bind(0, new Data.ToPhi("kettle")))).take();
+        MatcherAssert.assertThat(
+            "a string input must hit the cache the second time, but it didnt",
+            count.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void bypassesCacheForNonDataInput() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi length = new PhSticky(PhStickyTest.measurer(count));
+        new Dataized(
+            new PhApplication(length, new Bind(0, new PhDefault(new byte[] {(byte) 0x2A})))
+        ).take();
+        new Dataized(
+            new PhApplication(length, new Bind(0, new PhDefault(new byte[] {(byte) 0x2A})))
+        ).take();
+        MatcherAssert.assertThat(
+            "an input that is not a number or a string must not be cached, but it was",
+            count.get(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void cachesWhenReceiverIsANumber() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi halver = new PhSticky(PhStickyTest.receiver(count));
+        final Phi first = halver.copy();
+        first.put(Phi.RHO, new Data.ToPhi(84.0d));
+        new Dataized(first).take();
+        final Phi second = halver.copy();
+        second.put(Phi.RHO, new Data.ToPhi(84.0d));
+        new Dataized(second).take();
+        MatcherAssert.assertThat(
+            "a receiver put as a number must be an input like any other, but it wasnt cached",
+            count.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void asksForReceiverWhenOriginDeclaresOne() {
+        MatcherAssert.assertThat(
+            "the decorator must not hide the origin's appetite for a receiver, but it did",
+            new PhSticky(PhStickyTest.receiver(new AtomicInteger())).needsRho(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void evictsOldestEntryBeyondCapacity() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi twice = new PhSticky(PhStickyTest.doubler(count), 2);
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(1.0d)))).take();
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(2.0d)))).take();
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(3.0d)))).take();
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(1.0d)))).take();
+        MatcherAssert.assertThat(
+            "the entry evicted by the capacity bound must be recomputed, but it wasnt",
+            count.get(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
+    @Timeout(20L)
+    void staysCorrectUnderConcurrentDataization() throws Exception {
+        final Phi twice = new PhSticky(PhStickyTest.doubler(new AtomicInteger()));
+        final int threads = 8;
+        final ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            final Collection<Callable<Double>> tasks = new ArrayList<>(threads);
+            for (int idx = 0; idx < threads; ++idx) {
+                tasks.add(
+                    () -> new Dataized(
+                        new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))
+                    ).asNumber()
+                );
+            }
+            final List<Future<Double>> answers = pool.invokeAll(
+                tasks, 10L, TimeUnit.SECONDS
+            );
+            final Collection<Double> results = new ArrayList<>(threads);
+            for (final Future<Double> answer : answers) {
+                results.add(answer.get());
+            }
+            MatcherAssert.assertThat(
+                "every concurrent dataization must answer the same doubled input, but some didnt",
+                results,
+                Matchers.everyItem(Matchers.equalTo(42.0d))
+            );
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    /**
+     * A formation like {@code [x] > twice} with {@code x.times 2 > @},
+     * counting how many times its body runs.
+     * @param count The counter of body evaluations
+     * @return The formation
+     */
+    private static Phi doubler(final AtomicInteger count) {
+        final PhDefault twice = new PhDefault();
+        twice.add("x", new AtVoid("x"));
+        twice.add(
+            Phi.PHI,
+            new AtOnce(
+                new AtComposite(
+                    twice,
+                    self -> {
+                        count.incrementAndGet();
+                        return new Data.ToPhi(
+                            new Dataized(self.take("x")).asNumber() * 2.0d
+                        );
+                    }
+                )
+            )
+        );
+        return twice;
+    }
+
+    /**
+     * A formation like {@code [x] > length} answering the size of the
+     * bytes of its input, counting how many times its body runs.
+     * @param count The counter of body evaluations
+     * @return The formation
+     */
+    private static Phi measurer(final AtomicInteger count) {
+        final PhDefault length = new PhDefault();
+        length.add("x", new AtVoid("x"));
+        length.add(
+            Phi.PHI,
+            new AtOnce(
+                new AtComposite(
+                    length,
+                    self -> {
+                        count.incrementAndGet();
+                        return new Data.ToPhi(
+                            new Dataized(self.take("x")).take().length
+                        );
+                    }
+                )
+            )
+        );
+        return length;
+    }
+
+    /**
+     * A formation like {@code [^] > halver} with {@code ^.div 2 > @},
+     * counting how many times its body runs.
+     * @param count The counter of body evaluations
+     * @return The formation
+     */
+    private static Phi receiver(final AtomicInteger count) {
+        final PhDefault halver = new PhDefault();
+        halver.add(Phi.RHO, new AtRho());
+        halver.add(
+            Phi.PHI,
+            new AtOnce(
+                new AtComposite(
+                    halver,
+                    self -> {
+                        count.incrementAndGet();
+                        return new Data.ToPhi(
+                            new Dataized(self.take(Phi.RHO)).asNumber() / 2.0d
+                        );
+                    }
+                )
+            )
+        );
+        return halver;
+    }
+}


### PR DESCRIPTION
This adds the `PhSticky` decorator to eo-runtime and makes `to-java.xsl` wrap every nested formation that `purify.xsl` (#7536, merged in #7549) marked with `@pure`. The decorator keeps a bounded LRU cache of its own — no static table, no compile-time key — shared between the object and its copies, since an application copies the formation before filling it. The key is the puts the copy received, in arrival order, each reduced to bytes; only dataization goes through the cache.

The `pure` label is evidence about yesterday's callers, not a contract, so the decorator re-checks at runtime: unless every input normalizes to `Φ.number` or `Φ.string`, the dataization passes through uncached. This is the runtime half of #5165 and should stop the repeated-recomputation class of slowdowns seen in #6179, #6868 and #7384 once inference coverage grows.

Two wrap sites are left as a puzzle in `to-java.xsl`: top-level classes are instantiated by `PhPackage` through reflection and anonymous formations by a different template, so neither sees the label yet.