### PR TITLE
#7630: let a JVM `Error` out of an atom untouched

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtomSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/AtomSafe.java
@@ -8,8 +8,10 @@ package org.eolang;
  * Atom that catches exceptions.
  *
  * <p>A {@link RuntimeException} passes through untouched, so that an
- * EO-level error keeps its own message. Anything else turns into an
- * {@link ExFailure} carrying the original as its cause.</p>
+ * EO-level error keeps its own message. A JVM {@link Error} passes through
+ * too, since a broken JVM is not something EO code may recover from.
+ * Anything else turns into an {@link ExFailure} carrying the original as
+ * its cause.</p>
  *
  * <p>Elsewhere we let Cactoos catch for us, with {@code ScalarWithFallback}.
  * Here we catch by hand, because {@code eo-runtime} ships with no
@@ -33,15 +35,16 @@ public final class AtomSafe implements Atom {
         this.origin = atom;
     }
 
-    // @checkstyle IllegalCatchCheck (12 lines)
+    // @checkstyle IllegalCatchCheck (14 lines)
     @Override
+    @SuppressWarnings("java:S1181")
     public Phi lambda() {
         try {
             return ((Atom) this.origin).lambda();
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
             throw AtomSafe.failure(ex);
-        } catch (final RuntimeException ex) {
+        } catch (final RuntimeException | Error ex) {
             throw ex;
         } catch (final Throwable ex) {
             throw AtomSafe.failure(ex);

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -252,6 +252,7 @@ final class PhSafeTest {
      * @since 0.60.0
      */
     private final class Broken extends PhDefault implements Atom {
+
         @Override
         public Phi lambda() {
             throw new StackOverflowError("the stack is exhausted");

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -165,6 +165,19 @@ final class PhSafeTest {
     }
 
     @Test
+    void letsErrorThroughFromAtom() {
+        MatcherAssert.assertThat(
+            "a JVM Error from an atom must keep its own type, but it was wrapped",
+            Assertions.assertThrows(
+                StackOverflowError.class,
+                () -> new PhSafe(new PhSafeTest.Broken(), "file.eo", 3, 5).lambda(),
+                "was expected to fail with StackOverflowError"
+            ).getMessage(),
+            Matchers.equalTo("the stack is exhausted")
+        );
+    }
+
+    @Test
     void doesNotLetRecoveredInterceptError() {
         final EOrecovered recovered = new EOrecovered();
         recovered.put(
@@ -232,5 +245,16 @@ final class PhSafeTest {
                 Matchers.containsString("intentional error")
             )
         );
+    }
+
+    /**
+     * An atom that fails with a JVM error.
+     * @since 0.60.0
+     */
+    private final class Broken extends PhDefault implements Atom {
+        @Override
+        public Phi lambda() {
+            throw new StackOverflowError("the stack is exhausted");
+        }
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -251,7 +251,7 @@ final class PhSafeTest {
      * An atom that fails with a JVM error.
      * @since 0.60.0
      */
-    private final class Broken extends PhDefault implements Atom {
+    private static final class Broken extends PhDefault implements Atom {
 
         @Override
         public Phi lambda() {


### PR DESCRIPTION
`PhSafe.lambda()` goes through `AtomSafe`, whose `catch (Throwable)` turned a
JVM `Error` into a recoverable `ExFailure`, so the pass-through that `PhSafe`
has for `Error` did not apply to atoms. `AtomSafe` now rethrows `Error` the
same way it rethrows `RuntimeException`.

New test in `PhSafeTest` wraps an atom that fails with `StackOverflowError`
and checks it comes out as itself.

Closes #7630
