### PR TITLE
Fix UnplacingTest failing on CI when the build runs as super-user

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
@@ -13,6 +13,7 @@ import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -39,6 +40,10 @@ final class UnplacingTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void keepsCatalogEntryWhenDeletionFails(@TempDir final Path temp) throws IOException {
+        Assumptions.assumeTrue(
+            UnplacingTest.protects(temp.resolve("probe")),
+            "read-only directories don't stop deletions for this user (root?), can't test"
+        );
         final Path classes = temp.resolve("classes");
         Files.createDirectories(classes);
         final Path binary = classes.resolve("Foo.class");
@@ -60,5 +65,22 @@ final class UnplacingTest {
             placed.classes().iterator().next().placed(),
             Matchers.is(true)
         );
+    }
+
+    private static boolean protects(final Path dir) throws IOException {
+        Files.createDirectories(dir);
+        final Path file = dir.resolve("probe.txt");
+        Files.write(file, "probe".getBytes(StandardCharsets.UTF_8));
+        Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("r-xr-xr-x"));
+        boolean protects;
+        try {
+            Files.deleteIfExists(file);
+            protects = false;
+        } catch (final IOException ex) {
+            protects = true;
+        } finally {
+            Files.setPosixFilePermissions(dir, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+        return protects;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java
@@ -41,7 +41,7 @@ final class UnplacingTest {
     @DisabledOnOs(OS.WINDOWS)
     void keepsCatalogEntryWhenDeletionFails(@TempDir final Path temp) throws IOException {
         Assumptions.assumeTrue(
-            UnplacingTest.protects(temp.resolve("probe")),
+            this.protects(temp.resolve("probe")),
             "read-only directories don't stop deletions for this user (root?), can't test"
         );
         final Path classes = temp.resolve("classes");
@@ -67,7 +67,7 @@ final class UnplacingTest {
         );
     }
 
-    private static boolean protects(final Path dir) throws IOException {
+    private boolean protects(final Path dir) throws IOException {
         Files.createDirectories(dir);
         final Path file = dir.resolve("probe.txt");
         Files.write(file, "probe".getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
`UnplacingTest.keepsCatalogEntryWhenDeletionFails` fails on `master` ([run 32947991692](https://github.com/objectionary/eo/actions/runs/32947991692/job/98113706774)):

```
UnplacingTest.keepsCatalogEntryWhenDeletionFails:50 a deletion failure must
surface as an exception, not be swallowed ==> Expected java.lang.Exception
to be thrown, but nothing was thrown.
```

## Cause

The test makes the `classes` directory read-only (`r-xr-xr-x`) and expects `Files.deleteIfExists` inside `Unplacing` to fail. A super-user bypasses POSIX permission bits, so the deletion succeeds and no exception is thrown. The `ec2` runners build as `root`, hence the failure there while the test passes for ordinary users.

Reproduced locally as `root` (same failure) and verified that a non-root user gets `AccessDeniedException` on the very same operation, so the production behaviour in `Unplacing` is correct — only the test's premise does not hold in that environment.

## Change

Probe the capability before asserting: create a throwaway file in a read-only directory and try to delete it. If the OS actually enforces the permission, the test runs and asserts exactly as before; otherwise it is skipped via `Assumptions.assumeTrue` with an explicit reason instead of failing. `@DisabledOnOs(OS.WINDOWS)` is kept.

Only `eo-maven-plugin/src/test/java/org/eolang/maven/UnplacingTest.java` is touched; no production code changed.

## Verification

- `mvn -pl eo-maven-plugin test -Dtest=UnplacingTest` — green (1 skipped as root, was 1 failure).
- Standalone check as a non-root user: the probe returns `true` and the deletion throws `AccessDeniedException`, so the assertion still runs where it is meaningful.
- `mvn -pl eo-maven-plugin -Pqulice verify` — 225 files against 1015 rules, clean.
- Full `eo-maven-plugin` suite: 745 tests, no failures other than `OyRemoteTest` (reaches objectionary.com, blocked by this sandbox's proxy; green in the CI run above) and three `InvalidPath` errors caused by this container's non-UTF-8 locale (they pass under `LANG=C.UTF-8`). Both are unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A1X1hgg2Hxrm9wuCoQzoog)_