### PR TITLE
#7637: reject two arguments bound to one slot

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -60,6 +60,7 @@ public final class Canonical implements UnaryOperator<XML> {
         "/org/eolang/parser/parse/add-default-package.xsl",
         "/org/eolang/parser/parse/roll-bases.xsl",
         "/org/eolang/parser/parse/mandatory-as.xsl",
+        "/org/eolang/parser/parse/validate-bindings.xsl",
         "/org/eolang/parser/parse/set-locators.xsl"
     );
 

--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -44,6 +44,7 @@ public final class Canonical implements UnaryOperator<XML> {
         "/org/eolang/parser/parse/wrap-applications.xsl",
         "/org/eolang/parser/parse/resolve-local-names.xsl",
         "/org/eolang/parser/parse/validate-before-stars.xsl",
+        "/org/eolang/parser/parse/validate-bindings.xsl",
         "/org/eolang/parser/parse/resolve-before-stars.xsl",
         "/org/eolang/parser/parse/fragile-dispatch.xsl",
         "/org/eolang/parser/parse/wrap-method-calls.xsl",
@@ -60,7 +61,6 @@ public final class Canonical implements UnaryOperator<XML> {
         "/org/eolang/parser/parse/add-default-package.xsl",
         "/org/eolang/parser/parse/roll-bases.xsl",
         "/org/eolang/parser/parse/mandatory-as.xsl",
-        "/org/eolang/parser/parse/validate-bindings.xsl",
         "/org/eolang/parser/parse/set-locators.xsl"
     );
 

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-bindings.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-bindings.xsl
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="validate-bindings" version="2.0">
+  <!--
+  Here we add an error with severity 'critical' when two arguments of one
+  application are bound to the same slot, since they cannot both be written
+  into a single attribute.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/object">
+    <xsl:variable name="errors" as="element()*">
+      <xsl:for-each select="descendant::o[@as]">
+        <xsl:variable name="as" select="@as"/>
+        <xsl:if test="preceding-sibling::o[@as=$as]">
+          <error>
+            <xsl:attribute name="check" select="'validate-bindings'"/>
+            <xsl:attribute name="line" select="if (@line) then @line else 0"/>
+            <xsl:attribute name="severity" select="'critical'"/>
+            <xsl:if test="@pos">
+              <xsl:attribute name="pos" select="@pos"/>
+            </xsl:if>
+            <xsl:value-of select="concat('Argument is bound to &quot;', $as, '&quot;, which is already taken by another argument')"/>
+          </error>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:copy>
+      <xsl:apply-templates select="(node() except errors)|@*"/>
+      <xsl:if test="exists($errors) or exists(/object/errors)">
+        <errors>
+          <xsl:apply-templates select="/object/errors/error"/>
+          <xsl:copy-of select="$errors"/>
+        </errors>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-bindings.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-bindings.xsl
@@ -12,7 +12,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/object">
     <xsl:variable name="errors" as="element()*">
-      <xsl:for-each select="descendant::o[@as]">
+      <xsl:for-each select=".//o[@as]">
         <xsl:variable name="as" select="@as"/>
         <xsl:if test="preceding-sibling::o[@as=$as]">
           <error>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-arguments-in-one-slot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/two-arguments-in-one-slot.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  Argument is bound to "α0", which is already taken by another argument
+input: |
+  [] > main
+    foo 1:0 2:0 > @


### PR DESCRIPTION
`foo 1:0 2:0` parsed without errors and produced two arguments with the same
`@as` and the same locator, though only one of them can ever be written into
the attribute. A new `validate-bindings.xsl` sheet reports the second argument
that lands in a slot already taken, named or numbered.

Closes #7637
