### PR TITLE
fix(#7563): stop reporting EINVAL for the limited-broadcast address

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
@@ -5,6 +5,7 @@
 package org.eolang.posix;
 
 import com.sun.jna.Native;
+import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -24,6 +25,16 @@ public final class InetAddrSyscall implements Syscall {
     private static final int EINVAL = 22;
 
     /**
+     * The limited-broadcast address, whose conversion is {@code -1} — the
+     * same value {@code inet_addr} returns for text it cannot parse, which
+     * is why the two are told apart by the text rather than by the result.
+     * {@code socket.eo} makes the same comparison for the same reason.
+     */
+    private static final String BROADCAST = String.join(
+        ".", Collections.nCopies(4, "255")
+    );
+
+    /**
      * Posix object.
      */
     private final Phi posix;
@@ -39,10 +50,9 @@ public final class InetAddrSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        final int converted = CStdLib.INSTANCE.inet_addr(
-            new Dataized(params[0]).asString()
-        );
-        if (converted == -1) {
+        final String address = new Dataized(params[0]).asString();
+        final int converted = CStdLib.INSTANCE.inet_addr(address);
+        if (converted == -1 && !InetAddrSyscall.BROADCAST.equals(address)) {
             Native.setLastError(InetAddrSyscall.EINVAL);
         }
         result.put(0, new Data.ToPhi(converted));

--- a/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
@@ -5,6 +5,7 @@
 package org.eolang.posix;
 
 import com.sun.jna.Native;
+import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
@@ -27,6 +28,20 @@ final class InetAddrSyscallTest {
             "inet_addr does not set errno on failure, so the syscall wrapper must set it itself, to EINVAL, or a later strerror(errno) reads whatever an unrelated earlier call left behind",
             Native.getLastError(),
             Matchers.equalTo(22)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void doesNotReportInvalidForTheBroadcastAddress() {
+        Native.setLastError(0);
+        new InetAddrSyscall(Phi.Φ.take("posix").copy()).make(
+            new Data.ToPhi(String.join(".", Collections.nCopies(4, "255")))
+        );
+        MatcherAssert.assertThat(
+            "the limited-broadcast address converts to -1 like an unparsable one does, but it is valid, so EINVAL must not be reported for it",
+            Native.getLastError(),
+            Matchers.not(Matchers.equalTo(22))
         );
     }
 


### PR DESCRIPTION
Fixes #7563.

`inet_addr` answers `-1` for text it cannot parse and also for `255.255.255.255`, whose conversion is genuinely all ones. Reading failure out of the return value alone therefore invented an `EINVAL` for a valid address, and a caller that read `posix.errno` afterwards saw an error that never happened.

The two are now told apart by the text, which is what `socket.eo` already does for the same ambiguity (`^.^.address.eq "255.255.255.255"`, from #7240). Unparsable text still gets `EINVAL`, since `inet_addr` sets no errno of its own.

The new test starts from errno `0`, converts the broadcast address, and expects errno still `0`. It runs on POSIX only, like the two tests beside it, so this machine skips all three; the CI Linux and macOS jobs are what exercise them.

Worth saying plainly: this leaves the exotic spellings of the same address (`0xffffffff`, `4294967295`) still reported as `EINVAL`, because `inet_addr` accepts those forms too and the text no longer matches. Closing that gap means giving up `inet_addr` for `inet_pton`, which would also drop the hex and short forms the current call accepts. That is a bigger decision than this fix, and I would rather it be made deliberately than smuggled in here.
