### PR TITLE
#7511: socket provides misleading failure message for invalid IPv4 conversion due to unrelated errno

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.posix;
 
+import com.sun.jna.Native;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -15,6 +16,12 @@ import org.eolang.Syscall;
  * @since 0.40
  */
 public final class InetAddrSyscall implements Syscall {
+
+    /**
+     * {@code EINVAL}, the same value on every POSIX platform this library
+     * targets (Linux, macOS).
+     */
+    private static final int EINVAL = 22;
 
     /**
      * Posix object.
@@ -32,12 +39,13 @@ public final class InetAddrSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(
-                CStdLib.INSTANCE.inet_addr(new Dataized(params[0]).asString())
-            )
+        final int converted = CStdLib.INSTANCE.inet_addr(
+            new Dataized(params[0]).asString()
         );
+        if (converted == -1) {
+            Native.setLastError(InetAddrSyscall.EINVAL);
+        }
+        result.put(0, new Data.ToPhi(converted));
         result.put(1, new PhDefault());
         return result;
     }

--- a/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import com.sun.jna.Native;
+import org.eolang.Data;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link InetAddrSyscall}.
+ * @since 0.74.1
+ */
+final class InetAddrSyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void setsErrnoToInvalOnAnUnparsableAddress() {
+        new InetAddrSyscall(Phi.Φ.take("posix").copy()).make(new Data.ToPhi("nope"));
+        MatcherAssert.assertThat(
+            "inet_addr does not set errno on failure, so the syscall wrapper must set it itself, to EINVAL, or a later strerror(errno) reads whatever an unrelated earlier call left behind",
+            Native.getLastError(),
+            Matchers.equalTo(22)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void leavesErrnoAloneOnAValidAddress() {
+        Native.setLastError(0);
+        new InetAddrSyscall(Phi.Φ.take("posix").copy()).make(new Data.ToPhi("127.0.0.1"));
+        MatcherAssert.assertThat(
+            "A successful inet_addr conversion must not fabricate an error",
+            Native.getLastError(),
+            Matchers.equalTo(0)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7511. `inet_addr(3)` does not set `errno` on failure, so when `socket`
builds the "Couldn't convert an IPv4 address" message with
`strerror(errno)`, it reads whatever an earlier, unrelated native call left
behind.

The win32 half already handles this correctly: `InetAddrFuncCall` calls
`WSASetLastError(WSAEINVAL)` on the failure path, so `WSAGetLastError()`
reports something true. This mirrors that on the posix side: when
`inet_addr` returns `-1`, `InetAddrSyscall` now calls
`Native.setLastError(EINVAL)`, so a later `strerror(errno)` names the real
cause on both platforms.

Added `InetAddrSyscallTest`, matching the existing `RecvSyscallTest`
pattern, checking that a failed conversion sets errno to `EINVAL` and a
successful one leaves it alone.
