### PR TITLE
fix(#7566): write the terminator cause once, atomically

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhTerminator.java
+++ b/eo-runtime/src/main/java/org/eolang/PhTerminator.java
@@ -4,6 +4,8 @@
  */
 package org.eolang;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 /**
  * The terminator of φ-calculus — a terminated computation.
  *
@@ -44,9 +46,13 @@ public final class PhTerminator implements Phi {
 
     /**
      * The reason this computation terminated, used only as the panic
-     * message when the terminator is forced, or {@code null} when none was given.
+     * message when the terminator is forced, empty when none was given.
+     * Atomic because {@link #copy()} hands the same terminator to every
+     * branch of a concurrent evaluation: the write-once rule the class
+     * promises has to hold when two of those branches put at once, and the
+     * cause one of them stores has to be visible to the one that forces it.
      */
-    private Phi cause;
+    private final AtomicReference<Phi> cause;
 
     /**
      * The reason to fall back to if nothing is ever {@code put} into this
@@ -93,7 +99,7 @@ public final class PhTerminator implements Phi {
      * @param reason The default reason for the termination
      */
     private PhTerminator(final Phi cse, final String reason) {
-        this.cause = cse;
+        this.cause = new AtomicReference<>(cse);
         this.fallback = new Data.ToPhi(reason);
     }
 
@@ -116,8 +122,8 @@ public final class PhTerminator implements Phi {
 
     @Override
     public void put(final int pos, final Phi object) {
-        if (pos == 0 && this.cause == null) {
-            this.cause = object;
+        if (pos == 0) {
+            this.cause.compareAndSet(null, object);
         }
     }
 
@@ -157,8 +163,9 @@ public final class PhTerminator implements Phi {
 
     private Phi reason() {
         final Phi reason;
-        if (this.cause != null) {
-            reason = this.cause;
+        final Phi carried = this.cause.get();
+        if (carried != null) {
+            reason = carried;
         } else {
             reason = this.fallback;
         }

--- a/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhTerminatorTest.java
@@ -4,6 +4,11 @@
  */
 package org.eolang;
 
+import com.yegor256.Together;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.CyclicBarrier;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -23,6 +28,34 @@ final class PhTerminatorTest {
             ExFailure.class,
             () -> new Dataized(new PhTerminator()).take(),
             "dataizing the terminator must abort instead of returning data"
+        );
+    }
+
+    @Test
+    void keepsOneCauseWhenManyThreadsPutAtOnce() {
+        final int threads = 8;
+        final Phi term = new PhTerminator();
+        final Set<String> seen = Collections.synchronizedSet(new HashSet<>());
+        final CyclicBarrier gate = new CyclicBarrier(threads);
+        new Together<>(
+            threads,
+            thread -> {
+                gate.await();
+                term.put(0, new Data.ToPhi(String.format("cause %d", thread)));
+                seen.add(
+                    Assertions.assertThrows(
+                        ExFailure.class,
+                        () -> new Dataized(term).take(),
+                        "forcing the terminator must abort"
+                    ).getMessage()
+                );
+                return true;
+            }
+        ).asList();
+        MatcherAssert.assertThat(
+            "the cause is written once, so every thread must be told the same reason, but they werent",
+            seen,
+            Matchers.hasSize(1)
         );
     }
 


### PR DESCRIPTION
Fixes #7566.

The class promises that its cause is written once, and implemented that as an unsynchronised `cause == null` check followed by a plain assignment. Two threads can pass the check together and the second write wins, and since `copy()` deliberately hands the same terminator to every branch, a terminated computation flowing through concurrent branches is exactly where that happens. The field was also neither volatile nor locked, so a thread forcing the terminator had no guarantee of seeing a cause another thread had just supplied.

`cause` is now an `AtomicReference` and `put` is a `compareAndSet(null, object)`. Sequential behaviour is unchanged: the first cause still wins, a later put still does not replace it, and a birth-site default still loses to any put.

About the test, honestly: it aligns eight threads on a barrier, has each put its own cause and then force the terminator, and asserts they were all told the same reason. It passes with the fix. It also passes on master, three runs out of three, because the window between the check and the assignment is a few instructions wide and the threads do not land inside it. So it pins the contract rather than reproducing the race. I could not find a way to make the race deterministic without a seam in production code, and adding one for this seemed worse than the fix. Happy to drop the test if you would rather not carry a green-either-way case.
