### PR TITLE
Split Emit.object into null-free overloads by name/base presence

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
@@ -114,7 +114,7 @@ final class ChainEmission {
             if (idx == last) {
                 sink.object(label, ".".concat(chained.name()), line, chained.dot());
             } else {
-                sink.object(null, ".".concat(chained.name()), line, chained.dot());
+                sink.unnamedObject(".".concat(chained.name()), line, chained.dot());
             }
             sink.method(chained.fragile());
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -139,7 +139,7 @@ final class Emissions {
             Emissions.hex(emit, name, value, line);
         } else if (value.bytes()) {
             emit.object(name, "Φ.bytes", line, value.pos());
-            emit.object(null, null, line, value.pos());
+            emit.bareObject(line, value.pos());
             emit.set(value.raw());
             emit.close();
         } else if (value.string()) {
@@ -213,8 +213,8 @@ final class Emissions {
     static void bytesCarrier(
         final Emit emit, final int line, final int pos, final String hex
     ) {
-        emit.object(null, "Φ.bytes", line, pos);
-        emit.object(null, null, line, pos);
+        emit.unnamedObject("Φ.bytes", line, pos);
+        emit.bareObject(line, pos);
         emit.set(hex);
         emit.close();
         emit.close();
@@ -257,7 +257,7 @@ final class Emissions {
     private static void identity(
         final Emit emit, final String name, final Value value, final int line
     ) {
-        emit.object(name, null, line, value.pos());
+        emit.baselessObject(name, line, value.pos());
         emit.voidParam(Emissions.IDENTITY, line, value.pos());
         emit.object("φ", Emissions.IDENTITY, line, value.pos());
         emit.close();
@@ -480,7 +480,7 @@ final class Emissions {
         } else {
             label = name;
         }
-        emit.object(label, null, line, column);
+        emit.baselessObject(label, line, column);
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -296,7 +296,6 @@ final class Emit {
     /**
      * Open an unnamed {@code <o base="...">} element, i.e. one with
      * no {@code @name} — §9.0.2 / §9.4.2.
-     *
      * @param base Value for {@code @base}
      * @param line Source line for {@code @line}
      * @param pos Source column for {@code @pos}
@@ -309,7 +308,6 @@ final class Emit {
      * Open a named, base-less {@code <o>} element — one whose
      * {@code @base} is absent because the {@code wrap-applications}
      * reshape fills it in later — §9.0.2 / §9.4.2.
-     *
      * @param name Value for {@code @name}, or {@code null} to omit
      * @param line Source line for {@code @line}
      * @param pos Source column for {@code @pos}
@@ -321,42 +319,11 @@ final class Emit {
     /**
      * Open an unnamed, base-less {@code <o>} element — neither
      * {@code @name} nor {@code @base} is written — §9.0.2 / §9.4.2.
-     *
      * @param line Source line for {@code @line}
      * @param pos Source column for {@code @pos}
      */
     void bareObject(final int line, final int pos) {
         this.open(null, null, line, pos);
-    }
-
-    /**
-     * Open an {@code <o>} element at the current cursor, omitting
-     * {@code @name} and/or {@code @base} when either is {@code null}.
-     * {@code line} and {@code pos} are written as {@code @line} /
-     * {@code @pos} per R-9.1.
-     *
-     * @param name Value for {@code @name}, or {@code null} to omit
-     * @param base Value for {@code @base}, or {@code null} to omit
-     * @param line Source line for {@code @line}
-     * @param pos Source column for {@code @pos}
-     * @checkstyle ParameterNumberCheck (10 lines)
-     */
-    private void open(
-        final String name, final String base, final int line, final int pos
-    ) {
-        final Directives dirs = new Directives().add("o");
-        if (name != null) {
-            dirs.attr("name", name);
-        }
-        if (base != null) {
-            dirs.attr("base", base);
-        }
-        dirs.attr("line", line).attr("pos", pos);
-        if (!"∅".equals(base)) {
-            this.lambda();
-        }
-        this.append(dirs);
-        this.depth = this.depth + 1;
     }
 
     /**
@@ -528,6 +495,24 @@ final class Emit {
      */
     Iterable<Directive> directives() {
         return this.sink;
+    }
+
+    private void open(
+        final String name, final String base, final int line, final int pos
+    ) {
+        final Directives dirs = new Directives().add("o");
+        if (name != null) {
+            dirs.attr("name", name);
+        }
+        if (base != null) {
+            dirs.attr("base", base);
+        }
+        dirs.attr("line", line).attr("pos", pos);
+        if (!"∅".equals(base)) {
+            this.lambda();
+        }
+        this.append(dirs);
+        this.depth = this.depth + 1;
     }
 
     private void lambda() {

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -28,7 +28,8 @@ import org.xembly.Directives;
  * {@code /object} (metas, comments, errors). These wrap their
  * navigation in {@code push}/{@code pop} so the caller's cursor
  * position survives the call. Safe to invoke at any depth.</li>
- * <li><strong>Object tree</strong> ({@link #object}, {@link #close},
+ * <li><strong>Object tree</strong> ({@link #object}, {@link #unnamedObject},
+ * {@link #baselessObject}, {@link #bareObject}, {@link #close},
  * {@link #voidParam}, {@link #atomMarker}) — emit relative to the
  * current cursor, descending into the new {@code <o>} on
  * {@link #object} and ascending on {@link #close}. The caller must
@@ -272,17 +273,67 @@ final class Emit {
     }
 
     /**
-     * Open an {@code <o>} element at the current cursor — §9.0.2 /
-     * §9.4.2.
+     * Open an {@code <o base="...">} element at the current cursor —
+     * §9.0.2 / §9.4.2.
      *
      * <p>The cursor descends into the new element so subsequent
      * {@link #voidParam}, {@link #atomMarker}, and child {@link #object}
      * calls add as children. Must be balanced by {@link #close()} when
      * the element's body ends.</p>
      *
-     * <p>{@code name} and {@code base} may be {@code null} (omitted on
-     * the emitted element). {@code line} and {@code pos} are written as
-     * {@code @line} / {@code @pos} per R-9.1.</p>
+     * @param name Value for {@code @name}, or {@code null} to omit
+     * @param base Value for {@code @base}
+     * @param line Source line for {@code @line}
+     * @param pos Source column for {@code @pos}
+     * @checkstyle ParameterNumberCheck (10 lines)
+     */
+    void object(
+        final String name, final String base, final int line, final int pos
+    ) {
+        this.open(name, base, line, pos);
+    }
+
+    /**
+     * Open an unnamed {@code <o base="...">} element, i.e. one with
+     * no {@code @name} — §9.0.2 / §9.4.2.
+     *
+     * @param base Value for {@code @base}
+     * @param line Source line for {@code @line}
+     * @param pos Source column for {@code @pos}
+     */
+    void unnamedObject(final String base, final int line, final int pos) {
+        this.open(null, base, line, pos);
+    }
+
+    /**
+     * Open a named, base-less {@code <o>} element — one whose
+     * {@code @base} is absent because the {@code wrap-applications}
+     * reshape fills it in later — §9.0.2 / §9.4.2.
+     *
+     * @param name Value for {@code @name}, or {@code null} to omit
+     * @param line Source line for {@code @line}
+     * @param pos Source column for {@code @pos}
+     */
+    void baselessObject(final String name, final int line, final int pos) {
+        this.open(name, null, line, pos);
+    }
+
+    /**
+     * Open an unnamed, base-less {@code <o>} element — neither
+     * {@code @name} nor {@code @base} is written — §9.0.2 / §9.4.2.
+     *
+     * @param line Source line for {@code @line}
+     * @param pos Source column for {@code @pos}
+     */
+    void bareObject(final int line, final int pos) {
+        this.open(null, null, line, pos);
+    }
+
+    /**
+     * Open an {@code <o>} element at the current cursor, omitting
+     * {@code @name} and/or {@code @base} when either is {@code null}.
+     * {@code line} and {@code pos} are written as {@code @line} /
+     * {@code @pos} per R-9.1.
      *
      * @param name Value for {@code @name}, or {@code null} to omit
      * @param base Value for {@code @base}, or {@code null} to omit
@@ -290,7 +341,7 @@ final class Emit {
      * @param pos Source column for {@code @pos}
      * @checkstyle ParameterNumberCheck (10 lines)
      */
-    void object(
+    private void open(
         final String name, final String base, final int line, final int pos
     ) {
         final Directives dirs = new Directives().add("o");

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -661,8 +661,8 @@ final class Eo implements Iterable<Directive> {
             );
         }
         if (!level.tupled() && level.children() == level.count()) {
-            emit.object(
-                null, "Φ.tuple", level.start(), level.indent()
+            emit.unnamedObject(
+                "Φ.tuple", level.start(), level.indent()
             );
             emit.star();
             emit.close();
@@ -675,8 +675,8 @@ final class Eo implements Iterable<Directive> {
         if ((parent.kind() == Kind.COMPACT_TUPLE || parent.star())
             && !parent.tupled()
             && parent.children() == parent.count()) {
-            emit.object(
-                null, "Φ.tuple", parent.start(), parent.indent()
+            emit.unnamedObject(
+                "Φ.tuple", parent.start(), parent.indent()
             );
             emit.star();
             parent.openTuple();

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -134,9 +134,9 @@ final class LnFormation implements Line {
     private void emit(
         final Emit emit, final Suffix suffix, final List<String> params, final String binding
     ) {
-        emit.object(
+        emit.baselessObject(
             suffix.attribute(this.span.line(), this.span.indent()),
-            null, this.span.line(), this.span.indent()
+            this.span.line(), this.span.indent()
         );
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -134,9 +134,9 @@ final class LnOnlyPhi implements Line {
         );
         globals.clearBlanks();
         globals.markEmitted();
-        emit.object(
+        emit.baselessObject(
             suffix.attribute(this.span.line(), this.span.indent()),
-            null, this.span.line(), this.span.indent()
+            this.span.line(), this.span.indent()
         );
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -87,9 +87,9 @@ final class LnPipe implements Line {
         );
         globals.clearBlanks();
         globals.markEmitted();
-        emit.object(
+        emit.baselessObject(
             suffix.attribute(this.span.line(), this.span.indent()),
-            null, this.span.line(), this.span.indent()
+            this.span.line(), this.span.indent()
         );
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -110,12 +110,12 @@ final class LnTextBlock implements Line {
             }
             Emissions.bytesCarrier(emit, this.span.line(), this.span.indent(), hex);
         } else {
-            emit.object(null, "Φ.string", this.span.line(), this.span.indent());
+            emit.unnamedObject("Φ.string", this.span.line(), this.span.indent());
             Emissions.bytesCarrier(emit, this.span.line(), this.span.indent(), hex);
             emit.close();
             for (int idx = 0; idx < chain.size() - 1; idx = idx + 1) {
                 final MethodChain link = chain.get(idx);
-                emit.object(null, ".".concat(link.name()), this.span.line(), link.dot());
+                emit.unnamedObject(".".concat(link.name()), this.span.line(), link.dot());
                 emit.method(link.fragile());
                 emit.close();
             }

--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -189,10 +189,10 @@ final class EmitTest {
     @Test
     void opensObjectWithNameAndPosition() {
         final Emit emit = new Emit();
-        emit.object("foo", null, 3, 0);
+        emit.baselessObject("foo", 3, 0);
         emit.close();
         MatcherAssert.assertThat(
-            "object() must add an <o> at the current cursor with @name, @line, @pos",
+            "baselessObject() must add an <o> at the current cursor with @name, @line, @pos",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPath("/object/o[@name='foo' and @line='3' and @pos='0']")
         );
@@ -211,22 +211,36 @@ final class EmitTest {
     }
 
     @Test
-    void omitsNameAttributeWhenNull() {
+    void omitsNameAttributeWhenUnnamed() {
         final Emit emit = new Emit();
-        emit.object(null, "bar", 1, 0);
+        emit.unnamedObject("bar", 1, 0);
         emit.close();
         MatcherAssert.assertThat(
-            "passing a null name must omit @name on the emitted <o>",
+            "unnamedObject() must omit @name on the emitted <o>",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPath("/object/o[@base='bar' and not(@name)]")
         );
     }
 
     @Test
+    void omitsNameAndBaseAttributesWhenBare() {
+        final Emit emit = new Emit();
+        emit.bareObject(1, 0);
+        emit.close();
+        MatcherAssert.assertThat(
+            "bareObject() must omit both @name and @base on the emitted <o>",
+            EmitTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@line='1' and @pos='0' and not(@name) and not(@base)]"
+            )
+        );
+    }
+
+    @Test
     void nestsChildObjectInsideOpenParent() {
         final Emit emit = new Emit();
-        emit.object("outer", null, 1, 0);
-        emit.object("inner", null, 2, 2);
+        emit.baselessObject("outer", 1, 0);
+        emit.baselessObject("inner", 2, 2);
         emit.close();
         emit.close();
         MatcherAssert.assertThat(
@@ -239,7 +253,7 @@ final class EmitTest {
     @Test
     void emitsVoidParam() {
         final Emit emit = new Emit();
-        emit.object("foo", null, 1, 0);
+        emit.baselessObject("foo", 1, 0);
         emit.voidParam("x", 1, 1);
         emit.close();
         MatcherAssert.assertThat(
@@ -254,7 +268,7 @@ final class EmitTest {
     @Test
     void emitsAtomMarker() {
         final Emit emit = new Emit();
-        emit.object("foo", null, 1, 0);
+        emit.baselessObject("foo", 1, 0);
         emit.atomMarker("number", 1, 5);
         emit.close();
         MatcherAssert.assertThat(
@@ -282,7 +296,7 @@ final class EmitTest {
     @Test
     void marksObjectWithSlotAttribute() {
         final Emit emit = new Emit();
-        emit.object(null, "foo", 1, 0);
+        emit.unnamedObject("foo", 1, 0);
         emit.slot("label");
         emit.close();
         MatcherAssert.assertThat(
@@ -295,7 +309,7 @@ final class EmitTest {
     @Test
     void marksObjectAsStar() {
         final Emit emit = new Emit();
-        emit.object(null, "Φ.tuple", 1, 0);
+        emit.unnamedObject("Φ.tuple", 1, 0);
         emit.star();
         emit.close();
         MatcherAssert.assertThat(
@@ -308,7 +322,7 @@ final class EmitTest {
     @Test
     void setsTextContent() {
         final Emit emit = new Emit();
-        emit.object(null, "Φ.bytes", 1, 0);
+        emit.unnamedObject("Φ.bytes", 1, 0);
         emit.set("CA-FE-BE");
         emit.close();
         MatcherAssert.assertThat(
@@ -334,9 +348,9 @@ final class EmitTest {
     @Test
     void preservesCursorAcrossSidePanelEmissions() {
         final Emit emit = new Emit();
-        emit.object("outer", null, 1, 0);
+        emit.baselessObject("outer", 1, 0);
         emit.error(99, 7, "boom");
-        emit.object("inner", null, 2, 2);
+        emit.baselessObject("inner", 2, 2);
         emit.close();
         emit.close();
         MatcherAssert.assertThat(
@@ -349,7 +363,7 @@ final class EmitTest {
     @Test
     void retainsSidePanelErrorAlongsideTree() {
         final Emit emit = new Emit();
-        emit.object("outer", null, 1, 0);
+        emit.baselessObject("outer", 1, 0);
         emit.error(5, 0, "boom");
         emit.close();
         MatcherAssert.assertThat(


### PR DESCRIPTION
Emit.object(name, base, line, pos) let both name and base be null, and every one of its eleven call sites branched on that internally to decide whether the emitted `<o>` carries a `@name` or a `@base`. That's two attribute-presence decisions dressed up as one method, with null standing in for "omit this attribute."

This splits it into four intention-revealing methods: object (both name and base given), unnamedObject (base only), baselessObject (name only — the base is filled in later by the wrap-applications reshape), and bareObject (neither). Each call site now names what it's emitting instead of passing null, and the private open() helper keeps the original attribute-writing logic unchanged.

Updated every call site across Eo, Emissions, ChainEmission, LnPipe, LnFormation, LnOnlyPhi, LnTextBlock, and the Emit unit tests, adding a test for the new bareObject case.

Closes #7544