### PR TITLE
fix(#7541): route formation and text-block bindings through Bindings.observeChild

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -82,6 +82,7 @@ final class LnFormation implements Line {
         }
         Comments.seal(globals, emit, this.span);
         this.transition(stack, suffix);
+        Bindings.observeChild(stack, binding, this.span);
         globals.clearBlanks();
         globals.markEmitted();
         this.emit(emit, suffix, params, binding);

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -78,6 +78,7 @@ final class LnTextBlock implements Line {
             throw error;
         }
         this.transition(stack, suffix);
+        Bindings.observeChild(stack, outer, this.span);
         this.emit(emit, suffix, chain, joined);
         if (outer != null) {
             emit.slot(Emissions.bindingTag(outer));

--- a/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
@@ -262,6 +262,29 @@ final class LnFormationTest {
     }
 
     @Test
+    void rejectsBindingOnFormationChildUnderFormationParent() {
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnFormation(new Span("  []:tag > x", 2))
+                .into(stack, new Globals(), new Emit()),
+            "a formation child under a formation parent cannot carry a binding per R-3.12.3"
+        );
+    }
+
+    @Test
+    void acceptsBindingOnFormationChildUnderArgumentPositionParent() {
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.VAPPLICATION, Openness.OPEN);
+        Assertions.assertDoesNotThrow(
+            () -> new LnFormation(new Span("  []:tag > x", 2))
+                .into(stack, new Globals(), new Emit()),
+            "a formation child in argument position may still carry a binding"
+        );
+    }
+
+    @Test
     void replacesTopOnSameIndentSibling() {
         final Stack stack = new Stack();
         new LnFormation(new Span("[] > first", 1))

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -196,6 +196,35 @@ final class LnTextBlockTest {
         );
     }
 
+    @Test
+    void rejectsBindingOnTextBlockChildUnderFormationParent() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 2);
+        globals.appendTextLine("hi");
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnTextBlock(new Span("  \"\"\":tag", 3))
+                .into(stack, globals, new Emit()),
+            "a text-block child under a formation parent cannot carry a binding per R-3.12.3"
+        );
+    }
+
+    @Test
+    void acceptsBindingOnTextBlockChildUnderArgumentPositionParent() {
+        final Globals globals = new Globals();
+        globals.openTextBlock(1, 2);
+        globals.appendTextLine("hi");
+        final Stack stack = new Stack();
+        stack.push(0, 1, Kind.VAPPLICATION, Openness.OPEN);
+        Assertions.assertDoesNotThrow(
+            () -> new LnTextBlock(new Span("  \"\"\":tag", 3))
+                .into(stack, globals, new Emit()),
+            "a text-block child in argument position may still carry a binding"
+        );
+    }
+
     private static String render(final Emit emit) {
         return new Xembler(
             new Directives().add("object").append(emit.directives())


### PR DESCRIPTION
Closes #7541

LnFormation and LnTextBlock parsed their own outer `:label` binding but never validated it against the parent context, so a formation or text-block child sitting under a BARE_FORMATION parent silently accepted a binding that R-3.12.3 forbids — while a sibling application line carrying the same binding was rejected with "binding allowed only in argument position".

This routes each line shape's already-parsed binding through `Bindings.observeChild` right after its `transition` call, matching the existing pattern in `LnApplication` and `LnReversed`. That also keeps R-6.6.2 all-or-nothing group tracking consistent for their parents, not just the R-3.12.3 rejection.

Added tests covering both the rejection under a formation parent and the still-accepted case under an argument-position parent, for both `LnFormation` and `LnTextBlock`.