### PR TITLE
#7641: memoize `OyCached.contains()`

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -32,6 +32,11 @@ final class OyCached implements Objectionary {
     private final Map<String, Boolean> directories;
 
     /**
+     * The cache for presence checks.
+     */
+    private final Map<String, Boolean> presence;
+
+    /**
      * Ctor.
      * @param oby The objectionary
      */
@@ -56,9 +61,23 @@ final class OyCached implements Objectionary {
      */
     OyCached(final Objectionary oby, final Map<String, Input> progs,
         final Map<String, Boolean> dirs) {
+        this(oby, progs, dirs, new ConcurrentHashMap<>(0));
+    }
+
+    /**
+     * Ctor.
+     * @param oby The objectionary
+     * @param progs The cache for programs
+     * @param dirs The cache for directories
+     * @param present The cache for presence checks
+     * @checkstyle ParameterNumberCheck (5 lines)
+     */
+    OyCached(final Objectionary oby, final Map<String, Input> progs,
+        final Map<String, Boolean> dirs, final Map<String, Boolean> present) {
         this.origin = oby;
         this.programs = progs;
         this.directories = dirs;
+        this.presence = present;
     }
 
     @Override
@@ -82,9 +101,28 @@ final class OyCached implements Objectionary {
 
     @Override
     public boolean contains(final String name) throws IOException {
-        return this.programs.containsKey(name)
-            || Boolean.TRUE.equals(this.directories.get(name))
-            || this.origin.contains(name);
+        final boolean found;
+        if (this.programs.containsKey(name)
+            || Boolean.TRUE.equals(this.directories.get(name))) {
+            found = true;
+        } else {
+            try {
+                found = this.presence.computeIfAbsent(
+                    name, key -> {
+                        try {
+                            return this.origin.contains(name);
+                        } catch (final IOException exception) {
+                            throw new UncheckedIOException(exception);
+                        }
+                    }
+                );
+            } catch (final UncheckedIOException wrap) {
+                throw new IOException(
+                    String.format("Failed to check whether '%s' exists", name), wrap
+                );
+            }
+        }
+        return found;
     }
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyCached.java
@@ -70,7 +70,6 @@ final class OyCached implements Objectionary {
      * @param progs The cache for programs
      * @param dirs The cache for directories
      * @param present The cache for presence checks
-     * @checkstyle ParameterNumberCheck (5 lines)
      */
     OyCached(final Objectionary oby, final Map<String, Input> progs,
         final Map<String, Boolean> dirs, final Map<String, Boolean> present) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FailingObjectionary.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FailingObjectionary.java
@@ -9,8 +9,8 @@ import org.cactoos.Input;
 import org.cactoos.iterable.IterableOf;
 
 /**
- * An objectionary whose {@code get()} and {@code isDirectory()} always fail
- * with a given {@link IOException}.
+ * An objectionary whose {@code get()}, {@code contains()} and
+ * {@code isDirectory()} always fail with a given {@link IOException}.
  * @since 0.74.0
  */
 final class FailingObjectionary implements Objectionary {
@@ -34,8 +34,8 @@ final class FailingObjectionary implements Objectionary {
     }
 
     @Override
-    public boolean contains(final String name) {
-        return false;
+    public boolean contains(final String name) throws IOException {
+        throw this.failure;
     }
 
     @Override

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/OyCachedTest.java
@@ -86,6 +86,42 @@ final class OyCachedTest {
         );
     }
 
+    @RepeatedTest(10)
+    void checksPresenceInConcurrentEnvironment() {
+        final AtomicInteger calls = new AtomicInteger(0);
+        final Objectionary objectionary = new OyCached(
+            new Objectionary.Fake(
+                nme -> new InputOf("[] > foo"),
+                nme -> {
+                    calls.incrementAndGet();
+                    return true;
+                },
+                nme -> false
+            )
+        );
+        new Together<>(30, thread -> objectionary.contains("parallel")).asList();
+        final int expected = 1;
+        MatcherAssert.assertThat(
+            String.format("Original objectionary should be asked only %d time", expected),
+            calls.get(),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void propagatesOriginFailureFromContainsAsIoException() {
+        final IOException failure = new IOException("origin failed");
+        MatcherAssert.assertThat(
+            "the original IOException must stay in the cause chain",
+            Assertions.assertThrows(
+                IOException.class,
+                () -> new OyCached(new FailingObjectionary(failure)).contains("foo"),
+                "a failure from the origin objectionary must surface as IOException"
+            ).getCause().getCause(),
+            Matchers.sameInstance(failure)
+        );
+    }
+
     @Test
     void checksIsDirectoryWithEmptyCache() throws IOException {
         MatcherAssert.assertThat(


### PR DESCRIPTION
`contains()` consulted the two existing caches but, when neither had an entry,
went to the origin and kept nothing, so concurrent callers asking about the
same name each fired their own HTTP request. It now memoizes through its own
map with `computeIfAbsent`, the way `get()` and `isDirectory()` already do.

Tests: a 30-thread case checking the origin is asked once, and a case for the
`IOException` propagation. `FailingObjectionary.contains()` now fails like its
other two methods.

Closes #7641
