### PR TITLE
fix(#7583): mark a coverage hit as written only after the append lands

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -140,27 +140,32 @@ public final class PhCoverage implements Phi {
 
     private void hit() {
         final String property = PhCoverage.property();
-        if (property != null && this.hits.add(property + '\0' + this.record)) {
-            try {
-                Files.write(
-                    Paths.get(property),
-                    String.format("%s%n", this.record).getBytes(StandardCharsets.UTF_8),
-                    StandardOpenOption.CREATE,
-                    StandardOpenOption.APPEND
-                );
-            } catch (final IOException ex) {
-                throw new UncheckedIOException(
-                    String.format("Failed to append a coverage hit to '%s'", property),
-                    ex
-                );
-            } catch (final InvalidPathException ex) {
-                throw new IllegalArgumentException(
-                    String.format(
-                        "Invalid path '%s' in the 'eo.coverageFile' system property",
-                        property
-                    ),
-                    ex
-                );
+        if (property != null) {
+            final String seen = property + '\0' + this.record;
+            if (this.hits.add(seen)) {
+                try {
+                    Files.write(
+                        Paths.get(property),
+                        String.format("%s%n", this.record).getBytes(StandardCharsets.UTF_8),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND
+                    );
+                } catch (final IOException ex) {
+                    this.hits.remove(seen);
+                    throw new UncheckedIOException(
+                        String.format("Failed to append a coverage hit to '%s'", property),
+                        ex
+                    );
+                } catch (final InvalidPathException ex) {
+                    this.hits.remove(seen);
+                    throw new IllegalArgumentException(
+                        String.format(
+                            "Invalid path '%s' in the 'eo.coverageFile' system property",
+                            property
+                        ),
+                        ex
+                    );
+                }
             }
         }
     }

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -7,6 +7,7 @@ package org.eolang;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,6 +16,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Isolated;
@@ -61,6 +63,35 @@ final class PhCoverageTest {
                 "every location, hit repeatedly and through a copy, must be recorded exactly once",
                 Files.readAllLines(hits, StandardCharsets.UTF_8),
                 Matchers.containsInAnyOrder("Φ.foo:7:3", "Φ.bar:9:5")
+            );
+        } finally {
+            if (before == null) {
+                System.clearProperty("eo.coverageFile");
+            } else {
+                System.setProperty("eo.coverageFile", before);
+            }
+        }
+    }
+
+    @Test
+    void recordsALocationOnceTheDestinationBecomesWritable(@Mktmp final Path temp)
+        throws Exception {
+        final Path hits = temp.resolve("absent").resolve("hits.txt");
+        final String before = System.getProperty("eo.coverageFile");
+        System.setProperty("eo.coverageFile", hits.toString());
+        try {
+            final Phi covered = new PhCoverage(new Data.ToPhi(1L), "Φ.retry:4:2");
+            Assertions.assertThrows(
+                UncheckedIOException.class,
+                covered::delta,
+                "a hit that cannot be appended must fail loudly, but it didnt"
+            );
+            Files.createDirectory(hits.getParent());
+            covered.delta();
+            MatcherAssert.assertThat(
+                "a location must be recorded once the destination becomes writable, but it wasnt",
+                Files.readAllLines(hits, StandardCharsets.UTF_8),
+                Matchers.contains("Φ.retry:4:2")
             );
         } finally {
             if (before == null) {


### PR DESCRIPTION
Fixes #7583.

`hit()` added the location to the shared `hits` set as the guard of the write, so a failed append left the marker behind and the same wrapper never tried that destination again. A caller that fixes the external condition (creates the missing directory, remounts the disk) got silence instead of the hit.

The marker is now withdrawn when the append does not land, for both failure paths the method already distinguishes, so the next touch retries. At-most-once is unchanged: the set is still what stops a second write of a location that was written.

The new test walks the issue's sequence: the first `delta()` fails with the directory missing, the directory is created, the second `delta()` records the location. Without the change it fails on the missing file, with it the file holds exactly one line. `PhCoverageTest`: 7 run, 0 failures.
