### PR TITLE
#7575: wrap pure top-level classes and anonymous formations in PhSticky

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -343,12 +343,21 @@
     <xsl:value-of select="eo:class-name(@name)"/>
     <xsl:choose>
       <xsl:when test="@base">
-        <xsl:text> extends PhOnce {</xsl:text>
+        <xsl:text> extends PhOnce</xsl:text>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="concat(' extends ', $phiDefaultClass, ' {')"/>
+        <xsl:value-of select="concat(' extends ', $phiDefaultClass)"/>
       </xsl:otherwise>
     </xsl:choose>
+    <!--
+    A top-level formation purify.xsl marked @pure implements this marker, so
+    that PhPackage, which loads it through reflection and never sees @pure
+    itself, can still wrap the instance in PhSticky.
+    -->
+    <xsl:if test="@pure='true'">
+      <xsl:text> implements Pure</xsl:text>
+    </xsl:if>
+    <xsl:text> {</xsl:text>
     <xsl:value-of select="eo:eol(1)"/>
     <xsl:apply-templates select="." mode="ctors"/>
     <xsl:apply-templates select="nested"/>
@@ -540,8 +549,9 @@
   Abstract object as attribute. A formation that purify.xsl marked with
   @pure is returned wrapped in PhSticky, so that at run time it remembers
   the results of its own dataization (see #5165). A pure top-level class
-  and a pure anonymous formation are not wrapped yet (see the puzzle in
-  PhSticky.java).
+  and a pure anonymous formation are wrapped the same way, see the "class"
+  template's "implements Pure" and the "Anonymous abstract object" template
+  below.
   -->
   <xsl:template match="abstract">
     <xsl:param name="parent"/>
@@ -629,24 +639,42 @@
     <xsl:value-of select="eo:eol($indent)"/>
     <xsl:text>}))</xsl:text>
   </xsl:template>
-  <!-- Anonymous abstract object -->
+  <!--
+  Anonymous abstract object. A formation that purify.xsl marked with @pure
+  is returned wrapped in PhSticky, the same way a named nested formation
+  already is in the "abstract" template above.
+  -->
   <xsl:template match="o[not(@base) and not(@name)]" mode="object">
     <xsl:param name="indent"/>
     <xsl:param name="name"/>
     <xsl:value-of select="eo:eol($indent)"/>
-    <xsl:text>PhDefault </xsl:text>
+    <xsl:choose>
+      <xsl:when test="o and @pure='true'">
+        <xsl:text>Phi </xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:text>PhDefault </xsl:text>
+      </xsl:otherwise>
+    </xsl:choose>
     <xsl:value-of select="$name"/>
     <xsl:text> = </xsl:text>
+    <xsl:if test="o and @pure='true'">
+      <xsl:text>new PhSticky(</xsl:text>
+    </xsl:if>
     <xsl:choose>
       <xsl:when test="o">
         <xsl:text>new </xsl:text>
         <xsl:value-of select="eo:loc-to-class(eo:escape-plus(@loc))"/>
+        <xsl:text>()</xsl:text>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="concat('new ', $phiDefaultClass)"/>
+        <xsl:value-of select="concat('new ', $phiDefaultClass, '()')"/>
       </xsl:otherwise>
     </xsl:choose>
-    <xsl:text>();</xsl:text>
+    <xsl:if test="o and @pure='true'">
+      <xsl:text>)</xsl:text>
+    </xsl:if>
+    <xsl:text>;</xsl:text>
   </xsl:template>
   <!-- Attribute body: regular object, not method -->
   <xsl:template match="o[@base and @base!='' and not(starts-with(@base, '.'))]" mode="object">

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -148,6 +148,49 @@ final class MjTranspileTest {
     }
 
     @Test
+    void marksTopLevelPureFormationWithPureMarker(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a top-level formation marked as safe to cache must implement Pure in the generated Java, so PhPackage can wrap it in PhSticky, but it didnt",
+            new TextOf(
+                MjTranspileTest.pure(temp)
+                    .execute(MjParse.class)
+                    .execute(MjInference.class)
+                    .execute(MjTranspile.class)
+                    .result()
+                    .get("target/generated/org/eolang/EO_examples/EOx.java")
+            ).asString(),
+            Matchers.containsString("implements Pure")
+        );
+    }
+
+    @Test
+    void wrapsAnonymousPureFormationInPhSticky(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "an anonymous formation marked as safe to cache must be wrapped in PhSticky in the generated Java, but it wasnt",
+            new TextOf(
+                new FakeMaven(temp).withProgram(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package examples",
+                        "",
+                        "# Outer.",
+                        "[] > x",
+                        "  seq > @",
+                        "    []",
+                        "      42 > @"
+                    )
+                )
+                    .execute(MjParse.class)
+                    .execute(MjInference.class)
+                    .execute(MjTranspile.class)
+                    .result()
+                    .get("target/generated/org/eolang/EO_examples/EOx.java")
+            ).asString(),
+            Matchers.containsString("new PhSticky(")
+        );
+    }
+
+    @Test
     void leavesUnmarkedFormationBare(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "a formation nobody marked as safe to cache must not be wrapped in PhSticky, but it was",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -180,11 +180,11 @@ final class MjTranspileTest {
                         "      42 > @"
                     )
                 )
-                    .execute(MjParse.class)
-                    .execute(MjInference.class)
-                    .execute(MjTranspile.class)
-                    .result()
-                    .get("target/generated/org/eolang/EO_examples/EOx.java")
+                .execute(MjParse.class)
+                .execute(MjInference.class)
+                .execute(MjTranspile.class)
+                .result()
+                .get("target/generated/org/eolang/EO_examples/EOx.java")
             ).asString(),
             Matchers.containsString("new PhSticky(")
         );

--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -134,6 +134,9 @@ final class PhPackage implements Phi {
                 .asSubclass(Phi.class)
                 .getConstructor()
                 .newInstance();
+            if (loaded instanceof Pure) {
+                loaded = new PhSticky(loaded);
+            }
         } catch (final ClassNotFoundException phi) {
             try {
                 Class.forName(pinfo);

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -41,13 +41,6 @@ import java.util.stream.Collectors;
  * first.</p>
  *
  * @since 0.75
- * @todo #5165:60min Wrap the pure top-level classes and the anonymous
- *  formations in PhSticky too. Today only a named formation nested in
- *  another one (an "abstract" XMIR element) is decorated when purify.xsl
- *  marks it as pure: a top-level "class" is instantiated by PhPackage
- *  through reflection and an anonymous formation by the "o" template in
- *  mode "object", and neither site in to-java.xsl knows about the label
- *  yet.
  */
 public final class PhSticky implements Phi {
 

--- a/eo-runtime/src/main/java/org/eolang/Pure.java
+++ b/eo-runtime/src/main/java/org/eolang/Pure.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * Marker for a formation purify.xsl decided is safe to cache (see #5165).
+ *
+ * <p>A named formation nested inside another one is wrapped in
+ * {@link PhSticky} right where {@code to-java.xsl} writes its constructor
+ * call, because that call site is generated Java text the stylesheet
+ * already controls. A top-level formation has no such site: it is loaded by
+ * {@link PhPackage} through reflection, at a point that never sees the XMIR
+ * {@code @pure} attribute the class came from. Implementing this marker on
+ * the generated class carries that attribute across the reflection
+ * boundary, so {@link PhPackage} can wrap an instance in {@link PhSticky}
+ * itself once it sees the marker.</p>
+ *
+ * @since 0.75
+ */
+public interface Pure {
+}


### PR DESCRIPTION
Resolves the puzzle in PhSticky.java from #5165. Only a named formation
nested in another one (an "abstract" XMIR element) was wrapped in
PhSticky. A top-level formation, instantiated by PhPackage through
reflection, and an anonymous formation, built by the "o" template in mode
"object", were marked @pure by purify.xsl but nothing in to-java.xsl acted
on the label at either site.

For the anonymous case, to-java.xsl already controls the constructor call
site directly, so it now wraps it in PhSticky the same way the existing
"abstract" template does for a named nested formation.

For the top-level case, PhPackage loads the class through reflection and
never sees the XMIR @pure attribute. Added a marker interface, `Pure`,
that to-java.xsl adds to `implements` on the generated class when @pure is
set; PhPackage checks `instanceof Pure` after `newInstance()` and wraps in
PhSticky when it matches. This carries the label across the reflection
boundary without adding a static lookup table.

Added two tests, mirroring the existing `wrapsSafeToCacheFormationInPhSticky`:
one asserting the top-level class implements `Pure`, one asserting an
anonymous pure formation is wrapped in `new PhSticky(`. Ran the full
`eo-runtime`/`eo-maven-plugin` transpile against the existing test suite
(`MjTranspileTest`, `PhStickyTest`, `PhPackageTest`, `EOnumberTest`,
`EOstringTest`) to confirm nothing else in the generated Java changed.
