### PR TITLE
Cover console.eo write edge cases and read chaining

### DIFF
--- a/eo-integration-tests/src/test/resources/snippets/reads-via-console.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-via-console.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+out:
+  - ".*HelloWorld!.*"
+file: snippets/reads-via-console.eo
+args: ["snippets.reads-via-console"]
+stdin: |-
+  HelloWorld!
+eo: |
+  +package snippets
+
+  [] > reads-via-console
+    stdout > @
+      "%s%s%s".printf
+        *
+          string c1
+          string c2
+          string c3
+    console.read 5 > c1
+    c1.read 5 > c2
+    c2.read 1 > c3

--- a/eo-integration-tests/src/test/resources/snippets/reads-via-independent-console-calls.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-via-independent-console-calls.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+out:
+  - ".*HelloWorld!.*"
+file: snippets/reads-via-independent-console-calls.eo
+args: ["snippets.reads-via-independent-console-calls"]
+stdin: |-
+  HelloWorld!
+eo: |
+  +package snippets
+
+  [] > reads-via-independent-console-calls
+    stdout > @
+      "%s%s".printf
+        *
+          string c1
+          string c2
+    console.read 6 > c1
+    console.read 5 > c2

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -171,3 +171,12 @@
 
   console.write ++> can-write-to-the-console
     "Hello, console-test!\n"
+
+  console.write ++> can-write-an-empty-string-to-the-console
+    ""
+
+  console.write ++> can-write-a-non-ascii-string-to-the-console
+    "héllo, wörld! 日本語\n"
+
+  --> cannot-dataize-console-directly
+    console

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -179,5 +179,4 @@
   console.write ++> can-write-to-the-console
     "Hello, console-test!\n"
 
-  --> cannot-dataize-console-directly
-    console
+  console --> cannot-dataize-console-directly

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -178,5 +178,8 @@
   console.write ++> can-write-a-non-ascii-string-to-the-console
     "héllo, wörld! 日本語\n"
 
+  console.write ++> can-write-raw-bytes-to-the-console
+    48-65-6C-6C-6F-0A
+
   --> cannot-dataize-console-directly
     console

--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -169,17 +169,15 @@
     console.write > o1
       "part one, "
 
-  console.write ++> can-write-to-the-console
-    "Hello, console-test!\n"
-
-  console.write ++> can-write-an-empty-string-to-the-console
-    ""
-
   console.write ++> can-write-a-non-ascii-string-to-the-console
     "héllo, wörld! 日本語\n"
 
-  console.write ++> can-write-raw-bytes-to-the-console
-    48-65-6C-6C-6F-0A
+  console.write "" ++> can-write-an-empty-string-to-the-console
+
+  console.write 48-65-6C-6C-6F-0A ++> can-write-raw-bytes-to-the-console
+
+  console.write ++> can-write-to-the-console
+    "Hello, console-test!\n"
 
   --> cannot-dataize-console-directly
     console


### PR DESCRIPTION
console.eo had only two unit tests, both exercising a single successful
write of a short ASCII string. This adds a few more edge cases: writing
an empty string, writing a non-ASCII string (to exercise byte-length vs
character-length handling), and an error test confirming that dataizing
`console` directly fails, matching what the class docblock already says.

console.read cannot be exercised by a `++>` test since it reaches the
process's real file descriptor 0 through posix/win32, so this also adds
an integration snippet (reads-via-console.yaml) that feeds real stdin to
a forked JVM and checks that chained console.read calls reassemble the
original input correctly.