### PR TITLE
#7629: show the line terminators that make two texts differ

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.maven;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
@@ -17,6 +19,12 @@ import java.util.stream.Collectors;
  * {@code -} highlighted in red, and additions with {@code +} highlighted
  * in green. When the two texts are identical, {@link #colored()} returns
  * an empty string and {@link #same()} returns {@code true}.</p>
+ *
+ * <p>Line terminators are part of what is compared, since two texts that
+ * differ only in them are not the same text and a diff that shows nothing
+ * changed would say the opposite. A carriage return is rendered as
+ * {@code \r}, and a text that does not end with a newline carries the
+ * note {@code git} prints for it.</p>
  *
  * @since 0.57.0
  */
@@ -80,7 +88,17 @@ final class Diff {
     }
 
     private static List<String> lines(final String text) {
-        return text.lines().collect(Collectors.toList());
+        final List<String> out = new ArrayList<>(
+            Arrays.stream(text.split("\n", -1))
+                .map(line -> line.replace("\r", "\\r"))
+                .collect(Collectors.toList())
+        );
+        if (out.get(out.size() - 1).isEmpty()) {
+            out.remove(out.size() - 1);
+        } else {
+            out.add("\\ No newline at end of file");
+        }
+        return out;
     }
 
     private static String render(final List<String> before, final List<String> after) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiConsumer;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -29,6 +30,16 @@ import java.util.stream.Collectors;
  * @since 0.57.0
  */
 final class Diff {
+
+    /**
+     * The line feed every line ends with.
+     */
+    private static final Pattern FEED = Pattern.compile("\\n");
+
+    /**
+     * The carriage return a line may end with.
+     */
+    private static final Pattern RETURN = Pattern.compile("\\r");
 
     /**
      * ANSI escape that resets all coloring.
@@ -89,8 +100,8 @@ final class Diff {
 
     private static List<String> lines(final String text) {
         final List<String> out = new ArrayList<>(
-            Arrays.stream(text.split("\\n", -1))
-                .map(line -> line.replaceAll("\\r", "\\\\r"))
+            Arrays.stream(Diff.FEED.split(text, -1))
+                .map(line -> Diff.RETURN.matcher(line).replaceAll("\\\\r"))
                 .collect(Collectors.toList())
         );
         if (out.get(out.size() - 1).isEmpty()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Diff.java
@@ -89,8 +89,8 @@ final class Diff {
 
     private static List<String> lines(final String text) {
         final List<String> out = new ArrayList<>(
-            Arrays.stream(text.split("\n", -1))
-                .map(line -> line.replace("\r", "\\r"))
+            Arrays.stream(text.split("\\n", -1))
+                .map(line -> line.replaceAll("\\r", "\\\\r"))
                 .collect(Collectors.toList())
         );
         if (out.get(out.size() - 1).isEmpty()) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiffTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiffTest.java
@@ -54,6 +54,7 @@ final class DiffTest {
 
     @Test
     void showsTheCarriageReturnThatMakesTheTextsDiffer() {
+        // @checkstyle ProhibitLineSeparatorInStringsCheck (5 lines)
         MatcherAssert.assertThat(
             "a difference in line terminators must be shown as a changed line",
             new Diff("a\r\nb\r\n", "a\nb\n").colored(),
@@ -63,6 +64,7 @@ final class DiffTest {
 
     @Test
     void showsTheMissingNewlineAtTheEnd() {
+        // @checkstyle ProhibitLineSeparatorInStringsCheck (5 lines)
         MatcherAssert.assertThat(
             "a missing newline at the end must be shown, not passed over",
             new Diff("a\n", "a").colored(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DiffTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DiffTest.java
@@ -53,6 +53,24 @@ final class DiffTest {
     }
 
     @Test
+    void showsTheCarriageReturnThatMakesTheTextsDiffer() {
+        MatcherAssert.assertThat(
+            "a difference in line terminators must be shown as a changed line",
+            new Diff("a\r\nb\r\n", "a\nb\n").colored(),
+            Matchers.stringContainsInOrder("[31m-a\\r", "[32m+a")
+        );
+    }
+
+    @Test
+    void showsTheMissingNewlineAtTheEnd() {
+        MatcherAssert.assertThat(
+            "a missing newline at the end must be shown, not passed over",
+            new Diff("a\n", "a").colored(),
+            Matchers.containsString("No newline at end of file")
+        );
+    }
+
+    @Test
     void highlightsTrailingAdditions() {
         MatcherAssert.assertThat(
             "extra trailing lines must be shown as additions",


### PR DESCRIPTION
`colored()` split both texts with `String.lines()`, which drops the
terminators, so two texts differing only in CRLF or in a missing last newline
came out as a diff with no changed line at all, while `same()` said they
differ. The split now keeps that information: a carriage return is rendered as
`\r` and a text with no newline at the end carries the note git prints for it.

Two cases added to `DiffTest`.

Closes #7629
