### PR TITLE
fix(#7518): create a temporary file readable only by its owner

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -76,7 +76,7 @@
           plus.
             posix.rdonly.plus posix.creat
             posix.exclusive
-          posix.mode
+          posix.private
   [^] > tmpfile
     ^.exists.if > @
       Q.file touch.as-bytes
@@ -275,6 +275,19 @@
       temp.deleted
       regular
     temp.is-directory.not > regular!
+    mktemp.tmpfile > temp
+
+  ++> can-create-a-tmpfile-only-its-owner-can-read
+    seq * > @
+      owned
+      temp.deleted
+      owned
+    called. > info
+      posix *1
+        "stat"
+        temp.path
+    os.is-windows.or > owned!
+      info.output.mode.eq 33152
     mktemp.tmpfile > temp
 
   ++> can-create-an-empty-tmpfile

--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -28,6 +28,7 @@
   420 > mode
   -1 > none
   511 > permissions
+  384 > private
   0 > rdonly
   2 > rdwr
   [^ code output] > return


### PR DESCRIPTION
Closes #7518.

`directory.tmpfile` opened its file with `posix.mode`, which is 420 (0644). A temporary file lands in a world-writable shared directory, so every local user could read it. The name is built from the clock, the pid, an index and a clock-seeded pseudo-random number, so it is guessable, which makes the readable mode matter more than it otherwise would.

## What changed

- `posix.eo` gains `384 > private`, that is 0600 — the mode `mkstemp(3)` guarantees, and for the same reason.
- `directory.eo` opens the temporary file with `posix.private` instead of `posix.mode`. `posix.mode` stays 0644 for `file.touched`, where an ordinary file is what is being made.
- The Windows half of the same `opened` already passes `win32.mode`, which is 384, so it needed no change.

## Test

`can-create-a-tmpfile-only-its-owner-can-read` stats the file `mktemp.tmpfile` just created and asserts `st_mode` is 33152, that is 0100600: a regular file whose permissions are owner read and write and nothing else. Before this change the same stat reads 33188 (0100644). The test is skipped on Windows, where the C runtime's `_stat64` reports no group or other bits to check.

Verified locally: the new test and the neighbouring `can-create-a-regular-tmpfile` and `can-create-an-empty-tmpfile` all dataize to `true`, and `mvn test-compile -pl :eo-runtime` passes the `format` and `compile` (lint) goals.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JugyPW5uZJCeNWbsm6tKnF)_