### PR TITLE
Split Blanks.enterAfterMeta into a command and a Globals query

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -70,14 +70,12 @@ final class Blanks {
      *
      * @param span The offending line's span (used for error position)
      * @param stack The indent stack, read for the top-level object's kind
-     * @param blanks How many blank lines precede the line - read by the
-     *  caller before {@link #enterAfterMeta(Span, Globals, Emit)} had a
-     *  chance to consume them
+     * @param globals The global parser state, read for the blank count
      * @param emit The directives sink
      * @checkstyle ParameterNumberCheck (3 lines)
      */
     static void checkTest(
-        final Span span, final Stack stack, final int blanks, final Emit emit
+        final Span span, final Stack stack, final Globals globals, final Emit emit
     ) {
         final Kind top = stack.root().kind();
         if (span.indent() != 2 || top != Kind.BARE_FORMATION && top != Kind.ONLY_PHI) {
@@ -86,7 +84,7 @@ final class Blanks {
                 "test attribute legal only as direct child of top-level object"
             );
         }
-        if (blanks == 0) {
+        if (globals.pendingBlanks() == 0) {
             emit.error(
                 span.line(), span.indent(),
                 "missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute"
@@ -95,17 +93,15 @@ final class Blanks {
     }
 
     /**
-     * Report R-6.5.5 — the first non-meta non-blank line after the
-     * meta header must be preceded by exactly one blank line. Closes
-     * the meta-header window so subsequent lines are not re-checked.
+     * Close the meta header — called from the first non-meta non-blank
+     * line, reporting R-6.5.5 when that line is not preceded by
+     * exactly one blank line. Does nothing once the header is already
+     * closed.
      * @param span The first post-meta line's span
      * @param globals The global parser state
      * @param emit The directives sink
-     * @return How many blank lines preceded the line, counted before
-     *  this method consumed them
      */
-    static int enterAfterMeta(final Span span, final Globals globals, final Emit emit) {
-        final int blanks = globals.pendingBlanks();
+    static void enterAfterMeta(final Span span, final Globals globals, final Emit emit) {
         if (globals.inMetaHeader()) {
             if (globals.pendingBlanks() == 0) {
                 emit.error(
@@ -117,6 +113,5 @@ final class Blanks {
             }
             globals.closeMetaHeader();
         }
-        return blanks;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -68,7 +68,7 @@ final class LnApplication implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, globals.pendingBlanks(), emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -86,7 +86,7 @@ final class LnCompactTuple implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, globals.pendingBlanks(), emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -47,7 +47,7 @@ final class LnFormation implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        final int blanks = Blanks.enterAfterMeta(this.span, globals, emit);
+        Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
         final List<String> params;
         final String binding;
@@ -78,7 +78,7 @@ final class LnFormation implements Line {
         }
         this.checkAtomVoids(suffix, params);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, blanks, emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         }
         Comments.seal(globals, emit, this.span);
         this.transition(stack, suffix);

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -47,7 +47,6 @@ final class LnFormation implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
         final List<String> params;
         final String binding;
@@ -80,6 +79,7 @@ final class LnFormation implements Line {
         if (suffix.test()) {
             Blanks.checkTest(this.span, stack, globals, emit);
         }
+        Blanks.enterAfterMeta(this.span, globals, emit);
         Comments.seal(globals, emit, this.span);
         this.transition(stack, suffix);
         globals.clearBlanks();

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -75,7 +75,7 @@ final class LnMethod implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, globals.pendingBlanks(), emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -79,7 +79,7 @@ final class LnOnlyPhi implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        final int blanks = Blanks.enterAfterMeta(this.span, globals, emit);
+        Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
         final int phi = Eo.topLevelGreaterBracketIndex(body);
         final String lhs;
@@ -125,7 +125,7 @@ final class LnOnlyPhi implements Line {
             );
         }
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, blanks, emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         }
         Comments.seal(globals, emit, this.span);
         final Tokens tokens = this.slot(

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -79,7 +79,6 @@ final class LnOnlyPhi implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        Blanks.enterAfterMeta(this.span, globals, emit);
         final String body = this.span.body();
         final int phi = Eo.topLevelGreaterBracketIndex(body);
         final String lhs;
@@ -127,6 +126,7 @@ final class LnOnlyPhi implements Line {
         if (suffix.test()) {
             Blanks.checkTest(this.span, stack, globals, emit);
         }
+        Blanks.enterAfterMeta(this.span, globals, emit);
         Comments.seal(globals, emit, this.span);
         final Tokens tokens = this.slot(
             stack, suffix,

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -80,7 +80,7 @@ final class LnReversed implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, globals.pendingBlanks(), emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -60,7 +60,7 @@ final class LnTextBlock implements Line {
         );
         suffix.rejectAtomOutsideFormation(this.span);
         if (suffix.test()) {
-            Blanks.checkTest(this.span, stack, globals.pendingBlanks(), emit);
+            Blanks.checkTest(this.span, stack, globals, emit);
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }

--- a/eo-parser/src/test/java/org/eolang/parser/BlanksTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BlanksTest.java
@@ -6,7 +6,6 @@ package org.eolang.parser;
 
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -46,18 +45,6 @@ final class BlanksTest {
             XhtmlMatchers.hasXPaths(
                 "/object[not(errors/error[contains(text(),'missing blank line')])]"
             )
-        );
-    }
-
-    @Test
-    void leavesPendingBlanksUntouchedOutsideMetaHeader() {
-        final Globals globals = new Globals();
-        globals.blank();
-        Blanks.enterAfterMeta(new Span("[] > foo", 1), globals, new Emit());
-        MatcherAssert.assertThat(
-            "enterAfterMeta must not clear the pending-blank count once the meta header is already closed",
-            globals.pendingBlanks(),
-            Matchers.equalTo(1)
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/BlanksTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BlanksTest.java
@@ -17,7 +17,7 @@ import org.xembly.Xembler;
 final class BlanksTest {
 
     @Test
-    void reportsMissingBlankBeforeTestAttributeThroughGlobals() {
+    void reportsMissingBlankBeforeAttributeThroughGlobals() {
         final Emit emit = new Emit();
         final Stack stack = new Stack();
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
@@ -32,7 +32,7 @@ final class BlanksTest {
     }
 
     @Test
-    void staysSilentAboutTestAttributeBlankWhenGlobalsHasPendingBlanks() {
+    void staysSilentAboutAttributeBlankWhenGlobalsHasPendingBlanks() {
         final Emit emit = new Emit();
         final Stack stack = new Stack();
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);

--- a/eo-parser/src/test/java/org/eolang/parser/BlanksTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BlanksTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link Blanks}.
+ * @since 0.1
+ */
+final class BlanksTest {
+
+    @Test
+    void reportsMissingBlankBeforeTestAttributeThroughGlobals() {
+        final Emit emit = new Emit();
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        Blanks.checkTest(new Span("  +> foo", 2), stack, new Globals(), emit);
+        MatcherAssert.assertThat(
+            "checkTest must read the blank count from Globals and report a missing blank",
+            BlanksTest.render(emit),
+            XhtmlMatchers.hasXPaths(
+                "/object/errors/error[contains(text(),'missing blank line')]"
+            )
+        );
+    }
+
+    @Test
+    void staysSilentAboutTestAttributeBlankWhenGlobalsHasPendingBlanks() {
+        final Emit emit = new Emit();
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        final Globals globals = new Globals();
+        globals.blank();
+        Blanks.checkTest(new Span("  +> foo", 2), stack, globals, emit);
+        MatcherAssert.assertThat(
+            "checkTest must not report a missing blank once Globals carries a pending one",
+            BlanksTest.render(emit),
+            XhtmlMatchers.hasXPaths(
+                "/object[not(errors/error[contains(text(),'missing blank line')])]"
+            )
+        );
+    }
+
+    @Test
+    void leavesPendingBlanksUntouchedOutsideMetaHeader() {
+        final Globals globals = new Globals();
+        globals.blank();
+        Blanks.enterAfterMeta(new Span("[] > foo", 1), globals, new Emit());
+        MatcherAssert.assertThat(
+            "enterAfterMeta must not clear the pending-blank count once the meta header is already closed",
+            globals.pendingBlanks(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    private static String render(final Emit emit) {
+        return new Xembler(
+            new Directives().add("object").append(emit.directives())
+        ).xmlQuietly();
+    }
+}


### PR DESCRIPTION
\`Blanks.enterAfterMeta\` used to both mutate parser state (clear the pending-blank count, close the meta header) and answer how many blanks it found on the way in. Its callers only wanted one side of that: \`checkPlain\` called it purely to close the meta header and threw the answer away, while \`LnFormation.into\` and \`LnOnlyPhi.into\` called it for the count, stashed it in a local, and forwarded it into \`Blanks.checkTest\` as a fourth parameter.

\`enterAfterMeta\` is now a command: it closes the meta header and reports R-6.5.5, nothing more. \`checkTest\` now reads the blank count itself through \`Globals.pendingBlanks()\`, which already existed as the query side of this split, so its \`blanks\` parameter is gone. All eight call sites across the \`Ln*\` line handlers were updated to match.

No behavior changes — this is a pure seam split, and the existing snippet and unit tests for R-6.5.3/R-6.5.5 blank-line rules cover it unchanged.

Closes #7547