### PR TITLE
fix(#7584): keep the safety wrapper around a normalized object

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -163,7 +163,16 @@ public final class PhSafe implements Phi, Atom {
 
     @Override
     public Phi normalized() {
-        return this.through(this.origin::normalized);
+        final Phi normal = this.through(this.origin::normalized);
+        final Phi result;
+        if (normal instanceof PhTerminator) {
+            result = normal;
+        } else {
+            result = new PhSafe(
+                normal, this.program, this.line, this.position, this.location, this.oname
+            );
+        }
+        return result;
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -35,6 +35,35 @@ final class PhSafeTest {
     }
 
     @Test
+    void keepsProtectingANormalizedObject() {
+        MatcherAssert.assertThat(
+            "a failure of a normalized object must still name its location, but it didnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new PhSafe(
+                    new PhDefault() {
+                        @Override
+                        public Phi normalized() {
+                            return new PhDefault() {
+                                @Override
+                                public byte[] delta() {
+                                    throw new IllegalArgumentException("boom");
+                                }
+                            };
+                        }
+                    },
+                    "example.eo", 3, 5
+                ).normalized().delta(),
+                "was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("at example.eo:3:5"),
+                Matchers.containsString("boom")
+            )
+        );
+    }
+
+    @Test
     void catchesRuntimeException() {
         MatcherAssert.assertThat(
             "wraps a runtime exception into ExFailure with location and cause",


### PR DESCRIPTION
Fixes #7584.

`normalized()` guarded the normalization itself and then handed back the bare object, so the protection ended there: a failure raised later, through that object, came out as the raw runtime exception with no program, line, or position on it. `PhLogged.normalized()` next door wraps its normalized origin again, and `copy()` here already rebuilds the wrapper with the same coordinates.

`normalized()` now does the same, keeping program, line, position, location, and original name. The normalization call itself stays inside `through`, so a failure during normalization is wrapped exactly as before.

The new test is the issue's snippet: an object whose normalized form throws on `delta()`, wrapped as `example.eo:3:5`. Without the change it throws `IllegalArgumentException`; with it, an `ExFailure` naming `example.eo:3:5` and carrying the cause. `PhSafeTest`: 13 run, 0 failures.
