### PR TITLE
fix(#7583): keep the coverage retry test off transpiled objects

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -29,6 +29,13 @@ import org.junit.jupiter.api.parallel.Isolated;
  * instrumentation is on, a concurrent test would append its own hits to
  * this test's file and break the exact-contents assertion.</p>
  *
+ * <p>For the same reason every test that asserts on the contents of that
+ * file wraps a plain {@link PhDefault} and never a transpiled object like
+ * {@link Data.ToPhi}: with {@code eo.coverageTracking} on, the generated
+ * objects are themselves wrapped into {@link PhCoverage}, so dataizing one
+ * appends its own locations to the very file the test has just pointed the
+ * property at.</p>
+ *
  * @since 0.58
  */
 @Isolated
@@ -80,7 +87,9 @@ final class PhCoverageTest {
         final String before = System.getProperty("eo.coverageFile");
         System.setProperty("eo.coverageFile", hits.toString());
         try {
-            final Phi covered = new PhCoverage(new Data.ToPhi(1L), "Φ.retry:4:2");
+            final Phi covered = new PhCoverage(
+                new PhDefault(new byte[] {(byte) 0x01}), "Φ.retry:4:2"
+            );
             Assertions.assertThrows(
                 UncheckedIOException.class,
                 covered::delta,


### PR DESCRIPTION
The `codecov` job is [red on `master`](https://github.com/objectionary/eo/actions/runs/32825699881/job/97733122077):

```
[ERROR] PhCoverageTest.recordsALocationOnceTheDestinationBecomesWritable:91
  a location must be recorded once the destination becomes writable, but it wasnt
Expected: iterable containing ["Φ.retry:4:2"]
     but: not matched: "Φ.number.φ:13:2"
```

## Why it fails only there

That job is the only one that builds with `-Deo.coverageTracking=true`; `mvn.yml` and `ec2.yml` both pass `-Deo.coverageTracking=false`. With the flag on, `MjTranspile` wraps every located object of the generated EO classes into `PhCoverage`.

The test added in 3cb0be0 wrapped a `Data.ToPhi(1L)`, which dataizes the generated `number`. Under instrumentation, `number`'s own wrappers append `Φ.number.φ:13:2` to whatever `eo.coverageFile` currently names — and the test had just pointed that property at its own temp file. So after the retry the file held two lines, and `Matchers.contains(...)`, which asserts the exact contents, failed on the extra one.

## The fix

Wrap a plain `PhDefault` with raw bytes, as every other test in the class that asserts on the contents of that file already does. The test keeps its intent — a hit whose append failed is still recorded once the destination becomes writable — without dragging transpiled objects into the assertion. The class javadoc now records the reason, next to the existing note about `@Isolated`.

## Verification

Reproduced the failure outside CI by standing in for the instrumented `number` with a nested `PhCoverage`:

```
contents=[Φ.retry:4:2, Φ.number.φ:13:2]   # before
contents=[Φ.retry:4:2]                    # after
```

Ran `PhCoverageTest` against the runtime sources: the six tests that need no transpiled classes all pass, including the one that was failing. `staysEqualToItsOrigin` could not run in that harness — it uses `Data.ToPhi` and so needs the generated `EOnumber` on the classpath; it is untouched by this change and passes in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_016eeoT1SEWfthGYCAj4MJro)_