### PR TITLE
#7478: give every hop of a nameless continuation a line of its own

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -60,19 +60,32 @@
   (§3.5) dispatches on, or "" when "$o" is not that shape: its parent
   is not a formation (an application's own receiver and positional
   arguments are nameless too, but they are not this construct), it has
-  a name of its own, its base carries no dot, or the segment before
-  the last dot is not a plain one-hop self-reference ("ξ.<name>").
+  a name of its own, or its base is not rooted at a self-reference
+  ("ξ.<name>...").
   Such a continuation carries no receiver child - the base is already
   qualified with the receiver's name by an earlier shift - and is
   legal without a name only because the parser reconstructs that
   receiver from source position, not from an explicit head (#7452).
+  The base may name more than one hop past the receiver, since one such
+  line per hop collapses into a single object: "?.y" and "?.q" below a
+  "42 > z" are one "ξ.z.y.q" (#7478). Only the receiver is answered
+  here; "eo:continuation-hops" spells the hops that follow it.
   -->
   <xsl:function name="eo:continuation-receiver" as="xs:string">
     <xsl:param name="o" as="element()"/>
-    <xsl:variable name="base" select="string($o/@base)"/>
-    <xsl:variable name="last" select="tokenize($base, '\.')[last()]"/>
-    <xsl:variable name="rest" select="substring($base, 1, string-length($base) - string-length($last) - 1)"/>
-    <xsl:sequence select="if (eo:abstract($o/..) and not($o/@name) and contains($base, '.') and starts-with($rest, concat($eo:xi, '.')) and not(contains(substring-after($rest, concat($eo:xi, '.')), '.'))) then substring-after($rest, concat($eo:xi, '.')) else ''"/>
+    <xsl:variable name="segments" select="tokenize(string($o/@base), '\.')"/>
+    <xsl:sequence select="if (eo:abstract($o/..) and not($o/@name) and count($segments) &gt; 2 and $segments[1] = $eo:xi) then $segments[2] else ''"/>
+  </xsl:function>
+  <!--
+  The hops a nameless method-dispatch continuation makes past the
+  sibling it dispatches on: the segments of its base after the "ξ" and
+  the receiver's own name. Every hop was a line of its own in the
+  source and has to become one again, since the grammar takes only one
+  hop per line ("unexpected content after name suffix" otherwise).
+  -->
+  <xsl:function name="eo:continuation-hops" as="xs:string*">
+    <xsl:param name="o" as="element()"/>
+    <xsl:sequence select="tokenize(string($o/@base), '\.')[position() &gt; 2]"/>
   </xsl:function>
   <!--
   First name segment of a program-rooted base (Φ.foo.bar -> foo). The raw
@@ -287,6 +300,27 @@
         <xsl:sort select="if (not($sortable) or eo:void(.) or @name = $eo:phi) then '' else if (eo:continuation-receiver(.) != '') then concat(eo:continuation-receiver(.), '~') else string((@local, @name)[1])"/>
       </xsl:apply-templates>
     </line>
+  </xsl:template>
+  <!-- METHOD-DISPATCH CONTINUATION OVER SEVERAL HOPS (§3.5) -->
+  <!--
+  A line per hop, since the grammar reads one hop per continuation line
+  and the parser folds the run of them back into the single object this
+  node is: "?.y" and "?.q" below a "42 > z" are one "ξ.z.y.q", and
+  printing that as one line spells an object the grammar refuses inside
+  a formation, having no name to give it (#7478).
+  The fragile marker goes on the last hop. The base carries a single
+  "@fragile" for the whole run, and a dispatch that follows a fragile
+  one must repeat the "?." itself, so a run whose last hop is marked
+  reads back as this very object, while one marked earlier would not
+  parse at all.
+  -->
+  <xsl:template match="o[eo:continuation-receiver(.) != '' and count(eo:continuation-hops(.)) &gt; 1]" mode="tree" priority="3">
+    <xsl:variable name="fragile" select="exists(@fragile)"/>
+    <xsl:for-each select="eo:continuation-hops(.)">
+      <line abstract="no" test="no" reversed="no" data="no" tail="">
+        <xsl:attribute name="base" select="concat(if (position() = last() and $fragile) then '?' else '', '.', eo:printable(.))"/>
+      </line>
+    </xsl:for-each>
   </xsl:template>
   <!-- IDENTITY OBJECT -->
   <!--

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-continuation-over-several-hops.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/fragile-continuation-over-several-hops.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7478: two nameless continuation lines below the same object are one
+# object by the time the printer sees them - "?.y" and "?.q" under a
+# "42 > z" parse into a single "ξ.z.y.q" - and the grammar reads only one
+# hop per continuation line, so printing that object as one line spelled
+# a nameless application the parser refuses inside a formation. The fix
+# gives every hop a line of its own again. The fragile marker sits on the
+# last hop: the object carries one "@fragile" for the whole run, and a
+# dispatch following a fragile one has to repeat the "?." itself, so a
+# run marked on its last hop reads back as this very object while one
+# marked earlier does not parse at all.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > m
+    42 > z
+    .y
+    ?.q


### PR DESCRIPTION
Closes #7478.

## Problem

Two nameless continuation lines below the same object are **one** object by the time the printer sees them — `?.y` and `?.q` under a `42 > z` parse into a single `ξ.z.y.q`. The grammar reads one hop per continuation line, so printing that object as a single line spelled a nameless application the parser refuses inside a formation:

```
source:   [] > m        printed:  [] > m          reparse: error: 'object inside
            42 > z                  z.y?.q                 formation must have a name'
            ?.y                     42 > z
            ?.q
```

`MjFormat` reformats sources through this printer, so a file written that way was rewritten into one that no longer compiles.

Three of the four shapes in the issue were already fixed by #7452 (`ad62382c`) — this is the one row of its table still failing. `eo:continuation-receiver` required the segment past the receiver to be a *single* hop (`not(contains(substring-after($rest, 'ξ.'), '.'))`), so a two-hop base fell through to the generic head.

## Fix

- `eo:continuation-receiver` reads the receiver off the base without insisting the hop past it be the only one.
- A new `eo:continuation-hops` spells the hops that follow the receiver.
- A `tree`-mode template prints a run of several hops as the run of lines it came from, one `<line>` per hop.

The fragile marker goes on the **last** hop. The object carries a single `@fragile` for the whole run, and a dispatch following a fragile one must repeat the `?.` itself, so a run marked on its last hop reads back as this very object, while one marked earlier does not parse at all — measured:

| printed | reparses to |
| --- | --- |
| `.y` / `?.q` | `ξ.z.y.q` `[fragile]` |
| `?.y` / `?.q` | `ξ.z.y.q` `[fragile]` |
| `?.y` / `.q` | rejected: `regular dispatch on a fragile object requires '?.'` |
| `.y` / `.q` | `ξ.z.y.q` |

## Verification

All four rows of the issue's table now round-trip:

| source line | printed | reparses |
| --- | --- | --- |
| `?.y` | `?.y` | yes |
| `?.y > w` | `z?.y > w` | yes |
| `?.y` then `?.q` | `.y` / `?.q` | **yes** (was no) |
| `?.y` after a vertical application | `?.y` | yes |

- Deeper and non-fragile runs (3 hops fragile, 2 and 3 hops non-fragile, mixed `.y` then `?.q`) all reparse **and** yield an identical set of bases, so the round trip preserves the object and not just parseability.
- `mvn -pl eo-printer test` — 393 tests pass, up from 391; the new `print-packs` fixture adds a `printsToEo` and a `printsToParseableEo` case, and the existing 346 `XmirTest` cases are unchanged.
- Round-tripping the `eo-syntax` fixtures (parse → `toEO()` → parse) leaves 0 of 93 failing to reparse, before and after.
- 72 lines changed, within the `pr-size` limit.

## Note

While confirming this I found #7473 (same author, same sweep) no longer reproduces — #7453 fixed it — and left the evidence [there](https://github.com/objectionary/eo/issues/7473#issuecomment-5423463401) rather than opening a PR for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H)_