### PR TITLE
fix(#7570): refuse text with a NUL before it reaches a C string

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Cstring.java
+++ b/eo-runtime/src/main/java/org/eolang/Cstring.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+/**
+ * Transform {@link Expect} to text a C function can be given.
+ *
+ * <p>A C string ends at the first NUL byte, so text carrying one cannot
+ * cross that boundary intact: the native side would silently read a
+ * prefix of what EO handed over. Such text is refused here instead,
+ * the way {@link Natural} refuses a size that no syscall could mean.</p>
+ *
+ * @since 0.57.0
+ */
+public final class Cstring {
+
+    /**
+     * Expect.
+     */
+    private final Expect<Phi> expect;
+
+    /**
+     * Ctor.
+     * @param subject What the text is, for the failure message
+     * @param phi The object holding the text
+     */
+    public Cstring(final String subject, final Phi phi) {
+        this(new Expect<>(subject, () -> phi));
+    }
+
+    /**
+     * Ctor.
+     * @param expect Expect
+     */
+    public Cstring(final Expect<Phi> expect) {
+        this.expect = expect;
+    }
+
+    /**
+     * Return it.
+     * @return The text
+     */
+    public String it() {
+        return this.expect
+            .that(phi -> new Dataized(phi).asString())
+            .must(text -> text.indexOf('\0') < 0)
+            .otherwise("must not contain the NUL character, since a C string ends there")
+            .it();
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -32,12 +32,13 @@ public final class AccessSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of access", params[0]).it();
         final Phi result = this.posix.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.access(
-                    new Dataized(params[0]).asString(),
+                    path,
                     new Int("the 'mode' argument of access", params[1]).it()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,9 +31,10 @@ public final class CreatSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of creat", params[0]).it();
         final Phi result = this.posix.take("return").copy();
         final int code = CStdLib.INSTANCE.creat(
-            new Dataized(params[0]).asString(),
+            path,
             new Int("the 'mode' argument of creat", params[1]).it()
         );
         result.put(0, new Data.ToPhi(code));

--- a/eo-runtime/src/main/java/org/eolang/posix/GetenvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/GetenvSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -30,8 +30,9 @@ public final class GetenvSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String name = new Cstring("the 'name' argument of getenv", params[0]).it();
         final Phi result = this.posix.take("return").copy();
-        final String env = CStdLib.INSTANCE.getenv(new Dataized(params[0]).asString());
+        final String env = CStdLib.INSTANCE.getenv(name);
         final boolean present = env != null;
         result.put(0, new Data.ToPhi(present));
         if (present) {

--- a/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,9 +31,10 @@ public final class MkdirSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of mkdir", params[0]).it();
         final Phi result = this.posix.take("return").copy();
         final int code = CStdLib.INSTANCE.mkdir(
-            new Dataized(params[0]).asString(),
+            path,
             new Int("the 'mode' argument of mkdir", params[1]).it()
         );
         result.put(0, new Data.ToPhi(code));

--- a/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,9 +31,10 @@ public final class OpenSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of open", params[0]).it();
         final Phi result = this.posix.take("return").copy();
         final int code = CStdLib.INSTANCE.open(
-            new Dataized(params[0]).asString(),
+            path,
             new Int("the 'flags' argument of open", params[1]).it(),
             new Int("the 'mode' argument of open", params[2]).it()
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/RenameSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RenameSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -30,11 +30,10 @@ public final class RenameSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String from = new Cstring("the 'from' argument of rename", params[0]).it();
+        final String target = new Cstring("the 'to' argument of rename", params[1]).it();
         final Phi result = this.posix.take("return").copy();
-        final int code = CStdLib.INSTANCE.rename(
-            new Dataized(params[0]).asString(),
-            new Dataized(params[1]).asString()
-        );
+        final int code = CStdLib.INSTANCE.rename(from, target);
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/posix/RmdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RmdirSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -30,8 +30,9 @@ public final class RmdirSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of rmdir", params[0]).it();
         final Phi result = this.posix.take("return").copy();
-        final int code = CStdLib.INSTANCE.rmdir(new Dataized(params[0]).asString());
+        final int code = CStdLib.INSTANCE.rmdir(path);
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
@@ -7,8 +7,8 @@ package org.eolang.posix;
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import java.util.function.ToIntBiFunction;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -49,7 +49,7 @@ public final class StatSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        final String path = new Dataized(params[0]).asString();
+        final String path = new Cstring("the 'path' argument of stat", params[0]).it();
         final FileStat info;
         final int code;
         if (Platform.isMac()) {

--- a/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -34,11 +34,10 @@ public final class SymlinkSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String target = new Cstring("the 'target' argument of symlink", params[0]).it();
+        final String path = new Cstring("the 'path' argument of symlink", params[1]).it();
         final Phi result = this.posix.take("return").copy();
-        final int code = CStdLib.INSTANCE.symlink(
-            new Dataized(params[0]).asString(),
-            new Dataized(params[1]).asString()
-        );
+        final int code = CStdLib.INSTANCE.symlink(target, path);
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/posix/UnlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/UnlinkSyscall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.posix;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -30,8 +30,9 @@ public final class UnlinkSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of unlink", params[0]).it();
         final Phi result = this.posix.take("return").copy();
-        final int code = CStdLib.INSTANCE.unlink(new Dataized(params[0]).asString());
+        final int code = CStdLib.INSTANCE.unlink(path);
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/test/java/org/eolang/CstringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CstringTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Cstring}.
+ * @since 0.57.0
+ */
+final class CstringTest {
+
+    @Test
+    void takesOrdinaryText() {
+        MatcherAssert.assertThat(
+            "text without a NUL must pass through unchanged, but it didnt",
+            new Cstring(
+                new Expect<>("the 'path' argument", () -> new Data.ToPhi("/tmp/file"))
+            ).it(),
+            Matchers.equalTo("/tmp/file")
+        );
+    }
+
+    @Test
+    void refusesTextWithNul() {
+        MatcherAssert.assertThat(
+            "text carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Cstring(
+                    new Expect<>(
+                        "the 'name' argument",
+                        () -> new Data.ToPhi(String.join(String.valueOf((char) 0), "PATH", "nope"))
+                    )
+                ).it(),
+                "text with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("the 'name' argument"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/posix/GetenvSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/GetenvSyscallTest.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link GetenvSyscall}.
+ * @since 0.57.0
+ */
+final class GetenvSyscallTest {
+
+    @Test
+    void refusesAnEnvironmentNameWithNul() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new GetenvSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(String.join(String.valueOf((char) 0), "PATH", "nope"))
+            ),
+            "a name whose NUL would make getenv read only its prefix must fail, not answer for that prefix"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7570.

EO strings can hold U+0000; C strings cannot. The POSIX adapters handed the text straight to JNA, so the native side saw the prefix before the NUL and answered for that instead: `getenv("PATH\0not-a-name")` came back with the value of `PATH`, and a path or rename argument addressed a file nobody asked about.

New `Cstring` says what a C call can accept, in the shape `Natural` already uses for sizes:

```java
new Cstring(new Expect<>("the 'path' argument of open", () -> params[0])).it()
```

Ten adapters now take their text through it: `access`, `creat`, `getenv`, `mkdir`, `open`, `rename` (both), `rmdir`, `stat`, `symlink` (both), `unlink`. The check happens before `CStdLib.INSTANCE` is touched, so bad text fails the same way on every platform rather than depending on the native library loading first.

`inet_addr` is the one string-taking adapter left alone, only because #7563 is already editing that file; it should follow once one of the two lands.

Tests: `CstringTest` covers the helper (ordinary text passes, embedded NUL and a lone NUL are refused with the argument named), and `GetenvSyscallTest` covers the wiring through a real adapter with the issue's own example. Both run everywhere, since the refusal precedes the native call. `CstringTest`: 3 run, `GetenvSyscallTest`: 1 run, 0 failures.
