### PR TITLE
#7577: Winsock binds SOCKET as 64-bit even on Win32

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import org.eolang.Data;
 import org.eolang.Dataized;
@@ -38,15 +39,17 @@ public final class AcceptFuncCall implements Syscall {
         result.put(
             0,
             new Data.ToPhi(
-                Winsock.INSTANCE.accept(
-                    new Dataized(params[0]).asNumber().longValue(),
-                    new SockaddrIn(
-                        new Dataized(params[1].take("family")).take(Short.class),
-                        new Dataized(params[1].take("port")).take(Short.class),
-                        new Dataized(params[1].take("address")).take(Integer.class),
-                        new Dataized(params[1].take("padding")).take()
-                    ),
-                    new IntByReference(new Dataized(params[2]).asNumber().intValue())
+                Pointer.nativeValue(
+                    Winsock.INSTANCE.accept(
+                        new Pointer(new Dataized(params[0]).asNumber().longValue()),
+                        new SockaddrIn(
+                            new Dataized(params[1].take("family")).take(Short.class),
+                            new Dataized(params[1].take("port")).take(Short.class),
+                            new Dataized(params[1].take("address")).take(Integer.class),
+                            new Dataized(params[1].take("padding")).take()
+                        ),
+                        new IntByReference(new Dataized(params[2]).asNumber().intValue())
+                    )
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -38,7 +39,7 @@ public final class BindFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.bind(
-                    new Dataized(params[0]).asNumber().longValue(),
+                    new Pointer(new Dataized(params[0]).asNumber().longValue()),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),

--- a/eo-runtime/src/main/java/org/eolang/win32/ClosesocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ClosesocketFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -36,7 +37,9 @@ public final class ClosesocketFuncCall implements Syscall {
         result.put(
             0,
             new Data.ToPhi(
-                Winsock.INSTANCE.closesocket(new Dataized(params[0]).asNumber().longValue())
+                Winsock.INSTANCE.closesocket(
+                    new Pointer(new Dataized(params[0]).asNumber().longValue())
+                )
             )
         );
         result.put(1, new PhDefault());

--- a/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -38,7 +39,7 @@ public final class ConnectFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.connect(
-                    new Dataized(params[0]).asNumber().longValue(),
+                    new Pointer(new Dataized(params[0]).asNumber().longValue()),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),

--- a/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -37,7 +38,7 @@ public final class ListenFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.listen(
-                    new Dataized(params[0]).asNumber().longValue(),
+                    new Pointer(new Dataized(params[0]).asNumber().longValue()),
                     new Dataized(params[1]).asNumber().intValue()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
@@ -40,7 +41,7 @@ public final class RecvFuncCall implements Syscall {
         ).it();
         final byte[] buf = new byte[size];
         final int received = Winsock.INSTANCE.recv(
-            new Dataized(params[0]).asNumber().longValue(),
+            new Pointer(new Dataized(params[0]).asNumber().longValue()),
             buf,
             size,
             new Dataized(params[2]).asNumber().intValue()

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
@@ -50,7 +51,7 @@ public final class SendFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.send(
-                    new Dataized(params[0]).asNumber().longValue(),
+                    new Pointer(new Dataized(params[0]).asNumber().longValue()),
                     buf,
                     size,
                     new Dataized(params[3]).asNumber().intValue()

--- a/eo-runtime/src/main/java/org/eolang/win32/SocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SocketFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -36,10 +37,12 @@ public final class SocketFuncCall implements Syscall {
         result.put(
             0,
             new Data.ToPhi(
-                Winsock.INSTANCE.socket(
-                    new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).asNumber().intValue(),
-                    new Dataized(params[2]).asNumber().intValue()
+                Pointer.nativeValue(
+                    Winsock.INSTANCE.socket(
+                        new Dataized(params[0]).asNumber().intValue(),
+                        new Dataized(params[1]).asNumber().intValue(),
+                        new Dataized(params[2]).asNumber().intValue()
+                    )
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
@@ -5,6 +5,7 @@
 package org.eolang.win32;
 
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
@@ -77,19 +78,25 @@ public interface Winsock extends StdCallLibrary {
 
     /**
      * Creates a socket.
+     *
+     * <p>The return type is {@link Pointer} rather than a fixed-width
+     * primitive because a {@code SOCKET} is a Windows {@code UINT_PTR}:
+     * 4 bytes on Win32, 8 on Win64 (#7577). JNA marshals {@link Pointer}
+     * at the platform's actual pointer width, matching that either way.</p>
+     *
      * @param domain Socket domain
      * @param type Socket type
      * @param protocol Socket protocol
      * @return Socket descriptor
      */
-    long socket(int domain, int type, int protocol);
+    Pointer socket(int domain, int type, int protocol);
 
     /**
      * Closes a socket.
      * @param socket Socket descriptor
      * @return Zero on success, otherwise, a value of SOCKET_ERROR is returned
      */
-    int closesocket(long socket);
+    int closesocket(Pointer socket);
 
     /**
      * Connects to the server at the specified IP address and port.
@@ -98,7 +105,7 @@ public interface Winsock extends StdCallLibrary {
      * @param addrlen The size of the address structure
      * @return Zero on success, otherwise, a value of SOCKET_ERROR is returned
      */
-    int connect(long sockfd, SockaddrIn addr, int addrlen);
+    int connect(Pointer sockfd, SockaddrIn addr, int addrlen);
 
     /**
      * Assigns the address specified by {@code addr} to the socket referred to
@@ -108,7 +115,7 @@ public interface Winsock extends StdCallLibrary {
      * @param addrlen The size of the address structure
      * @return Zero on success, -1 on error
      */
-    int bind(long sockfd, SockaddrIn addr, int addrlen);
+    int bind(Pointer sockfd, SockaddrIn addr, int addrlen);
 
     /**
      * Listen for incoming connections on socket.
@@ -117,7 +124,7 @@ public interface Winsock extends StdCallLibrary {
      *  waiting to be accepted
      * @return Zero on success, -1 on error
      */
-    int listen(long sockfd, int backlog);
+    int listen(Pointer sockfd, int backlog);
 
     /**
      * Accept connection on socket.
@@ -127,7 +134,7 @@ public interface Winsock extends StdCallLibrary {
      * @return On success, file descriptor for the accepted socket (a nonnegative integer)
      *  is returned. On error, -1 is returned
      */
-    long accept(long sockfd, SockaddrIn addr, IntByReference addrlen);
+    Pointer accept(Pointer sockfd, SockaddrIn addr, IntByReference addrlen);
 
     /**
      * Send a message to a socket.
@@ -137,7 +144,7 @@ public interface Winsock extends StdCallLibrary {
      * @param flags Flags
      * @return The number of sent bytes on success, -1 on error
      */
-    int send(long sockfd, byte[] buf, int len, int flags);
+    int send(Pointer sockfd, byte[] buf, int len, int flags);
 
     /**
      * Receive a message from a socket.
@@ -147,7 +154,7 @@ public interface Winsock extends StdCallLibrary {
      * @param flags Flags
      * @return The number of received bytes on success, -1 on error
      */
-    int recv(long sockfd, byte[] buf, int len, int flags);
+    int recv(Pointer sockfd, byte[] buf, int len, int flags);
 
     /**
      * Retrieve the last error from winsock.

--- a/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOwin32EOφTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang;
 
+import com.sun.jna.Pointer;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
@@ -156,15 +157,17 @@ final class EOwin32EOφTest {
         }
 
         private long createsSocket() {
-            return Winsock.INSTANCE.socket(
-                Winsock.AF_INET,
-                Winsock.SOCK_STREAM,
-                Winsock.IPPROTO_TCP
+            return Pointer.nativeValue(
+                Winsock.INSTANCE.socket(
+                    Winsock.AF_INET,
+                    Winsock.SOCK_STREAM,
+                    Winsock.IPPROTO_TCP
+                )
             );
         }
 
         private int closesSocket(final long socket) {
-            return Winsock.INSTANCE.closesocket(socket);
+            return Winsock.INSTANCE.closesocket(new Pointer(socket));
         }
 
         private int startupsWinsock() {

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -348,7 +348,10 @@ final class SyscallTest {
                 try {
                     this.ensure(client >= 0);
                     final SockaddrIn sockaddr = this.sockaddr(port);
-                    this.ensure(Winsock.INSTANCE.connect(new Pointer(client), sockaddr, sockaddr.size()) == 0);
+                    final int connected = Winsock.INSTANCE.connect(
+                        new Pointer(client), sockaddr, sockaddr.size()
+                    );
+                    this.ensure(connected == 0);
                     final byte[] buf = "Hello, Socket!".getBytes(StandardCharsets.UTF_8);
                     final int sent = Winsock.INSTANCE.send(new Pointer(client), buf, buf.length, 0);
                     MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -348,10 +348,10 @@ final class SyscallTest {
                 try {
                     this.ensure(client >= 0);
                     final SockaddrIn sockaddr = this.sockaddr(port);
-                    final int connected = Winsock.INSTANCE.connect(
-                        new Pointer(client), sockaddr, sockaddr.size()
+                    this.ensure(
+                        Winsock.INSTANCE.connect(new Pointer(client), sockaddr, sockaddr.size())
+                            == 0
                     );
-                    this.ensure(connected == 0);
                     final byte[] buf = "Hello, Socket!".getBytes(StandardCharsets.UTF_8);
                     final int sent = Winsock.INSTANCE.send(new Pointer(client), buf, buf.length, 0);
                     MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -8,6 +8,7 @@ import codes.ivanov.ephpo.Ephemeral;
 import codes.ivanov.ephpo.EphemeralResolver;
 import com.jcabi.log.Logger;
 import com.sun.jna.Native;
+import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import io.github.artsok.RepeatedIfExceptionsTest;
 import java.io.IOException;
@@ -208,7 +209,7 @@ final class SyscallTest {
                             "Windows socket should have been connected to local server via syscall, but it didn't, error code is: %d",
                             this.getError()
                         ),
-                        Winsock.INSTANCE.connect(socket, addr, addr.size()),
+                        Winsock.INSTANCE.connect(new Pointer(socket), addr, addr.size()),
                         Matchers.equalTo(0)
                     );
                 } finally {
@@ -230,7 +231,7 @@ final class SyscallTest {
                     final SockaddrIn addr = this.sockaddr(port);
                     MatcherAssert.assertThat(
                         "Connection via windows syscall to a loopback port nobody listens on must be refused",
-                        Winsock.INSTANCE.connect(socket, addr, addr.size()),
+                        Winsock.INSTANCE.connect(new Pointer(socket), addr, addr.size()),
                         Matchers.equalTo(-1)
                     );
                 } finally {
@@ -279,7 +280,7 @@ final class SyscallTest {
                             "Posix socket should have been bound to localhost via syscall, but it didn't, reason: %s",
                             this.getError()
                         ),
-                        Winsock.INSTANCE.listen(socket, 2),
+                        Winsock.INSTANCE.listen(new Pointer(socket), 2),
                         Matchers.equalTo(0)
                     );
                 } finally {
@@ -311,7 +312,7 @@ final class SyscallTest {
                             "Socket should have been connected to local server on sockets, but it didn't, reason: %s",
                             this.getError()
                         ),
-                        Winsock.INSTANCE.connect(client, sockaddr, sockaddr.size()),
+                        Winsock.INSTANCE.connect(new Pointer(client), sockaddr, sockaddr.size()),
                         Matchers.equalTo(0)
                     );
                     server.join();
@@ -347,9 +348,9 @@ final class SyscallTest {
                 try {
                     this.ensure(client >= 0);
                     final SockaddrIn sockaddr = this.sockaddr(port);
-                    this.ensure(Winsock.INSTANCE.connect(client, sockaddr, sockaddr.size()) == 0);
+                    this.ensure(Winsock.INSTANCE.connect(new Pointer(client), sockaddr, sockaddr.size()) == 0);
                     final byte[] buf = "Hello, Socket!".getBytes(StandardCharsets.UTF_8);
-                    final int sent = Winsock.INSTANCE.send(client, buf, buf.length, 0);
+                    final int sent = Winsock.INSTANCE.send(new Pointer(client), buf, buf.length, 0);
                     MatcherAssert.assertThat(
                         String.format(
                             "Client had to send %d bytes to the server, but sent %d, reason: %s",
@@ -369,17 +370,19 @@ final class SyscallTest {
         }
 
         private long openSocket() {
-            final long socket = Winsock.INSTANCE.socket(
-                Winsock.AF_INET,
-                Winsock.SOCK_STREAM,
-                Winsock.IPPROTO_TCP
+            final long socket = Pointer.nativeValue(
+                Winsock.INSTANCE.socket(
+                    Winsock.AF_INET,
+                    Winsock.SOCK_STREAM,
+                    Winsock.IPPROTO_TCP
+                )
             );
             Logger.debug(this, "Opened socket: %d", socket);
             return socket;
         }
 
         private int closeSocket(final long socket) {
-            final int closed = Winsock.INSTANCE.closesocket(socket);
+            final int closed = Winsock.INSTANCE.closesocket(new Pointer(socket));
             if (closed == 0) {
                 Logger.debug(this, "Closed socket: %d", socket);
             } else {
@@ -411,7 +414,7 @@ final class SyscallTest {
 
         private int bindSocket(final long socket, final int port) throws UnknownHostException {
             return Winsock.INSTANCE.bind(
-                socket,
+                new Pointer(socket),
                 this.sockaddr(port),
                 16
             );
@@ -438,10 +441,12 @@ final class SyscallTest {
             try {
                 this.ensure(socket > 0);
                 this.ensure(this.bindSocket(socket, port) == 0);
-                this.ensure(Winsock.INSTANCE.listen(socket, 5) == 0);
+                this.ensure(Winsock.INSTANCE.listen(new Pointer(socket), 5) == 0);
                 final SockaddrIn addr = new SockaddrIn();
-                final long accepted = Winsock.INSTANCE.accept(
-                    socket, addr, new IntByReference(addr.size())
+                final long accepted = Pointer.nativeValue(
+                    Winsock.INSTANCE.accept(
+                        new Pointer(socket), addr, new IntByReference(addr.size())
+                    )
                 );
                 Logger.debug(this, "Accepted socket: %d", accepted);
                 accept.set((int) accepted);
@@ -467,15 +472,17 @@ final class SyscallTest {
             try {
                 this.ensure(socket > 0);
                 this.ensure(this.bindSocket(socket, port) == 0);
-                this.ensure(Winsock.INSTANCE.listen(socket, 5) == 0);
+                this.ensure(Winsock.INSTANCE.listen(new Pointer(socket), 5) == 0);
                 final SockaddrIn addr = new SockaddrIn();
-                accepted = Winsock.INSTANCE.accept(
-                    socket, addr, new IntByReference(addr.size())
+                accepted = Pointer.nativeValue(
+                    Winsock.INSTANCE.accept(
+                        new Pointer(socket), addr, new IntByReference(addr.size())
+                    )
                 );
                 Logger.debug(this, "Accepted socket: %d", accepted);
                 this.ensure(accepted > 0);
                 final byte[] buf = new byte[1024];
-                received.set(Winsock.INSTANCE.recv(accepted, buf, buf.length, 0));
+                received.set(Winsock.INSTANCE.recv(new Pointer(accepted), buf, buf.length, 0));
                 bytes.set(Arrays.copyOf(buf, received.get()));
             } catch (final UnknownHostException exception) {
                 throw new IllegalStateException(exception);


### PR DESCRIPTION
Fixes #7577. #6886 changed every Winsock `SOCKET` binding to Java `long`
because a `long` is always 8 bytes in JNA, which happens to match
`UINT_PTR` on Win64. It is still wrong on Win32, where `UINT_PTR`, and
therefore `SOCKET`, is 4 bytes: every Win32 socket call had a mismatched
stdcall signature, supplying an 8-byte descriptor where Winsock expects 4.

Switched `socket`, `accept`, `closesocket`, `connect`, `bind`, `listen`,
`send` and `recv` in `Winsock` to `com.sun.jna.Pointer`, which JNA marshals
at the platform's actual pointer width (4 bytes on Win32, 8 on Win64) -
this project depends on base `jna` only, not `jna-platform`, so `Pointer`
is the width-correct mapping available without a new dependency. Updated
the eight call sites to wrap a descriptor argument in `new Pointer(...)`
and unwrap a returned one with `Pointer.nativeValue(...)`.

No behavior test added beyond the existing `SyscallTest`/`EOwin32EOφTest`
Windows-only coverage, updated for the new signatures: this is a stdcall
ABI width bug, invisible on the Win64 CI runner either way, and the
existing socket round-trip tests already exercise every changed call site.
