### PR TITLE
#7626: take the first package meta in `build-fqns.xsl`

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -83,7 +83,7 @@
         <xsl:apply-templates select="." mode="to-method">
           <xsl:with-param name="of">
             <xsl:apply-templates select="$start" mode="recursive-package">
-              <xsl:with-param name="pkg" select="/object/metas/meta[head='package']/part[1]/text()"/>
+              <xsl:with-param name="pkg" select="(/object/metas/meta[head='package'])[1]/part[1]/text()"/>
             </xsl:apply-templates>
           </xsl:with-param>
         </xsl:apply-templates>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/two-package-metas-with-a-self-reference.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/two-package-metas-with-a-self-reference.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='y' and @base='Φ.a.main.x']
+input: |
+  +package a
+  +package b
+
+  [] > main
+    main.x > y
+    5 > x


### PR DESCRIPTION
`part[1]` takes the first part of every `+package` meta, not the part of the
first meta, so a file with two of them handed two strings to `contains()` and
the parser threw instead of parsing. It now takes the first meta, the way
`to-eo-tree.xsl` and `add-default-package.xsl` do it since #7448.

New pack parses the two-meta file that carries a reference to a sibling
object, which is what enters the template at all.

Closes #7626
