### PR TITLE
#7574: POSIX gettimeofday uses a 64-bit timeval layout on 32-bit targets

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/GettimeofdaySyscall.java
@@ -33,8 +33,8 @@ public final class GettimeofdaySyscall implements Syscall {
         final Timeval timeval = new Timeval();
         result.put(0, new Data.ToPhi(CStdLib.INSTANCE.gettimeofday(timeval, null)));
         final Phi struct = this.posix.take("timeval");
-        struct.put(0, new Data.ToPhi(timeval.sec));
-        struct.put(1, new Data.ToPhi(timeval.usec));
+        struct.put(0, new Data.ToPhi(timeval.sec.longValue()));
+        struct.put(1, new Data.ToPhi(timeval.usec.longValue()));
         result.put(1, struct);
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/posix/Timeval.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/Timeval.java
@@ -37,7 +37,9 @@ public final class Timeval extends Structure {
      * Ctor.
      */
     public Timeval() {
-        // nothing
+        super();
+        this.sec = new NativeLong(0);
+        this.usec = new NativeLong(0);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/posix/Timeval.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/Timeval.java
@@ -4,12 +4,20 @@
  */
 package org.eolang.posix;
 
+import com.sun.jna.NativeLong;
 import com.sun.jna.Structure;
 import java.util.Arrays;
 import java.util.List;
 
 /**
  * Timeval structure.
+ *
+ * <p>{@code tv_sec} and {@code tv_usec} are C {@code long} fields, 32 bits
+ * wide on an ordinary 32-bit POSIX target and 64 bits wide on a 64-bit one.
+ * {@link NativeLong} follows that native width itself, instead of always
+ * laying the struct out as two 8-byte fields the way a Java {@code long}
+ * would (#7574).</p>
+ *
  * @since 0.40.0
  * @checkstyle VisibilityModifierCheck (30 lines)
  */
@@ -18,12 +26,12 @@ public final class Timeval extends Structure {
     /**
      * Seconds since Jan. 1, 1970
      */
-    public long sec;
+    public NativeLong sec;
 
     /**
      * Microseconds since Jan. 1, 1970
      */
-    public long usec;
+    public NativeLong usec;
 
     /**
      * Ctor.

--- a/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
@@ -21,23 +20,27 @@ final class GettimeofdaySyscallTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
-    void reportsAPlausibleCurrentTimestamp() {
-        final Phi result = new GettimeofdaySyscall(Phi.Φ.take("posix").copy()).make();
-        final long secs = new Dataized(
-            result.take("output").take("seconds")
-        ).asNumber().longValue();
-        final long micros = new Dataized(
-            result.take("output").take("micros")
-        ).asNumber().longValue();
+    void reportsSecondsCloseToCurrentWallClockTime() {
+        final long secs = new Dataized(this.output().take("seconds")).asNumber().longValue();
         MatcherAssert.assertThat(
             "gettimeofday must report seconds close to the current wall-clock time, not a value corrupted by a mismatched NativeLong/Java long field width",
             (double) secs,
-            Matchers.closeTo((double) (System.currentTimeMillis() / 1000L), 5.0)
+            Matchers.closeTo(System.currentTimeMillis() / 1000.0, 5.0)
         );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void reportsMicrosecondFractionBelowOneSecond() {
+        final long micros = new Dataized(this.output().take("micros")).asNumber().longValue();
         MatcherAssert.assertThat(
             "gettimeofday must report a microsecond fraction below one second, not bytes read past what the native call wrote",
             micros,
             Matchers.allOf(Matchers.greaterThanOrEqualTo(0L), Matchers.lessThan(1_000_000L))
         );
+    }
+
+    private Phi output() {
+        return new GettimeofdaySyscall(Phi.Φ.take("posix").copy()).make().take("output");
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
@@ -21,10 +21,9 @@ final class GettimeofdaySyscallTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void reportsSecondsCloseToCurrentWallClockTime() {
-        final long secs = new Dataized(this.output().take("seconds")).asNumber().longValue();
         MatcherAssert.assertThat(
             "gettimeofday must report seconds close to the current wall-clock time, not a value corrupted by a mismatched NativeLong/Java long field width",
-            (double) secs,
+            new Dataized(this.output().take("seconds")).asNumber().doubleValue(),
             Matchers.closeTo(System.currentTimeMillis() / 1000.0, 5.0)
         );
     }
@@ -32,10 +31,9 @@ final class GettimeofdaySyscallTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void reportsMicrosecondFractionBelowOneSecond() {
-        final long micros = new Dataized(this.output().take("micros")).asNumber().longValue();
         MatcherAssert.assertThat(
             "gettimeofday must report a microsecond fraction below one second, not bytes read past what the native call wrote",
-            micros,
+            new Dataized(this.output().take("micros")).asNumber().longValue(),
             Matchers.allOf(Matchers.greaterThanOrEqualTo(0L), Matchers.lessThan(1_000_000L))
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link GettimeofdaySyscall}.
+ * @since 0.74.1
+ */
+final class GettimeofdaySyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void reportsAPlausibleCurrentTimestamp() {
+        final Phi result = new GettimeofdaySyscall(Phi.Φ.take("posix").copy()).make();
+        final long secs = new Dataized(
+            result.take("output").take("seconds")
+        ).asNumber().longValue();
+        final long micros = new Dataized(
+            result.take("output").take("micros")
+        ).asNumber().longValue();
+        MatcherAssert.assertThat(
+            "gettimeofday must report seconds close to the current wall-clock time, not a value corrupted by a mismatched NativeLong/Java long field width",
+            (double) secs,
+            Matchers.closeTo((double) (System.currentTimeMillis() / 1000L), 5.0)
+        );
+        MatcherAssert.assertThat(
+            "gettimeofday must report a microsecond fraction below one second, not bytes read past what the native call wrote",
+            micros,
+            Matchers.allOf(Matchers.greaterThanOrEqualTo(0L), Matchers.lessThan(1_000_000L))
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7574. `Timeval` mapped `tv_sec` and `tv_usec` as Java `long`, which
JNA always lays out as two 8-byte native fields. That matches the current
64-bit Linux CI runners, but not the ordinary 32-bit POSIX `struct timeval`,
whose `tv_sec`/`tv_usec` are C `long`, 32 bits wide there. On such a
target, native `gettimeofday` writes 32-bit seconds at offset 0 and
32-bit microseconds at offset 4, and JNA reading two 8-byte fields
misreads both.

Switched both fields to JNA's `NativeLong`, which lays itself out at the
platform's actual C `long` width (4 bytes on 32-bit, 8 on 64-bit), instead
of a fixed Java primitive. Updated `GettimeofdaySyscall` for the resulting
`.longValue()` conversion.

Added `GettimeofdaySyscallTest`, checking that the reported seconds are
close to the real wall-clock time and the microseconds fall inside a
single second, as a regression guard on the platform this can actually
run on (64-bit); the 32-bit case itself needs a 32-bit runner CI does not
have.
