### PR TITLE
Cover mktemp.eo with more test edge cases

### DIFF
--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -90,14 +90,17 @@
     seq * > @
       different
       temp.deleted
+      different
     not. > different!
       temp.path.eq mktemp.path
     mktemp.tmpfile > temp
 
   ++> can-return-a-tmpfile-with-a-non-empty-basename
     seq * > @
-      temp.as-path.basename.length.gt 0
+      named
       temp.deleted
+      named
+    temp.as-path.basename.length.gt 0 > named!
     mktemp.tmpfile > temp
 
   mktemp.as-path.eq ++> can-return-the-same-path-through-as-path-and-path
@@ -107,6 +110,8 @@
 
   ++> can-tell-that-a-fresh-tmpfile-is-not-a-directory
     seq * > @
-      temp.is-directory.not
+      regular
       temp.deleted
+      regular
+    temp.is-directory.not > regular!
     mktemp.tmpfile > temp

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -86,7 +86,7 @@
     path.separator.joined
       * mktemp.path "eo-mktemp-child"
 
-  ++> can-return-a-tmpfile-whose-path-differs-from-the-temp-directorys-path
+  ++> can-return-a-tmpfile-whose-path-differs-from-the-temp-directory-path
     seq * > @
       different
       temp.deleted

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -75,24 +75,16 @@
 
   mktemp.exists ++> can-point-at-an-existing-global-temp-directory
 
-  eq. ++> can-report-being-a-directory-consistently-across-repeated-calls
-    mktemp.is-directory
-    mktemp.is-directory
+  ++> can-report-being-a-directory-consistently-across-repeated-calls
+    mktemp.is-directory.eq mktemp.is-directory > @
 
-  eq. ++> can-report-existing-consistently-across-repeated-calls
-    mktemp.exists
+  mktemp.exists.eq ++> can-report-existing-consistently-across-repeated-calls
     mktemp.exists
 
   eq. ++> can-resolve-a-child-path-under-the-temp-directory
     mktemp.as-path.resolved "eo-mktemp-child"
     path.separator.joined
       * mktemp.path "eo-mktemp-child"
-
-  ++> can-return-a-tmpfile-with-a-non-empty-basename
-    seq * > @
-      temp.as-path.basename.length.gt 0
-      temp.deleted
-    mktemp.tmpfile > temp
 
   ++> can-return-a-tmpfile-whose-path-differs-from-the-temp-directorys-path
     seq * > @
@@ -102,13 +94,19 @@
       temp.path.eq mktemp.path
     mktemp.tmpfile > temp
 
-  mktemp.as-path.eq mktemp.path ++> can-return-the-same-path-through-as-path-and-path
+  ++> can-return-a-tmpfile-with-a-non-empty-basename
+    seq * > @
+      temp.as-path.basename.length.gt 0
+      temp.deleted
+    mktemp.tmpfile > temp
+
+  mktemp.as-path.eq ++> can-return-the-same-path-through-as-path-and-path
+    mktemp.path
 
   mktemp.path.eq mktemp.path ++> can-return-the-same-temp-directory
 
   ++> can-tell-that-a-fresh-tmpfile-is-not-a-directory
     seq * > @
-      not.
-        temp.is-directory
+      temp.is-directory.not
       temp.deleted
     mktemp.tmpfile > temp

--- a/eo-runtime/src/main/eo/mktemp.eo
+++ b/eo-runtime/src/main/eo/mktemp.eo
@@ -46,8 +46,69 @@
 
   mktemp.tmpfile.exists ++> can-create-a-temp-file
 
+  ++> can-create-a-tmpfile-directly-inside-the-temp-directory
+    seq * > @
+      same
+      temp.deleted
+      same
+    temp.as-path.dirname.eq mktemp.path > same!
+    mktemp.tmpfile > temp
+
+  ++> can-create-tmpfiles-with-distinct-paths-across-calls
+    seq * > @
+      first.exists.and second.exists
+      first.deleted
+      second.deleted
+      different
+    not. > different!
+      first.path.eq second.path
+    mktemp.tmpfile > first
+    mktemp.tmpfile > second
+
+  ++> can-keep-the-temp-directory-after-deleting-a-tmpfile
+    seq * > @
+      temp.deleted
+      mktemp.exists
+    mktemp.tmpfile > temp
+
   mktemp.is-directory ++> can-point-at-a-global-temp-directory
 
   mktemp.exists ++> can-point-at-an-existing-global-temp-directory
 
+  eq. ++> can-report-being-a-directory-consistently-across-repeated-calls
+    mktemp.is-directory
+    mktemp.is-directory
+
+  eq. ++> can-report-existing-consistently-across-repeated-calls
+    mktemp.exists
+    mktemp.exists
+
+  eq. ++> can-resolve-a-child-path-under-the-temp-directory
+    mktemp.as-path.resolved "eo-mktemp-child"
+    path.separator.joined
+      * mktemp.path "eo-mktemp-child"
+
+  ++> can-return-a-tmpfile-with-a-non-empty-basename
+    seq * > @
+      temp.as-path.basename.length.gt 0
+      temp.deleted
+    mktemp.tmpfile > temp
+
+  ++> can-return-a-tmpfile-whose-path-differs-from-the-temp-directorys-path
+    seq * > @
+      different
+      temp.deleted
+    not. > different!
+      temp.path.eq mktemp.path
+    mktemp.tmpfile > temp
+
+  mktemp.as-path.eq mktemp.path ++> can-return-the-same-path-through-as-path-and-path
+
   mktemp.path.eq mktemp.path ++> can-return-the-same-temp-directory
+
+  ++> can-tell-that-a-fresh-tmpfile-is-not-a-directory
+    seq * > @
+      not.
+        temp.is-directory
+      temp.deleted
+    mktemp.tmpfile > temp


### PR DESCRIPTION
Adds ten more \`++>\` tests to \`mktemp.eo\`, covering behavior that wasn't exercised yet: tmpfiles are created directly inside the temp directory, repeated calls create tmpfiles with distinct paths, the temp directory survives after a tmpfile is deleted, \`is-directory\` and \`exists\` are consistent across repeated calls, child paths resolve correctly under the temp directory, a fresh tmpfile has a non-empty basename and a path distinct from the temp directory's own path, \`as-path\` and \`path\` agree, and a fresh tmpfile is not itself a directory.

No issue exists for this yet, so nothing is closed by this PR.