### PR TITLE
#7205: exercise the race made.eo rescues, from many threads at once

### DIFF
--- a/eo-runtime/src/main/eo/directory/made.eo
+++ b/eo-runtime/src/main/eo/directory/made.eo
@@ -4,13 +4,10 @@
 # any non-directory entry) occupies the path, the computation terminates
 # instead of returning that entry decorated as a directory.
 #
-# @todo #7080:60min Add a synchronization-based regression test that creates
-#  the target directory between the exists() probe and mkdir below, so the
-#  race this fixes is actually exercised. A single-threaded EO `++>` test
-#  can't trigger it, same reasoning as the puzzle in file/touched.eo: it
-#  needs a JUnit test against the generated `EOmade` class with real thread
-#  interleaving (see PhDefaultRaceTest.java for the com.yegor256.Together
-#  idiom this repo already uses for exactly this kind of interleaving).
+# The path may be made by somebody else between the question and the answer,
+# so a `mkdir` coming back with `EEXIST` over a directory is taken for the
+# directory it names rather than for a failure. `EOdirectoryEOmadeRaceTest`
+# holds the interleaving that reaches that branch.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -6,9 +6,7 @@
 package org.eolang;
 
 import com.yegor256.Together;
-import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
@@ -29,7 +27,9 @@ import org.junit.jupiter.api.io.TempDir;
  * the two steps: every thread is given the same missing path, so whichever one
  * wins the {@code mkdir} leaves the rest to take the {@code EEXIST} branch, and
  * a deep path gives them several levels to collide on. A thread that is refused
- * comes back through {@code Together} as the failure it threw.</p>
+ * comes back through {@code Together} as the failure it threw, and one that is
+ * answered reads {@code exists} off what it was given, which is the directory
+ * on disk and not a claim about it.</p>
  *
  * <p>Four threads are enough to leave somebody holding the {@code EEXIST}, and
  * every thread of them builds a graph of objects of its own: a dozen at once is
@@ -42,23 +42,17 @@ final class EOdirectoryEOmadeRaceTest {
 
     @RepeatedTest(10)
     void makesOneDirectoryFromManyThreadsAtOnce(@TempDir final Path temp) {
-        final Path target = temp.resolve("one").resolve("two").resolve("three");
-        final int threads = 4;
-        final List<Boolean> outcomes = new Together<>(
-            threads,
-            thread -> new Dataized(
-                this.made(target.toString()).take("exists")
-            ).asBool()
-        ).asList();
         MatcherAssert.assertThat(
             "every thread racing for the same missing directory must be told it is there, since the one that loses the mkdir is the one the EEXIST branch rescues",
-            outcomes,
+            new Together<>(
+                4,
+                thread -> new Dataized(
+                    this.made(
+                        temp.resolve("one").resolve("two").resolve("three").toString()
+                    ).take("exists")
+                ).asBool()
+            ).asList(),
             Matchers.everyItem(Matchers.is(true))
-        );
-        MatcherAssert.assertThat(
-            "the directory the threads raced for must be on disk once they are done",
-            Files.isDirectory(target),
-            Matchers.is(true)
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.yegor256.Together;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@link EOdirectory$EOmade} under concurrency.
+ *
+ * <p>{@code made} asks whether the path is there and makes it when it is not,
+ * and the two questions are not one step: another thread can make the very
+ * same directory in between, so the {@code mkdir} of this one comes back with
+ * {@code EEXIST} having done nothing wrong. Answering that with the directory
+ * rather than with a failure is the branch this exercises, and a single-threaded
+ * {@code ++>} test cannot reach it, since nothing there ever loses the race
+ * (#7080).</p>
+ *
+ * <p>The interleaving is left to the threads instead of being forced between
+ * the two steps: every thread is given the same missing path, so whichever one
+ * wins the {@code mkdir} leaves the rest to take the {@code EEXIST} branch, and
+ * a deep path gives them several levels to collide on. A thread that is refused
+ * comes back through {@code Together} as the failure it threw.</p>
+ *
+ * @since 0.75.0
+ */
+final class EOdirectoryEOmadeRaceTest {
+
+    /**
+     * How many threads race for the same directory.
+     */
+    private static final int THREADS = 16;
+
+    @RepeatedTest(20)
+    void makesOneDirectoryFromManyThreadsAtOnce(@TempDir final Path temp) {
+        final Path target = temp.resolve("one").resolve("two").resolve("three");
+        final List<Boolean> outcomes = new Together<>(
+            EOdirectoryEOmadeRaceTest.THREADS,
+            thread -> new Dataized(
+                EOdirectoryEOmadeRaceTest.made(target.toString()).take("exists")
+            ).asBool()
+        ).asList();
+        MatcherAssert.assertThat(
+            "every thread racing for the same missing directory must be told it is there, since the one that loses the mkdir is the one the EEXIST branch rescues",
+            outcomes,
+            Matchers.everyItem(Matchers.is(true))
+        );
+        MatcherAssert.assertThat(
+            "the directory the threads raced for must be on disk once they are done",
+            Files.isDirectory(target),
+            Matchers.is(true)
+        );
+    }
+
+    private static Phi made(final String path) {
+        final Phi file = Phi.Φ.take("file").copy();
+        file.put(0, new Data.ToPhi(path));
+        final Phi directory = Phi.Φ.take("directory").copy();
+        directory.put(0, file);
+        return new PhApplication(new EOdirectory$EOmade(), Phi.RHO, directory);
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
- * Test case for {@link EOdirectory$EOmade} under concurrency.
+ * Test case for {@code directory.made} under concurrency.
  *
  * <p>{@code made} asks whether the path is there and makes it when it is not,
  * and the two questions are not one step: another thread can make the very
@@ -66,6 +66,6 @@ final class EOdirectoryEOmadeRaceTest {
         file.put(0, new Data.ToPhi(path));
         final Phi directory = Phi.Φ.take("directory").copy();
         directory.put(0, file);
-        return new PhApplication(new EOdirectory$EOmade(), Phi.RHO, directory);
+        return directory.take("made");
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -31,25 +31,23 @@ import org.junit.jupiter.api.io.TempDir;
  * a deep path gives them several levels to collide on. A thread that is refused
  * comes back through {@code Together} as the failure it threw.</p>
  *
+ * <p>Four threads are enough to leave somebody holding the {@code EEXIST}, and
+ * every thread of them builds a graph of objects of its own: a dozen at once is
+ * gigabytes of heap and minutes of collecting it, for no more of the race than
+ * four reach.</p>
+ *
  * @since 0.75.0
  */
 final class EOdirectoryEOmadeRaceTest {
 
-    /**
-     * How many threads race for the same directory. Four is enough to leave
-     * somebody holding the {@code EEXIST}, and every thread of them builds a
-     * graph of objects of its own: a dozen at once is gigabytes of heap and
-     * minutes of collecting it, for no more of the race than this reaches.
-     */
-    private static final int THREADS = 4;
-
     @RepeatedTest(10)
     void makesOneDirectoryFromManyThreadsAtOnce(@TempDir final Path temp) {
         final Path target = temp.resolve("one").resolve("two").resolve("three");
+        final int threads = 4;
         final List<Boolean> outcomes = new Together<>(
-            EOdirectoryEOmadeRaceTest.THREADS,
+            threads,
             thread -> new Dataized(
-                EOdirectoryEOmadeRaceTest.made(target.toString()).take("exists")
+                this.made(target.toString()).take("exists")
             ).asBool()
         ).asList();
         MatcherAssert.assertThat(
@@ -64,7 +62,7 @@ final class EOdirectoryEOmadeRaceTest {
         );
     }
 
-    private static Phi made(final String path) {
+    private Phi made(final String path) {
         final Phi file = Phi.Φ.take("file").copy();
         file.put(0, new Data.ToPhi(path));
         final Phi directory = Phi.Φ.take("directory").copy();

--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -36,11 +36,14 @@ import org.junit.jupiter.api.io.TempDir;
 final class EOdirectoryEOmadeRaceTest {
 
     /**
-     * How many threads race for the same directory.
+     * How many threads race for the same directory. Four is enough to leave
+     * somebody holding the {@code EEXIST}, and every thread of them builds a
+     * graph of objects of its own: a dozen at once is gigabytes of heap and
+     * minutes of collecting it, for no more of the race than this reaches.
      */
-    private static final int THREADS = 16;
+    private static final int THREADS = 4;
 
-    @RepeatedTest(20)
+    @RepeatedTest(10)
     void makesOneDirectoryFromManyThreadsAtOnce(@TempDir final Path temp) {
         final Path target = temp.resolve("one").resolve("two").resolve("three");
         final List<Boolean> outcomes = new Together<>(


### PR DESCRIPTION
Closes #7205 (puzzle `7080-bb23990c`).

## What the puzzle asked

`made` asks whether the path is there and makes it when it is not, and the two steps are not one: another thread can make the very same directory in between, so this thread's `mkdir` comes back with `EEXIST` having done nothing wrong. Taking that for the directory rather than for a failure is what `errno.eq eexist` and `d.is-directory` do, and nothing reached it — a single-threaded `++>` test never loses the race.

## The test

Four threads are handed the same missing, three-level path, so whichever wins each `mkdir` leaves the rest on the `EEXIST` branch, and a thread that is refused comes back through `Together` as the failure it threw. Ten rounds, using the `com.yegor256.Together` idiom of `PhDefaultRaceTest`.

## It provably reaches the branch

A passing race test proves nothing on its own, so I removed the rescue from `made.eo` — replacing the `or` of `created.code.eq 0` and the `EEXIST` pair with just `created.code.eq 0` — and ran the same test against it:

| `made.eo` | result |
| --- | --- |
| as it is | `Tests run: 10, Failures: 0, Errors: 0` (38.5s) |
| rescue removed | `Tests run: 10, Errors: 10` — every round `Cant make the directory '/tmp/junit-.../one': File exists` |

Ten out of ten rounds catch it, so the interleaving is reached reliably rather than now and then. The mutant was local only; `made.eo` here differs from `master` by the comment alone.

## Two notes for the reviewer

**There is no generated `EOmade` class.** The puzzle asks for "a JUnit test against the generated `EOmade` class", but the transpiler emits none for `directory.made`: `EOdirectory$EOlisted` exists because `listed` is a hand-written atom, while `made` is written in EO and compiles into `EOdirectory`'s own tree. The test takes `made` off the directory instead, which reaches the same object through the package with the receiver bound, the way the `++>` tests in the file reach it.

**Four threads, not sixteen.** Each thread builds a graph of objects of its own, and a dozen at once is gigabytes: at 16 threads the test spent minutes collecting and then died of `Java heap space` (reproduced at 12 threads under a 1G heap, and in surefire at 16). Measured on this machine, one `made` is ~700ms, 4 threads ~1.5s, 8 ~2.7s, 12 OOM. Four keeps a round near 4s and still loses the race every time, as the table above shows.

The test is a real race, so it is timing-dependent by nature, as `PhDefaultRaceTest` is; the ten-of-ten mutant result is the evidence I have that it is not flaky in the direction that matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H

---
_Generated by [Claude Code](https://claude.ai/code/session_01BW7sVWnb57VW2CpgEJoN2H)_