### PR TITLE
#7633: hash long names with two polynomial digests

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -68,11 +68,32 @@
   their first 240-odd characters still disambiguate, and the same name always
   fingerprints the same way regardless of which call site of "eo:class-name" asks,
   so a declaration and a reference to the same over-long name never diverge (#7254).
+  Two polynomial hashes with different bases and different prime moduli, since a
+  single weighted sum of the code points cancels out for names that differ in two
+  positions only (#7633).
   -->
   <xsl:function name="eo:fingerprint" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
     <xsl:variable name="codes" select="string-to-codepoints($n)"/>
-    <xsl:value-of select="concat('_', string(sum(for $i in 1 to count($codes) return $codes[$i] * $i) mod 100000000))"/>
+    <xsl:value-of select="concat('_', string(eo:polynomial($codes, 131, 1000000007, 0)), '_', string(eo:polynomial($codes, 137, 998244353, 0)))"/>
+  </xsl:function>
+  <!--
+  A polynomial hash of the code points, folded left to right, so that the same
+  characters in another order hash differently.
+  -->
+  <xsl:function name="eo:polynomial" as="xs:integer">
+    <xsl:param name="codes" as="xs:integer*"/>
+    <xsl:param name="base" as="xs:integer"/>
+    <xsl:param name="modulo" as="xs:integer"/>
+    <xsl:param name="acc" as="xs:integer"/>
+    <xsl:choose>
+      <xsl:when test="empty($codes)">
+        <xsl:sequence select="$acc"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="eo:polynomial(subsequence($codes, 2), $base, $modulo, ($acc * $base + $codes[1]) mod $modulo)"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
   <!--
   A cut prefix with any trailing dot dropped, so the digit-starting fingerprint

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -16,6 +16,7 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,10 +70,15 @@ final class MjTranspileTest {
 
     @Test
     void givesDistinctClassNamesToLongNamesDifferingBeyondTheLimit() throws IOException {
+        final String head = String.join("", Collections.nCopies(249, "a"));
         MatcherAssert.assertThat(
             "two names that differ only past the length limit must not share a Java class name",
-            this.javaName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaazaaaaaaaaaaaaaaa"),
-            Matchers.not(Matchers.equalTo(this.javaName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaataaaaHaaaaaaaaaaaaaaa")))
+            this.javaName(String.format("%sAaaaazaaaaaaaaaaaaaaa", head)),
+            Matchers.not(
+                Matchers.equalTo(
+                    this.javaName(String.format("%staaaaHaaaaaaaaaaaaaaa", head))
+                )
+            )
         );
     }
 
@@ -779,11 +785,6 @@ final class MjTranspileTest {
         );
     }
 
-    /**
-     * The Java class name the transpiler gives to an object with this name.
-     * @param name The name of the object in EO
-     * @return The Java name of the class
-     */
     private String javaName(final String name) throws IOException {
         return new Xsline(
             new TrClasspath<>(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -8,7 +8,9 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
+import com.yegor256.xsline.Xsline;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -62,6 +64,15 @@ final class MjTranspileTest {
             "passed without exceptions",
             story,
             new XtoryMatcher()
+        );
+    }
+
+    @Test
+    void givesDistinctClassNamesToLongNamesDifferingBeyondTheLimit() throws IOException {
+        MatcherAssert.assertThat(
+            "two names that differ only past the length limit must not share a Java class name",
+            this.javaName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaAaaaazaaaaaaaaaaaaaaa"),
+            Matchers.not(Matchers.equalTo(this.javaName("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaataaaaHaaaaaaaaaaaaaaa")))
         );
     }
 
@@ -766,5 +777,25 @@ final class MjTranspileTest {
                 "    42 > @"
             )
         );
+    }
+
+    /**
+     * The Java class name the transpiler gives to an object with this name.
+     * @param name The name of the object in EO
+     * @return The Java name of the class
+     */
+    private String javaName(final String name) throws IOException {
+        return new Xsline(
+            new TrClasspath<>(
+                "/org/eolang/parser/parse/set-locators.xsl",
+                "/org/eolang/maven/transpile/set-original-names.xsl",
+                "/org/eolang/maven/transpile/classes.xsl",
+                "/org/eolang/maven/transpile/attrs.xsl",
+                "/org/eolang/maven/transpile/data.xsl",
+                "/org/eolang/maven/transpile/to-java.xsl"
+            ).back()
+        ).pass(
+            new EoSyntax(String.format("[] > %s%n  42 > @%n", name)).parsed()
+        ).xpath("//@java-name").get(0);
     }
 }


### PR DESCRIPTION
The fingerprint appended to an over-long Java class name was one weighted sum
of the code points, so two names differing in two positions can cancel each
other out and land in the same class. It is now two polynomial hashes, with
different bases and different prime moduli, folded left to right.

Test: the two 270-character names from the issue, which share their truncated
prefix and the old fingerprint, now get different Java names.

Closes #7633
