### PR TITLE
fix(#7565): check the numbers that become C int arguments

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Int.java
+++ b/eo-runtime/src/main/java/org/eolang/Int.java
@@ -7,9 +7,15 @@ package org.eolang;
 
 /**
  * Transform {@link Expect} to Integer.
+ *
+ * <p>Public because the syscall adapters, which live in another package,
+ * map EO numbers onto C {@code int} parameters and have to refuse the
+ * numbers no such parameter can mean, the way {@link Natural} refuses the
+ * sizes.</p>
+ *
  * @since 0.51
  */
-final class Int {
+public final class Int {
 
     /**
      * Expect.
@@ -18,9 +24,18 @@ final class Int {
 
     /**
      * Ctor.
+     * @param subject What the number is, for the failure message
+     * @param phi The object holding the number
+     */
+    public Int(final String subject, final Phi phi) {
+        this(new Expect<>(subject, () -> phi));
+    }
+
+    /**
+     * Ctor.
      * @param expect Expect
      */
-    Int(final Expect<Phi> expect) {
+    public Int(final Expect<Phi> expect) {
         this.expect = expect;
     }
 
@@ -28,7 +43,7 @@ final class Int {
      * Return it.
      * @return The token
      */
-    Integer it() {
+    public Integer it() {
         return this.expect
             .that(phi -> new Dataized(phi).asNumber())
             .otherwise("must be a number")

--- a/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
@@ -7,6 +7,7 @@ package org.eolang.posix;
 import com.sun.jna.ptr.IntByReference;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.SockaddrIn;
@@ -38,14 +39,14 @@ public final class AcceptSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.accept(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Int("the 'descriptor' argument of accept", params[0]).it(),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
                     ),
-                    new IntByReference(new Dataized(params[2]).asNumber().intValue())
+                    new IntByReference(new Int("the 'length' argument of accept", params[2]).it())
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -37,7 +38,7 @@ public final class AccessSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.access(
                     new Dataized(params[0]).asString(),
-                    new Dataized(params[1]).asNumber().intValue()
+                    new Int("the 'mode' argument of access", params[1]).it()
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.SockaddrIn;
@@ -37,14 +38,14 @@ public final class BindSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.bind(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Int("the 'descriptor' argument of bind", params[0]).it(),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
                     ),
-                    new Dataized(params[2]).asNumber().intValue()
+                    new Int("the 'length' argument of bind", params[2]).it()
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/CloseSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CloseSyscall.java
@@ -5,7 +5,7 @@
 package org.eolang.posix;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,11 +31,11 @@ public final class CloseSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int descriptor = new Int(
+            "the 'descriptor' argument of close", params[0]
+        ).it();
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(CStdLib.INSTANCE.close(new Dataized(params[0]).asNumber().intValue()))
-        );
+        result.put(0, new Data.ToPhi(CStdLib.INSTANCE.close(descriptor)));
         result.put(1, new PhDefault());
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.SockaddrIn;
@@ -37,14 +38,14 @@ public final class ConnectSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.connect(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Int("the 'descriptor' argument of connect", params[0]).it(),
                     new SockaddrIn(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
                     ),
-                    new Dataized(params[2]).asNumber().intValue()
+                    new Int("the 'length' argument of connect", params[2]).it()
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -33,7 +34,7 @@ public final class CreatSyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final int code = CStdLib.INSTANCE.creat(
             new Dataized(params[0]).asString(),
-            new Dataized(params[1]).asNumber().intValue()
+            new Int("the 'mode' argument of creat", params[1]).it()
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/posix/ListenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ListenSyscall.java
@@ -5,7 +5,7 @@
 package org.eolang.posix;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -36,8 +36,8 @@ public final class ListenSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.listen(
-                    new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).asNumber().intValue()
+                    new Int("the 'descriptor' argument of listen", params[0]).it(),
+                    new Int("the 'backlog' argument of listen", params[1]).it()
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -33,7 +34,7 @@ public final class MkdirSyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final int code = CStdLib.INSTANCE.mkdir(
             new Dataized(params[0]).asString(),
-            new Dataized(params[1]).asNumber().intValue()
+            new Int("the 'mode' argument of mkdir", params[1]).it()
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
@@ -6,6 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -33,8 +34,8 @@ public final class OpenSyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final int code = CStdLib.INSTANCE.open(
             new Dataized(params[0]).asString(),
-            new Dataized(params[1]).asNumber().intValue(),
-            new Dataized(params[2]).asNumber().intValue()
+            new Int("the 'flags' argument of open", params[1]).it(),
+            new Int("the 'mode' argument of open", params[2]).it()
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import java.util.Arrays;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -39,7 +39,7 @@ public final class ReadSyscall implements Syscall {
         final Phi result = this.posix.take("return").copy();
         final byte[] buf = new byte[size];
         final int count = CStdLib.INSTANCE.read(
-            new Dataized(params[0]).asNumber().intValue(), buf, size
+            new Int("the 'descriptor' argument of read", params[0]).it(), buf, size
         );
         result.put(0, new Data.ToPhi(count));
         result.put(1, new Data.ToPhi(Arrays.copyOf(buf, Math.max(count, 0))));

--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import java.util.Arrays;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -39,10 +39,10 @@ public final class RecvSyscall implements Syscall {
         ).it();
         final byte[] buf = new byte[size];
         final int received = CStdLib.INSTANCE.recv(
-            new Dataized(params[0]).asNumber().intValue(),
+            new Int("the 'descriptor' argument of recv", params[0]).it(),
             buf,
             size,
-            new Dataized(params[2]).asNumber().intValue()
+            new Int("the 'flags' argument of recv", params[2]).it()
         );
         result.put(0, new Data.ToPhi(received));
         result.put(1, new Data.ToPhi(Arrays.copyOf(buf, Math.max(received, 0))));

--- a/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
@@ -8,6 +8,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -49,10 +50,10 @@ public final class SendSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.send(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Int("the 'descriptor' argument of send", params[0]).it(),
                     buf,
                     size,
-                    new Dataized(params[3]).asNumber().intValue()
+                    new Int("the 'flags' argument of send", params[3]).it()
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/SocketSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SocketSyscall.java
@@ -5,7 +5,7 @@
 package org.eolang.posix;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -36,9 +36,9 @@ public final class SocketSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.socket(
-                    new Dataized(params[0]).asNumber().intValue(),
-                    new Dataized(params[1]).asNumber().intValue(),
-                    new Dataized(params[2]).asNumber().intValue()
+                    new Int("the 'domain' argument of socket", params[0]).it(),
+                    new Int("the 'type' argument of socket", params[1]).it(),
+                    new Int("the 'protocol' argument of socket", params[2]).it()
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/StrerrorSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StrerrorSyscall.java
@@ -5,7 +5,7 @@
 package org.eolang.posix;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,11 +31,9 @@ public final class StrerrorSyscall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int errno = new Int("the 'errno' argument of strerror", params[0]).it();
         final Phi result = this.posix.take("return").copy();
-        result.put(
-            0,
-            new Data.ToPhi(CStdLib.INSTANCE.strerror(new Dataized(params[0]).asNumber().intValue()))
-        );
+        result.put(0, new Data.ToPhi(CStdLib.INSTANCE.strerror(errno)));
         result.put(1, new PhDefault());
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
@@ -8,6 +8,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -49,7 +50,7 @@ public final class WriteSyscall implements Syscall {
             0,
             new Data.ToPhi(
                 CStdLib.INSTANCE.write(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    new Int("the 'descriptor' argument of write", params[0]).it(),
                     buf,
                     size
                 )

--- a/eo-runtime/src/test/java/org/eolang/posix/StrerrorSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/StrerrorSyscallTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link StrerrorSyscall}.
+ * @since 0.57.0
+ */
+final class StrerrorSyscallTest {
+
+    @Test
+    void refusesAFractionalErrorNumber() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new StrerrorSyscall(Phi.Φ.take("posix").copy()).make(new Data.ToPhi(2.5)),
+            "a fractional error number must fail instead of quietly looking up another error"
+        );
+    }
+
+    @Test
+    void refusesAnErrorNumberBeyondIntRange() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new StrerrorSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(3.0e9)
+            ),
+            "an error number past the int range must fail instead of saturating"
+        );
+    }
+}


### PR DESCRIPTION
Fixes #7565.

The POSIX adapters turned an EO number into a C `int` with `Double.intValue()`, which truncates and saturates without saying so. `posix "strerror" 2.5` looked up error 2 and answered `No such file or directory`, as if that had been asked for. The same conversion carried descriptors, flags, modes, socket family and type, backlog and address lengths, so a malformed number could act on a descriptor or a flag set the program never named. The size arguments of `read`, `write`, `recv` and `send` were already checked, through `Natural`.

`Int`, which already spells out that check, is now public next to `Natural`, and the twenty-four remaining conversions go through it:

```java
new Int(new Expect<>("the 'flags' argument of open", () -> params[1])).it()
```

A fractional number, a non-finite one, and one outside the `int` range are refused, each naming the argument it came from. Sizes keep `Natural`, since they need the stronger non-negative check as well.

`StrerrorSyscall` also has its conversion hoisted above the native call, so the issue's own example can be tested on any platform rather than only where the C library loads. Its two tests fail without the change and pass with it. `SyscallTest`: 12 run, 0 failures.
