### PR TITLE
#7576: WinStat reads a file timestamp as the size returned by _stat64

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/WinStat.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WinStat.java
@@ -56,14 +56,14 @@ public final class WinStat extends Structure {
     public int rdev;
 
     /**
-     * Size in bytes.
-     */
-    public long bytes;
-
-    /**
      * Access, modification and change 64-bit timestamps EO does not read.
      */
     public byte[] times;
+
+    /**
+     * Size in bytes.
+     */
+    public long bytes;
 
     /**
      * Ctor.
@@ -77,7 +77,7 @@ public final class WinStat extends Structure {
     public List<String> getFieldOrder() {
         return Arrays.asList(
             "dev", "ino", "mode", "nlink", "uid",
-            "gid", "padding", "rdev", "bytes", "times"
+            "gid", "padding", "rdev", "times", "bytes"
         );
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/win32/WinStat.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WinStat.java
@@ -56,14 +56,14 @@ public final class WinStat extends Structure {
     public int rdev;
 
     /**
-     * Access, modification and change 64-bit timestamps EO does not read.
-     */
-    public byte[] times;
-
-    /**
      * Size in bytes.
      */
     public long bytes;
+
+    /**
+     * Access, modification and change 64-bit timestamps EO does not read.
+     */
+    public byte[] times;
 
     /**
      * Ctor.
@@ -77,7 +77,7 @@ public final class WinStat extends Structure {
     public List<String> getFieldOrder() {
         return Arrays.asList(
             "dev", "ino", "mode", "nlink", "uid",
-            "gid", "padding", "rdev", "times", "bytes"
+            "gid", "padding", "rdev", "bytes", "times"
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/win32/Stat64FuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/Stat64FuncCallTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Stat64FuncCall}.
+ * @since 0.74.1
+ */
+@ExtendWith(MktmpResolver.class)
+final class Stat64FuncCallTest {
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void reportsTheFileSizeNotATimestamp(@Mktmp final Path temp) throws IOException {
+        final byte[] content = "queried by a distinct, visibly-sized payload".getBytes();
+        final Path file = temp.resolve("sized.txt");
+        Files.write(file, content);
+        final Phi result = new Stat64FuncCall(Phi.Φ.take("win32").copy()).make(
+            new Data.ToPhi(file.toString())
+        );
+        MatcherAssert.assertThat(
+            "The reported size must be the file's actual byte length, not an epoch timestamp misread from the following field",
+            new Dataized(result.take("output").take("size")).asNumber().longValue(),
+            Matchers.equalTo((long) content.length)
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/Stat64FuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/Stat64FuncCallTest.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eolang.Data;
@@ -29,15 +30,19 @@ final class Stat64FuncCallTest {
     @Test
     @DisabledOnOs({OS.MAC, OS.LINUX})
     void reportsTheFileSizeNotATimestamp(@Mktmp final Path temp) throws IOException {
-        final byte[] content = "queried by a distinct, visibly-sized payload".getBytes();
+        final byte[] content = "queried by a distinct, visibly-sized payload".getBytes(
+            StandardCharsets.UTF_8
+        );
         final Path file = temp.resolve("sized.txt");
         Files.write(file, content);
-        final Phi result = new Stat64FuncCall(Phi.Φ.take("win32").copy()).make(
-            new Data.ToPhi(file.toString())
-        );
         MatcherAssert.assertThat(
             "The reported size must be the file's actual byte length, not an epoch timestamp misread from the following field",
-            new Dataized(result.take("output").take("size")).asNumber().longValue(),
+            new Dataized(
+                new Stat64FuncCall(Phi.Φ.take("win32").copy())
+                    .make(new Data.ToPhi(file.toString()))
+                    .take("output")
+                    .take("size")
+            ).asNumber().longValue(),
             Matchers.equalTo((long) content.length)
         );
     }


### PR DESCRIPTION
Fixes #7576. `WinStat` mapped `_stat64` fields after `rdev` as `bytes, times`,
but the native struct's order there is the three 64-bit timestamps
(`st_atime`, `st_mtime`, `st_ctime`) followed by the 64-bit `st_size`. JNA
laid the struct out by the declared field order, so `bytes`, which
`Stat64FuncCall` exposes as `file.size`, actually read the first timestamp:
on Windows `file.size` reported an epoch timestamp instead of the file's
byte length.

Swapped the two fields, in both the declaration order and
`getFieldOrder()`, so `times` (the 24-byte timestamp blob) comes before
`bytes` (the size), matching the native layout.

Added `Stat64FuncCallTest`, enabled on Windows only (matching the existing
`RecvFuncCallTest` pattern), that stats a file with a distinct, known byte
length and asserts the reported size equals it exactly, not a timestamp.
