### PR TITLE
fix(#7572): refuse an unmapped architecture instead of reading the x86-64 layout

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/StatLayout.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatLayout.java
@@ -1,0 +1,79 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import com.sun.jna.Platform;
+import org.eolang.ExFailure;
+
+/**
+ * The layout of {@code struct stat} on one platform.
+ *
+ * <p>Linux x86-64, Linux aarch64 and macOS order the fields of that struct
+ * differently, and an architecture that is none of the three, RISC-V among
+ * them, orders them differently again while mapping none of them. Which of
+ * them this is gets decided when the object is made, so a test can ask for
+ * the struct of a platform other than the one it runs on.</p>
+ *
+ * @since 0.74.0
+ */
+final class StatLayout {
+
+    /**
+     * Whether this is macOS.
+     */
+    private final boolean mac;
+
+    /**
+     * Whether the architecture is an ARM one.
+     */
+    private final boolean arm;
+
+    /**
+     * Whether the architecture is an x86 one.
+     */
+    private final boolean intel;
+
+    /**
+     * Ctor, for the platform this JVM runs on.
+     */
+    StatLayout() {
+        this(Platform.isMac(), Platform.isARM(), Platform.isIntel());
+    }
+
+    /**
+     * Ctor.
+     * @param mac Whether this is macOS
+     * @param arm Whether the architecture is an ARM one
+     * @param intel Whether the architecture is an x86 one
+     */
+    StatLayout(final boolean mac, final boolean arm, final boolean intel) {
+        this.mac = mac;
+        this.arm = arm;
+        this.intel = intel;
+    }
+
+    /**
+     * An empty struct of this layout, for the C call to fill.
+     * @param path The path being asked about, for the failure message
+     * @return The struct, waiting to be filled
+     */
+    StatSyscall.FileStat stat(final String path) {
+        if (!this.mac && !this.arm && !this.intel) {
+            throw new ExFailure(
+                "Can't read the status of '%s': no 'struct stat' is mapped for the '%s' architecture",
+                path, Platform.ARCH
+            );
+        }
+        final StatSyscall.FileStat info;
+        if (this.mac) {
+            info = new MacFileStat();
+        } else if (this.arm) {
+            info = new LinuxArmFileStat();
+        } else {
+            info = new LinuxFileStat();
+        }
+        return info;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.posix;
 
-import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import java.util.function.ToIntBiFunction;
 import org.eolang.Cstring;
@@ -19,7 +18,9 @@ import org.eolang.Syscall;
  * {@code stat} or through {@code lstat} when a symbolic link has to be seen as
  * itself, and hands its mode bits and byte size to EO. Linux x86-64, Linux
  * aarch64 and macOS lay that struct out differently, so each keeps its own
- * {@link FileStat}; the divergence is spelled out rather than papered over.</p>
+ * {@link FileStat}; the divergence is spelled out rather than papered over.
+ * An architecture whose layout is none of those three fails loudly instead of
+ * reading the fields of another ABI.</p>
  *
  * @since 0.57.0
  */
@@ -50,22 +51,8 @@ public final class StatSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
         final String path = new Cstring("the 'path' argument of stat", params[0]).it();
-        final FileStat info;
-        final int code;
-        if (Platform.isMac()) {
-            final MacFileStat mac = new MacFileStat();
-            code = this.call.applyAsInt(path, mac);
-            info = mac;
-        } else if (Platform.isARM()) {
-            final LinuxArmFileStat arm = new LinuxArmFileStat();
-            code = this.call.applyAsInt(path, arm);
-            info = arm;
-        } else {
-            final LinuxFileStat linux = new LinuxFileStat();
-            code = this.call.applyAsInt(path, linux);
-            info = linux;
-        }
-        result.put(0, new Data.ToPhi(code));
+        final FileStat info = new StatLayout().stat(path);
+        result.put(0, new Data.ToPhi(this.call.applyAsInt(path, (Structure) info)));
         final Phi struct = this.posix.take("stat");
         struct.put(0, new Data.ToPhi(info.mode()));
         struct.put(1, new Data.ToPhi(info.length()));

--- a/eo-runtime/src/test/java/org/eolang/posix/StatLayoutTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/StatLayoutTest.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.ExFailure;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StatLayout}.
+ * @since 0.74.0
+ */
+final class StatLayoutTest {
+
+    @Test
+    void picksTheMacLayout() {
+        MatcherAssert.assertThat(
+            "macOS must get its own struct stat, but it didnt",
+            new StatLayout(true, false, false).stat("/tmp/f"),
+            Matchers.instanceOf(MacFileStat.class)
+        );
+    }
+
+    @Test
+    void picksTheArmLayout() {
+        MatcherAssert.assertThat(
+            "ARM must get the aarch64 struct stat, but it didnt",
+            new StatLayout(false, true, false).stat("/tmp/f"),
+            Matchers.instanceOf(LinuxArmFileStat.class)
+        );
+    }
+
+    @Test
+    void picksTheIntelLayout() {
+        MatcherAssert.assertThat(
+            "an x86 Linux must get the x86-64 struct stat, but it didnt",
+            new StatLayout(false, false, true).stat("/tmp/f"),
+            Matchers.instanceOf(LinuxFileStat.class)
+        );
+    }
+
+    @Test
+    void refusesAnArchitectureItDoesNotKnow() {
+        MatcherAssert.assertThat(
+            "an unmapped architecture must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new StatLayout(false, false, false).stat("/tmp/f"),
+                "an unmapped architecture was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("/tmp/f"),
+                Matchers.containsString("architecture")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7572.

The last branch handed `LinuxFileStat` to every platform that is neither macOS nor ARM, and that struct is the Linux x86-64 layout: `dev`, `ino`, `nlink`, then `mode` at offset 24. Linux on RISC-V uses the asm-generic layout, where offset 24 is `uid`, so `file.is-directory` was masking a user id and answering from it.

The x86-64 layout is now taken only for an x86 architecture. Anything else says what it does not know:

```
Can't read the status of '/tmp/f': the 'struct stat' of the 'riscv64' architecture
is not mapped yet, and reading it as another one would answer with the wrong fields
```

Mapping asm-generic properly would be the other half, and the issue says as much, but I cannot write that struct blind and leave it untested: this machine has no RISC-V and the layout differs in field widths as well as offsets. A refusal at least stops the runtime from answering confidently with the wrong field.

The choice moved into `StatSyscall.layout`, which takes the platform answers as arguments so it can be tested for a platform other than the one running the tests. `StatSyscallTest`: 4 run, 0 failures.

Note for whoever merges this together with #7571: both PRs rework this same dispatch (that one is the ARM branch selecting an aarch64 layout for 32-bit ARM), so the second one in will want a small rebase. Happy to do it either way round.
