### PR TITLE
fix(#7585): keep the coverage wrapper around a normalized object

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -124,6 +124,7 @@ public final class PhCoverage implements Phi {
 
     @Override
     public Phi normalized() {
+        this.hit();
         return this.origin.normalized();
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -112,6 +112,28 @@ final class PhCoverageTest {
     }
 
     @Test
+    void recordsALocationTouchedThroughANormalizedObject(@Mktmp final Path temp)
+        throws Exception {
+        final Path hits = temp.resolve("hits.txt");
+        final String before = System.getProperty("eo.coverageFile");
+        System.setProperty("eo.coverageFile", hits.toString());
+        try {
+            new PhCoverage(new Data.ToPhi(1L), "Φ.normalized:3:5").normalized().delta();
+            MatcherAssert.assertThat(
+                "a location touched through a normalized object must still be recorded, but it wasnt",
+                Files.readAllLines(hits, StandardCharsets.UTF_8),
+                Matchers.contains("Φ.normalized:3:5")
+            );
+        } finally {
+            if (before == null) {
+                System.clearProperty("eo.coverageFile");
+            } else {
+                System.setProperty("eo.coverageFile", before);
+            }
+        }
+    }
+
+    @Test
     void writesToEachConfiguredDestinationOnce(@Mktmp final Path temp) throws Exception {
         final Path first = temp.resolve("first.txt");
         final Path second = temp.resolve("second.txt");


### PR DESCRIPTION
Fixes #7585.

`normalized()` handed back `origin.normalized()` bare and recorded nothing, so the location of an object that was only normalized never reached the coverage file. Normalizing is a touch, exactly like `take()` and `delta()`, so `normalized()` now calls `hit()` before delegating. The decorator itself does not have to survive normalization: the hit set already dedups, so one record at normalization time is all the file ever gets.

The new test touches a normalized object and expects its location in the file, which is what the issue's snippet does. It fails against `master` and passes here. `PhCoverageTest`: 8 run, 0 failures.
