### PR TITLE
Read the memory block through the copy in EOmallocEOofTest

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/EOmallocEOofTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOmallocEOofTest.java
@@ -25,6 +25,11 @@ final class EOmallocEOofTest {
                 dummy
             )
         ).take();
+        MatcherAssert.assertThat(
+            "the dummy must capture the identifier of the allocated block",
+            dummy.id,
+            Matchers.greaterThanOrEqualTo(0.0d)
+        );
         Assertions.assertThrows(
             ExAbstract.class,
             () -> Heaps.INSTANCE.size((int) dummy.id),
@@ -44,6 +49,11 @@ final class EOmallocEOofTest {
                 )
             ).take(),
             "Should throw an exception on attempting to use ErrorDummy, but it didn't"
+        );
+        MatcherAssert.assertThat(
+            "the dummy must capture the identifier of the allocated block before failing",
+            dummy.id,
+            Matchers.greaterThanOrEqualTo(0.0d)
         );
         Assertions.assertThrows(
             ExAbstract.class,
@@ -110,10 +120,11 @@ final class EOmallocEOofTest {
 
         /**
          * Ctor.
-         * @checkstyle ConstructorsCodeFreeCheck (20 lines)
+         * @checkstyle ConstructorsCodeFreeCheck (21 lines)
          */
         @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         Dummy() {
+            this.id = -1.0d;
             this.add("m", new AtVoid("m"));
             this.add(
                 Phi.PHI,
@@ -143,10 +154,11 @@ final class EOmallocEOofTest {
 
         /**
          * Ctor.
-         * @checkstyle ConstructorsCodeFreeCheck (25 lines)
+         * @checkstyle ConstructorsCodeFreeCheck (26 lines)
          */
         @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
         ErrorDummy() {
+            this.id = -1.0d;
             this.add("m", new AtVoid("m"));
             this.add(
                 Phi.PHI,
@@ -154,7 +166,7 @@ final class EOmallocEOofTest {
                     this,
                     rho -> {
                         this.id = new Dataized(
-                            this.take("m").take("id")
+                            rho.take("m").take("id")
                         ).asNumber();
                         return new PhApplication(
                             Phi.Φ.take("error").copy(),


### PR DESCRIPTION
Fixes the `master` build failure in [run 32968395637](https://github.com/objectionary/eo/actions/runs/32968395637/job/98176764758):

```
EOmallocEOofTest.freesMemoryIfErrorIsOccurred:48 Heaps should throw an exception on
attempting to reach already freed memory after failure, but it didn't
==> Expected org.eolang.ExAbstract to be thrown, but nothing was thrown.
```

## What was wrong

`ErrorDummy`'s lambda read the memory block through `this.take("m")`, where `this` is the lexically captured *original* formation rather than the copy the lambda is applied to. `AtComposite.copy(self)` rebinds its argument to the copy, so only the copy ever gets the void `m` filled; the original's `m` stays vacant, and `AtVoid.get` hands back a `PhTerminator` that aborts with `the attribute "m" is not set`.

That still satisfied the first assertion — an `ExAbstract` *was* thrown, just not the one the test meant — while leaving `id` at its default `0`. The second assertion then probed block `0` instead of the block the scope had actually been given.

Reverting just the receiver locally reproduces it exactly:

```
EOmallocEOofTest.freesMemory:27 » ExFailure Error in "Φ.malloc.for.Δ" ... ;
  the attribute "m" is not set
```

## Why it surfaced now

`#7304` (2c4ffdcf) made identifiers a monotonic counter starting at zero, so block `0` is a real block that a concurrently running test may still hold — `Heaps.size(0)` then returns a length instead of throwing. Before that, identifiers came from `Phi.hashCode` and `0` practically never collided, which is why the mistake stayed hidden. Nothing in the runtime is broken; `Heaps.malloc` frees in a `finally` and does so correctly.

## The fix

- `ErrorDummy` reads `rho.take("m")`, the way `Dummy` already did.
- Both dummies start `id` at `-1`, and both tests assert the identifier was actually captured before probing `Heaps`. A missed capture now fails on its own terms instead of silently turning into a probe of whatever block `0` happens to be.

## Verification

Run in a UTF-8 locale (`LC_ALL=C.UTF-8`), against `eo-runtime`:

| Check | Result |
| --- | --- |
| `-Dtest=EOmallocEOofTest` | 4 run, 0 failures |
| `-Dtest=EOmallocEOofTest,HeapsTest,EOmallocTest` | 68 run, 0 failures, 2 skipped |
| `-Pqulice qulice:check` | BUILD SUCCESS |

The added guard was checked against the old receiver as a negative control: it fails there, confirming it catches the defect rather than merely passing alongside it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01URiZps6ozXyfuVsYUuDX9z)_