### PR TITLE
#7573: DpsDefault accepts empty mandatory components in +rt jvm coordinates

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsDefault.java
@@ -9,6 +9,7 @@ import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.log.Logger;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -131,6 +132,14 @@ final class DpsDefault implements Dependencies {
                     Logger.format(
                         "Malformed '+rt jvm' location '%s' at %[file]s: expected 3 or 4 colon-separated parts (group:artifact:version or group:artifact:classifier:version), got %d",
                         location, file, parts.length
+                    )
+                );
+            }
+            if (Arrays.stream(parts).anyMatch(String::isEmpty)) {
+                throw new IllegalStateException(
+                    Logger.format(
+                        "Malformed '+rt jvm' location '%s' at %[file]s: every colon-separated part (group:artifact:version or group:artifact:classifier:version) must be non-empty",
+                        location, file
                     )
                 );
             }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -145,7 +145,8 @@ final class MjResolveTest {
     }
 
     @Test
-    void reportsRtJvmLocationWithAnEmptyComponentClearly(@Mktmp final Path temp) throws IOException {
+    void reportsRtJvmLocationWithAnEmptyComponentClearly(@Mktmp final Path temp)
+        throws IOException {
         final Path xmir = temp.resolve("dep.xmir");
         Files.writeString(
             xmir,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjResolveTest.java
@@ -145,6 +145,32 @@ final class MjResolveTest {
     }
 
     @Test
+    void reportsRtJvmLocationWithAnEmptyComponentClearly(@Mktmp final Path temp) throws IOException {
+        final Path xmir = temp.resolve("dep.xmir");
+        Files.writeString(
+            xmir,
+            String.join(
+                "",
+                "<object><metas><meta><head>rt</head>",
+                "<tail>jvm org.eolang:eo-runtime:</tail>",
+                "<part>jvm</part><part>org.eolang:eo-runtime:</part>",
+                "</meta></metas></object>"
+            )
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("dep").withXmir(xmir).withVersion("1.0.0");
+        MatcherAssert.assertThat(
+            "The error must name the malformed '+rt jvm' location",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new DpsDefault(tojos, false, false, false).iterator(),
+                "A '+rt jvm' location with an empty mandatory component, such as a missing version, must fail with a clear error, not register a dependency with a blank coordinate"
+            ).getMessage(),
+            Matchers.containsString("org.eolang:eo-runtime:")
+        );
+    }
+
+    @Test
     void resolvesDefaultJnaDependency(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "Default JNA dependency must be resolved",


### PR DESCRIPTION
Fixes #7573. `DpsDefault.artifact()` checked the number of colon-separated
parts in a `+rt jvm` coordinate but not the parts themselves, so a
coordinate with an empty group, artifact, version or classifier
(`:eo-runtime:0.0.0`, `org.eolang::0.0.0`, `org.eolang:eo-runtime:`,
`org.eolang:eo-runtime::0.0.0`) passed validation and registered a
dependency with a blank component.

Added a check that every part is non-empty, right after the existing arity
check, using the same exception format (source XMIR path, complete
malformed coordinate).

Added a regression test mirroring the existing
`reportsMalformedRtJvmLocationClearly` for the arity case.
