### PR TITLE
fix(#7520): remove dead reset of count in LnCompactTuple.readCount

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -104,7 +104,6 @@ final class LnCompactTuple implements Line {
 
     private static int readCount(final Tokens tokens, final Span span) {
         long count = 0;
-        boolean any = false;
         final int start = tokens.cursor();
         while (!tokens.atEnd()) {
             final char glyph = tokens.current();
@@ -119,10 +118,6 @@ final class LnCompactTuple implements Line {
                 );
             }
             tokens.seek(tokens.cursor() + 1);
-            any = true;
-        }
-        if (!any) {
-            count = 0;
         }
         return (int) count;
     }

--- a/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
@@ -7,6 +7,7 @@ package org.eolang.parser;
 import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 import org.xembly.Xembler;
@@ -50,6 +51,65 @@ final class LnCompactTupleTest {
             "an absent N must default to 0 per R-3.9.1",
             stack.top().count(),
             Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void recordsNFromMultiDigitInteger() {
+        final Stack stack = new Stack();
+        new LnCompactTuple(new Span("sprintf *123 > x", 1))
+            .into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "a multi-digit *N value must accumulate across every digit read",
+            stack.top().count(),
+            Matchers.equalTo(123)
+        );
+    }
+
+    @Test
+    void recordsZeroFromExplicitZeroDigit() {
+        final Stack stack = new Stack();
+        new LnCompactTuple(new Span("sprintf *0 > x", 1))
+            .into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "an explicit *0 must record the same count as an absent N",
+            stack.top().count(),
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void recordsNFromLeadingZeroDigits() {
+        final Stack stack = new Stack();
+        new LnCompactTuple(new Span("sprintf *007 > x", 1))
+            .into(stack, new Globals(), new Emit());
+        MatcherAssert.assertThat(
+            "leading zero digits must not change the accumulated count",
+            stack.top().count(),
+            Matchers.equalTo(7)
+        );
+    }
+
+    @Test
+    void rejectsCountAboveIntegerMax() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnCompactTuple(new Span("sprintf *99999999999 > x", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a *N value past Integer.MAX_VALUE must raise a positioned ParseError"
+        );
+    }
+
+    @Test
+    void rejectsCountAboveIntegerMaxWithCanonicalMessage() {
+        MatcherAssert.assertThat(
+            "the overflow error must carry the canonical §9.9 message",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnCompactTuple(new Span("sprintf *99999999999 > x", 1))
+                    .into(new Stack(), new Globals(), new Emit())
+            ).getMessage(),
+            Matchers.equalTo("compact tuple count is too large")
         );
     }
 


### PR DESCRIPTION
readCount reset count to 0 whenever no digit was consumed on a compact-tuple line. That reset was unreachable: count starts at 0 and the only statement that ever writes it runs inside the digit loop, so the branch never had anything to undo. The any flag existed only to drive that dead branch, so it goes too.

Closes #7520

Added a few more edge cases to LnCompactTupleTest while here: multi-digit counts, an explicit *0, leading zero digits, and the Integer.MAX_VALUE overflow path that raises the canonical ParseError message.