### PR TITLE
#7636: copy every entry given to `Attrs`

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Attr.java
+++ b/eo-runtime/src/main/java/org/eolang/Attr.java
@@ -10,14 +10,16 @@ import java.util.AbstractMap;
  * A {@link java.util.Map.Entry} of an attribute name to its {@link Attribute}.
  *
  * <p>This is just a typed alias for
- * {@link AbstractMap.SimpleEntry SimpleEntry&lt;String, Attr&gt;}, kept short
- * so that subclasses of {@link PhDefault} can write
+ * {@link AbstractMap.SimpleImmutableEntry SimpleImmutableEntry&lt;String,
+ * Attr&gt;}, kept short so that subclasses of {@link PhDefault} can write
  * {@code super(new Attrs(new Attr("x", new AtVoid("x"))))} without
- * any method calls in the constructor body.</p>
+ * any method calls in the constructor body. The entry is immutable, so an
+ * {@link Attrs} it was handed to keeps what it was given, no matter what the
+ * caller does with its own copy of the entry afterwards.</p>
  *
  * @since 0.59
  */
-public final class Attr extends AbstractMap.SimpleEntry<String, Attribute> {
+public final class Attr extends AbstractMap.SimpleImmutableEntry<String, Attribute> {
 
     /**
      * Serialization identifier.

--- a/eo-runtime/src/main/java/org/eolang/Attrs.java
+++ b/eo-runtime/src/main/java/org/eolang/Attrs.java
@@ -20,23 +20,18 @@ import java.util.Set;
  * call) being acceptable as a {@code Map.Entry} factory.</p>
  *
  * <p>The underlying {@link LinkedHashMap} is built lazily on first access, so
- * the constructor does nothing but copy the key and the value of every entry
- * it was given. The copy is what keeps the map immune to a caller that
- * mutates its own array, or any entry inside it, after handing it over.</p>
+ * the constructor does nothing but copy the array it was given. The copy of
+ * the array, together with the immutability of {@link Attr}, is what keeps the
+ * map immune to a caller that changes what it handed over.</p>
  *
  * @since 0.59
  */
 public final class Attrs extends AbstractMap<String, Attribute> {
 
     /**
-     * Names of the initial entries, our own copy of them.
+     * Initial entries supplied via constructor, our own copy of them.
      */
-    private final String[] names;
-
-    /**
-     * Attributes of the initial entries, our own copy of them.
-     */
-    private final Attribute[] attributes;
+    private final Attr[] entries;
 
     /**
      * Lazily-resolved backing map.
@@ -47,15 +42,9 @@ public final class Attrs extends AbstractMap<String, Attribute> {
      * Ctor.
      * @param initial Entries to populate the map with
      */
-    @SafeVarargs
-    public Attrs(final Map.Entry<String, Attribute>... initial) {
+    public Attrs(final Attr... initial) {
         super();
-        this.names = new String[initial.length];
-        this.attributes = new Attribute[initial.length];
-        for (int idx = 0; idx < initial.length; ++idx) {
-            this.names[idx] = initial[idx].getKey();
-            this.attributes[idx] = initial[idx].getValue();
-        }
+        this.entries = initial.clone();
     }
 
     @Override
@@ -70,9 +59,9 @@ public final class Attrs extends AbstractMap<String, Attribute> {
 
     private Map<String, Attribute> resolve() {
         if (this.resolved == null) {
-            final Map<String, Attribute> map = new LinkedHashMap<>(this.names.length);
-            for (int idx = 0; idx < this.names.length; ++idx) {
-                map.put(this.names[idx], this.attributes[idx]);
+            final Map<String, Attribute> map = new LinkedHashMap<>(this.entries.length);
+            for (final Map.Entry<String, Attribute> ent : this.entries) {
+                map.put(ent.getKey(), ent.getValue());
             }
             this.resolved = map;
         }

--- a/eo-runtime/src/main/java/org/eolang/Attrs.java
+++ b/eo-runtime/src/main/java/org/eolang/Attrs.java
@@ -20,18 +20,23 @@ import java.util.Set;
  * call) being acceptable as a {@code Map.Entry} factory.</p>
  *
  * <p>The underlying {@link LinkedHashMap} is built lazily on first access, so
- * the constructor does nothing but copy the entries it was given. The copy is
- * what keeps the map immune to a caller that mutates its own array after
- * handing it over.</p>
+ * the constructor does nothing but copy the key and the value of every entry
+ * it was given. The copy is what keeps the map immune to a caller that
+ * mutates its own array, or any entry inside it, after handing it over.</p>
  *
  * @since 0.59
  */
 public final class Attrs extends AbstractMap<String, Attribute> {
 
     /**
-     * Initial entries supplied via constructor, our own copy of them.
+     * Names of the initial entries, our own copy of them.
      */
-    private final Map.Entry<String, Attribute>[] entries;
+    private final String[] names;
+
+    /**
+     * Attributes of the initial entries, our own copy of them.
+     */
+    private final Attribute[] attributes;
 
     /**
      * Lazily-resolved backing map.
@@ -45,7 +50,12 @@ public final class Attrs extends AbstractMap<String, Attribute> {
     @SafeVarargs
     public Attrs(final Map.Entry<String, Attribute>... initial) {
         super();
-        this.entries = initial.clone();
+        this.names = new String[initial.length];
+        this.attributes = new Attribute[initial.length];
+        for (int idx = 0; idx < initial.length; ++idx) {
+            this.names[idx] = initial[idx].getKey();
+            this.attributes[idx] = initial[idx].getValue();
+        }
     }
 
     @Override
@@ -60,9 +70,9 @@ public final class Attrs extends AbstractMap<String, Attribute> {
 
     private Map<String, Attribute> resolve() {
         if (this.resolved == null) {
-            final Map<String, Attribute> map = new LinkedHashMap<>(this.entries.length);
-            for (final Map.Entry<String, Attribute> ent : this.entries) {
-                map.put(ent.getKey(), ent.getValue());
+            final Map<String, Attribute> map = new LinkedHashMap<>(this.names.length);
+            for (int idx = 0; idx < this.names.length; ++idx) {
+                map.put(this.names[idx], this.attributes[idx]);
             }
             this.resolved = map;
         }

--- a/eo-runtime/src/test/java/org/eolang/AttrsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AttrsTest.java
@@ -6,6 +6,7 @@ package org.eolang;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -39,13 +40,17 @@ final class AttrsTest {
     }
 
     @Test
-    void ignoresLaterChangesToTheEntryItWasGiven() {
+    void refusesToChangeTheEntryItWasGiven() {
         final Attribute attr = new AtVoid("x");
         final Attr entry = new Attr("x", attr);
         final Attrs attrs = new Attrs(entry);
-        entry.setValue(new AtVoid("y"));
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            () -> entry.setValue(new AtVoid("y")),
+            "an entry already given away must not be changeable, but it was"
+        );
         MatcherAssert.assertThat(
-            "a change to the entry must not reach the attributes, but it did",
+            "the attributes must still hold what the entry was made with, but they didnt",
             attrs.get("x"),
             Matchers.sameInstance(attr)
         );

--- a/eo-runtime/src/test/java/org/eolang/AttrsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/AttrsTest.java
@@ -39,6 +39,19 @@ final class AttrsTest {
     }
 
     @Test
+    void ignoresLaterChangesToTheEntryItWasGiven() {
+        final Attribute attr = new AtVoid("x");
+        final Attr entry = new Attr("x", attr);
+        final Attrs attrs = new Attrs(entry);
+        entry.setValue(new AtVoid("y"));
+        MatcherAssert.assertThat(
+            "a change to the entry must not reach the attributes, but it did",
+            attrs.get("x"),
+            Matchers.sameInstance(attr)
+        );
+    }
+
+    @Test
     void countsTheEntriesWithoutReadingThemAll() {
         MatcherAssert.assertThat(
             "the size must count every entry given, but it didnt",


### PR DESCRIPTION
`Attrs` cloned only the varargs array, so every entry inside it stayed shared
with the caller and `setValue()` on it changed what the object was built with.
`Attr` now extends `AbstractMap.SimpleImmutableEntry`, so an entry cannot be
changed after it is handed over, and `Attrs` takes `Attr` rather than any
`Map.Entry`. Copying the entries inside the constructor was the other option,
but a constructor here must stay free of method calls.

New test in `AttrsTest` tries to change the entry after handing it over and
checks the map still holds what it was given.

Closes #7636
