### PR TITLE
fix(#7571): refuse a 32-bit ARM stat instead of reading the aarch64 layout

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/StatLayout.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatLayout.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import com.sun.jna.Platform;
+import org.eolang.ExFailure;
+
+/**
+ * The layout of {@code struct stat} on one platform.
+ *
+ * <p>Linux x86-64, Linux aarch64 and macOS order the fields of that struct
+ * differently, and a 32-bit ARM kernel orders them differently again, while
+ * mapping none of the three. Which of them this is gets decided when the
+ * object is made, so a test can ask for the struct of a platform other than
+ * the one it runs on.</p>
+ *
+ * @since 0.74.0
+ */
+final class StatLayout {
+
+    /**
+     * Whether this is macOS.
+     */
+    private final boolean mac;
+
+    /**
+     * Whether the architecture name is an ARM one, 32- or 64-bit.
+     */
+    private final boolean arm;
+
+    /**
+     * Whether the architecture is 64-bit.
+     */
+    private final boolean wide;
+
+    /**
+     * Ctor, for the platform this JVM runs on.
+     */
+    StatLayout() {
+        this(Platform.isMac(), Platform.isARM(), Platform.is64Bit());
+    }
+
+    /**
+     * Ctor.
+     * @param mac Whether this is macOS
+     * @param arm Whether the architecture name is an ARM one, 32- or 64-bit
+     * @param wide Whether the architecture is 64-bit
+     */
+    StatLayout(final boolean mac, final boolean arm, final boolean wide) {
+        this.mac = mac;
+        this.arm = arm;
+        this.wide = wide;
+    }
+
+    /**
+     * An empty struct of this layout, for the C call to fill.
+     * @param path The path being asked about, for the failure message
+     * @return The struct, waiting to be filled
+     */
+    StatSyscall.FileStat stat(final String path) {
+        if (!this.mac && this.arm && !this.wide) {
+            throw new ExFailure(
+                "Can't read the status of '%s': the 32-bit ARM 'struct stat' is not mapped yet",
+                path
+            );
+        }
+        final StatSyscall.FileStat info;
+        if (this.mac) {
+            info = new MacFileStat();
+        } else if (this.arm) {
+            info = new LinuxArmFileStat();
+        } else {
+            info = new LinuxFileStat();
+        }
+        return info;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.posix;
 
-import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import java.util.function.ToIntBiFunction;
 import org.eolang.Cstring;
@@ -19,7 +18,9 @@ import org.eolang.Syscall;
  * {@code stat} or through {@code lstat} when a symbolic link has to be seen as
  * itself, and hands its mode bits and byte size to EO. Linux x86-64, Linux
  * aarch64 and macOS lay that struct out differently, so each keeps its own
- * {@link FileStat}; the divergence is spelled out rather than papered over.</p>
+ * {@link FileStat}; the divergence is spelled out rather than papered over.
+ * An architecture whose layout is not mapped fails loudly instead of reading
+ * the fields of another ABI.</p>
  *
  * @since 0.57.0
  */
@@ -50,22 +51,8 @@ public final class StatSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
         final String path = new Cstring("the 'path' argument of stat", params[0]).it();
-        final FileStat info;
-        final int code;
-        if (Platform.isMac()) {
-            final MacFileStat mac = new MacFileStat();
-            code = this.call.applyAsInt(path, mac);
-            info = mac;
-        } else if (Platform.isARM()) {
-            final LinuxArmFileStat arm = new LinuxArmFileStat();
-            code = this.call.applyAsInt(path, arm);
-            info = arm;
-        } else {
-            final LinuxFileStat linux = new LinuxFileStat();
-            code = this.call.applyAsInt(path, linux);
-            info = linux;
-        }
-        result.put(0, new Data.ToPhi(code));
+        final FileStat info = new StatLayout().stat(path);
+        result.put(0, new Data.ToPhi(this.call.applyAsInt(path, (Structure) info)));
         final Phi struct = this.posix.take("stat");
         struct.put(0, new Data.ToPhi(info.mode()));
         struct.put(1, new Data.ToPhi(info.length()));

--- a/eo-runtime/src/test/java/org/eolang/posix/StatLayoutTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/StatLayoutTest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.ExFailure;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StatLayout}.
+ * @since 0.74.0
+ */
+final class StatLayoutTest {
+
+    @Test
+    void picksTheMacLayout() {
+        MatcherAssert.assertThat(
+            "macOS must get its own struct stat, but it didnt",
+            new StatLayout(true, false, true).stat("/tmp/f"),
+            Matchers.instanceOf(MacFileStat.class)
+        );
+    }
+
+    @Test
+    void picksTheWideArmLayout() {
+        MatcherAssert.assertThat(
+            "a 64-bit ARM must get the aarch64 struct stat, but it didnt",
+            new StatLayout(false, true, true).stat("/tmp/f"),
+            Matchers.instanceOf(LinuxArmFileStat.class)
+        );
+    }
+
+    @Test
+    void picksTheLinuxLayout() {
+        MatcherAssert.assertThat(
+            "a non-ARM Linux must get the x86-64 struct stat, but it didnt",
+            new StatLayout(false, false, true).stat("/tmp/f"),
+            Matchers.instanceOf(LinuxFileStat.class)
+        );
+    }
+
+    @Test
+    void refusesToReadThirtyTwoBitArm() {
+        MatcherAssert.assertThat(
+            "32-bit ARM must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new StatLayout(false, true, false).stat("/tmp/f"),
+                "32-bit ARM was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("32-bit ARM"),
+                Matchers.containsString("/tmp/f")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7571.

`Platform.isARM()` is true for both `aarch64` and 32-bit names such as `armv7l`, and the branch behind it hands the call a `LinuxArmFileStat`, which is the aarch64 layout: two 64-bit fields first, `mode` at offset 16. A 32-bit ARM kernel fills a different `struct stat`, so `file.is-directory`, `file.is-symlink` and `file.size` were deciding from whatever those offsets happened to hold.

The aarch64 layout is now taken only when the architecture is both ARM and 64-bit. A 32-bit ARM asks for a layout that is not mapped, and says so:

```
Can't read the status of '/tmp/f': the 32-bit ARM 'struct stat' is laid out
differently from the aarch64 one and is not mapped yet
```

That is the second option the issue offers. Mapping the 32-bit layout would be the other one, but it is not something I can write blind and leave untested: the fields differ in width as well as in offset, and this machine cannot run it. A loud refusal is at least honest about what the runtime knows.

The choice moved into `StatSyscall.layout`, which takes the three platform answers as arguments, so it can be tested for a platform other than the one running the tests. The new test covers all four outcomes. `StatSyscallTest`: 4 run, 0 failures.
