### PR TITLE
fix(#7564): let a star tuple carry a method chain in argument position

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -27,7 +27,7 @@ final class Value {
      * Kinds of value that may carry a {@code .method} chain behind them.
      */
     private static final Set<Kind> CHAINABLE = Set.of(
-        Kind.IDENTIFIER, Kind.ROOT, Kind.GROUP, Kind.TERM,
+        Kind.IDENTIFIER, Kind.ROOT, Kind.GROUP, Kind.TERM, Kind.STAR,
         Kind.INTEGER, Kind.FLOAT, Kind.STRING, Kind.BYTES, Kind.HEX
     );
 

--- a/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ValueTest.java
@@ -177,11 +177,11 @@ final class ValueTest {
     }
 
     @Test
-    void marksStarNotChainable() {
+    void marksStarChainable() {
         MatcherAssert.assertThat(
-            "a STAR tuple marker must not allow a .method chain behind it",
+            "a STAR tuple marker must allow a .method chain behind it, as R-3.6 spells out with `*.with 1`",
             new Value(Value.Kind.STAR, "*", 0).chainable(),
-            Matchers.equalTo(false)
+            Matchers.equalTo(true)
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/star-tuple-chain-in-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/star-tuple-chain-in-argument.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A star tuple carries a method chain in argument position, the same way
+# it does as a line head (R-3.6), so `*.with 1` is parsable where the
+# specification says it is.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='first' and @base='Φ.foo']/o[@as='α0' and @base='Φ.tuple.empty.bar']
+  - //o[@name='second' and @base='Φ.tuple.empty.bar']
+input: |
+  [] > app
+    foo *.bar > first
+    *.bar > second


### PR DESCRIPTION
Fixes #7564.

`Tokens.readArg` reads a trailing method chain only for the kinds `Value.CHAINABLE` names, and `STAR` was missing from that set, so `*.bar` parsed as a line head but not as an argument. R-3.6 says a horizontal argument may be a `*` tuple with a chain and spells the example out as `*.with 1`, so the two disagreed and the documented form was unparsable.

`STAR` joins the set. Nothing else changes: `emitArg` already routes a value that carries a chain through `ChainEmission.link`, the same path the head takes, so `foo *.bar` emits `Φ.foo` with one `α0` argument based on `Φ.tuple.empty.bar`.

The fixture pins the argument form next to the head form in one program, so the two stay together.
