### PR TITLE
Restore Emit's depth and owed atom signature on rollback

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -120,7 +120,6 @@ final class Emit {
      * three must roll back together via {@link #rollback(Savepoint)}, or
      * an error recovered mid-formation leaves {@link #depth} drifted from
      * the tree it describes (#7539).
-     *
      * @return Savepoint token
      */
     Savepoint savepoint() {
@@ -137,14 +136,14 @@ final class Emit {
      * @param token Savepoint token from {@link #savepoint()}
      */
     void rollback(final Savepoint token) {
-        while (this.sink.size() > token.sink) {
+        while (this.sink.size() > token.sink()) {
             this.sink.remove(this.sink.size() - 1);
         }
-        this.depth = token.depth;
-        this.signature = token.signature;
-        this.sigline = token.sigline;
-        this.sigpos = token.sigpos;
-        this.sigdepth = token.sigdepth;
+        this.depth = token.depth();
+        this.signature = token.signature();
+        this.sigline = token.sigline();
+        this.sigpos = token.sigpos();
+        this.sigdepth = token.sigdepth();
     }
 
     /**
@@ -522,64 +521,5 @@ final class Emit {
             result = located;
         }
         return result;
-    }
-
-    /**
-     * Opaque token from {@link #savepoint()}, restored by
-     * {@link #rollback(Savepoint)} — bundles the sink size with
-     * {@link #depth} and the owed atom signature so a rollback puts all
-     * three back in step (#7539).
-     *
-     * @since 0.1
-     */
-    static final class Savepoint {
-
-        /** Sink size at the savepoint. */
-        private final int sink;
-
-        /** {@link Emit#depth} at the savepoint. */
-        private final int depth;
-
-        /** {@link Emit#signature} at the savepoint. */
-        private final String signature;
-
-        /** {@link Emit#sigline} at the savepoint. */
-        private final int sigline;
-
-        /** {@link Emit#sigpos} at the savepoint. */
-        private final int sigpos;
-
-        /** {@link Emit#sigdepth} at the savepoint. */
-        private final int sigdepth;
-
-        /**
-         * Ctor.
-         * @param sink Sink size at the savepoint
-         * @param depth Open element depth at the savepoint
-         * @param signature Owed atom signature at the savepoint
-         * @param sigline Source line of the owed marker
-         * @param sigpos Source column of the owed marker
-         * @param sigdepth Depth of the object owing the marker
-         * @checkstyle ParameterNumberCheck (5 lines)
-         */
-        Savepoint(
-            final int sink, final int depth, final String signature,
-            final int sigline, final int sigpos, final int sigdepth
-        ) {
-            this.sink = sink;
-            this.depth = depth;
-            this.signature = signature;
-            this.sigline = sigline;
-            this.sigpos = sigpos;
-            this.sigdepth = sigdepth;
-        }
-
-        /**
-         * Sink size at the savepoint.
-         * @return Sink size
-         */
-        int sink() {
-            return this.sink;
-        }
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -156,6 +156,7 @@ final class Emit {
      * @param line Source line of the owed marker
      * @param pos Source column of the owed marker
      * @param level Depth of the object owing the marker
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     void signature(final String owed, final int line, final int pos, final int level) {
         this.signature = owed;

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -139,11 +139,29 @@ final class Emit {
         while (this.sink.size() > token.sink()) {
             this.sink.remove(this.sink.size() - 1);
         }
-        this.depth = token.depth();
-        this.signature = token.signature();
-        this.sigline = token.sigline();
-        this.sigpos = token.sigpos();
-        this.sigdepth = token.sigdepth();
+        token.restore(this);
+    }
+
+    /**
+     * Put {@link #depth} back to what it was at a savepoint.
+     * @param cursor Depth to restore
+     */
+    void depth(final int cursor) {
+        this.depth = cursor;
+    }
+
+    /**
+     * Put the owed atom signature back to what it was at a savepoint.
+     * @param owed Signature owed to the open object, empty when nothing is owed
+     * @param line Source line of the owed marker
+     * @param pos Source column of the owed marker
+     * @param level Depth of the object owing the marker
+     */
+    void signature(final String owed, final int line, final int pos, final int level) {
+        this.signature = owed;
+        this.sigline = line;
+        this.sigpos = pos;
+        this.sigdepth = level;
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -17,7 +17,7 @@ import org.xembly.Directives;
  * <p>Wraps a growing list of {@link Directive} that downstream
  * {@code Xembler} converts into XMIR. Each emission method appends to the
  * sink in source order; the caller controls when to take a
- * {@link #savepoint()} and how to {@link #rollback(int)} on a per-line
+ * {@link #savepoint()} and how to {@link #rollback(Savepoint)} on a per-line
  * recovery (R-7.2).</p>
  *
  * <p>The class exposes two families of methods:</p>
@@ -115,28 +115,36 @@ final class Emit {
     }
 
     /**
-     * Take a savepoint of the current sink size.
+     * Take a savepoint of the emitter's cursor: sink size, {@link #depth},
+     * and any atom signature owed to an open {@code <o>} — R-7.2. All
+     * three must roll back together via {@link #rollback(Savepoint)}, or
+     * an error recovered mid-formation leaves {@link #depth} drifted from
+     * the tree it describes (#7539).
      *
-     * <p>R-7.2 — the parser takes one of these at the start of each line.
-     * On a parse error inside that line, the caller invokes
-     * {@link #rollback(int)} with this token to drop the line's
-     * half-built directives.</p>
-     *
-     * @return Savepoint token (current sink size)
+     * @return Savepoint token
      */
-    int savepoint() {
-        return this.sink.size();
+    Savepoint savepoint() {
+        return new Savepoint(
+            this.sink.size(), this.depth, this.signature,
+            this.sigline, this.sigpos, this.sigdepth
+        );
     }
 
     /**
-     * Roll the sink back to the given savepoint, discarding any
-     * directives appended after it.
+     * Roll the sink and cursor back to the given savepoint, discarding
+     * any directives appended after it and restoring {@link #depth} and
+     * the owed atom signature to what they were at that point.
      * @param token Savepoint token from {@link #savepoint()}
      */
-    void rollback(final int token) {
-        while (this.sink.size() > token) {
+    void rollback(final Savepoint token) {
+        while (this.sink.size() > token.sink) {
             this.sink.remove(this.sink.size() - 1);
         }
+        this.depth = token.depth;
+        this.signature = token.signature;
+        this.sigline = token.sigline;
+        this.sigpos = token.sigpos;
+        this.sigdepth = token.sigdepth;
     }
 
     /**
@@ -514,5 +522,64 @@ final class Emit {
             result = located;
         }
         return result;
+    }
+
+    /**
+     * Opaque token from {@link #savepoint()}, restored by
+     * {@link #rollback(Savepoint)} — bundles the sink size with
+     * {@link #depth} and the owed atom signature so a rollback puts all
+     * three back in step (#7539).
+     *
+     * @since 0.1
+     */
+    static final class Savepoint {
+
+        /** Sink size at the savepoint. */
+        private final int sink;
+
+        /** {@link Emit#depth} at the savepoint. */
+        private final int depth;
+
+        /** {@link Emit#signature} at the savepoint. */
+        private final String signature;
+
+        /** {@link Emit#sigline} at the savepoint. */
+        private final int sigline;
+
+        /** {@link Emit#sigpos} at the savepoint. */
+        private final int sigpos;
+
+        /** {@link Emit#sigdepth} at the savepoint. */
+        private final int sigdepth;
+
+        /**
+         * Ctor.
+         * @param sink Sink size at the savepoint
+         * @param depth Open element depth at the savepoint
+         * @param signature Owed atom signature at the savepoint
+         * @param sigline Source line of the owed marker
+         * @param sigpos Source column of the owed marker
+         * @param sigdepth Depth of the object owing the marker
+         * @checkstyle ParameterNumberCheck (5 lines)
+         */
+        Savepoint(
+            final int sink, final int depth, final String signature,
+            final int sigline, final int sigpos, final int sigdepth
+        ) {
+            this.sink = sink;
+            this.depth = depth;
+            this.signature = signature;
+            this.sigline = sigline;
+            this.sigpos = sigpos;
+            this.sigdepth = sigdepth;
+        }
+
+        /**
+         * Sink size at the savepoint.
+         * @return Sink size
+         */
+        int sink() {
+            return this.sink;
+        }
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -280,7 +280,7 @@ final class Eo implements Iterable<Directive> {
     ) {
         if (Eo.closesTextBlock(span, globals)) {
             stack.popDeeperThan(span.indent());
-            final int token = emit.savepoint();
+            final Emit.Savepoint token = emit.savepoint();
             final java.util.List<Level> frame = stack.snapshot();
             try {
                 new LnTextBlock(span).into(stack, globals, emit);
@@ -330,7 +330,7 @@ final class Eo implements Iterable<Directive> {
         if (!span.blank() && span.head() != '#') {
             stack.popDeeperThan(span.indent());
         }
-        final int token = emit.savepoint();
+        final Emit.Savepoint token = emit.savepoint();
         final java.util.List<Level> frame = stack.snapshot();
         final Globals saved = globals.savepoint();
         boolean failed = false;

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -280,7 +280,7 @@ final class Eo implements Iterable<Directive> {
     ) {
         if (Eo.closesTextBlock(span, globals)) {
             stack.popDeeperThan(span.indent());
-            final Emit.Savepoint token = emit.savepoint();
+            final Savepoint token = emit.savepoint();
             final java.util.List<Level> frame = stack.snapshot();
             try {
                 new LnTextBlock(span).into(stack, globals, emit);
@@ -330,7 +330,7 @@ final class Eo implements Iterable<Directive> {
         if (!span.blank() && span.head() != '#') {
             stack.popDeeperThan(span.indent());
         }
-        final Emit.Savepoint token = emit.savepoint();
+        final Savepoint token = emit.savepoint();
         final java.util.List<Level> frame = stack.snapshot();
         final Globals saved = globals.savepoint();
         boolean failed = false;

--- a/eo-parser/src/main/java/org/eolang/parser/Globals.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Globals.java
@@ -309,8 +309,7 @@ final class Globals {
      * leave the file without its top comment block and with every later
      * comment rejected. {@link Eo} takes one of these next to
      * {@link Emit#savepoint()} and hands it back to
-     * {@link #restore(Globals)} next to {@link Emit#rollback(int)}.</p>
-     *
+     * {@link #restore(Globals)} next to {@link Emit#rollback(Savepoint)}.</p>
      * @return Detached copy of the current state
      */
     Globals savepoint() {

--- a/eo-parser/src/main/java/org/eolang/parser/Globals.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Globals.java
@@ -310,6 +310,7 @@ final class Globals {
      * comment rejected. {@link Eo} takes one of these next to
      * {@link Emit#savepoint()} and hands it back to
      * {@link #restore(Globals)} next to {@link Emit#rollback(Savepoint)}.</p>
+     *
      * @return Detached copy of the current state
      */
     Globals savepoint() {

--- a/eo-parser/src/main/java/org/eolang/parser/ParseError.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParseError.java
@@ -10,7 +10,7 @@ package org.eolang.parser;
  *
  * <p>Carries the {@code line} and {@code pos} (R-9.1.1 / R-9.1.2) of the
  * failure plus the canonical message text from §9.9. The walker catches
- * this, calls {@link Emit#rollback(Emit.Savepoint)} with the line's savepoint
+ * this, calls {@link Emit#rollback(Savepoint)} with the line's savepoint
  * (R-7.2), and emits the error via {@link Emit#error(int, int, String)}.
  * Subsequent lines continue against the post-recovery state.</p>
  *

--- a/eo-parser/src/main/java/org/eolang/parser/ParseError.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ParseError.java
@@ -10,7 +10,7 @@ package org.eolang.parser;
  *
  * <p>Carries the {@code line} and {@code pos} (R-9.1.1 / R-9.1.2) of the
  * failure plus the canonical message text from §9.9. The walker catches
- * this, calls {@link Emit#rollback(int)} with the line's savepoint
+ * this, calls {@link Emit#rollback(Emit.Savepoint)} with the line's savepoint
  * (R-7.2), and emits the error via {@link Emit#error(int, int, String)}.
  * Subsequent lines continue against the post-recovery state.</p>
  *

--- a/eo-parser/src/main/java/org/eolang/parser/Savepoint.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Savepoint.java
@@ -61,42 +61,12 @@ final class Savepoint {
     }
 
     /**
-     * Open element depth at the savepoint.
-     * @return Depth
+     * Put {@link Emit}'s depth and owed atom signature back to what they
+     * were at this savepoint.
+     * @param emit Emitter to restore
      */
-    int depth() {
-        return this.depth;
-    }
-
-    /**
-     * Owed atom signature at the savepoint.
-     * @return Signature
-     */
-    String signature() {
-        return this.signature;
-    }
-
-    /**
-     * Source line of the owed marker.
-     * @return Line
-     */
-    int sigline() {
-        return this.sigline;
-    }
-
-    /**
-     * Source column of the owed marker.
-     * @return Column
-     */
-    int sigpos() {
-        return this.sigpos;
-    }
-
-    /**
-     * Depth of the object owing the marker.
-     * @return Depth
-     */
-    int sigdepth() {
-        return this.sigdepth;
+    void restore(final Emit emit) {
+        emit.depth(this.depth);
+        emit.signature(this.signature, this.sigline, this.sigpos, this.sigdepth);
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Savepoint.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Savepoint.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+/**
+ * Opaque token from {@link Emit#savepoint()}, restored by
+ * {@link Emit#rollback(Savepoint)} — bundles the sink size with
+ * {@link Emit}'s depth and the owed atom signature so a rollback puts all
+ * three back in step (#7539).
+ * @since 0.1
+ */
+final class Savepoint {
+
+    /** Sink size at the savepoint. */
+    private final int sink;
+
+    /** {@link Emit}'s depth at the savepoint. */
+    private final int depth;
+
+    /** {@link Emit}'s signature at the savepoint. */
+    private final String signature;
+
+    /** {@link Emit}'s sigline at the savepoint. */
+    private final int sigline;
+
+    /** {@link Emit}'s sigpos at the savepoint. */
+    private final int sigpos;
+
+    /** {@link Emit}'s sigdepth at the savepoint. */
+    private final int sigdepth;
+
+    /**
+     * Ctor.
+     * @param sink Sink size at the savepoint
+     * @param depth Open element depth at the savepoint
+     * @param signature Owed atom signature at the savepoint
+     * @param sigline Source line of the owed marker
+     * @param sigpos Source column of the owed marker
+     * @param sigdepth Depth of the object owing the marker
+     */
+    Savepoint(
+        final int sink, final int depth, final String signature,
+        final int sigline, final int sigpos, final int sigdepth
+    ) {
+        this.sink = sink;
+        this.depth = depth;
+        this.signature = signature;
+        this.sigline = sigline;
+        this.sigpos = sigpos;
+        this.sigdepth = sigdepth;
+    }
+
+    /**
+     * Sink size at the savepoint.
+     * @return Sink size
+     */
+    int sink() {
+        return this.sink;
+    }
+
+    /**
+     * Open element depth at the savepoint.
+     * @return Depth
+     */
+    int depth() {
+        return this.depth;
+    }
+
+    /**
+     * Owed atom signature at the savepoint.
+     * @return Signature
+     */
+    String signature() {
+        return this.signature;
+    }
+
+    /**
+     * Source line of the owed marker.
+     * @return Line
+     */
+    int sigline() {
+        return this.sigline;
+    }
+
+    /**
+     * Source column of the owed marker.
+     * @return Column
+     */
+    int sigpos() {
+        return this.sigpos;
+    }
+
+    /**
+     * Depth of the object owing the marker.
+     * @return Depth
+     */
+    int sigdepth() {
+        return this.sigdepth;
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -162,7 +162,7 @@ final class EmitTest {
     @Test
     void dropsDirectivesAfterTokenOnRollback() {
         final Emit emit = new Emit();
-        final Emit.Savepoint token = emit.savepoint();
+        final Savepoint token = emit.savepoint();
         emit.error(1, 0, "boom");
         emit.rollback(token);
         MatcherAssert.assertThat(
@@ -176,7 +176,7 @@ final class EmitTest {
     void keepsDirectivesBeforeTokenOnRollback() {
         final Emit emit = new Emit();
         emit.meta(1, "keep", Collections.emptyList());
-        final Emit.Savepoint token = emit.savepoint();
+        final Savepoint token = emit.savepoint();
         emit.error(2, 0, "boom");
         emit.rollback(token);
         MatcherAssert.assertThat(
@@ -191,7 +191,7 @@ final class EmitTest {
         final Emit emit = new Emit();
         emit.object("foo", null, 1, 0);
         emit.atomMarker("number", 1, 5);
-        final Emit.Savepoint token = emit.savepoint();
+        final Savepoint token = emit.savepoint();
         emit.object("bar", "Φ.string", 2, 0);
         emit.rollback(token);
         emit.close();

--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -142,7 +142,7 @@ final class EmitTest {
     void returnsZeroSavepointForFreshEmit() {
         MatcherAssert.assertThat(
             "the initial savepoint of an empty Emit must be 0",
-            new Emit().savepoint(),
+            new Emit().savepoint().sink(),
             Matchers.equalTo(0)
         );
     }
@@ -150,11 +150,11 @@ final class EmitTest {
     @Test
     void growsSavepointAfterEmission() {
         final Emit emit = new Emit();
-        final int before = emit.savepoint();
+        final int before = emit.savepoint().sink();
         emit.meta(1, "x", Collections.emptyList());
         MatcherAssert.assertThat(
             "after emitting, the savepoint must advance past the pre-emit position",
-            emit.savepoint(),
+            emit.savepoint().sink(),
             Matchers.greaterThan(before)
         );
     }
@@ -162,7 +162,7 @@ final class EmitTest {
     @Test
     void dropsDirectivesAfterTokenOnRollback() {
         final Emit emit = new Emit();
-        final int token = emit.savepoint();
+        final Emit.Savepoint token = emit.savepoint();
         emit.error(1, 0, "boom");
         emit.rollback(token);
         MatcherAssert.assertThat(
@@ -176,13 +176,34 @@ final class EmitTest {
     void keepsDirectivesBeforeTokenOnRollback() {
         final Emit emit = new Emit();
         emit.meta(1, "keep", Collections.emptyList());
-        final int token = emit.savepoint();
+        final Emit.Savepoint token = emit.savepoint();
         emit.error(2, 0, "boom");
         emit.rollback(token);
         MatcherAssert.assertThat(
             "rollback must preserve directives appended before the savepoint",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPath("/object/metas/meta/head[text()='keep']")
+        );
+    }
+
+    @Test
+    void restoresDepthAndOwedAtomMarkerOnRollback() {
+        final Emit emit = new Emit();
+        emit.object("foo", null, 1, 0);
+        emit.atomMarker("number", 1, 5);
+        final Emit.Savepoint token = emit.savepoint();
+        emit.object("bar", "Φ.string", 2, 0);
+        emit.rollback(token);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a rollback must restore depth and the owed atom signature "
+            + "alongside the sink, so a recovered error inside the atom's "
+            + "body cannot drop its λ marker (#7539)",
+            EmitTest.render(emit),
+            XhtmlMatchers.hasXPaths(
+                "/object[count(o)=1]",
+                "/object/o[@name='foo']/o[@name='λ' and @atom='number']"
+            )
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmitTest.java
@@ -196,9 +196,7 @@ final class EmitTest {
         emit.rollback(token);
         emit.close();
         MatcherAssert.assertThat(
-            "a rollback must restore depth and the owed atom signature "
-            + "alongside the sink, so a recovered error inside the atom's "
-            + "body cannot drop its λ marker (#7539)",
+            "a rollback must restore depth and the owed atom signature alongside the sink, so a recovered error inside the atom's body cannot drop its λ marker (#7539)",
             EmitTest.render(emit),
             XhtmlMatchers.hasXPaths(
                 "/object[count(o)=1]",

--- a/eo-parser/src/test/java/org/eolang/parser/LnBlankTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnBlankTest.java
@@ -53,8 +53,8 @@ final class LnBlankTest {
         new LnBlank(new Span("", 1)).into(new Stack(), new Globals(), emit);
         MatcherAssert.assertThat(
             "a blank line cannot append directives — its only effect is the counter bump",
-            emit.savepoint(),
-            Matchers.equalTo(0)
+            emit.directives(),
+            Matchers.emptyIterable()
         );
     }
 }


### PR DESCRIPTION
Emit.savepoint()/rollback(int) only tracked the sink size. When a recovered parse error had opened an <o> element without ever closing it — for example Emissions.string throwing on a broken unicode escape — the rollback discarded the half-built directives but left Emit.depth one higher than the tree it actually describes, and left any atom signature owed to an open formation already cleared by the aborted lambda() call.

Once depth drifts, lambda() never fires again for the rest of the file, since it only emits the λ marker when depth equals the depth of the object that owns it. A formation whose atom body happens to contain one recovered error just silently stops declaring itself an atom, with nothing failing loudly.

savepoint() now returns an Emit.Savepoint that bundles the sink size with depth and the owed signature state, and rollback(Savepoint) restores all of them together, so the emitter's cursor stays consistent with the directives it actually kept.

Closes #7539