### PR TITLE
#7627: fold the inference tables into the transpile cache key

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Fingerprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Fingerprint.java
@@ -7,9 +7,15 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Collections;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Short hex fingerprint of a set of classpath resources.
@@ -19,6 +25,12 @@ import java.util.function.Supplier;
  * fold the content of the bundled transpile XSLs into the transpile
  * cache key, so that a change in the transformation logic invalidates
  * the cache even when the plugin version does not change (see #5578).</p>
+ *
+ * <p>A directory of files is hashed the same way, its files taken in the
+ * order of their names, which is how the tables of {@link MjInference}
+ * join the same key (see #7627). A directory that is not there hashes to
+ * the digest of nothing, which is what a build without those tables
+ * deserves and still tells it apart from a build with them.</p>
  *
  * @since 0.63
  */
@@ -30,10 +42,34 @@ final class Fingerprint implements Supplier<String> {
     private final String[] resources;
 
     /**
+     * The directories whose files to hash, in the order of their names.
+     * Empty when only the resources are hashed.
+     */
+    private final Iterable<Path> dirs;
+
+    /**
      * Ctor.
      * @param res Classpath resource paths to hash
      */
     Fingerprint(final String... res) {
+        this(Collections.emptyList(), res);
+    }
+
+    /**
+     * Ctor.
+     * @param files The directory whose files to hash
+     */
+    Fingerprint(final Path files) {
+        this(Collections.singletonList(files), new String[0]);
+    }
+
+    /**
+     * Ctor.
+     * @param files The directories whose files to hash
+     * @param res Classpath resource paths to hash
+     */
+    private Fingerprint(final Iterable<Path> files, final String... res) {
+        this.dirs = files;
         this.resources = res.clone();
     }
 
@@ -49,6 +85,19 @@ final class Fingerprint implements Supplier<String> {
                         );
                     }
                     digest.update(input.readAllBytes());
+                }
+            }
+            for (final Path base : this.dirs) {
+                if (Files.isDirectory(base)) {
+                    try (Stream<Path> found = Files.walk(base)) {
+                        for (final Path file : found.filter(Files::isRegularFile)
+                            .sorted().collect(Collectors.toList())) {
+                            digest.update(
+                                base.relativize(file).toString().getBytes(StandardCharsets.UTF_8)
+                            );
+                            digest.update(Files.readAllBytes(file));
+                        }
+                    }
                 }
             }
             final StringBuilder hex = new StringBuilder(64);

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -21,6 +21,9 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 import org.eolang.parser.TrFull;
 
 /**
@@ -121,13 +124,16 @@ final class Transpilation {
     /**
      * The directory with the tables of {@link MjInference}, which
      * {@code purify.xsl} reads to find out which formations are safe to
-     * cache. It stays out of {@link #version()} on purpose: nothing in the
-     * generated Java depends on the label yet, so a result cached by an
-     * earlier build is still the right one, and a path differs from one
-     * machine to another anyway, which would keep a shared cache from ever
-     * being hit.
+     * cache.
      */
     private final Path inference;
+
+    /**
+     * The fingerprint of those tables, worked out once and kept, since
+     * {@link #version()} is asked for every source file of the build and
+     * the tables of {@code eo-runtime} are tens of megabytes.
+     */
+    private final Scalar<String> fingerprint;
 
     /**
      * Ctor.
@@ -155,6 +161,7 @@ final class Transpilation {
         this.measures = measures;
         this.target = dir;
         this.inference = tables;
+        this.fingerprint = new Sticky<>(() -> new Fingerprint(tables).get());
     }
 
     /**
@@ -175,17 +182,24 @@ final class Transpilation {
      * {@code to-java.xsl} emits (see #6031 and #5955), and
      * {@code trackSteps} decides whether the XMIRs of the train are written
      * at all, which a cache hit would otherwise skip (see #7628).
+     * The content of the inference tables is folded in for the same reason:
+     * {@code purify.xsl} reads them and stamps {@code @pure}, which
+     * {@code to-java.xsl} turns into {@code new PhSticky(...)}, so the same
+     * source with different tables, or with none, is different Java (see
+     * #7627). The content and not the path, since a path differs from one
+     * machine to another and a shared cache would never be hit again.
      * @return The version segment for {@link CachePath}
      */
     String version() {
         return String.format(
-            "%s-%s-%b-%b-%b-%s",
+            "%s-%s-%s-%b-%b-%b-%s",
             this.version,
             new Fingerprint(
                 Stream.concat(
                     Arrays.stream(Transpilation.XSLS), Arrays.stream(Transpilation.IMPORTS)
                 ).toArray(String[]::new)
             ).get(),
+            new Unchecked<>(this.fingerprint).value(),
             this.tracking.locations(), this.tracking.steps(), this.coverage, this.superclass
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
@@ -4,16 +4,23 @@
  */
 package org.eolang.maven;
 
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Transpilation}.
  * @since 0.74
  */
+@ExtendWith(MktmpResolver.class)
 final class TranspilationTest {
 
     @Test
@@ -23,6 +30,21 @@ final class TranspilationTest {
             this.transpilation(new Tracking(true, false)).version(),
             Matchers.not(
                 Matchers.equalTo(this.transpilation(new Tracking(false, false)).version())
+            )
+        );
+    }
+
+    @Test
+    void tellsInferenceTablesApartInTheCacheKey(@Mktmp final Path temp) throws IOException {
+        final Path tables = Files.createDirectories(temp.resolve("tables"));
+        Files.writeString(tables.resolve("provides.xml"), "<provides/>");
+        MatcherAssert.assertThat(
+            "a build that read the tables must not take the result of one that had none",
+            this.transpilation(tables).version(),
+            Matchers.not(
+                Matchers.equalTo(
+                    this.transpilation(temp.resolve("absent")).version()
+                )
             )
         );
     }
@@ -52,6 +74,18 @@ final class TranspilationTest {
             Paths.get("xsl-measures.csv"),
             Paths.get("target"),
             Paths.get("target/eo/6-inference")
+        );
+    }
+
+    private Transpilation transpilation(final Path tables) {
+        return new Transpilation(
+            "1.0-SNAPSHOT",
+            new Tracking(false, false),
+            false,
+            "PhDefault",
+            Paths.get("xsl-measures.csv"),
+            Paths.get("target"),
+            tables
         );
     }
 }


### PR DESCRIPTION
`purify.xsl` reads the inference tables and stamps `@pure`, which `to-java.xsl`
turns into `new PhSticky(...)`, so the same source with different tables, or
with none at all, is different Java. The key did not say so, and a cached
result was served for a build that would have produced something else.

The content of the tables now joins the key. `Fingerprint` hashes a directory
of files the same way it already hashes classpath resources, so there is one
digest and one place that formats it, and the fingerprint is worked out once
per build rather than once per source file.

New test in `TranspilationTest` checks a build with tables and one without
have different keys.

Closes #7627
