### PR TITLE
fix(#7429): write the decimals a double can divide without i64 long division

### DIFF
--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -20,38 +20,58 @@
       n.eq -9.223372036854776e18
       "-9223372036854775808".as-bytes
       if.
-        n.abs.gte
-          2.power 63
+        n.abs.gte 9.223372036854776e18
         T
           "Can't write this number as decimal digits: its magnitude is 2^63 or larger, past the range of a signed 64-bit integer"
         if.
-          n.lt 0
-          if. > [^ m] >> negative
-            m.as-number.eq 0
-            digits m
+          n.abs.lt 9007199254740992
+          if.
+            and.
+              n.lt 0
+              not.
+                truncated.eq 0
             "-".as-bytes.concat
+              [^ m] >> quick
+                if. > @
+                  m.lt 10
+                  as-char.
+                    m.plus 48
+                  concat.
+                    ^.quick head
+                    as-char.
+                      plus.
+                        m.minus (head.times 10)
+                        48
+                floor. > head
+                  m.div 10
+              | truncated
+            quick truncated
+          if.
+            n.lt 0
+            if. > [^ m] >> negative
+              m.as-number.eq 0
               digits m
-          |
-            as-i64.
-              n.times -1
-              T message > [^ message] >> failure
-          [^ n] >> digits
-            if. > @
-              n.lt ^.ten
-              as-char.
-                n.as-number.plus 48
-              concat.
-                ^.digits q
+              "-".as-bytes.concat
+                digits m
+            |
+              as-i64.
+                n.times -1
+                T message > [^ message] >> failure
+            [^ n] >> digits
+              if. > @
+                n.lt ^.ten
                 as-char.
-                  plus.
-                    as-number.
-                      n.minus (q.times ^.ten)
-                    48
-            n.div ^.ten failure > bits!
-            i64 bits > q
-          | (n.as-i64 failure)
+                  n.as-number.plus 48
+                concat.
+                  ^.digits q
+                  as-char.
+                    plus. (n.minus (q.times ^.ten)).as-number 48
+              n.div ^.ten failure > bits!
+              i64 bits > q
+            | (n.as-i64 failure)
   ^ > n
   10.as-i64 failure > ten!
+  n.abs.floor > truncated
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one
     "0"

--- a/eo-runtime/src/main/eo/number/as-fixed.eo
+++ b/eo-runtime/src/main/eo/number/as-fixed.eo
@@ -87,8 +87,7 @@
             positive a
         | (n.times -1)
         positive n
-  n.abs.gte > huge
-    2.power 63
+  n.abs.gte 9.223372036854776e18 > huge
   ^ > n
   if. > [^ p] >> pow10
     p.eq 0


### PR DESCRIPTION
Fixes #7429, partly, and takes the crash out of it.

Two things cost the time, and neither is in `printf`.

**The magnitude guard.** `as-decimal` and `as-fixed` both open with `n.abs.gte (2.power 63)`, and `power` is not a constant: it costs 1.8 s every call, on every number, however small. That is the floor under `"%d".printf * 1`. The same value written as the literal `9.223372036854776e18` is the identical double (`43e0000000000000` either way), and `as-decimal` already compares against it one line above for the negative bound.

**The digits.** Each digit was peeled with `i64.div`, and `i64.div` is pure EO: a restoring long division that loops 64 times. That is roughly 0.6 s per digit, so a 13-digit epoch value takes eight seconds of it.

A double divides by ten exactly for every magnitude below 2^53, which is what the file's own header says the `i64` path exists to get past. So magnitudes under 2^53 now peel their digits with plain number arithmetic, and only larger ones go through `i64`. The boundary cases already had examples on both sides: `9007199254740991` takes the new path, `9007199254740992` the old one.

Measured against the transpiled runtime, one core, warm:

| call | before | after |
| --- | --- | --- |
| `7.as-decimal` | 2.1 s | 0.7 s |
| `1793000000000.as-decimal` | 8.2 s | 2.5 s |
| `"%d-%d-%d-%f".printf * 1793000000000 12345 0 0.123456` | OutOfMemoryError on 2 GB | 7.5 s, completes on 2 GB |

`EOnumberTest`: 508 run, 0 failures.

What this does not fix: the remaining seconds. `%f` still goes through `as-fixed`, whose fraction scaling keeps the `i64` path, and `i64.div` is still what it is. So `mktemp.tmpfile` should stop exhausting the heap, but it will not be quick. I would rather land the crash fix and keep the rest of #7429 open than sit on both.
