### PR TITLE
fix(deps): keep Maven Resolver on 1.x

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -15,6 +15,7 @@
   <name>eo-maven-plugin</name>
   <description>EO-to-Java Maven Plugin</description>
   <properties>
+    <!-- Don't upgrade to 2.x: there is no maven-resolver-supplier there and Maven 3.9 ships resolver 1.x -->
     <maven.resolver.version>1.9.27</maven.resolver.version>
   </properties>
   <dependencies>

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,14 @@
       "matchPackageNames": [
         "maven-compiler-plugin"
       ]
+    },
+    {
+      "description": "Maven Resolver 2.x has no maven-resolver-supplier artifact and targets Maven 4, while eo-maven-plugin runs inside Maven 3.9",
+      "allowedVersions": "<2",
+      "matchPackageNames": [
+        "org.apache.maven.resolver:maven-resolver-api",
+        "org.apache.maven.resolver:maven-resolver-supplier"
+      ]
     }
   ]
 }


### PR DESCRIPTION
The `site` build failed on Renovate's `renovate/major-maven.resolver.version` branch (PR #5014, [run 32828064330](https://github.com/objectionary/eo/actions/runs/32828064330/job/97740383782)):

```
[ERROR] Failed to execute goal on project eo-maven-plugin: Could not resolve dependencies
  for project org.eolang:eo-maven-plugin:maven-plugin:1.0-SNAPSHOT
[ERROR] dependency: org.apache.maven.resolver:maven-resolver-supplier:jar:2.0.21 (provided)
[ERROR]   Could not find artifact org.apache.maven.resolver:maven-resolver-supplier:jar:2.0.21
  in central (https://repo.maven.apache.org/maven2)
```

Two reasons the bump cannot work:

1. `eo-maven-plugin/pom.xml` drives both `maven-resolver-api` and `maven-resolver-supplier` from one `maven.resolver.version` property. `maven-resolver-api` has a `2.0.21` release, but `maven-resolver-supplier` [stops at `1.9.27`](https://repo.maven.apache.org/maven2/org/apache/maven/resolver/maven-resolver-supplier/maven-metadata.xml) — Resolver 2.0 replaced it with `maven-resolver-supplier-mvn3`/`-mvn4`. So raising the shared property makes the artifact unresolvable, and the reactor dies at `eo-maven-plugin`.
2. Even with the artifact renamed, Resolver 2.x targets Maven 4, while the plugin declares `maven-core`, `maven-plugin-api` and `maven-resolver-provider` at `3.9.16` and runs inside Maven 3.9, which supplies Resolver 1.x at runtime. All the resolver dependencies are `provided`, so compiling against the 2.x API would fail at runtime rather than at build time.

So the fix is to stop the major bump, not to chase it.

## Changes

- `renovate.json` — add a package rule capping `org.apache.maven.resolver:maven-resolver-api` and `org.apache.maven.resolver:maven-resolver-supplier` at `<2`, with a `description` recording why. Renovate closes the open major PR once this lands.
- `eo-maven-plugin/pom.xml` — one-line comment above `maven.resolver.version` so the pin is visible where the version is set.

No Java or build-logic changes; `master` stays on `1.9.27`, which is the latest 1.x.

## Follow-up

PR #5014 stays red until Renovate re-evaluates. Left it open — say the word and I'll close it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DFwMDu3q852kSXqZKmUpnu)_