### PR TITLE
#7639: reject one alias declared twice

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -54,6 +54,7 @@ public final class Canonical implements UnaryOperator<XML> {
         "/org/eolang/parser/parse/validate-object-presence.xsl",
         "/org/eolang/parser/parse/build-fqns.xsl",
         "/org/eolang/parser/parse/expand-aliases.xsl",
+        "/org/eolang/parser/parse/validate-aliases.xsl",
         "/org/eolang/parser/parse/resolve-aliases.xsl",
         "/org/eolang/parser/parse/add-default-package.xsl",
         "/org/eolang/parser/parse/roll-bases.xsl",

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-aliases.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-aliases.xsl
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="validate-aliases" version="2.0">
+  <!--
+  Here we add an error with severity 'critical' when one alias name is
+  declared more than once, since a name with two targets cannot be resolved
+  and would otherwise end up as a space-joined base.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/object">
+    <xsl:variable name="errors" as="element()*">
+      <xsl:for-each select="metas/meta[head='alias']">
+        <xsl:variable name="name" select="part[1]"/>
+        <xsl:if test="preceding-sibling::meta[head='alias' and part[1]=$name]">
+          <error>
+            <xsl:attribute name="check" select="'validate-aliases'"/>
+            <xsl:attribute name="line" select="if (@line) then @line else 0"/>
+            <xsl:attribute name="severity" select="'critical'"/>
+            <xsl:value-of select="concat('Alias &quot;', $name, '&quot; is declared more than once')"/>
+          </error>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:copy>
+      <xsl:apply-templates select="(node() except errors)|@*"/>
+      <xsl:if test="exists($errors) or exists(/object/errors)">
+        <errors>
+          <xsl:apply-templates select="/object/errors/error"/>
+          <xsl:copy-of select="$errors"/>
+        </errors>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-declared-twice.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-declared-twice.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  Alias "x" is declared more than once
+input: |
+  +alias x Φ.foo
+  +alias x Φ.bar
+
+  [] > main
+    x > @


### PR DESCRIPTION
Two `+alias` directives with the same name parsed without errors and
`resolve-aliases.xsl` joined both targets into one base like `Φ.foo Φ.bar`,
which nothing downstream can use. A new `validate-aliases.xsl` sheet runs
right after the aliases are expanded and reports the second declaration at its
own line.

Closes #7639
