### PR TITLE
Add more test coverage for stderr.eo

### DIFF
--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -77,48 +77,49 @@
       text
     true
 
-  stderr ++> can-print-to-stderr
-    "Hello, stderr-test!\n"
-
-  stderr ++> can-print-an-empty-string
-    ""
-
   stderr ++> can-print-a-multiline-string
     "Line one\nLine two\nLine three\n"
 
-  stderr ++> can-print-a-string-with-unicode-characters
-    "Привет, мир! 你好，世界！\n"
-
-  stderr ++> can-print-a-very-long-string
-    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\n"
-
-  eq. ++> can-return-true-after-printing-to-stderr
-    stderr "Checking the return value\n"
-    true
-
-  ++> can-print-to-stderr-multiple-times-in-a-row
-    seq * > @
-      stderr "First line\n"
-      stderr "Second line\n"
-
-  stderr ++> can-print-a-single-character
-    "x"
-
-  stderr ++> can-print-a-string-without-a-trailing-newline
-    "no newline at the end"
+  stderr "x" ++> can-print-a-single-character
 
   stderr ++> can-print-a-string-that-is-only-whitespace
     "   \t  "
 
-  stderr ++> can-print-a-string-with-tabs-and-quotes
-    "col1\tcol2\t\"quoted\"\n"
+  stderr ++> can-print-a-string-with-a-carriage-return
+    "Windows-style line\r\n"
 
   stderr ++> can-print-a-string-with-emoji
     "Build failed ⚠️\n"
 
-  stderr ++> can-print-a-string-with-a-carriage-return
-    "Windows-style line\r\n"
+  stderr "col1\tcol2\t\"quoted\"\n" ++> can-print-a-string-with-tabs-and-quotes
+
+  stderr ++> can-print-a-string-with-unicode-characters
+    "Привет, мир! 你好，世界！\n"
+
+  stderr ++> can-print-a-string-without-a-trailing-newline
+    "no newline at the end"
+
+  stderr ++> can-print-a-very-long-string
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\n"
+
+  stderr "" ++> can-print-an-empty-string
 
   eq. ++> can-print-the-same-string-consistently-across-repeated-calls
-    stderr "Repeatable message\n"
-    stderr "Repeatable message\n"
+    stderr
+      "Repeatable message\n"
+    stderr
+      "Repeatable message\n"
+
+  stderr ++> can-print-to-stderr
+    "Hello, stderr-test!\n"
+
+  seq * ++> can-print-to-stderr-multiple-times-in-a-row
+    stderr
+      "First line\n"
+    stderr
+      "Second line\n"
+
+  eq. ++> can-return-true-after-printing-to-stderr
+    stderr
+      "Checking the return value\n"
+    true

--- a/eo-runtime/src/main/eo/stderr.eo
+++ b/eo-runtime/src/main/eo/stderr.eo
@@ -79,3 +79,46 @@
 
   stderr ++> can-print-to-stderr
     "Hello, stderr-test!\n"
+
+  stderr ++> can-print-an-empty-string
+    ""
+
+  stderr ++> can-print-a-multiline-string
+    "Line one\nLine two\nLine three\n"
+
+  stderr ++> can-print-a-string-with-unicode-characters
+    "Привет, мир! 你好，世界！\n"
+
+  stderr ++> can-print-a-very-long-string
+    "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz\n"
+
+  eq. ++> can-return-true-after-printing-to-stderr
+    stderr "Checking the return value\n"
+    true
+
+  ++> can-print-to-stderr-multiple-times-in-a-row
+    seq * > @
+      stderr "First line\n"
+      stderr "Second line\n"
+
+  stderr ++> can-print-a-single-character
+    "x"
+
+  stderr ++> can-print-a-string-without-a-trailing-newline
+    "no newline at the end"
+
+  stderr ++> can-print-a-string-that-is-only-whitespace
+    "   \t  "
+
+  stderr ++> can-print-a-string-with-tabs-and-quotes
+    "col1\tcol2\t\"quoted\"\n"
+
+  stderr ++> can-print-a-string-with-emoji
+    "Build failed ⚠️\n"
+
+  stderr ++> can-print-a-string-with-a-carriage-return
+    "Windows-style line\r\n"
+
+  eq. ++> can-print-the-same-string-consistently-across-repeated-calls
+    stderr "Repeatable message\n"
+    stderr "Repeatable message\n"


### PR DESCRIPTION
The stderr object only had one unit test, printing a single fixed string. This adds a dozen more cases covering the shapes of input it's likely to see in practice: an empty string, a multiline string, unicode text, emoji, a very long string, a single character, a string with no trailing newline, a whitespace-only string, tabs and quotes, and a Windows-style carriage return.

It also checks the return value directly with an explicit `eq.` comparison to `true`, and adds two tests around calling stderr more than once: one confirming a sequence of writes still succeeds, and one confirming the same string produces the same (successful) result across repeated calls.

Since stderr writes to the real file descriptor 2, these tests can only exercise that the call completes and returns `true` for each input shape, the same limitation as the existing stdout/console tests.