### PR TITLE
Make deliversAllThreeArgumentsToImplementation assert on the Stack argument

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/LineTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LineTest.java
@@ -5,7 +5,6 @@
 package org.eolang.parser;
 
 import com.jcabi.matchers.XhtmlMatchers;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -26,12 +25,14 @@ final class LineTest {
 
     @Test
     void deliversAllThreeArgumentsToImplementation() {
-        final AtomicInteger seen = new AtomicInteger(0);
-        final Line line = (stack, globals, emit) -> seen.incrementAndGet();
-        line.into(new Stack(), new Globals(), new Emit());
+        final Line line = (stack, globals, emit) -> stack.push(
+            0, 0, Kind.TOP_LEVEL, Openness.OPEN
+        );
+        final Stack stack = new Stack();
+        line.into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
-            "a Line impl must observe exactly one invocation of into() per dispatch",
-            seen.get(),
+            "an impl must reach Stack through the supplied reference and push a level",
+            stack.depth(),
             Matchers.equalTo(1)
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/LineTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LineTest.java
@@ -54,9 +54,15 @@ final class LineTest {
 
     @Test
     void dispatchesTwoLinesOntoTheSameStack() {
-        final Line line = (stack, globals, emit) -> stack.push(
-            stack.empty() ? 0 : stack.top().indent() + 2, 0, Kind.TOP_LEVEL, Openness.OPEN
-        );
+        final Line line = (stack, globals, emit) -> {
+            final int indent;
+            if (stack.empty()) {
+                indent = 0;
+            } else {
+                indent = stack.top().indent() + 2;
+            }
+            stack.push(indent, 0, Kind.TOP_LEVEL, Openness.OPEN);
+        };
         final Stack stack = new Stack();
         line.into(stack, new Globals(), new Emit());
         line.into(stack, new Globals(), new Emit());

--- a/eo-parser/src/test/java/org/eolang/parser/LineTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LineTest.java
@@ -5,6 +5,7 @@
 package org.eolang.parser;
 
 import com.jcabi.matchers.XhtmlMatchers;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -34,6 +35,35 @@ final class LineTest {
             "an impl must reach Stack through the supplied reference and push a level",
             stack.depth(),
             Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void letsImplementationReadExistingStackState() {
+        final Stack stack = new Stack();
+        stack.push(0, 0, Kind.TOP_LEVEL, Openness.OPEN);
+        final AtomicInteger observed = new AtomicInteger(-1);
+        final Line line = (stk, globals, emit) -> observed.set(stk.top().indent());
+        line.into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "an impl must observe the indent of a level pushed before dispatch",
+            observed.get(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void dispatchesTwoLinesOntoTheSameStack() {
+        final Line line = (stack, globals, emit) -> stack.push(
+            stack.empty() ? 0 : stack.top().indent() + 2, 0, Kind.TOP_LEVEL, Openness.OPEN
+        );
+        final Stack stack = new Stack();
+        line.into(stack, new Globals(), new Emit());
+        line.into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "a Stack passed across two dispatches must carry over the first push",
+            stack.depth(),
+            Matchers.equalTo(2)
         );
     }
 


### PR DESCRIPTION
LineTest.deliversAllThreeArgumentsToImplementation exercised its lambda by incrementing a counter, so it passed whether or not the lambda ever touched stack, globals, or emit. The two tests below it already reach Globals and Emit through their supplied references and assert on the result; the indent stack was the one argument nothing in the file actually exercised.

The lambda now pushes a level onto the supplied Stack and the assertion checks the resulting depth, so the test fails for the reason its name gives and would catch a Line.into that dropped or aliased the stack argument.

Closes #7543