### PR TITLE
Cover stdin.eo with snippet tests

### DIFF
--- a/eo-integration-tests/src/test/resources/snippets/reads-empty-first-line.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-empty-first-line.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+out:
+  - '.*<next-line>.*'
+file: snippets/reads-empty-first-line.eo
+args: ["snippets.reads-empty-first-line"]
+stdin: "\nвторая\n"
+eo: |
+  +package snippets
+
+  [] > reads-empty-first-line
+    stdout > @
+      "<".concat
+        stdin.next-line.concat "next-line>"

--- a/eo-integration-tests/src/test/resources/snippets/reads-line-without-carriage-return.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-line-without-carriage-return.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+out:
+  - '.*<日本語>.*'
+file: snippets/reads-line-without-carriage-return.eo
+args: ["snippets.reads-line-without-carriage-return"]
+stdin: "日本語\r\n"
+eo: |
+  +package snippets
+
+  [] > reads-line-without-carriage-return
+    stdout > @
+      "<".concat
+        stdin.all-lines.concat ">"

--- a/eo-integration-tests/src/test/resources/snippets/reads-next-line.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-next-line.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+out:
+  - '.*<первая>.*'
+file: snippets/reads-next-line.eo
+args: ["snippets.reads-next-line"]
+stdin: |
+  первая
+  вторая
+  третья
+eo: |
+  +package snippets
+
+  [] > reads-next-line
+    stdout > @
+      "<".concat
+        stdin.next-line.concat ">"

--- a/eo-integration-tests/src/test/resources/snippets/reads-nothing-from-blank-stdin.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-nothing-from-blank-stdin.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+out:
+  - '.*<all-lines>.*'
+file: snippets/reads-nothing-from-blank-stdin.eo
+args: ["snippets.reads-nothing-from-blank-stdin"]
+stdin: "\n"
+eo: |
+  +package snippets
+
+  [] > reads-nothing-from-blank-stdin
+    stdout > @
+      "<".concat
+        stdin.all-lines.concat "all-lines>"

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -23,8 +23,8 @@
 # Reading from the console cannot be exercised by a `++>` test, since
 # `console.read` reaches the process's real file descriptor 0 through
 # `posix`/`win32` and neither can be substituted in EO. The
-# `reads-all-lines` snippet feeds real standard input to a forked JVM and
-# checks what comes back.
+# `reads-*` snippets of `eo-integration-tests` feed real standard input to a
+# forked JVM and check what comes back.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo


### PR DESCRIPTION
`stdin.eo` had no tests at all — it carries `+unlint unit-test-missing`, and the only thing exercising it was the `reads-all-lines` snippet. A `++>` test cannot reach it: `console.read` goes to the process's real file descriptor 0 through `posix`/`win32`, and neither can be substituted from EO. So the coverage goes where the existing one already lives, in the integration-test snippets that fork a JVM and hand it a real standard input.

Four new snippets: `reads-next-line` checks that `next-line` stops at the first line instead of swallowing the rest; `reads-line-without-carriage-return` feeds `\r\n` and multi-byte text, so it covers both the CRLF branch of the inner `rec-read` and the multi-byte ordering the docblock talks about; `reads-empty-first-line` reads a line that is empty; `reads-nothing-from-blank-stdin` runs `all-lines` over a stream that ends after one blank line.

Each snippet wraps the result in angle brackets before printing, so the assertion fails when the object returns more text than the line it was asked for — a bare substring match would pass either way.

Note that these are failsafe tests and PR checks run with `-PskipITs`, so they only get exercised by the `ec2` workflow on master.
