### PR TITLE
#7613: ask about a receiver the formation reads but never declares

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
@@ -105,7 +105,7 @@
             <xsl:sequence select="false()"/>
           </xsl:when>
           <xsl:otherwise>
-            <xsl:sequence select="eo:closed($f)"/>
+            <xsl:sequence select="eo:closed($f) and not(eo:borrowed($f, $row))"/>
           </xsl:otherwise>
         </xsl:choose>
       </xsl:otherwise>
@@ -115,6 +115,34 @@
   <xsl:function name="eo:closed" as="xs:boolean">
     <xsl:param name="f" as="element()"/>
     <xsl:sequence select="empty($f/descendant-or-self::*[@base = $eo:program or (starts-with(@base, concat($eo:program, '.')) and not(@base = $eo:literals))])"/>
+  </xsl:function>
+  <!--
+  Whether this element is a formation, the same shape the template below
+  matches: an object with a locator of its own, copying nothing, that is
+  neither the "λ" of an atom nor a piece of data.
+  -->
+  <xsl:function name="eo:formation" as="xs:boolean">
+    <xsl:param name="e" as="element()"/>
+    <xsl:sequence select="exists($e/@loc) and empty($e/@base) and not($e/@name = $eo:lambda) and not($e/text()[normalize-space()])"/>
+  </xsl:function>
+  <!--
+  Whether this formation reads the object it is attached to without declaring
+  it. Rule 1 above judges the receiver like any other input, and "eo:filled"
+  asks that of every void the row has; a receiver the formation never declared
+  has no void to be witnessed, so an empty list of voids answers the question
+  before it is put and the label goes on with the receiver never looked at
+  (#7613). The cheap half is asked first: a formation that declares "ρ" has
+  been judged on it already.
+  Only the reads of this very formation count, which is why the nearest
+  formation around each read has to be this one. A nested formation declaring
+  its own receiver and reading that says nothing about the formation around
+  it - its "ρ" is another attribute of another object - and counting those
+  would withhold the label from most of the formations of a program.
+  -->
+  <xsl:function name="eo:borrowed" as="xs:boolean">
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="row" as="element()"/>
+    <xsl:sequence select="empty($row/attr[@void = 'true'][@name = $eo:rho]) and exists($f/descendant::*[(@base = concat($eo:xi, '.', $eo:rho) or starts-with(@base, concat($eo:xi, '.', $eo:rho, '.'))) and (ancestor::*[eo:formation(.)][1] is $f)])"/>
   </xsl:function>
   <!--
   Whether every void of this row is witnessed as a number or a string, the

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/purify-packs/receiver-read-without-being-declared-is-not-pure.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/purify-packs/receiver-read-without-being-declared-is-not-pure.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A formation reads the object it is attached to without declaring it. It has
+# no voids of its own, so the question about its inputs is asked of an empty
+# list and answered before it is put, yet the body still reads "^" and nothing
+# ever witnessed what that is. The receiver is an input like any other, so the
+# label is withheld until the formation declares it and the table sees it
+# filled with data. The nested one is the other half of the same rule: "kept"
+# declares its own receiver and reads that, which says nothing about "outer"
+# above it, and "outer" keeps the label.
+eo:
+  app.eo: |
+    [] > app
+      probe > @
+      42 > pattern
+      [] > probe
+        ^.pattern > @
+      [] > outer
+        kept > @
+        [^] > kept
+          ^ > @
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+pure:
+  - "//o[@name='probe' and not(@pure)]"
+  - "//o[@name='outer' and @pure='true']"


### PR DESCRIPTION
Closes #7613.

## Problem

`eo:filled` asks that every void of a formation's row be witnessed as data, the receiver among them. `every ... satisfies` over an empty sequence is true, so a formation that declares **no** receiver has no void standing for one: the question is answered before it is put, and a body reading `^` gets the label with that receiver never looked at.

## What the measurement says

The description lists five formations of `eo-runtime` as reading `ξ.ρ` without declaring it. Attributing each read to the **nearest enclosing** formation rather than to every formation above it, only one of the five is really doing so:

| attribution | formations reading `ξ.ρ`, declaring no `ρ` |
| --- | --- |
| any formation above the read (`descendant::`) | 45 |
| the formation the read is really in | **1** |

The one is `Φ.string.regex.-rejects-serialized-bytes-of-the-wrong-type`, whose body is `^.pattern ...`. The other four in the list — `Φ.bool.+can-take-a-parent-object` among them — enclose a *nested* formation that declares its own `[^]` and reads that, e.g. the read at `Φ.bool.+can-take-a-parent-object.a.take.φ.ρ` belongs to `take`. Their `ρ` is another attribute of another object and says nothing about the formation around it.

That distinction is the whole design of the fix: counting reads by `descendant::` would withhold the label from 45 formations entitled to it in order to catch the one that is not.

## Fix

- `eo:formation` — whether an element is a formation, the same shape the stamping template matches.
- `eo:borrowed` — whether the formation reads `ξ.ρ` (or something under it) in its *own* body while its row declares no `ρ` void. The cheap half is asked first, so a formation that declares `ρ` short-circuits, having been judged by `eo:filled` already.
- `eo:pure` withholds the label when that holds. It is asked in the last branch, next to `eo:closed`, keeping the walk off the objects the table already rejected — the ordering the stylesheet's own comment asks for.

The label is only ever withheld, never added, so this can lose caching but cannot make anything cache that did not.

## Verification

- A new `purify-packs` pack. It **fails on master** with exactly `//o[@name='probe' and not(@pure)]` unmatched, and passes with the fix.
- The same pack carries the other half as a control: an `outer` with no voids whose nested `kept` declares and reads its own receiver must keep the label. That assertion passes on master too, so it guards against exactly the descendant-scoped mistake above.
- `mvn -pl eo-maven-plugin test -Dtest=StPureTest` — 15 tests pass; the 13 existing packs are untouched.
- 58 lines changed, within the `pr-size` limit.

## Note

While picking this up I found #7455 and #7456 already fixed in master (by `065c247f` and #7534) and left the evidence on each rather than opening PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H)_