### PR TITLE
fix(#7569): choose the positional vacancy under the same lock add uses

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -199,7 +199,12 @@ public class PhDefault implements Phi, Cloneable {
 
     @Override
     public void put(final int pos, final Phi object) {
-        this.put(this.vacancy(pos), object);
+        this.lock.lock();
+        try {
+            this.put(this.vacancy(pos), object);
+        } finally {
+            this.lock.unlock();
+        }
     }
 
     @Override

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultRaceTest.java
@@ -17,6 +17,30 @@ import org.junit.jupiter.api.RepeatedTest;
 final class PhDefaultRaceTest {
 
     @RepeatedTest(20)
+    void appliesPositionallyWhileAttributesAreAdded() {
+        final PhDefault phi = new PhDefault();
+        phi.add("first", new AtVoid("first"));
+        final Phi value = new Data.ToPhi(42L);
+        new Together<>(
+            16,
+            thread -> {
+                if (thread == 0) {
+                    phi.put(0, value);
+                } else {
+                    final String name = String.format("a%d", thread);
+                    phi.add(name, new AtVoid(name));
+                }
+                return true;
+            }
+        ).asList();
+        MatcherAssert.assertThat(
+            "a positional put must land on the attribute that was first when it was made, but it didnt",
+            new Dataized(phi.take("first")).asNumber(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @RepeatedTest(20)
     void loadsAttributesOnceUnderConcurrentTake() {
         final int threads = 32;
         final Phi phi = new PhDefault(


### PR DESCRIPTION
Fixes #7569.

`add()` mutates `order` while holding `lock`, but positional application walked the same list with no lock at all: `put(int, Phi)` called `vacancy()`, which reads `order.size()` and `order.get()`, and only then wrote the attribute. A concurrent `add()` could therefore grow the list under the reader, and the value could land on a vacancy other than the one the position chose.

The whole path is now under that lock: the vacancy is resolved and the attribute written before it is released. The lock is reentrant, so the inner `put(String, Phi)` and the `loaded()` calls behave as they did. No EO code runs inside: every `Attribute.put` in the runtime either stores the object (`AtVoid` does a compare-and-set) or refuses it, so nothing dataizes while the lock is held and there is no new path for a deadlock.

About the test, honestly: it races one positional `put(0, …)` against fifteen threads adding attributes, twenty times over, and checks the value landed on the attribute that was first. It passes with the fix, and it also passes on master, three runs of twenty out of three, because the window between reading `order` and writing is narrow. So it pins the contract rather than reproducing the race, which is the same thing the issue's suggested regression would do. Happy to drop it if you would rather not carry a green-either-way case.

`PhDefaultTest` (54), `PhDefaultRaceTest` (40), `PhApplicationTest` (19), `PhStickyTest` (11): 0 failures.
