### PR TITLE
Add test coverage for false.eo

### DIFF
--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -8,8 +8,28 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-bool > false
-  [^]
-    ? >> left
-    ? >> right
-    right > @
+[^] > false
+  bool > @
+    [^]
+      ? >> left
+      ? >> right
+      right > @
+
+  eq. ++> can-avoid-evaluating-the-left-argument
+    false.if
+      1.div 0
+      42
+    42
+
+  eq. ++> can-choose-the-right-argument
+    false.if 1 2
+    2
+
+  false.eq false ++> can-equal-itself
+
+  false.as-bytes.eq 00- ++> can-expose-the-byte-representation-of-false
+
+  false.not.eq true ++> can-negate-to-true
+
+  not. ++> cannot-equal-true
+    false.eq true

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -27,11 +27,11 @@
       2
     2
 
+  not. ++> can-differ-from-true
+    false.eq true
+
   false.eq false ++> can-equal-itself
 
   false.as-bytes.eq 00- ++> can-expose-the-byte-representation-of-false
 
   false.not.eq true ++> can-negate-to-true
-
-  not. ++> cannot-equal-true
-    false.eq true

--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -22,7 +22,9 @@
     42
 
   eq. ++> can-choose-the-right-argument
-    false.if 1 2
+    false.if
+      1
+      2
     2
 
   false.eq false ++> can-equal-itself


### PR DESCRIPTION
false.eo had no dedicated tests of its own; its behavior was only exercised indirectly through bool.eo.

This adds tests that check the false-specific choice behavior: that if. picks the right argument, that the left argument is never evaluated (a division by zero in it does not terminate the program), the byte representation, negation, and equality against itself and against true.

To attach test attributes to the object, false was rewritten from a bare `bool > false` application into a `[^] > false` wrapper that decorates through `bool > @`, matching the pattern used elsewhere in the runtime (e.g. eol.eo, directory/deleted.eo) for adding tests to an otherwise plain value.