### PR TITLE
#7628: fold `trackSteps` into the transpile cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -161,28 +161,32 @@ final class Transpilation {
      * Cache-key version segment: the plugin version combined with a
      * fingerprint of the bundled transpile XSLs and the libraries they
      * {@code xsl:import}, plus the {@code trackLocations}/
-     * {@code coverageTracking} flags. Folding the XSL content in means
+     * {@code trackSteps}/{@code coverageTracking} flags. Folding the XSL
+     * content in means
      * that a change in the transformation logic invalidates the global
      * transpile cache even when the plugin version is unchanged (a
      * constant {@code -SNAPSHOT} during development), see #5578; folding
      * the imported libraries in too closes the gap where editing one of
      * them changed the actual output without changing anything in
-     * {@link #XSLS} itself, see #6032. Folding the two flags and the name
+     * {@link #XSLS} itself, see #6032. Folding the three flags and the name
      * of the base class in means changing any of them also invalidates the
-     * cache, since all of them change what {@code to-java.xsl} emits (see
-     * #6031 and #5955).
+     * cache, since all of them change what a build of the same source
+     * produces: the first two and the base class change what
+     * {@code to-java.xsl} emits (see #6031 and #5955), and
+     * {@code trackSteps} decides whether the XMIRs of the train are written
+     * at all, which a cache hit would otherwise skip (see #7628).
      * @return The version segment for {@link CachePath}
      */
     String version() {
         return String.format(
-            "%s-%s-%b-%b-%s",
+            "%s-%s-%b-%b-%b-%s",
             this.version,
             new Fingerprint(
                 Stream.concat(
                     Arrays.stream(Transpilation.XSLS), Arrays.stream(Transpilation.IMPORTS)
                 ).toArray(String[]::new)
             ).get(),
-            this.tracking.locations(), this.coverage, this.superclass
+            this.tracking.locations(), this.tracking.steps(), this.coverage, this.superclass
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
@@ -5,6 +5,8 @@
 package org.eolang.maven;
 
 import java.nio.file.Paths;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -13,6 +15,17 @@ import org.junit.jupiter.api.Test;
  * @since 0.74
  */
 final class TranspilationTest {
+
+    @Test
+    void tellsTrackedStepsApartInTheCacheKey() {
+        MatcherAssert.assertThat(
+            "a build that writes the XMIRs of the train must not take the result of one that didnt",
+            this.transpilation(new Tracking(true, false)).version(),
+            Matchers.not(
+                Matchers.equalTo(this.transpilation(new Tracking(false, false)).version())
+            )
+        );
+    }
 
     @Test
     void buildsSourceFunctionForParentlessMeasuresPath() {
@@ -27,6 +40,23 @@ final class TranspilationTest {
                 Paths.get("target/eo/6-inference")
             ).forSource("foo"),
             "forSource() must not throw when eo.xslMeasuresFile is a bare relative path with no parent directory"
+        );
+    }
+
+    /**
+     * A transpilation with the given tracking and everything else fixed.
+     * @param tracking Which diagnostic artifacts to emit
+     * @return The transpilation
+     */
+    private Transpilation transpilation(final Tracking tracking) {
+        return new Transpilation(
+            "1.0-SNAPSHOT",
+            tracking,
+            false,
+            "PhDefault",
+            Paths.get("xsl-measures.csv"),
+            Paths.get("target"),
+            Paths.get("target/eo/6-inference")
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
@@ -43,11 +43,6 @@ final class TranspilationTest {
         );
     }
 
-    /**
-     * A transpilation with the given tracking and everything else fixed.
-     * @param tracking Which diagnostic artifacts to emit
-     * @return The transpilation
-     */
     private Transpilation transpilation(final Tracking tracking) {
         return new Transpilation(
             "1.0-SNAPSHOT",


### PR DESCRIPTION
`trackSteps` decides whether the XMIRs of the transpile train are written, but
it was not part of the cache key, so a build with the flag on took the result
of an earlier build that had it off and wrote nothing. The flag now joins the
key, the way `trackLocations` and `coverage` already do.

New test in `TranspilationTest` checks the two keys differ.

Closes #7628
