### PR TITLE
Level docblock names the six actual mutators, not just Stack

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -17,9 +17,10 @@ package org.eolang.parser;
  * <p>Per the parser-pragmatism rule, this class deliberately holds more
  * than four fields and is mutable in-place: an immutable {@code Level} +
  * copy-on-write would allocate a new object on every line transition,
- * pushing the parser's per-line cost from O(1) to O(D). Mutation is
- * confined to the {@link Stack} that owns this entry; no other class
- * keeps a reference. *
+ * pushing the parser's per-line cost from O(1) to O(D). Mutation is not
+ * confined to {@link Stack}: {@link LnMethod}, {@link LnCompactTuple},
+ * {@link LnOnlyPhi}, {@link Bindings} and {@link Eo} all hold a reference
+ * to a live entry and call its mutators directly.
  *
  * @since 0.1
  */


### PR DESCRIPTION
The class docblock of Level says mutation is confined to the Stack that owns each entry and that no other class keeps a reference. Neither half holds: LnMethod calls upgradeArgBinding, become, close and name on entries it's handed; LnCompactTuple and LnOnlyPhi call compact; Bindings.observeChild calls parent.observeBinding; and Eo calls openTuple and child. Eo also holds a List<Level> handed out by Stack.snapshot() for the length of a parse line.

The pragmatism exemption itself is fine — an immutable Level really would push per-line cost from O(1) to O(D). The problem is just the two sentences describing where mutation happens, which will mislead whoever touches this class next into assuming Stack is the only mutator.

Closes #7514