### PR TITLE
Read the winsock last error from the copy JNA saves

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/WSAGetLastErrorFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WSAGetLastErrorFuncCall.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Native;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -11,6 +12,16 @@ import org.eolang.Syscall;
 
 /**
  * WSAGetLastError WS2_32 function call.
+ *
+ * <p>The code comes from {@link Native#getLastError()} rather than from
+ * {@code ws2_32}, because the last error lives in a per-thread slot that the
+ * JNI and JNA machinery between the two calls overwrites: by the time a
+ * mapped {@code WSAGetLastError} runs, the slot holds whatever that machinery
+ * left there, usually zero. JNA keeps a copy of the slot taken the instant
+ * every mapped call returns, and that copy is what an EO program has to read.
+ * JNA itself does the same for Kernel32's {@code GetLastError}, which it
+ * short-circuits to the very same copy.</p>
+ *
  * @see <a href="https://learn.microsoft.com/en-us/windows/win32/api/winsock2/nf-winsock2-wsagetlasterror">here for details</a>
  * @since 0.40.0
  * @checkstyle AbbreviationAsWordInNameCheck (5 lines)
@@ -33,7 +44,7 @@ public final class WSAGetLastErrorFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        result.put(0, new Data.ToPhi(Winsock.INSTANCE.WSAGetLastError()));
+        result.put(0, new Data.ToPhi(Native.getLastError()));
         result.put(1, new PhDefault());
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
@@ -182,15 +182,19 @@ public interface Winsock extends StdCallLibrary {
     int inet_addr(byte[] address);
 
     /**
-     * Retrieve the last error from winsock.
-     * @return The code of the last winsock error
-     */
-    int WSAGetLastError();
-
-    /**
-     * Set the last winsock error, so a following {@code WSAGetLastError} reads it
-     * back. It is the winsock counterpart of Kernel32's {@code SetLastError} and
-     * writes the same per-thread last-error slot.
+     * Set the last winsock error. It is the winsock counterpart of Kernel32's
+     * {@code SetLastError} and writes the same per-thread last-error slot.
+     *
+     * <p>There is no {@code WSAGetLastError} here on purpose. The slot it reads
+     * is overwritten by the JNI and JNA machinery that stands between a mapped
+     * call and the Java code around it, so a mapped {@code WSAGetLastError}
+     * answers with whatever that machinery left behind, usually zero, instead
+     * of the code the previous call set. The code is read back from
+     * {@link com.sun.jna.Native#getLastError()}, which hands over the copy JNA
+     * takes of the slot the instant every mapped call returns — this one
+     * included. JNA short-circuits Kernel32's {@code GetLastError} to that same
+     * copy for the same reason.</p>
+     *
      * @param error The error code to set
      */
     void WSASetLastError(int error);

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -412,7 +412,7 @@ final class SyscallTest {
         }
 
         private int getError() {
-            return Winsock.INSTANCE.WSAGetLastError();
+            return Native.getLastError();
         }
 
         private int bindSocket(final long socket, final int port) throws UnknownHostException {

--- a/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
@@ -33,7 +33,7 @@ final class InetAddrFuncCallTest {
     void readsALeadingZeroAsOctal() {
         MatcherAssert.assertThat(
             "a part behind a leading zero is octal to inet_addr, so 010 is 8, and reading it as decimal ten sends an EO program to a different host than the POSIX half of this call sends it to",
-            InetAddrFuncCallTest.converted("010.1.1.1"),
+            this.converted("010.1.1.1"),
             Matchers.equalTo(16_843_016.0d)
         );
     }
@@ -43,7 +43,7 @@ final class InetAddrFuncCallTest {
     void acceptsTheTwoPartForm() {
         MatcherAssert.assertThat(
             "the last part of a shortened address fills the bytes still left, so 127.1 is 127.0.0.1, not text to refuse",
-            InetAddrFuncCallTest.converted("127.1"),
+            this.converted("127.1"),
             Matchers.equalTo(16_777_343.0d)
         );
     }
@@ -53,7 +53,7 @@ final class InetAddrFuncCallTest {
     void widensTheAddressToUnsigned() {
         MatcherAssert.assertThat(
             "inet_addr answers with an in_addr_t, which is unsigned, so an address whose last byte is 128 or above must not reach EO as a negative number",
-            InetAddrFuncCallTest.converted("10.0.0.200"),
+            this.converted("10.0.0.200"),
             Matchers.equalTo(3_355_443_210.0d)
         );
     }
@@ -62,7 +62,7 @@ final class InetAddrFuncCallTest {
     @DisabledOnOs({OS.MAC, OS.LINUX})
     void doesNotReportInvalidForTheBroadcastAddress() {
         Native.setLastError(0);
-        InetAddrFuncCallTest.made(String.join(".", Collections.nCopies(4, "255")));
+        this.made(String.join(".", Collections.nCopies(4, "255")));
         MatcherAssert.assertThat(
             "the limited-broadcast address converts to INADDR_NONE like unconvertible text does, but it is valid, so WSAEINVAL must not be reported for it",
             Native.getLastError(),
@@ -74,7 +74,7 @@ final class InetAddrFuncCallTest {
     @DisabledOnOs({OS.MAC, OS.LINUX})
     void reportsInvalidOnUnconvertibleText() {
         Native.setLastError(0);
-        InetAddrFuncCallTest.made("nope");
+        this.made("nope");
         MatcherAssert.assertThat(
             "inet_addr does not set the last winsock error itself, so the call must set it, or a later read of the last error answers with whatever an unrelated earlier call left behind",
             Native.getLastError(),
@@ -82,13 +82,13 @@ final class InetAddrFuncCallTest {
         );
     }
 
-    private static Double converted(final String address) {
+    private Double converted(final String address) {
         return new Dataized(
-            InetAddrFuncCallTest.made(address).take("code")
+            this.made(address).take("code")
         ).asNumber();
     }
 
-    private static Phi made(final String address) {
+    private Phi made(final String address) {
         return new InetAddrFuncCall(Phi.Φ.take("win32").copy())
             .make(new Data.ToPhi(address));
     }

--- a/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.win32;
 
+import com.sun.jna.Native;
 import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.Dataized;
@@ -16,6 +17,13 @@ import org.junit.jupiter.api.condition.OS;
 
 /**
  * Test case for {@link InetAddrFuncCall}.
+ *
+ * <p>The tests that watch the last winsock error read it from
+ * {@link Native#getLastError()}, straight after the call and before anything
+ * is dataized: that read hands over the copy JNA takes of the per-thread
+ * last-error slot the instant every mapped call returns, and any later call
+ * of ours would replace the copy with its own.</p>
+ *
  * @since 0.75.0
  */
 final class InetAddrFuncCallTest {
@@ -53,11 +61,11 @@ final class InetAddrFuncCallTest {
     @Test
     @DisabledOnOs({OS.MAC, OS.LINUX})
     void doesNotReportInvalidForTheBroadcastAddress() {
-        Winsock.INSTANCE.WSASetLastError(0);
-        InetAddrFuncCallTest.converted(String.join(".", Collections.nCopies(4, "255")));
+        Native.setLastError(0);
+        InetAddrFuncCallTest.made(String.join(".", Collections.nCopies(4, "255")));
         MatcherAssert.assertThat(
             "the limited-broadcast address converts to INADDR_NONE like unconvertible text does, but it is valid, so WSAEINVAL must not be reported for it",
-            Winsock.INSTANCE.WSAGetLastError(),
+            Native.getLastError(),
             Matchers.not(Matchers.equalTo(Winsock.WSAEINVAL))
         );
     }
@@ -65,19 +73,23 @@ final class InetAddrFuncCallTest {
     @Test
     @DisabledOnOs({OS.MAC, OS.LINUX})
     void reportsInvalidOnUnconvertibleText() {
-        InetAddrFuncCallTest.converted("nope");
+        Native.setLastError(0);
+        InetAddrFuncCallTest.made("nope");
         MatcherAssert.assertThat(
-            "inet_addr does not set the last winsock error itself, so the call must set it, or a later WSAGetLastError reads whatever an unrelated earlier call left behind",
-            Winsock.INSTANCE.WSAGetLastError(),
+            "inet_addr does not set the last winsock error itself, so the call must set it, or a later read of the last error answers with whatever an unrelated earlier call left behind",
+            Native.getLastError(),
             Matchers.equalTo(Winsock.WSAEINVAL)
         );
     }
 
     private static Double converted(final String address) {
         return new Dataized(
-            new InetAddrFuncCall(Phi.Φ.take("win32").copy())
-                .make(new Data.ToPhi(address))
-                .take("code")
+            InetAddrFuncCallTest.made(address).take("code")
         ).asNumber();
+    }
+
+    private static Phi made(final String address) {
+        return new InetAddrFuncCall(Phi.Φ.take("win32").copy())
+            .make(new Data.ToPhi(address));
     }
 }


### PR DESCRIPTION
The Windows build of master [failed](https://github.com/objectionary/eo/actions/runs/32953804370/job/98131006470) on `InetAddrFuncCallTest.reportsInvalidOnUnconvertibleText`:

```
[ERROR] InetAddrFuncCallTest.reportsInvalidOnUnconvertibleText:69 inet_addr does not set
the last winsock error itself, so the call must set it, or a later WSAGetLastError reads
whatever an unrelated earlier call left behind
Expected: <10022>
     but: was <0>
```

The test converts `nope`, which makes `InetAddrFuncCall` set the last error to `WSAEINVAL`, and then reads the code back through the mapped `WSAGetLastError`.

That read cannot work. The last error lives in a per-thread slot, and the JNI and JNA machinery standing between a mapped call and the Java code around it writes to that slot too, so by the time a mapped `WSAGetLastError` runs it answers with whatever that machinery left there, which is zero. JNA knows this: it short-circuits Kernel32's `GetLastError` to `Native.getLastError()`, which hands over the copy JNA takes of the slot the instant every mapped call returns.

So the code is now read from `Native.getLastError()`:

* the EO-visible `"WSAGetLastError"` object reads it, so a program that dataizes it after a failed socket call gets the code that call set instead of a zero — `socket.eo` prints exactly that in `WSA error code %d`;
* `WSAGetLastError` is gone from the `Winsock` binding, where it could only ever mislead, and the reason is written down next to `WSASetLastError`;
* the test asserts on the same read, straight after the call and before anything is dataized, since any later mapped call of ours would replace the copy with its own.

The Windows job runs on pushes to master only, so this test first ran when #7730 merged.

Checked here: `mvn clean verify -PskipTests -Pqulice` is green, and against JNA 5.19.1 the saved copy holds the error after both value-returning and void-returning mapped calls (`WSASetLastError` is void) and survives arbitrary Java work in between. The assertion itself can only be exercised by the Windows job.


---
_Generated by [Claude Code](https://claude.ai/code/session_013tqSVBgCPszS187as1jj87)_