### PR TITLE
Delete the root of a walked directory and fix two unpassable tests

### DIFF
--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -1,5 +1,10 @@
 # Recursively deletes a directory and all of its contents. It is a method of
-# `directory`, and `d` is the directory it is taken off.
+# `directory`, and `d` is the directory it is taken off. The walk that feeds
+# `entries` reports everything underneath `d` and never `d` itself, so the
+# recursion below empties the directory but leaves it standing. The root is
+# removed by the step after it, once the walk is done and the directory is
+# empty, through `file.deleted`, which reaches for `rmdir` over `unlink`
+# when the path it is given is a directory.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -17,6 +22,7 @@
         tup.head.deleted
         ^.r tup.tail
     | entries
+    d.as-path.as-file.deleted
     d
   ^ > d
   recovered > [^] > entries
@@ -52,7 +58,7 @@
     dir.tmpfile > second
 
   ++> can-delete-an-already-absent-directory
-    d.deleted.deleted.exists.not d > @
+    d.deleted.deleted.exists.not > @
     mktemp.tmpfile.deleted.as-path.as-dir > d
 
   not. ++> can-delete-an-empty-directory

--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -243,7 +243,6 @@
   ++> can-create-the-target-of-a-dangling-symlink-on-writing
     os.is-windows.or > @
       seq *
-        target.as-file.exists
         code.
           posix *1
             "symlink"
@@ -252,8 +251,10 @@
         link.as-file.open
           "w"
           f.write "created" > [^ f]
-    target.resolved "dangling-link" > link
-    mktemp.tmpfile.deleted.as-path > target
+        target.as-file.exists
+    mktemp.tmpfile.deleted.as-path.as-dir.made.as-path > d
+    d.resolved "dangling-link" > link
+    d.resolved "absent-target" > target
 
   eq. ++> can-keep-the-size-of-a-file-opened-for-appending
     size.


### PR DESCRIPTION
Fixes the two failures of [run 32953804241](https://github.com/objectionary/eo/actions/runs/32953804241/job/98131560676) on `master`:

```
[ERROR] Failures:
[ERROR]   EOdirectoryTest.can_delete_an_empty_directory:3642 expected: <true> but was: <false>
[ERROR] Errors:
[ERROR]   EOfileTest.can_create_the_target_of_a_dangling_symlink_on_writing:1989 » ExFailure
              Couldn't open file '/tmp/1787737927250-12480-0-0.000198/dangling-link': No such file or directory
```

The `ec2` job is the only one whose `eo.deadline` is long enough for these two to report at all; everywhere else `org.eolang.Deadline` swallows them among the 109 skipped, which is why they landed green.

### `directory.deleted` never removed its own directory

The walk that feeds `entries` reports everything underneath the root and never the root itself: `walked` starts with an empty `prefix`, and its base case returns `accum` untouched when the prefix is empty. So the recursion emptied the directory and then returned it, still on disk. One step removes it now, after the walk is done and the directory is empty, through `file.deleted`, which reaches for `rmdir` over `unlink` when the path it is given is a directory.

`can_delete_a_directory_with_a_file_and_a_directory` and `can_delete_a_directory_with_files_recursively` assert `dir.deleted.exists.not` too, and so does `can_tell_that_a_deleted_directory_is_no_longer_a_directory` in `directory.eo`; none of them could hold before this, and all pass now.

### The dangling-symlink test asked for the impossible

`target` was `mktemp.tmpfile.deleted.as-path`, a path that had just been deleted, and `link` was `target.resolved "dangling-link"` — an entry *inside* it. `symlink` therefore failed with `ENOENT`, no link was ever created, and `open` reported the missing path rather than creating a target through a dangling link. Both now sit in a directory the test makes first.

The `seq` also used to end on the value of `open`, which is a file, not a boolean, so `os.is-windows.or` was handed path bytes. Its last step is now `target.as-file.exists`, which is the thing the test is named after.

### `can_delete_an_already_absent_directory`

It read `d.deleted.deleted.exists.not d`, applying `bool.not` — whose voids are all filled, since it is `if false true` — to `d`, and died with `This void attribute "a🌵13-4" is already set, can't reset`. The stray argument is gone. This one did not fail in the run above (it is slow enough to be skipped there); I confirmed it fails the same way with `directory/deleted.eo` reverted, so it is not a consequence of the change above.

### Verification

```
mvn test -pl :eo-runtime -Deo.deadline=3600 -DforkCount=1 -Dheap-size=9G \
  -Dtest='EOdirectoryTest#...,EOfileTest#can_create_the_target_of_a_dangling_symlink_on_writing'
```

| test | before | after |
| --- | --- | --- |
| `EOdirectoryTest.can_delete_an_empty_directory` | fail | pass |
| `EOfileTest.can_create_the_target_of_a_dangling_symlink_on_writing` | error | pass |
| `EOdirectoryTest.can_delete_an_already_absent_directory` | error | pass |
| `EOdirectoryTest.can_tell_that_a_deleted_directory_is_no_longer_a_directory` | fail | pass |
| `EOdirectoryTest.can_delete_a_directory_with_a_file_and_a_directory` | fail | pass |
| `EOdirectoryTest.can_delete_a_directory_with_files_recursively` | fail | pass |
| `EOdirectoryTest.can_delete_a_tmpfile_without_orphans` | pass | pass |
| `EOdirectoryTest.can_retry_tmpfile_creation_after_a_collision` | pass | pass |
| `EOdirectoryTest.can_make_a_new_directory` | pass | pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015bgkQonD72cLkzjBk9t5fE

---
_Generated by [Claude Code](https://claude.ai/code/session_015bgkQonD72cLkzjBk9t5fE)_