### PR TITLE
#7654: isolate the locale-changing tests of `AutoNameTest`

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/AutoNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/AutoNameTest.java
@@ -8,11 +8,18 @@ import java.util.Locale;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Isolated;
 
 /**
  * Tests {@link AutoName}.
+ *
+ * <p>Three of these tests change the process-wide default formatting locale,
+ * which every other test of the module would see while they run. The whole
+ * class is therefore isolated: nothing else runs beside it.</p>
+ *
  * @since 0.58.1
  */
+@Isolated
 final class AutoNameTest {
 
     @Test


### PR DESCRIPTION
Three tests in `AutoNameTest` set the JVM-wide default formatting locale while
the rest of the module runs concurrently, so any test that formats a number
without an explicit locale in that window can get non-ASCII digits. The class
is now `@Isolated`, so nothing else runs beside it and the mutation cannot
reach another test.

Closes #7654
