### PR TITLE
#7634: escape existing underscores in `eo:loc-to-class`

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -183,7 +183,7 @@
   <!-- Convert location to class name -->
   <xsl:function name="eo:loc-to-class">
     <xsl:param name="loc"/>
-    <xsl:value-of select="concat('EO', eo:identifier(replace(translate(string-join(tokenize($loc, '\.'), ''), '-', '_'), $eo:cactoos, $eo:alpha)))"/>
+    <xsl:value-of select="concat('EO', eo:identifier(replace(translate(replace(string-join(tokenize($loc, '\.'), ''), '_', '__'), '-', '_'), $eo:cactoos, $eo:alpha)))"/>
   </xsl:function>
   <!-- Get RHO variable depends on context -->
   <xsl:function name="eo:rho">

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/hyphen-and-underscore-nested-classes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/hyphen-and-underscore-nested-classes.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - /object/class/java[contains(text(), 'private static class EOΦmaina_bφα0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'private static class EOΦmaina__bφα0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'new EOΦmaina_bφα0();')]
+  - /object/class/java[contains(text(), 'new EOΦmaina__bφα0();')]
+input: |
+  [] > main
+    [] > a-b
+      foo > @
+        []
+          42 > @
+    [] > a_b
+      foo > @
+        []
+          43 > @


### PR DESCRIPTION
`eo:loc-to-class()` mapped a hyphen to an underscore without escaping an
underscore already present in the locator, so `Φ.main.a-b.φ.α0` and
`Φ.main.a_b.φ.α0` produced the same nested class name. Now it escapes `_` to
`__` first, the same way `eo:clean()` does.

New transpile pack asserts both nested classes are declared and instantiated
under distinct names.

Closes #7634
