### PR TITLE
fix(#7523): remove never-called comment from Blanks private constructor

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -28,7 +28,6 @@ final class Blanks {
      * Utility class.
      */
     private Blanks() {
-        // never called
     }
 
     /**


### PR DESCRIPTION
Closes #7523

The private constructor of `Blanks` carried a `// never called` comment as its whole body. The project's guidance is that a method body holds no comments, and the comment said nothing the `private` keyword above it hadn't already said.

This drops the comment so `Blanks` matches its three siblings in the same package — `Comments`, `Escapes`, and `Bindings` — which all leave their private constructor body empty.