### PR TITLE
Cover deleting a directory whose subdirectory is not empty

### DIFF
--- a/eo-runtime/src/main/eo/directory/deleted.eo
+++ b/eo-runtime/src/main/eo/directory/deleted.eo
@@ -45,6 +45,14 @@
     dir.tmpfile > f
     as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
 
+  ++> can-delete-a-directory-with-a-nested-file
+    and. > @
+      nested.exists.and dir.deleted.exists.not
+      nested.exists.not
+    as-dir. (directory mktemp.tmpfile.deleted).made.as-path > dir
+    as-dir. (directory dir.tmpfile.deleted).made.as-path > inner
+    inner.tmpfile > nested
+
   ++> can-delete-a-directory-with-files-recursively
     and. > @
       and.


### PR DESCRIPTION
This branch started as a fix for the `ec2` failure on `master` ([run 32966035691](https://github.com/objectionary/eo/actions/runs/32966035691/job/98169172783)):

```
[ERROR] EOdirectoryTest.can_delete_an_empty_directory:3642 expected: <true> but was: <false>
```

While it was open, #7735 landed the same fix on `master` (`d.as-path.as-file.deleted` plus the `bool.not d` correction in `can-delete-an-already-absent-directory`), so the failure is already gone. The branch is rebuilt on top of that and now carries only what `master` still lacks: a test for the one property of `directory.deleted` that nothing asserts.

## Why

`directory.deleted` walks the tree, deletes each entry the walk offers and then removes the root. The walk hands out a child before its parent, so the recursion deletes the head of the tuple before it steps into the tail. Reverse those two lines and `rmdir` is asked to remove a directory that still holds entries.

Neither existing test notices:

- `can-delete-a-directory-with-a-file-and-a-directory` puts an **empty** directory next to a file, and an empty directory is removable in any order;
- `can-delete-a-directory-with-files-recursively` keeps its two files flat.

## What changed

One test in `eo-runtime/src/main/eo/directory/deleted.eo`, hanging a file inside a subdirectory — the shape that needs the child gone first.

## Verification

On this branch:

```
mvn -pl eo-runtime test -Deo.deadline=600 -Dtest='EOdirectoryTest#can_delete_a_directory_with_a_nested_file'
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

With the recursion in `deleted.eo` stepping into `tup.tail` before deleting `tup.head` (the deliberate break, not part of this diff), the same test fails:

```
[ERROR] EOdirectoryTest.can_delete_a_directory_with_a_nested_file » ExFailure ...
  Cant delete the file '/tmp/.../...': Directory not empty
```

`format` and the lints run clean over the edited source (`All 171 EO source(s) are formatted canonically`).

Aside, from chasing the original failure: with `eo.deadline` at one second, `Deadline` turns a timeout into a `TestAbortedException`, so surefire reports slow tests as skipped — 31 of the 44 tests in `EOdirectoryTest` in that EC2 run. Three of this object's four tests were failing on `master` and only the fastest one was ever reported.