### PR TITLE
fix(#7579): let a cache of no capacity keep nothing instead of failing

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Lru.java
+++ b/eo-runtime/src/main/java/org/eolang/Lru.java
@@ -19,6 +19,10 @@ import java.util.Set;
  * {@link java.util.Collections#synchronizedMap(Map)} when several
  * threads share it.</p>
  *
+ * <p>A capacity below one keeps nothing: every {@code put} is accepted
+ * and forgotten, so a caller that asks for no cache gets no cache rather
+ * than a failure.</p>
+ *
  * @since 0.75
  */
 final class Lru implements Map<String, byte[]> {
@@ -69,12 +73,18 @@ final class Lru implements Map<String, byte[]> {
 
     @Override
     public byte[] put(final String key, final byte[] value) {
-        if (this.origin.size() >= this.capacity && !this.origin.containsKey(key)) {
-            final Iterator<String> eldest = this.origin.keySet().iterator();
-            eldest.next();
-            eldest.remove();
+        final byte[] before;
+        if (this.capacity < 1) {
+            before = this.origin.remove(key);
+        } else {
+            if (this.origin.size() >= this.capacity && !this.origin.containsKey(key)) {
+                final Iterator<String> eldest = this.origin.keySet().iterator();
+                eldest.next();
+                eldest.remove();
+            }
+            before = this.origin.put(key, value);
         }
-        return this.origin.put(key, value);
+        return before;
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhStickyTest.java
@@ -35,6 +35,33 @@ final class PhStickyTest {
     }
 
     @Test
+    void computesWithoutACache() {
+        MatcherAssert.assertThat(
+            "a decorator asked to keep nothing must still compute its answer, but it didnt",
+            new Dataized(
+                new PhApplication(
+                    new PhSticky(PhStickyTest.doubler(new AtomicInteger()), 0),
+                    new Bind(0, new Data.ToPhi(21.0d))
+                )
+            ).asNumber(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @Test
+    void recomputesWithoutACache() {
+        final AtomicInteger count = new AtomicInteger();
+        final Phi twice = new PhSticky(PhStickyTest.doubler(count), 0);
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))).take();
+        new Dataized(new PhApplication(twice, new Bind(0, new Data.ToPhi(21.0d)))).take();
+        MatcherAssert.assertThat(
+            "a decorator that keeps nothing must recompute the same input, but it didnt",
+            count.get(),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
     void dataizesBodyOnceForEqualInputs() {
         final AtomicInteger count = new AtomicInteger();
         final Phi twice = new PhSticky(PhStickyTest.doubler(count));


### PR DESCRIPTION
Fixes #7579.

`PhSticky` takes a capacity through a public constructor, and zero made the first cacheable dataization fail: `Lru.put` saw `size() >= capacity` on an empty map, went to evict, and called `next()` on an empty iterator. A `NoSuchElementException` from inside the cache reached the caller of a perfectly ordinary `Phi`.

`Lru` now answers for the whole range of its argument. Below one it keeps nothing: the put is accepted, any earlier value for that key is dropped, and the map stays empty, so a caller asking for no cache gets no cache. One and above behave exactly as before.

That is the second of the two options the issue lists, and it seemed the better one: a capacity is a tuning knob, and turning it down to nothing is a sensible thing to ask for, while an exception would make `new PhSticky(obj, 0)` a trap that only shows up at the first dataization.

The new test dataizes through a zero-capacity decorator twice and checks both that the answer is right and that the body ran both times, since nothing is remembered. `PhStickyTest`: 11 run, 0 failures.
