### PR TITLE
#7632: reject duplicate voids in one formation

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Canonical.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Canonical.java
@@ -53,6 +53,7 @@ public final class Canonical implements UnaryOperator<XML> {
         "/org/eolang/parser/parse/validate-objects-count.xsl",
         "/org/eolang/parser/parse/validate-object-presence.xsl",
         "/org/eolang/parser/parse/validate-attribute-names.xsl",
+        "/org/eolang/parser/parse/validate-voids.xsl",
         "/org/eolang/parser/parse/build-fqns.xsl",
         "/org/eolang/parser/parse/expand-aliases.xsl",
         "/org/eolang/parser/parse/validate-aliases.xsl",

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-voids.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-voids.xsl
@@ -13,7 +13,7 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:template match="/object">
     <xsl:variable name="errors" as="element()*">
-      <xsl:for-each select="descendant::o[@base='∅']">
+      <xsl:for-each select=".//o[@base='∅']">
         <xsl:variable name="name" select="@name"/>
         <xsl:if test="preceding-sibling::o[@base='∅' and @name=$name]">
           <error>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-voids.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-voids.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="validate-voids" version="2.0">
+  <!--
+  Here we add an error with severity 'critical' when one formation declares
+  two voids with the same name, in the brackets or in vertical lines, since
+  the object built at run time keeps one attribute per name and the arity of
+  the formation would silently shrink.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:template match="/object">
+    <xsl:variable name="errors" as="element()*">
+      <xsl:for-each select="descendant::o[@base='∅']">
+        <xsl:variable name="name" select="@name"/>
+        <xsl:if test="preceding-sibling::o[@base='∅' and @name=$name]">
+          <error>
+            <xsl:attribute name="check" select="'validate-voids'"/>
+            <xsl:attribute name="line" select="if (@line) then @line else 0"/>
+            <xsl:attribute name="severity" select="'critical'"/>
+            <xsl:if test="@pos">
+              <xsl:attribute name="pos" select="@pos"/>
+            </xsl:if>
+            <xsl:value-of select="concat('Void &quot;', $name, '&quot; is declared more than once in the same formation')"/>
+          </error>
+        </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+    <xsl:copy>
+      <xsl:apply-templates select="(node() except errors)|@*"/>
+      <xsl:if test="exists($errors) or exists(/object/errors)">
+        <errors>
+          <xsl:apply-templates select="/object/errors/error"/>
+          <xsl:copy-of select="$errors"/>
+        </errors>
+      </xsl:if>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/phi-void-declared-twice.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/phi-void-declared-twice.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  Void "φ" is declared more than once in the same formation
+input: |
+  [@ @] > pair
+    42 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-declared-twice.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-declared-twice.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  Void "x" is declared more than once in the same formation
+input: |
+  [x x] > pair
+    x > @


### PR DESCRIPTION
`[x x] > pair` parsed without errors and emitted two void children with one
name, while the object built at run time keeps a single attribute, so the
declared arity and the real one disagree. A new `validate-voids.xsl` sheet
reports the second void at its own line and position. It works after the
special names are mapped, so `[^ ^]` and `[@ @]` are caught too, and it looks
at all voids of a formation, so a bracket parameter repeated by a vertical
`? > x` line is caught as well.

Closes #7632
