### PR TITLE
admission names the level itself instead of handing out a nullable label

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Admission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Admission.java
@@ -5,9 +5,10 @@
 package org.eolang.parser;
 
 /**
- * A line's naming suffix, as {@link Transition#apply} needs it: the
- * label to attach to the pushed-or-replaced level, and whether the line
- * shape is allowed to sit under an atom parent (R-3.10.13).
+ * A line's naming suffix, as {@link Transition#apply} needs it: names
+ * the pushed-or-replaced level when the line carries a name suffix, and
+ * says whether the line shape is allowed to sit under an atom parent
+ * (R-3.10.13).
  * @since 0.1
  */
 final class Admission {
@@ -34,11 +35,13 @@ final class Admission {
     }
 
     /**
-     * The suffix's source name.
-     * @return The label, or {@code null}
+     * Name the level with this suffix's label, when there is one.
+     * @param level The level to name
      */
-    String label() {
-        return this.label;
+    void name(final Level level) {
+        if (this.label != null) {
+            level.name(this.label);
+        }
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -63,9 +63,7 @@ final class Transition {
                 "atom may contain only test attributes"
             );
         }
-        if (admission.label() != null) {
-            level.name(admission.label());
-        }
+        admission.name(level);
         return level;
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/AdmissionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/AdmissionTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Admission}.
+ * @since 0.1
+ */
+final class AdmissionTest {
+
+    @Test
+    void namesTheLevelWhenLabelIsGiven() {
+        final Level level = new Stack().push(0, 1, Kind.HEAD, Openness.OPEN);
+        new Admission("nu", false).name(level);
+        MatcherAssert.assertThat(
+            "a level named through a non-null label must be recorded as named",
+            level.named(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void leavesTheLevelUnnamedWhenLabelIsNull() {
+        final Level level = new Stack().push(0, 1, Kind.HEAD, Openness.OPEN);
+        new Admission(null, false).name(level);
+        MatcherAssert.assertThat(
+            "a level left untouched by a null label must stay unnamed",
+            level.named(),
+            Matchers.is(false)
+        );
+    }
+}


### PR DESCRIPTION
Admission.label() was a getter that handed a nullable field straight out, exactly so Transition.apply could test it against null and decide whether to call level.name(...). The knowledge of whether the line was named lived in Admission, but the branch on that knowledge lived in Transition.

Admission.name(Level) replaces the getter with a command: it names the level itself when there is a label, and does nothing otherwise. Transition.apply now just calls admission.name(level), with no null check left in its body.

AdmissionTest covers the new method directly, both with a label present and with a null one. TransitionTest already exercised the same behavior through apply and still passes unchanged.

Closes #7545