### PR TITLE
fix(maven-plugin): stream the raw coverage hits instead of listing them

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -11,8 +11,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -45,6 +45,18 @@ import org.eolang.parser.EoSyntax;
  * body at all. Such a file used to be absent from the tracefile
  * altogether, which left the report unable to tell it apart from a file
  * that was never compiled (#7057).</p>
+ *
+ * <p>The raw hits are read one line at a time and never held together in
+ * memory. What the report keeps out of them is one counter per line of
+ * source, so its own size is bounded by the manifest, but the file the
+ * runtime appends to is not: every {@code PhCoverage} wrapper starts with
+ * a dedup set of its own, so a location touched through many instances of
+ * the same object is appended once per instance (#6508), and a whole test
+ * suite leaves gigabytes of duplicates behind for the few thousand
+ * distinct locations in them. Reading that file into a list first is what
+ * killed the {@code eo-runtime} coverage build with an
+ * {@code OutOfMemoryError} once it outgrew the 4Gb heap
+ * {@code .mvn/jvm.config} gives Maven.</p>
  *
  * @since 0.75.0
  */
@@ -126,12 +138,15 @@ public final class MjCoverageReport extends MjSafe {
                 }
             }
         }
-        final List<String> records = Files.readAllLines(this.hits.toPath());
-        for (final String hit : records) {
-            final String source = fileof.get(hit);
-            if (source != null) {
-                perfile.get(source).merge(lineof.get(hit), 1, Integer::sum);
-            }
+        try (Stream<String> records = Files.lines(this.hits.toPath())) {
+            records.forEach(
+                hit -> {
+                    final String source = fileof.get(hit);
+                    if (source != null) {
+                        perfile.get(source).merge(lineof.get(hit), 1, Integer::sum);
+                    }
+                }
+            );
         }
         final LcovReport report = new LcovReport(perfile);
         new Saved(report.text(), this.lcov.toPath()).value();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -10,6 +10,7 @@ import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -53,6 +54,34 @@ final class MjCoverageReportTest {
             "the LCOV report must record at least one hit line, but LH:0 everywhere",
             Files.readString(lcov),
             Matchers.not(Matchers.containsString("LH:0"))
+        );
+    }
+
+    @Test
+    void countsEveryRepeatOfTheSameLocation(@Mktmp final Path temp) throws Exception {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(System.lineSeparator(), "[] > x", "  42 > y")
+        ).execute(MjParse.class);
+        final String location = new CoverageManifest().locations(
+            new XMLDocument(maven.programTojo().xmir())
+        ).iterator().next();
+        final int last = location.lastIndexOf(':');
+        final String line = location.substring(
+            location.lastIndexOf(':', last - 1) + 1, last
+        );
+        final int repeats = 10_000;
+        final Path hits = temp.resolve("coverage.txt");
+        Files.write(hits, Collections.nCopies(repeats, location));
+        final Path lcov = temp.resolve("coverage.info");
+        maven.with("hits", hits.toFile())
+            .with("lcov", lcov.toFile())
+            .execute(MjCoverageReport.class);
+        MatcherAssert.assertThat(
+            "every repeat of a location must be counted, however many of them the raw hits file holds, but they werent",
+            Files.readString(lcov),
+            Matchers.containsString(
+                String.format("DA:%s,%d", line, repeats)
+            )
         );
     }
 


### PR DESCRIPTION
Fixes the `codecov` build failure in [run 32758039406](https://github.com/objectionary/eo/actions/runs/32758039406/job/97530027329):

```
[INFO] --- eo:1.0-SNAPSHOT:coverage-report (coverage-report) @ eo-runtime ---
java.lang.OutOfMemoryError: Java heap space
Dumping heap to java_pid2166.hprof ...
Heap dump file created [5181782225 bytes in 16.327 secs]
[ERROR] Failed to execute goal org.eolang:eo-maven-plugin:1.0-SNAPSHOT:coverage-report
  (coverage-report) on project eo-runtime: 'MjCoverageReport' execution failed:
  java.lang.OutOfMemoryError: Java heap space
```

## Diagnosis

Not flaky, and not caused by any one of the recent merges — it is a threshold that the build had been walking towards for a while and finally crossed.

`MjCoverageReport.report()` read the whole `eo.coverageFile` into a `List<String>` before counting it. That file is not bounded by the manifest the report is built from. Every `PhCoverage` wrapper starts with a dedup set of its own, so a location touched through many instances of the same object is appended once per instance — the very thing the `#6508` puzzle in `PhCoverage` is about. A local `eo-runtime` run with `-Deo.coverageTracking=true` left:

| | |
|---|---|
| `target/coverage.txt` | 1,153,650,734 bytes |
| lines in it | 44,287,231 |
| distinct locations in the report | ~6,000 |

Holding those 44M lines as `String`s needs more than 3Gb of the 4Gb heap `.mvn/jvm.config` gives Maven, measured directly on that exact file:

| how it is read | `-Xmx256m` | `-Xmx3072m` | `-Xmx4096m` |
|---|---|---|---|
| `Files.readAllLines` | OOM | OOM | ok |
| one line at a time | ok | ok | ok |

So the goal was finishing with under a gigabyte of headroom for everything else it does (Saxon, re-parsing 171 `.eo` sources, the tojos). Anything that nudged the file a little bigger tipped it over, which is what happened on master.

Reproduced end to end by growing that same file by 25% (55,287,231 lines, 1.44Gb) and running the goal against it:

* before this change → `java.lang.OutOfMemoryError: Java heap space`, heap dump **5,152,623,043 bytes** — the same failure as CI, whose dump was 5,181,782,225 bytes;
* after this change → `EO object coverage: 75.3%, LCOV report saved to ...`, `BUILD SUCCESS`, ~48s.

## Changes

* `MjCoverageReport` counts the raw hits off a lazy `Files.lines` stream instead of materialising them with `Files.readAllLines`. Same counters, same LCOV output, memory now bounded by the manifest rather than by the file — the file can be any size at all. A mid-read `IOException` still fails the build the same way: `Deadline.spent` reports whatever `exec()` throws, checked or not, as a `MojoFailureException`. Class javadoc explains why.
* `MjCoverageReportTest.countsEveryRepeatOfTheSameLocation` covers the counting loop over a file that repeats one location 10,000 times, so the `DA:` count stays exact when the file is mostly duplicates.

Left alone deliberately: the duplicates themselves. A `PhCoverage` set shared by the whole program would shrink this file by four orders of magnitude, but that is `#6508`'s job and it changes what the `DA:` counts mean.

## Verification

* `mvn test -pl eo-maven-plugin -Dtest=MjCoverageReportTest,LcovReportTest,CoverageManifestTest` — 21 tests, all pass.
* `mvn -Pqulice qulice:check -pl eo-maven-plugin` — `BUILD SUCCESS`.
* The `coverage-report` goal run against the real 1.44Gb hits file, as above, three times: 48s, 48s, and once 1:27 on a loaded machine.
* Reading 55.3M lines off `Files.lines` and off a `BufferedReader` loop benchmarked the same (~7.2s each), so the stream costs nothing over an explicit read loop and keeps the `nulls` count level with master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013kyobC1tW1qBedDLniPbMC