### PR TITLE
fix(#7568): let the terminator term carry a method chain in argument position

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -27,7 +27,7 @@ final class Value {
      * Kinds of value that may carry a {@code .method} chain behind them.
      */
     private static final Set<Kind> CHAINABLE = Set.of(
-        Kind.IDENTIFIER, Kind.ROOT, Kind.GROUP,
+        Kind.IDENTIFIER, Kind.ROOT, Kind.GROUP, Kind.TERM,
         Kind.INTEGER, Kind.FLOAT, Kind.STRING, Kind.BYTES, Kind.HEX
     );
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/term-chain-in-argument.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/term-chain-in-argument.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The terminator term is a value wherever a value is expected and may
+# carry a method chain (§2.3), in argument position as well as at the head
+# of a line. `T` is the receiver of the chain here, not a head taking
+# arguments of its own.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='first' and @base='Φ.foo']/o[@as='α0' and @base='⊥.bar']
+  - //o[@name='second' and @base='⊥.bar']
+input: |
+  [] > app
+    foo T.bar > first
+    T.bar > second


### PR DESCRIPTION
Fixes #7568.

`LnApplication` reads a method chain for a line head unconditionally, while `Tokens.readArg` reads one only for the kinds in `Value.CHAINABLE`, and `TERM` was missing there. So `T.bar` parsed at the head of a line and `foo T` parsed as an argument, but `foo T.bar` was rejected at the dot. §2.3 calls `T` a value that may carry a `.method` chain, with `T.foo` as its own example.

`TERM` joins the set. `T` is the receiver of the dispatch here, not a head taking arguments of its own, and the argument comes out with the same base the head form produces, `⊥.bar`.

The fixture pins the two forms side by side.
