### PR TITLE
Reproduce the still-open `file.touched` race from #7077

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.yegor256.Together;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for the {@code touched} attribute of {@code file}.
+ *
+ * <p>This is the synchronization-based regression the {@code @todo #7077}
+ * in {@code file/touched.eo} asks for. It fails today: the exclusive open
+ * landed, but the arm that tolerates {@code EEXIST} reads {@code errno}
+ * after {@code linked} has re-run {@code lstat}, so the error code
+ * {@code open} set is gone by the time it is compared, and {@code touched}
+ * terminates instead of returning the file another thread created.</p>
+ *
+ * @since 0.75.0
+ */
+final class EOfileEOtouchedTest {
+
+    /**
+     * What the writing thread puts into the shared file.
+     */
+    private static final byte[] CONTENT = "not empty".getBytes(StandardCharsets.UTF_8);
+
+    @RepeatedTest(20)
+    void keepsWhatAnotherThreadWroteInBetween(@TempDir final Path temp) throws IOException {
+        final Path target = temp.resolve("shared.txt");
+        new Together<>(
+            8,
+            thread -> {
+                if (thread == 0) {
+                    Files.write(target, EOfileEOtouchedTest.CONTENT);
+                } else {
+                    new Dataized(EOfileEOtouchedTest.touched(target)).take();
+                }
+                return true;
+            }
+        ).asList();
+        MatcherAssert.assertThat(
+            "touching a path that another thread created between the probe and the open must leave what it wrote alone, but the file came back truncated",
+            Files.size(target),
+            Matchers.equalTo((long) EOfileEOtouchedTest.CONTENT.length)
+        );
+    }
+
+    /**
+     * The {@code touched} of the file at this path.
+     * @param path The path of the file
+     * @return The object to dataize
+     */
+    private static Phi touched(final Path path) {
+        final Phi file = Phi.Φ.take("file").copy();
+        file.put(0, new Data.ToPhi(path.toString()));
+        return file.take("touched");
+    }
+}


### PR DESCRIPTION
**This pull request fails on purpose. Do not merge it as it stands.** It is a reproduction, not a fix.

Related: #7077 (the race), #7206 (the puzzle asking for this test).

## What it shows

The exclusive open that #7077 asked for did land in `file/touched.eo`, but the arm that is supposed to tolerate `EEXIST` never fires, so the race is still open. This is the synchronization-based regression the `@todo #7077` in that file asks for: eight `Together` threads, one writing content to a shared path while the others `touched` it, twenty rounds. It goes red:

```
EOfileEOtouchedTest.keepsWhatAnotherThreadWroteInBetween »
  TogetherFailure Round #0 failed in thread #1 after 2230ms:
  Error in "Φ.file.touched.φ.α1.α1.Δ" at .file:45:6;
  Cant touch the file '/tmp/junit-.../shared.txt': File exists
```

`.file:45` is the `T "Cant touch the file '%s': %s"` terminator, so `open` did return `EEXIST` and

```eo
      or.
        descriptor.gte 0
        linked.not.and
          errno.eq eexist
```

still came out `false`. `and` dataizes `linked` before it reads `errno`, and `linked` is `f.is-symlink false`, not a const, so another `lstat` runs in between and overwrites the code `open` set.

I tried the obvious one-token repair, making `linked` a const so the second read is cached. It does not work: `!` hands the arm a dataized value, and `exclusive` then fails with `the 'flags' argument of open must be a number`. The real fix needs the errno that belongs to that `open` — `opened` is already the `called.` result whose `output` the error message uses, so it is in reach — but that is a change to the production code, not to a test, and it is not in this branch.

## Why the `@todo` is untouched

#7206 is not resolved by a test that shows the bug is real, so the puzzle stays in `file/touched.eo` and this branch adds nothing but the test.

## Note on CI

Besides this test's deliberate failure, `mvn (ubuntu-24.04, 26)` is currently red on unrelated branches too, from the locale race filed as #7654.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JugyPW5uZJCeNWbsm6tKnF)_