### PR TITLE
#7608: take the first package meta in `to-java.xsl`

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/atoms-table.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/atoms-table.xsl
@@ -13,7 +13,7 @@
   skipped. The collected list is wrapped in a single `<atoms>` element.
   -->
   <xsl:output encoding="UTF-8" indent="yes" method="xml"/>
-  <xsl:variable name="pkg" select="/object/metas/meta[head='package']/part[1]/text()"/>
+  <xsl:variable name="pkg" select="/object/metas/meta[head='package'][1]/part[1]/text()"/>
   <xsl:template match="/">
     <atoms>
       <xsl:for-each select="//o[@name='λ' and @atom and string-length(@atom) &gt; 0]">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -314,7 +314,7 @@
     </xsl:attribute>
     <xsl:attribute name="java-name">
       <xsl:text>org.eolang.</xsl:text>
-      <xsl:variable name="pkg" select="/object/metas/meta[head='package']/part[1]"/>
+      <xsl:variable name="pkg" select="/object/metas/meta[head='package'][1]/part[1]"/>
       <xsl:if test="$pkg">
         <xsl:value-of select="eo:package-name($pkg)"/>
         <xsl:text>.</xsl:text>
@@ -1008,7 +1008,7 @@
     <xsl:text>package org.eolang</xsl:text>
     <xsl:if test="/object/metas/meta[head='package']">
       <xsl:text>.</xsl:text>
-      <xsl:value-of select="eo:package-name(/object/metas/meta[head='package']/tail)"/>
+      <xsl:value-of select="eo:package-name(/object/metas/meta[head='package'][1]/tail)"/>
     </xsl:if>
     <xsl:text>;</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/two-package-metas.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/two-package-metas.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/package.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //class[@java-name='org.eolang.EO_a.EOmain']
+  - //java[contains(text(), 'package org.eolang.EO_a;')]
+input: |
+  +package a
+  +package b
+
+  [] > main
+    5 > x


### PR DESCRIPTION
`part[1]` and `tail` were read from every `+package` meta at once, so a file
with two of them handed a sequence to `eo:package-name()` and the transpiler
threw. All three places now take the first meta, the same way `package.xsl` and
`set-locators.xsl` already do.

New transpile pack builds the two-meta file and checks the class lands in the
package of the first meta.

Closes #7608
