### PR TITLE
Give an indented meta its own error message

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1353,6 +1353,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | `[x]` as a bare argument (horizontal anonym in arg position) | `horizontal formation not allowed as argument` |
 | Malformed BYTES literal (R-3.13.1 — invalid byte form, e.g., `Z9-`, single trailing dash without prefix, odd hex run) | `invalid bytes literal` |
 | Meta after first non-meta object | `meta directive must precede all other objects` |
+| Meta at indent other than 0 (R-3.2.1) | `meta directive must sit at indent 0, found indent <n>` (indent substituted) |
 | Plain child without name in formation | `object inside formation must have a name` |
 | Root identifier glued to a letter or a digit (e.g. the legacy `QQ.io.stdout`) | `<token> is not a valid object name, root <root> must be followed by a dot` (token and root substituted) |
 | Atom containing non-test child | `atom may contain only test attributes` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -6,6 +6,7 @@ package org.eolang.parser;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * A meta-directive line — §3.2 of the spec.
@@ -41,7 +42,11 @@ final class LnMeta implements Line {
         if (this.span.indent() != 0) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
-                "meta directive must precede all other objects"
+                String.format(
+                    Locale.ROOT,
+                    "meta directive must sit at indent 0, found indent %d",
+                    this.span.indent()
+                )
             );
         }
         if (globals.firstObjectEmitted()) {

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -92,6 +92,91 @@ final class LnMetaTest {
     }
 
     @Test
+    void namesTheIndentItFoundInsteadOfBlamingOrdering() {
+        MatcherAssert.assertThat(
+            "an indented meta must name the indent it found, not the ordering rule",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("  +package foo", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "a meta line at indent 2 must be rejected per R-3.2.1"
+            ).getMessage(),
+            Matchers.equalTo("meta directive must sit at indent 0, found indent 2")
+        );
+    }
+
+    @Test
+    void namesADeeperIndentToo() {
+        MatcherAssert.assertThat(
+            "the message must carry whatever indent the meta actually sat at, not a fixed one",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("    +package foo", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "a meta line at indent 4 must be rejected per R-3.2.1"
+            ).getMessage(),
+            Matchers.equalTo("meta directive must sit at indent 0, found indent 4")
+        );
+    }
+
+    @Test
+    void reportsIndentAtAnOddDepthToo() {
+        MatcherAssert.assertThat(
+            "an odd, not just an even, indent must still be named in the message",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span(" +foo", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "a meta line at indent 1 must be rejected per R-3.2.1"
+            ).getMessage(),
+            Matchers.equalTo("meta directive must sit at indent 0, found indent 1")
+        );
+    }
+
+    @Test
+    void keepsPointingAtTheIndentedColumn() {
+        MatcherAssert.assertThat(
+            "the error position must still be the column of the offending indent",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("  +foo", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "a meta line at indent 2 must be rejected per R-3.2.1"
+            ).pos(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
+    void keepsReportingTheOffendingLineNumber() {
+        MatcherAssert.assertThat(
+            "the error must still name the source line the indented meta sat on",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("  +foo", 9))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "a meta line at indent 2 on line 9 must be rejected per R-3.2.1"
+            ).line(),
+            Matchers.equalTo(9)
+        );
+    }
+
+    @Test
+    void stillRejectsOrderingSeparatelyFromIndent() {
+        final Globals globals = new Globals();
+        globals.markEmitted();
+        MatcherAssert.assertThat(
+            "a meta at indent 0 arriving after the first object keeps the ordering message",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("+foo", 5)).into(new Stack(), globals, new Emit()),
+                "a meta arriving after the first non-meta object must be rejected per R-3.2.2"
+            ).getMessage(),
+            Matchers.equalTo("meta directive must precede all other objects")
+        );
+    }
+
+    @Test
     void rejectsMetaAfterFirstObject() {
         final Globals globals = new Globals();
         globals.markEmitted();

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -162,7 +162,7 @@ final class LnMetaTest {
     }
 
     @Test
-    void stillRejectsOrderingSeparatelyFromIndent() {
+    void rejectsOrderingSeparatelyFromIndent() {
         final Globals globals = new Globals();
         globals.markEmitted();
         MatcherAssert.assertThat(


### PR DESCRIPTION
LnMeta.into threw the exact same ParseError text, meta directive must precede all other objects, for two conditions that have nothing to do with each other: an indented meta line, and a meta arriving after the first object has already been emitted.

Only the second one is actually about ordering. A file whose very first line is an indented +package foo has nothing preceding it, so the old message named a rule the source did not break and said nothing about the indentation that was actually wrong.

The indent branch now reports its own text, naming the indent it found and the indent 0 a meta must sit at. PARSER_SPEC.md's canonical-message table gets a matching row for this case, next to the existing ordering row.

Closes #7517