### PR TITLE
fix(#7567): let the identity object carry a method chain in argument position

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -27,7 +27,7 @@ final class Value {
      * Kinds of value that may carry a {@code .method} chain behind them.
      */
     private static final Set<Kind> CHAINABLE = Set.of(
-        Kind.IDENTIFIER, Kind.ROOT, Kind.GROUP, Kind.TERM,
+        Kind.IDENTIFIER, Kind.ROOT, Kind.GROUP, Kind.TERM, Kind.IDENTITY,
         Kind.INTEGER, Kind.FLOAT, Kind.STRING, Kind.BYTES, Kind.HEX
     );
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/identity-chain-in-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/identity-chain-in-argument.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The identity glyph is a value wherever a value is expected and may
+# carry a method chain (R-3.16.1), in argument position as well as at the
+# head of a line. It is the receiver of the chain here, not the subject of
+# an application, which R-3.16.1 still forbids.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='first' and @base='Φ.foo']/o[@as='α0' and @base='.bar']
+  - //o[@name='first']/o[@as='α0']/o[not(@base)][o[@base='∅' and @name='x']]
+  - //o[@name='second' and @base='.bar']
+input: |
+  [] > app
+    foo I.bar > first
+    I.bar > second


### PR DESCRIPTION
Fixes #7567.

`Tokens.readArg` reads a trailing method chain only for the kinds in `Value.CHAINABLE`, and `IDENTITY` was not one of them, so `I.bar` parsed as a line head and `foo I` parsed as an argument, but `foo I.bar` was rejected at the dot. R-3.16.1 calls `I` a value recognised wherever a value is expected and says it carries a `.method` chain, so argument position should be no different from head position.

`IDENTITY` joins the set. This is the chain, not the application: `I` is the receiver of `.bar` and the result is the single argument of `foo`. Applying arguments to the glyph (`I 5`) stays rejected, as #7477 asks.

The fixture pins the argument form next to the head form and checks that the receiver is still the identity formation, with its void `x`.
