### PR TITLE
#7512: let ws2_32 convert an address instead of reading it here

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -4,9 +4,9 @@
  */
 package org.eolang.win32;
 
-import java.nio.ByteBuffer;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import com.sun.jna.Native;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -15,24 +15,30 @@ import org.eolang.Syscall;
 
 /**
  * The 'inet_addr' WS2_32 function call.
+ *
+ * <p>The text is handed to {@code ws2_32} rather than read here, because
+ * {@code inet_addr} takes four forms — {@code a.b.c.d}, {@code a.b.c},
+ * {@code a.b} and {@code a} — and reads every part the way C does, octal behind
+ * a leading zero and hexadecimal behind a leading {@code 0x}. A parser of our
+ * own accepted only the first form and read every part as decimal, so the two
+ * halves of this call answered the same program differently: {@code 010.1.1.1}
+ * is 8.1.1.1 to both C libraries and was 10.1.1.1 here, a different host with
+ * no error on either side, and {@code 127.1} was refused outright (#7512).</p>
+ *
  * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-inet_addr">here for details</a>
  * @since 0.40.0
  */
 public final class InetAddrFuncCall implements Syscall {
 
     /**
-     * {@code INADDR_NONE}, what {@code inet_addr} answers with when it cannot
-     * convert the text. It is an {@code in_addr_t}, that is unsigned, so it
-     * reaches EO as 4294967295 and not as -1, matching {@code win32.unresolved}
-     * and the POSIX half of the same call.
+     * The limited-broadcast address, whose conversion is {@code INADDR_NONE}
+     * — the same value {@code inet_addr} answers with for text it cannot
+     * convert, which is why the two are told apart by the text rather than by
+     * the result. The POSIX half of this call makes the same comparison for
+     * the same reason.
      */
-    private static final long NONE = 4_294_967_295L;
-
-    /**
-     * Dotted-decimal IPv4 literal, e.g. "127.0.0.1".
-     */
-    private static final Pattern IPV4 = Pattern.compile(
-        "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})"
+    private static final String BROADCAST = String.join(
+        ".", Collections.nCopies(4, "255")
     );
 
     /**
@@ -51,34 +57,15 @@ public final class InetAddrFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final Matcher matcher = InetAddrFuncCall.IPV4.matcher(new Dataized(params[0]).asString());
-        if (matcher.matches() && InetAddrFuncCall.octetsValid(matcher)) {
-            final ByteBuffer buffer = ByteBuffer.allocate(4);
-            for (int octet = 1; octet <= 4; ++octet) {
-                buffer.put((byte) Integer.parseInt(matcher.group(octet)));
-            }
-            result.put(
-                0,
-                new Data.ToPhi(
-                    Integer.toUnsignedLong(Integer.reverseBytes(buffer.getInt(0)))
-                )
-            );
-        } else {
+        final String address = new Dataized(params[0]).asString();
+        final int converted = Winsock.INSTANCE.inet_addr(
+            Native.toByteArray(address, StandardCharsets.UTF_8)
+        );
+        if (converted == -1 && !InetAddrFuncCall.BROADCAST.equals(address)) {
             Winsock.INSTANCE.WSASetLastError(Winsock.WSAEINVAL);
-            result.put(0, new Data.ToPhi(InetAddrFuncCall.NONE));
         }
+        result.put(0, new Data.ToPhi(Integer.toUnsignedLong(converted)));
         result.put(1, new PhDefault());
         return result;
-    }
-
-    private static boolean octetsValid(final Matcher matcher) {
-        boolean valid = true;
-        for (int octet = 1; octet <= 4; ++octet) {
-            if (Integer.parseInt(matcher.group(octet)) > 255) {
-                valid = false;
-                break;
-            }
-        }
-        return valid;
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
@@ -157,6 +157,31 @@ public interface Winsock extends StdCallLibrary {
     int recv(Pointer sockfd, byte[] buf, int len, int flags);
 
     /**
+     * Convert an IPv4 address from text into a 32-bit number in network byte
+     * order.
+     *
+     * <p>Four forms are accepted — {@code a.b.c.d}, {@code a.b.c}, {@code a.b}
+     * and {@code a} — and every part is read the way C reads a number: decimal,
+     * octal behind a leading zero, or hexadecimal behind a leading {@code 0x}.
+     * A part that is not the last one stands for one byte, and the last one
+     * fills all the bytes still left, so {@code 127.1} is {@code 127.0.0.1}.</p>
+     *
+     * <p>The address arrives as NUL-terminated bytes and not as a
+     * {@link String} because this library is loaded with
+     * {@link W32APIOptions#DEFAULT_OPTIONS}, whose type mapper hands a
+     * {@link String} over as {@code wchar_t*}. That is right for the wide
+     * entry points of WS2_32 and wrong for this one, which takes a narrow
+     * {@code const char*}: {@code 127.0.0.1} would reach it as UTF-16 and be
+     * read as {@code 1}, the byte after the first one being NUL. An array
+     * bypasses the mapper and is passed as the bytes it holds.</p>
+     *
+     * @param address The address to convert, NUL-terminated
+     * @return The address in network byte order, or {@code INADDR_NONE} when
+     *  the text is not one of those forms
+     */
+    int inet_addr(byte[] address);
+
+    /**
      * Retrieve the last error from winsock.
      * @return The code of the last winsock error
      */

--- a/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
@@ -56,7 +56,7 @@ final class InetAddrFuncCallTest {
         Winsock.INSTANCE.WSASetLastError(0);
         InetAddrFuncCallTest.converted(String.join(".", Collections.nCopies(4, "255")));
         MatcherAssert.assertThat(
-            "the limited-broadcast address converts to INADDR_NONE like unconvertable text does, but it is valid, so WSAEINVAL must not be reported for it",
+            "the limited-broadcast address converts to INADDR_NONE like unconvertible text does, but it is valid, so WSAEINVAL must not be reported for it",
             Winsock.INSTANCE.WSAGetLastError(),
             Matchers.not(Matchers.equalTo(Winsock.WSAEINVAL))
         );
@@ -64,7 +64,7 @@ final class InetAddrFuncCallTest {
 
     @Test
     @DisabledOnOs({OS.MAC, OS.LINUX})
-    void reportsInvalidOnUnconvertableText() {
+    void reportsInvalidOnUnconvertibleText() {
         InetAddrFuncCallTest.converted("nope");
         MatcherAssert.assertThat(
             "inet_addr does not set the last winsock error itself, so the call must set it, or a later WSAGetLastError reads whatever an unrelated earlier call left behind",

--- a/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import java.util.Collections;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link InetAddrFuncCall}.
+ * @since 0.75.0
+ */
+final class InetAddrFuncCallTest {
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void readsALeadingZeroAsOctal() {
+        MatcherAssert.assertThat(
+            "a part behind a leading zero is octal to inet_addr, so 010 is 8, and reading it as decimal ten sends an EO program to a different host than the POSIX half of this call sends it to",
+            InetAddrFuncCallTest.converted("010.1.1.1"),
+            Matchers.equalTo(16_843_016.0d)
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void acceptsTheTwoPartForm() {
+        MatcherAssert.assertThat(
+            "the last part of a shortened address fills the bytes still left, so 127.1 is 127.0.0.1, not text to refuse",
+            InetAddrFuncCallTest.converted("127.1"),
+            Matchers.equalTo(16_777_343.0d)
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void widensTheAddressToUnsigned() {
+        MatcherAssert.assertThat(
+            "inet_addr answers with an in_addr_t, which is unsigned, so an address whose last byte is 128 or above must not reach EO as a negative number",
+            InetAddrFuncCallTest.converted("10.0.0.200"),
+            Matchers.equalTo(3_355_443_210.0d)
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void doesNotReportInvalidForTheBroadcastAddress() {
+        Winsock.INSTANCE.WSASetLastError(0);
+        InetAddrFuncCallTest.converted(String.join(".", Collections.nCopies(4, "255")));
+        MatcherAssert.assertThat(
+            "the limited-broadcast address converts to INADDR_NONE like unconvertable text does, but it is valid, so WSAEINVAL must not be reported for it",
+            Winsock.INSTANCE.WSAGetLastError(),
+            Matchers.not(Matchers.equalTo(Winsock.WSAEINVAL))
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void reportsInvalidOnUnconvertableText() {
+        InetAddrFuncCallTest.converted("nope");
+        MatcherAssert.assertThat(
+            "inet_addr does not set the last winsock error itself, so the call must set it, or a later WSAGetLastError reads whatever an unrelated earlier call left behind",
+            Winsock.INSTANCE.WSAGetLastError(),
+            Matchers.equalTo(Winsock.WSAEINVAL)
+        );
+    }
+
+    private static Double converted(final String address) {
+        return new Dataized(
+            new InetAddrFuncCall(Phi.Φ.take("win32").copy())
+                .make(new Data.ToPhi(address))
+                .take("code")
+        ).asNumber();
+    }
+}


### PR DESCRIPTION
Closes #7512.

## Problem

`win32/InetAddrFuncCall.java` never called `ws2_32!inet_addr`. It matched
`(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})` and read every group as decimal,
while the real `inet_addr` takes four forms and reads every part the way C
does. So the two halves of the same call answered the same EO program
differently:

| text | POSIX (measured) | win32 (before) |
|:--|--:|--:|
| `010.1.1.1` | 16843016 (8.1.1.1) | 16843018 (10.1.1.1) |
| `127.1` | 16777343 (127.0.0.1) | `INADDR_NONE` |

`socket "010.1.1.1" 80` reached a different host on each platform, with no error
on either side.

## Fix

- `Winsock` declares `inet_addr`, and the call hands the text to `ws2_32`
  instead of reading it here, so both platforms agree by construction and the
  hand-written parser is gone.
- `INADDR_NONE` and the limited-broadcast address are told apart by the text,
  not by the result, the way `InetAddrSyscall` already tells them apart — so
  `255.255.255.255` no longer looks like a failure.

The address is passed as NUL-terminated bytes rather than as a `String`.
`Winsock` is loaded with `W32APIOptions.DEFAULT_OPTIONS`, whose type mapper
converts a `String` to `wchar_t*`. That is right for the wide entry points of
WS2_32 and wrong for this one, which takes a narrow `const char*`: `127.0.0.1`
would have reached it as UTF-16 and been read as `1`, the byte after the first
being NUL. An array bypasses the mapper. This is why `Msvcrt` and `Kernel32`
are loaded without options and spell `WString` explicitly.

## Verification

Please note what is and is not covered, since this is Windows-only code and the
work was done on Linux:

- The five new tests in `InetAddrFuncCallTest` are
  `@DisabledOnOs({OS.MAC, OS.LINUX})`, as every other win32 test in this repo
  is, so **CI will skip them**. They need a Windows runner to execute.
- What was verified on Linux: the `byte[]` marshalling path, which is the part
  of this change that could plausibly be wrong. Calling libc's `inet_addr`
  through JNA with `Native.toByteArray(text, UTF_8)` returns values identical
  to the `String` path and to the C library measured through `ctypes`, for
  `127.0.0.1`, `127.1`, `010.1.1.1`, `0x7f.1`, `10.0.0.200`,
  `255.255.255.255` and `nope`. Those measurements are where the expected
  numbers in the tests come from. JNA marshals an array as a pointer to its
  bytes on every platform, so this carries to WS2_32.
- `mvn -pl eo-runtime -Pqulice test-compile qulice:check` and compilation of
  the changed sources and the new test.
- Not verified: that `ws2_32.dll` resolves the undecorated `inet_addr` under
  the UNICODE function mapper. The mapper falls back to the plain name when
  `<name>W` is absent, which is how `socket`, `connect`, `send`, `recv` and
  the rest of this interface already resolve, so the same fallback applies.

An address carrying an embedded NUL is now truncated at it, exactly as the
POSIX half already truncates one — that agreement is the point of this issue,
and the truncation itself is #7570, which has its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H


---
_Generated by [Claude Code](https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H)_