### PR TITLE
fix(#7515): read an inet address as the unsigned number it is

### DIFF
--- a/eo-runtime/src/main/eo/posix.eo
+++ b/eo-runtime/src/main/eo/posix.eo
@@ -52,6 +52,7 @@
   os.is-macos.if > trunc
     1024
     512
+  4294967295 > unresolved
   1 > wronly
 
   ++> can-close-a-tcp-socket
@@ -110,6 +111,14 @@
         0
         0
 
+  os.is-windows.or ++> can-return-an-inet-address-above-the-signed-range
+    eq.
+      code.
+        posix *1
+          "inet_addr"
+          "10.0.0.200"
+      3355443210
+
   os.is-windows.or ++> can-return-an-inet-address-for-localhost
     eq.
       code.
@@ -117,6 +126,14 @@
           "inet_addr"
           "127.0.0.1"
       16777343
+
+  os.is-windows.or ++> can-return-the-limited-broadcast-address
+    eq.
+      code.
+        posix *1
+          "inet_addr"
+          "255.255.255.255"
+      posix.unresolved
 
   --> stops-on-write-size-being-negative
     os.is-windows.if > @

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -55,7 +55,11 @@
         sys.raw *1
           "inet_addr"
           ^.address
-      addr.as-i32 > addrint
+      as-i32. > addrint
+        if.
+          addr.gt 2147483647
+          addr.minus 4294967296
+          addr
       [^ descriptor] > closed-socket
         if. > @
           closed.eq -1
@@ -139,7 +143,7 @@
           ^.^.guarded opened ^.sys.cleanup
         if. > converted
           and.
-            ^.addr.eq ^.sys.none
+            ^.addr.eq ^.sys.unresolved
             not.
               ^.^.address.eq "255.255.255.255"
           cant

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -51,6 +51,7 @@
   6 > tcp
   [^ time millitm] > timeb
   512 > trunc
+  4294967295 > unresolved
   02-02 > version
   32769 > wronly
 
@@ -60,7 +61,7 @@
         win32 *1
           "inet_addr"
           "localhost"
-      win32.invalid
+      win32.unresolved
 
   os.is-windows.not.or ++> can-report-an-ipv6-address-as-invalid
     eq.
@@ -68,7 +69,15 @@
         win32 *1
           "inet_addr"
           "::1"
-      win32.invalid
+      win32.unresolved
+
+  os.is-windows.not.or ++> can-return-an-inet-address-above-the-signed-range
+    eq.
+      code.
+        win32 *1
+          "inet_addr"
+          "10.0.0.200"
+      3355443210
 
   os.is-windows.not.or ++> can-return-an-inet-address-for-localhost
     eq.

--- a/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
@@ -14,6 +14,13 @@ import org.eolang.Syscall;
 
 /**
  * The 'inet_addr' syscall.
+ *
+ * <p>{@code inet_addr} returns {@code in_addr_t}, which POSIX defines as an
+ * unsigned 32-bit integer, so the C {@code int} is widened before it becomes
+ * an EO number: {@code 10.0.0.200} reads as 3355443210, not as -939524086,
+ * and the {@code INADDR_NONE} the function reports for text it cannot parse
+ * reads as 4294967295, the {@code posix.unresolved} constant.</p>
+ *
  * @since 0.40
  */
 public final class InetAddrSyscall implements Syscall {
@@ -25,10 +32,11 @@ public final class InetAddrSyscall implements Syscall {
     private static final int EINVAL = 22;
 
     /**
-     * The limited-broadcast address, whose conversion is {@code -1} — the
-     * same value {@code inet_addr} returns for text it cannot parse, which
-     * is why the two are told apart by the text rather than by the result.
-     * {@code socket.eo} makes the same comparison for the same reason.
+     * The limited-broadcast address, whose conversion is {@code INADDR_NONE}
+     * — the same value {@code inet_addr} returns for text it cannot parse,
+     * which is why the two are told apart by the text rather than by the
+     * result. {@code socket.eo} makes the same comparison for the same
+     * reason.
      */
     private static final String BROADCAST = String.join(
         ".", Collections.nCopies(4, "255")
@@ -55,7 +63,7 @@ public final class InetAddrSyscall implements Syscall {
         if (converted == -1 && !InetAddrSyscall.BROADCAST.equals(address)) {
             Native.setLastError(InetAddrSyscall.EINVAL);
         }
-        result.put(0, new Data.ToPhi(converted));
+        result.put(0, new Data.ToPhi(Integer.toUnsignedLong(converted)));
         result.put(1, new PhDefault());
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -21,6 +21,14 @@ import org.eolang.Syscall;
 public final class InetAddrFuncCall implements Syscall {
 
     /**
+     * {@code INADDR_NONE}, what {@code inet_addr} answers with when it cannot
+     * convert the text. It is an {@code in_addr_t}, that is unsigned, so it
+     * reaches EO as 4294967295 and not as -1, matching {@code win32.unresolved}
+     * and the POSIX half of the same call.
+     */
+    private static final long NONE = 4_294_967_295L;
+
+    /**
      * Dotted-decimal IPv4 literal, e.g. "127.0.0.1".
      */
     private static final Pattern IPV4 = Pattern.compile(
@@ -49,10 +57,15 @@ public final class InetAddrFuncCall implements Syscall {
             for (int octet = 1; octet <= 4; ++octet) {
                 buffer.put((byte) Integer.parseInt(matcher.group(octet)));
             }
-            result.put(0, new Data.ToPhi(Integer.reverseBytes(buffer.getInt(0))));
+            result.put(
+                0,
+                new Data.ToPhi(
+                    Integer.toUnsignedLong(Integer.reverseBytes(buffer.getInt(0)))
+                )
+            );
         } else {
             Winsock.INSTANCE.WSASetLastError(Winsock.WSAEINVAL);
-            result.put(0, new Data.ToPhi(-1));
+            result.put(0, new Data.ToPhi(InetAddrFuncCall.NONE));
         }
         result.put(1, new PhDefault());
         return result;

--- a/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
@@ -7,6 +7,7 @@ package org.eolang.posix;
 import com.sun.jna.Native;
 import java.util.Collections;
 import org.eolang.Data;
+import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -39,9 +40,23 @@ final class InetAddrSyscallTest {
             new Data.ToPhi(String.join(".", Collections.nCopies(4, "255")))
         );
         MatcherAssert.assertThat(
-            "the limited-broadcast address converts to -1 like an unparsable one does, but it is valid, so EINVAL must not be reported for it",
+            "the limited-broadcast address converts to INADDR_NONE like an unparsable one does, but it is valid, so EINVAL must not be reported for it",
             Native.getLastError(),
             Matchers.not(Matchers.equalTo(22))
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void widensTheAddressToUnsigned() {
+        MatcherAssert.assertThat(
+            "inet_addr returns in_addr_t, which POSIX defines as unsigned, so an address whose first octet is 128 or above must not reach EO as a negative number",
+            new Dataized(
+                new InetAddrSyscall(Phi.Φ.take("posix").copy())
+                    .make(new Data.ToPhi("10.0.0.200"))
+                    .take("code")
+            ).asNumber(),
+            Matchers.equalTo(3_355_443_210.0d)
         );
     }
 


### PR DESCRIPTION
Closes #7515.

`inet_addr` returns `in_addr_t`, which POSIX defines as unsigned 32-bit, and both halves of the call put the C `int` straight into `Data.ToPhi`. Every address whose first octet is 128 or above came back negative:

```
inet_addr 10.0.0.200      = -939524086   (should be 3355443210)
inet_addr 255.255.255.255 = -1           (should be 4294967295)
```

The bits still reached `sockaddr_in` unharmed, so connecting worked; what broke was EO code that reads or compares the number it was given.

## What changed

- `posix/InetAddrSyscall` and `win32/InetAddrFuncCall` widen the value with `Integer.toUnsignedLong` before it becomes an EO number. Both halves move together so the two platforms keep agreeing on the same program — that is the property #7512 is about, and it would be lost if only the POSIX half were widened.
- `INADDR_NONE`, what either half answers with for text it cannot convert, is now named `unresolved` (4294967295) in `posix.eo` and `win32.eo`, since -1 is no longer what it reads as. `win32.invalid` stays -1 for `GetFileAttributesW`, which is a different call with a different return type.
- `socket.eo` compares against `sys.unresolved` instead of `sys.none`, and folds the unsigned reading back to a signed 32-bit one before handing it to `sockaddr-in`, where the bit pattern rather than the number is what counts. Without that fold `as-i32` would refuse any address at or above `128.0.0.0`.

## Tests

- `posix.eo`: `can-return-an-inet-address-above-the-signed-range` (`10.0.0.200` → 3355443210) and `can-return-the-limited-broadcast-address` (→ `posix.unresolved`).
- `win32.eo`: the same above-the-range case, and the two existing invalid-address tests now expect `win32.unresolved`.
- `InetAddrSyscallTest.widensTheAddressToUnsigned` pins the Java side directly.

Verified locally on Linux: `EOposixTest` (9), `EOwin32Test` (6) and `EOsocketTest` (9) all pass, and the `format` and `compile` (lint) goals are clean.

Note on one pre-existing local observation, unrelated to this change: running `-Dtest=InetAddrSyscallTest` on its own in a container makes `leavesErrnoAloneOnAValidAddress` read `errno` as 2. It does the same on `master` with this branch's test removed, so it is not caused here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JugyPW5uZJCeNWbsm6tKnF)_