### PR TITLE
#7656: remember the bytes of an application whose parts are data

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
@@ -73,6 +73,12 @@
   <xsl:variable name="eo:dir" as="xs:string" select="if ($inference = '' or ends-with($inference, '/')) then $inference else concat($inference, '/')"/>
   <xsl:variable name="eo:provides" as="document-node()?" select="if ($eo:dir != '' and doc-available(concat($eo:dir, 'provides.xml'))) then doc(concat($eo:dir, 'provides.xml')) else ()"/>
   <!--
+  The table that says what every part of an application is, by the locator of
+  that part. Absent for the same reasons "provides.xml" may be absent, and
+  then no application is labeled.
+  -->
+  <xsl:variable name="eo:links" as="document-node()?" select="if ($eo:dir != '' and doc-available(concat($eo:dir, 'links.xml'))) then doc(concat($eo:dir, 'links.xml')) else ()"/>
+  <!--
   The objects whose bytes a caller may pass in: a number, a string and a bytes
   are the kinds of data a formation can be given and still be worth caching by
   what it was given, since each one of them is decided by its bytes alone.
@@ -152,6 +158,46 @@
     <xsl:param name="row" as="element()"/>
     <xsl:sequence select="every $v in $row/attr[@void = 'true'] satisfies (exists($v/witnessed) and empty($v/witnessed/descendant::*[not(self::union or (self::ref and @loc = $eo:data))]))"/>
   </xsl:function>
+  <!--
+  Whether this application is decided by the bytes of its own parts. Every
+  part it has, the receiver among them, must be a copy of data, which is what
+  a row of "links.xml" holding one "ref" to a data object says:
+  &lt;type id="Φ.app.x.ρ"&gt;
+  &lt;ref loc="Φ.number"/&gt;
+  &lt;/type&gt;
+  A part with no row of its own, or one holding anything else, leaves the
+  application unlabeled.
+  -->
+  <xsl:function name="eo:applied" as="xs:boolean">
+    <xsl:param name="a" as="element()"/>
+    <xsl:sequence select="exists($eo:links) and exists($a/o[@loc]) and (every $p in $a/o[@loc] satisfies eo:copies-data(key('eo:row', $p/@loc, $eo:links)))"/>
+  </xsl:function>
+  <!-- Whether this row of "links.xml" says its object is a copy of data. -->
+  <xsl:function name="eo:copies-data" as="xs:boolean">
+    <xsl:param name="row" as="element()?"/>
+    <xsl:sequence select="exists($row) and count($row/*) = 1 and exists($row/ref[@loc = $eo:data])"/>
+  </xsl:function>
+  <!--
+  An application whose parts are all data is labeled too, so that the answer
+  it works out is remembered instead of being worked out on every read.
+  @todo #7656:90min Label an application whose parts are data by the other
+  kinds of evidence "links.xml" holds. Today only a part that is a copy of
+  data - a literal, or a local that holds one - counts, and the three other
+  cases the table already carries are ignored: a "var" of a void whose row
+  in "provides.xml" is witnessed as data (the same question "eo:filled"
+  asks), a "ref" to a formation whose row says "returns" a data object, and
+  a "union" all of whose members are one of those. Each of them widens the
+  set of applications that stop being recomputed, and none of them needs a
+  new table.
+  -->
+  <xsl:template match="*[@loc][@base][not(@base = $eo:literals)][o[@loc]]">
+    <xsl:copy>
+      <xsl:if test="eo:applied(.)">
+        <xsl:attribute name="pure">true</xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
   <xsl:template match="*[@loc][not(@base)][not(@name = $eo:lambda)][not(text()[normalize-space()])]">
     <xsl:copy>
       <xsl:if test="eo:pure(.)">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
@@ -73,11 +73,15 @@
   <xsl:variable name="eo:dir" as="xs:string" select="if ($inference = '' or ends-with($inference, '/')) then $inference else concat($inference, '/')"/>
   <xsl:variable name="eo:provides" as="document-node()?" select="if ($eo:dir != '' and doc-available(concat($eo:dir, 'provides.xml'))) then doc(concat($eo:dir, 'provides.xml')) else ()"/>
   <!--
+  Where the table of links is expected to be.
+  -->
+  <xsl:variable name="eo:links-file" as="xs:string" select="concat($eo:dir, 'links.xml')"/>
+  <!--
   The table that says what every part of an application is, by the locator of
   that part. Absent for the same reasons "provides.xml" may be absent, and
   then no application is labeled.
   -->
-  <xsl:variable name="eo:links" as="document-node()?" select="if ($eo:dir != '' and doc-available(concat($eo:dir, 'links.xml'))) then doc(concat($eo:dir, 'links.xml')) else ()"/>
+  <xsl:variable name="eo:links" as="document-node()?" select="if ($eo:dir != '' and doc-available($eo:links-file)) then doc($eo:links-file) else ()"/>
   <!--
   The objects whose bytes a caller may pass in: a number, a string and a bytes
   are the kinds of data a formation can be given and still be worth caching by

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -806,6 +806,11 @@
     </xsl:if>
   </xsl:template>
   <!-- Application -->
+  <!--
+  Application of an object to its arguments. One that purify.xsl marked with
+  @pure is wrapped in PhSticky, so that the bytes it works out are remembered
+  instead of being worked out on every read of it.
+  -->
   <xsl:template match="*" mode="application">
     <xsl:param name="indent"/>
     <xsl:param name="name"/>
@@ -826,7 +831,11 @@
     <xsl:if test="$inners">
       <xsl:value-of select="eo:eol($indent)"/>
       <xsl:value-of select="$name"/>
-      <xsl:text> = new PhApplication(</xsl:text>
+      <xsl:text> = </xsl:text>
+      <xsl:if test="@pure='true'">
+        <xsl:text>new PhSticky(</xsl:text>
+      </xsl:if>
+      <xsl:text>new PhApplication(</xsl:text>
       <xsl:value-of select="$name"/>
       <xsl:for-each select="$inners">
         <xsl:text>, new Bind(</xsl:text>
@@ -843,7 +852,11 @@
         <xsl:value-of select="position()"/>
         <xsl:text>)</xsl:text>
       </xsl:for-each>
-      <xsl:text>);</xsl:text>
+      <xsl:text>)</xsl:text>
+      <xsl:if test="@pure='true'">
+        <xsl:text>)</xsl:text>
+      </xsl:if>
+      <xsl:text>;</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="value">
       <xsl:with-param name="name" select="$name"/>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -8,6 +8,8 @@ import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.StClasspath;
 import com.yegor256.xsline.TrClasspath;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Xsline;
@@ -204,6 +206,46 @@ final class MjTranspileTest {
                 .get("target/generated/org/eolang/EO_examples/EOx.java")
             ).asString(),
             Matchers.containsString("new PhSticky(")
+        );
+    }
+
+    @Test
+    void wrapsApplicationOfDataInPhSticky(@Mktmp final Path temp) throws IOException {
+        final Path parsed = Files.createDirectories(temp.resolve("parsed"));
+        Files.writeString(
+            parsed.resolve("app.xmir"),
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[] > app", "  2.plus 3 > x", "  x > @", ""
+                )
+            ).parsed().toString()
+        );
+        Files.writeString(
+            parsed.resolve("number.xmir"),
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[as-bytes] > number", "  as-bytes > @",
+                    "  [x] > plus", "    x > @", ""
+                )
+            ).parsed().toString()
+        );
+        final Path tables = temp.resolve("tables");
+        new Inferring(parsed, temp.resolve("pre"), tables).exec();
+        MatcherAssert.assertThat(
+            "an application whose parts are all data must be wrapped in PhSticky, but it wasnt",
+            new Xsline(
+                new TrDefault<Shift>()
+                    .with(new StClasspath("/org/eolang/parser/parse/set-locators.xsl"))
+                    .with(new StClasspath("/org/eolang/maven/transpile/set-original-names.xsl"))
+                    .with(new StClasspath("/org/eolang/maven/transpile/classes.xsl"))
+                    .with(new StClasspath("/org/eolang/maven/transpile/attrs.xsl"))
+                    .with(new StClasspath("/org/eolang/maven/transpile/data.xsl"))
+                    .with(new StPure("/org/eolang/maven/transpile/purify.xsl", tables))
+                    .with(new StClasspath("/org/eolang/maven/transpile/to-java.xsl"))
+            ).pass(new XMLDocument(parsed.resolve("app.xmir"))).toString(),
+            Matchers.containsString("new PhSticky(new PhApplication(")
         );
     }
 

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/purify-packs/application-of-data-is-pure.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/purify-packs/application-of-data-is-pure.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An application whose receiver and every argument are data answers the same
+# bytes every time, so it is worth remembering instead of working it out on
+# every read.
+eo:
+  app.eo: |
+    [] > app
+      2.power 63 > x
+      x > @
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+      [x] > power
+        x > @
+pure:
+  - "//o[@name='x' and @pure='true']"


### PR DESCRIPTION
`purify.xsl` labeled only formations, so an application like `2.power 63` was
emitted as a bare `PhApplication` and its `Δ` was worked out on every read.
It now also labels an application whose every part, the receiver among them,
is a copy of data according to `links.xml`, and `to-java.xsl` wraps such an
application in `PhSticky`.

Only one of the four kinds of evidence the table carries is read here, the
copy-of-data one. The other three are left to the `@todo` next to the new
template, since each of them widens the set of applications on its own and
the change is easier to read one kind at a time.

Tests: a purify pack with an application of two literals, and a case in
`MjTranspileTest` that runs the whole transpile train over inferred tables and
checks the generated Java wraps the application.

Fixes the reported case for #7656; the rest is in the added `@todo`.
