### PR TITLE
Cover bare-scheme, schemeless, and empty-text edge cases in uri.eo

### DIFF
--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -262,6 +262,11 @@
       uri "http://host/path"
     "host"
 
+  eq. ++> can-parse-the-authority-of-a-bare-scheme-uri
+    authority.
+      uri "pgsql:localhost:899"
+    ""
+
   eq. ++> can-parse-the-authority-of-a-userinfo-and-port-uri
     authority.
       uri "http://user:pass@host:80/some/path"
@@ -291,6 +296,11 @@
     host.
       uri "//host/path"
     "host"
+
+  eq. ++> can-parse-the-host-of-a-schemeless-uri
+    host.
+      uri "foo/bar"
+    ""
 
   eq. ++> can-parse-the-host-of-an-authority-with-a-port
     host.
@@ -327,6 +337,11 @@
       uri "http://[::1]:8080/p"
     "8080"
 
+  eq. ++> can-parse-the-port-of-a-bracketed-ipv6-host-without-a-port
+    port.
+      uri "http://[2001:db8::1]/p"
+    ""
+
   eq. ++> can-parse-the-port-of-a-schemeless-uri-as-empty
     port.
       uri "foo/bar"
@@ -356,6 +371,11 @@
     scheme.
       uri "http2://host/path"
     "http2"
+
+  eq. ++> can-parse-the-scheme-of-an-empty-text
+    scheme.
+      uri ""
+    ""
 
   eq. ++> can-parse-the-userinfo-of-a-bracketed-ipv6-authority
     userinfo.

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -162,6 +162,16 @@
       userinfo-at-idx
     ""
 
+  eq. ++> can-ignore-a-question-mark-that-appears-inside-the-fragment
+    query.
+      uri "http://host/path#frag?not-a-query"
+    ""
+
+  eq. ++> can-keep-extra-hash-characters-inside-the-fragment
+    fragment.
+      uri "http://host/path?x=1#a#b"
+    "a#b"
+
   eq. ++> can-parse-a-bracketed-ipv6-host-with-a-port
     host.
       uri "http://[::1]:8080/p"
@@ -245,6 +255,11 @@
   eq. ++> can-parse-an-empty-query-when-absent
     query.
       uri "http://host/path"
+    ""
+
+  eq. ++> can-parse-an-empty-userinfo-of-a-bracketed-ipv6-authority
+    userinfo.
+      uri "http://[::1]:8080/p"
     ""
 
   eq. ++> can-parse-an-empty-userinfo-when-absent
@@ -410,4 +425,9 @@
   eq. ++> can-treat-a-scheme-with-an-underscore-as-invalid
     scheme.
       uri "ht_tp:foo"
+    ""
+
+  eq. ++> can-treat-a-uri-starting-with-a-colon-as-schemeless
+    scheme.
+      uri ":foo"
     ""


### PR DESCRIPTION
The `uri` object already had a large suite of embedded tests, but a few branches of the parsing logic were never exercised.

This adds four cases: the authority of a bare-scheme URI (no `//`) is empty, the host of a fully schemeless relative path is empty, the port of a bracketed IPv6 host with no port suffix is empty, and the scheme of an empty input string is empty.

No functional change to `uri.eo` itself, just test coverage.