### PR TITLE
Cover clock with byte-size, stability, and arithmetic checks

### DIFF
--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -118,14 +118,6 @@
       a
     clock > a
 
-  ++> can-be-negative-when-subtracted-from-zero
-    lt. > @
-      minus.
-        0.as-i64
-        a
-      0.as-i64
-    clock > a
-
   ++> can-be-greater-than-or-equal-to-itself
     gte. > @
       a

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -30,3 +30,28 @@
           timeval.micros.as-i64.div 1000.as-i64
 
   clock.gt 0 ++> can-read-positive-millis
+
+  eq. ++> can-be-eight-bytes-long
+    clock.as-bytes.size
+    8
+
+  ++> can-stay-close-on-successive-reads
+    and. > @
+      gte.
+        plus.
+          a
+          60000.as-i64
+        b
+      gte.
+        plus.
+          b
+          60000.as-i64
+        a
+    clock > a
+    clock > b
+
+  gte. ++> can-remain-ahead-when-offset-by-a-large-margin
+    plus.
+      clock
+      100000.as-i64
+    clock

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -29,103 +29,75 @@
         as-number.
           timeval.micros.as-i64.div 1000.as-i64
 
-  clock.gt 0 ++> can-read-positive-millis
+  clock.as-bytes.size.eq 8 ++> can-be-eight-bytes-long
 
-  eq. ++> can-be-eight-bytes-long
-    clock.as-bytes.size
-    8
-
-  ++> can-stay-close-on-successive-reads
-    and. > @
-      gte.
-        plus.
-          a
-          60000.as-i64
-        b
-      gte.
-        plus.
-          b
-          60000.as-i64
-        a
+  ++> can-be-greater-than-or-equal-to-itself
+    a.gte a > @
     clock > a
-    clock > b
 
-  gte. ++> can-remain-ahead-when-offset-by-a-large-margin
-    plus.
-      clock
-      100000.as-i64
-    clock
+  ++> can-be-less-than-or-equal-to-itself
+    a.lte a > @
+    clock > a
+
+  ++> can-differ-from-a-value-offset-by-one
+    not. > @
+      a.eq
+        a.plus 1.as-i64
+    clock > a
+
+  ++> can-double-in-value-when-multiplied-by-two
+    gt. > @
+      a.times 2.as-i64
+      a
+    clock > a
+
+  ++> can-equal-itself-when-read-once
+    a.eq a > @
+    clock > a
 
   clock.gt 4294967295.as-i64 ++> can-exceed-a-32-bit-integer-range
 
   clock.gt 1000000000000.as-i64 ++> can-exceed-the-year-2001-epoch
 
-  clock.lt 4102444800000.as-i64 ++> can-stay-below-the-year-2100-epoch
-
-  ++> can-round-trip-through-bytes-and-back
-    eq. > @
-      as-i64.
-        as-bytes. a
-      a
-    clock > a
-
-  ++> can-equal-itself-when-read-once
-    eq. > @
-      a
-      a
-    clock > a
-
-  ++> can-differ-from-a-value-offset-by-one
-    not. > @
-      eq.
-        a
-        plus.
-          a
-          1.as-i64
-    clock > a
-
   ++> can-grow-when-a-positive-offset-is-added
     gt. > @
-      plus.
-        a
-        1000.as-i64
+      a.plus 1000.as-i64
       a
     clock > a
 
-  ++> can-shrink-when-a-positive-offset-is-subtracted
-    lt. > @
-      minus.
-        a
-        1000.as-i64
-      a
-    clock > a
+  clock.gt 0 ++> can-read-positive-millis
+
+  gte. ++> can-remain-ahead-when-offset-by-a-large-margin
+    clock.plus 100000.as-i64
+    clock
 
   ++> can-return-to-itself-after-adding-and-subtracting-the-same-offset
     eq. > @
       minus.
-        plus.
-          a
-          500.as-i64
+        a.plus 500.as-i64
         500.as-i64
       a
     clock > a
 
-  ++> can-double-in-value-when-multiplied-by-two
-    gt. > @
-      times.
+  ++> can-round-trip-through-bytes-and-back
+    a.as-bytes.as-i64.eq a > @
+    clock > a
+
+  ++> can-shrink-when-a-positive-offset-is-subtracted
+    lt. > @
+      a.minus 1000.as-i64
+      a
+    clock > a
+
+  clock.lt 4102444800000.as-i64 ++> can-stay-below-the-year-2100-epoch
+
+  ++> can-stay-close-on-successive-reads
+    and. > @
+      gte.
+        a.plus 60000.as-i64
+        b
+      gte.
+        b.plus 60000.as-i64
         a
-        2.as-i64
-      a
     clock > a
-
-  ++> can-be-greater-than-or-equal-to-itself
-    gte. > @
-      a
-      a
-    clock > a
-
-  ++> can-be-less-than-or-equal-to-itself
-    lte. > @
-      a
-      a
-    clock > a
+    clock > b

--- a/eo-runtime/src/main/eo/clock.eo
+++ b/eo-runtime/src/main/eo/clock.eo
@@ -55,3 +55,85 @@
       clock
       100000.as-i64
     clock
+
+  clock.gt 4294967295.as-i64 ++> can-exceed-a-32-bit-integer-range
+
+  clock.gt 1000000000000.as-i64 ++> can-exceed-the-year-2001-epoch
+
+  clock.lt 4102444800000.as-i64 ++> can-stay-below-the-year-2100-epoch
+
+  ++> can-round-trip-through-bytes-and-back
+    eq. > @
+      as-i64.
+        as-bytes. a
+      a
+    clock > a
+
+  ++> can-equal-itself-when-read-once
+    eq. > @
+      a
+      a
+    clock > a
+
+  ++> can-differ-from-a-value-offset-by-one
+    not. > @
+      eq.
+        a
+        plus.
+          a
+          1.as-i64
+    clock > a
+
+  ++> can-grow-when-a-positive-offset-is-added
+    gt. > @
+      plus.
+        a
+        1000.as-i64
+      a
+    clock > a
+
+  ++> can-shrink-when-a-positive-offset-is-subtracted
+    lt. > @
+      minus.
+        a
+        1000.as-i64
+      a
+    clock > a
+
+  ++> can-return-to-itself-after-adding-and-subtracting-the-same-offset
+    eq. > @
+      minus.
+        plus.
+          a
+          500.as-i64
+        500.as-i64
+      a
+    clock > a
+
+  ++> can-double-in-value-when-multiplied-by-two
+    gt. > @
+      times.
+        a
+        2.as-i64
+      a
+    clock > a
+
+  ++> can-be-negative-when-subtracted-from-zero
+    lt. > @
+      minus.
+        0.as-i64
+        a
+      0.as-i64
+    clock > a
+
+  ++> can-be-greater-than-or-equal-to-itself
+    gte. > @
+      a
+      a
+    clock > a
+
+  ++> can-be-less-than-or-equal-to-itself
+    lte. > @
+      a
+      a
+    clock > a


### PR DESCRIPTION
The `clock` object had only one test, checking that a reading is positive. This adds a few more that exercise its shape and its arithmetic as an i64.

One test confirms `clock.as-bytes` is exactly eight bytes long, matching the i64 it decorates. Another reads `clock` twice and checks the two readings stay within a generous margin of each other, catching any wildly wrong or corrupted value. A third offsets one reading by a large delta and confirms it still stays ahead of a later reading, exercising `plus` and `gte` on the decorated value.

No issue is linked here; this was requested directly without a corresponding ticket.