### PR TITLE
test(#7548): cover win32 sockets, file flags and stat

### DIFF
--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -55,6 +55,76 @@
   02-02 > version
   32769 > wronly
 
+  ++> can-close-a-tcp-socket
+    os.is-windows.not.or > @
+      seq *
+        sd
+        not.
+          eq.
+            code.
+              win32 *1
+                "closesocket"
+                sd
+            -1
+    code. > sd
+      win32 *1
+        "socket"
+        win32.inet
+        win32.stream
+        win32.tcp
+
+  ++> can-compute-the-size-of-a-sockaddr-in
+    addr.size.eq 16 > @
+    win32.sockaddr-in > addr
+      00-00
+      00-00
+      00-00-00-00
+
+  ++> can-open-a-file-with-the-append-flag
+    os.is-windows.not.or > @
+      seq *
+        code.
+          win32 *1
+            "_close"
+            fd
+        fd.gt -1
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly.plus win32.append
+        0
+
+  ++> can-open-a-file-with-the-trunc-flag
+    os.is-windows.not.or > @
+      seq *
+        code.
+          win32 *1
+            "_close"
+            fd
+        fd.gt -1
+    code. > fd
+      win32 *1
+        "_open"
+        "NUL"
+        win32.wronly.plus win32.trunc
+        0
+
+  ++> can-open-a-tcp-socket
+    os.is-windows.not.or > @
+      seq *
+        code.
+          win32 *1
+            "closesocket"
+            sd
+        sd.gt 0
+    code. > sd
+      win32 *1
+        "socket"
+        win32.inet
+        win32.stream
+        win32.tcp
+
   os.is-windows.not.or ++> can-report-a-host-name-as-invalid
     eq.
       code.
@@ -86,6 +156,32 @@
           "inet_addr"
           "127.0.0.1"
       16777343
+
+  ++> can-stat-the-size-of-nul
+    os.is-windows.not.or > @
+      info.size.eq 0
+    output. > info
+      win32 *1
+        "_stat64"
+        "NUL"
+
+  os.is-windows.not.if --> stops-on-creating-an-existing-file-exclusively
+    1.div 0
+    seq *
+      code.
+        win32 *1
+          "_open"
+          "NUL"
+          plus.
+            win32.rdonly.plus win32.creat
+            win32.exclusive
+          win32.mode
+      eq.
+        code.
+          win32
+            "_errno"
+            *
+        win32.eexist
 
   --> stops-on-write-size-being-negative
     os.is-windows.not.if > @


### PR DESCRIPTION
This supersedes #7701, whose CI failure prompted it ([job](https://github.com/objectionary/eo/actions/runs/32889028981/job/97936276859?pr=7701)).

## What was actually wrong

The reported failure was `MjFormat`: *"1 of 171 EO source(s) are not formatted canonically"* on `eo-runtime/src/main/eo/win32.eo`. That was only the first goal to notice. Underneath, six of the seven new tests in #7701 do not parse at all:

- Five of them (`can-close-a-tcp-socket`, `can-open-a-file-with-the-append-flag`, `can-open-a-file-with-the-trunc-flag`, `can-open-a-tcp-socket`, `can-stat-the-size-of-nul`) use the `head ++> name` form, which builds an *application* whose children are its arguments — not a formation. A `code. > sd` written among them becomes a named attribute of an only-phi formation, and the parser rejects it: `'sd cannot be a named attribute of only-phi formation can-close-a-tcp-socket, which binds only its φ decoratee'`.
- `can-compute-the-size-of-a-sockaddr-in` leaves its assertion anonymous beside a named `addr`, which no formation allows: `'object inside formation must have a name'`, plus `anonymous-objects-inside-formation/S` and `unit-test-without-phi/S`.

Running `-Deo.autoFix` as the error message suggests does not save it — the printer faithfully round-trips the broken structure and `compile` then fails with 2 errors instead of 7. The tests had to be rewritten, not reformatted.

To confirm the parse errors were real rather than an artifact of the format goal running first, I commented `<goal>format</goal>` out of `eo-runtime/pom.xml` locally and ran `process-classes` on #7701's file: 7 parse errors, 1 warning. `master` itself formats cleanly (`All 171 EO source(s) are formatted canonically`), so this was never a repo-wide CI break — it is specific to that branch.

## The change

The tests are rewritten the way `posix.eo` already writes the very same checks: the OS gate becomes `os.is-windows.not.or > @` *inside* the formation, and the socket or file descriptor stays a named sibling next to it.

```
++> can-close-a-tcp-socket
  os.is-windows.not.or > @
    seq *
      sd
      not.
        eq.
          code.
            win32 *1
              "closesocket"
              sd
          -1
  code. > sd
    win32 *1
      "socket"
      win32.inet
      win32.stream
      win32.tcp
```

`can-compute-the-size-of-a-sockaddr-in` gets an explicit `> @` on its assertion. `stops-on-creating-an-existing-file-exclusively` needs no named sibling, so canonical form collapses it to the `os.is-windows.not.if --> name` head form. All seven are placed in the alphabetical order `MjFormat` expects, so `format` passes without `-Deo.autoFix`.

## Coverage added

Opening and closing a TCP socket through Winsock (`socket` / `closesocket`), the byte size of a `sockaddr-in`, `_open` with the append and trunc flags, `_stat64` on `NUL`, and the `EEXIST` an exclusive create reports through `_errno`.

## Verification

Locally, `mvn -pl eo-runtime test`:

- `format` — `All 171 EO source(s) are formatted canonically`
- `compile` / lints — clean, no errors or warnings on `win32.eo`
- `TEST-org.eolang.EOwin32Test.xml` — `tests="13" errors="0" failures="0"`, covering all 7 new names

The only failures in that local run are environmental and reproduce on `master`: `MainTest.printsVersion` (no release manifest in a `1.0-SNAPSHOT` build) and 10 `SyscallTest` cases that cannot allocate a TCP port in this sandbox.

The coverage here is @Thayorns's from #7701; only the EO structure is rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136jKioegvmLk22p7F7oRDc

---
_Generated by [Claude Code](https://claude.ai/code/session_0136jKioegvmLk22p7F7oRDc)_