### PR TITLE
#7578: CommitHashesText ignores its fallback when the tags service has a non-DNS I/O failure

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHashesText.java
@@ -71,17 +71,6 @@ final class CommitHashesText extends TextEnvelope {
         super(new Synced(new Sticky(() -> CommitHashesText.safe(source))));
     }
 
-    /**
-     * Read the source, falling back to {@link CommitHashesText#FALLBACK} when
-     * every retried attempt to read it fails with an I/O error.
-     *
-     * <p>Malformed content that a successful read did return is not this
-     * class's concern: {@code source} answers for its own shape, and a
-     * caller downstream of the cache diagnoses that separately.</p>
-     *
-     * @param source Text source
-     * @return The source's text, or the fallback table
-     */
     private static String safe(final Text source) throws Exception {
         String hashes;
         try {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHashesText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CommitHashesText.java
@@ -6,6 +6,7 @@ package org.eolang.maven;
 
 import com.jcabi.aspects.RetryOnFailure;
 import com.jcabi.log.Logger;
+import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import org.cactoos.Text;
@@ -58,23 +59,34 @@ final class CommitHashesText extends TextEnvelope {
      * Constructor.
      */
     CommitHashesText() {
-        this(CommitHashesText::asText);
+        this(CommitHashesText::fetch);
     }
 
     /**
      * Constructor.
-     * @param source Text source
+     * @param source Text source, retried on its own before this class falls
+     *  back to {@link CommitHashesText#FALLBACK}
      */
-    private CommitHashesText(final Text source) {
-        super(new Synced(new Sticky(source)));
+    CommitHashesText(final Text source) {
+        super(new Synced(new Sticky(() -> CommitHashesText.safe(source))));
     }
 
-    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
-    private static String asText() throws Exception {
+    /**
+     * Read the source, falling back to {@link CommitHashesText#FALLBACK} when
+     * every retried attempt to read it fails with an I/O error.
+     *
+     * <p>Malformed content that a successful read did return is not this
+     * class's concern: {@code source} answers for its own shape, and a
+     * caller downstream of the cache diagnoses that separately.</p>
+     *
+     * @param source Text source
+     * @return The source's text, or the fallback table
+     */
+    private static String safe(final Text source) throws Exception {
         String hashes;
         try {
-            hashes = new TextOf(new URL(CommitHashesText.HOME)).asString();
-        } catch (final java.net.UnknownHostException ex) {
+            hashes = source.asString();
+        } catch (final IOException ex) {
             Logger.warn(
                 CommitHashesText.class,
                 "Can't load hashes: %[exception]s",
@@ -83,5 +95,10 @@ final class CommitHashesText extends TextEnvelope {
             hashes = CommitHashesText.FALLBACK;
         }
         return hashes;
+    }
+
+    @RetryOnFailure(delay = 1L, unit = TimeUnit.SECONDS)
+    private static String fetch() throws Exception {
+        return new TextOf(new URL(CommitHashesText.HOME)).asString();
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
@@ -6,8 +6,10 @@ package org.eolang.maven;
 
 import com.yegor256.Together;
 import com.yegor256.WeAreOnline;
+import javax.net.ssl.SSLException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -15,10 +17,36 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Test case for {@link CommitHashesText}.
  * @since 0.37.0
  */
-@ExtendWith(WeAreOnline.class)
 final class CommitHashesTextTest {
 
     @Test
+    void fallsBackOnATransportFailureThatIsNotUnknownHost() throws Exception {
+        MatcherAssert.assertThat(
+            "A transport failure other than an unknown host must still fall back to the built-in table, not propagate and fail the build",
+            new CommitHashesText(
+                () -> {
+                    throw new SSLException("handshake failed");
+                }
+            ).asString(),
+            Matchers.containsString("0.28.9")
+        );
+    }
+
+    @Test
+    void propagatesAFailureThatIsNotAnIOException() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new CommitHashesText(
+                () -> {
+                    throw new IllegalStateException("not an I/O failure");
+                }
+            ).asString(),
+            "A non-I/O failure must not be swallowed into the fallback table"
+        );
+    }
+
+    @Test
+    @ExtendWith(WeAreOnline.class)
     void downloadsDefaultList() throws Exception {
         MatcherAssert.assertThat(
             "CommitHashesText downloads the default list of hashes from Objectionary",
@@ -28,6 +56,7 @@ final class CommitHashesTextTest {
     }
 
     @Test
+    @ExtendWith(WeAreOnline.class)
     void isThreadSafe() {
         final CommitHashesText text = new CommitHashesText();
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
@@ -33,7 +33,7 @@ final class CommitHashesTextTest {
     }
 
     @Test
-    void propagatesAFailureThatIsNotAnIOException() {
+    void propagatesAFailureThatIsNotAnIoError() {
         Assertions.assertThrows(
             IllegalStateException.class,
             () -> new CommitHashesText(


### PR DESCRIPTION
Fixes #7578. `CommitHashesText` caught only `UnknownHostException`, so a
reachable host that still failed to serve the tags table (connection
refused, TLS failure, read timeout, transient transport error) bypassed
the fallback table and made the Mojo fail after `@RetryOnFailure`'s retry
attempts were exhausted.

Split the fetch from the fallback: `fetch()` keeps the retried network
call, `safe()` wraps any `Text` source and catches `IOException` (the
common supertype of `UnknownHostException` and every transport failure
named in the issue) once the retries are exhausted, falling back to the
built-in table. A failure that is not an `IOException` still propagates,
so a genuine bug is not silently swallowed into the fallback.

Made the two-arg constructor package-private so tests can inject a source
that fails a specific way, without depending on the network. Added tests
for a non-DNS transport failure falling back, and a non-I/O failure still
propagating.
