### PR TITLE
fix(#7585): keep the normalized coverage test off transpiled objects

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -118,7 +118,9 @@ final class PhCoverageTest {
         final String before = System.getProperty("eo.coverageFile");
         System.setProperty("eo.coverageFile", hits.toString());
         try {
-            new PhCoverage(new Data.ToPhi(1L), "Φ.normalized:3:5").normalized().delta();
+            new PhCoverage(
+                new PhDefault(new byte[] {(byte) 0x01}), "Φ.normalized:3:5"
+            ).normalized().delta();
             MatcherAssert.assertThat(
                 "a location touched through a normalized object must still be recorded, but it wasnt",
                 Files.readAllLines(hits, StandardCharsets.UTF_8),


### PR DESCRIPTION
The `codecov` job on `master` is red: [run 32983196772](https://github.com/objectionary/eo/actions/runs/32983196772/job/98225028166).

```
[ERROR] PhCoverageTest.recordsALocationTouchedThroughANormalizedObject:122
  a location touched through a normalized object must still be recorded, but it wasnt
Expected: iterable containing ["Φ.normalized:3:5"]
     but: not matched: "Φ.number.φ:13:2"
```

`recordsALocationTouchedThroughANormalizedObject`, added in c8a670ee, wrapped a
`Data.ToPhi(1L)`. That job runs `mvn install -Pjacoco -Deo.coverageTracking=true`,
so the transpiler wraps every located object of the generated EO classes into
`PhCoverage` as well. Dataizing the generated `number` made its own wrappers
append `Φ.number.φ:13:2` to the very file the test had just pointed
`eo.coverageFile` at, so the exact-contents assertion saw that line instead of
the one the test recorded — the same failure dde37d77 fixed for
`recordsALocationOnceTheDestinationBecomesWritable`, and the one the class
javadoc warns about.

The test now wraps a plain `PhDefault` with raw bytes, like every other test in
the class that asserts on the contents of that file. A `PhDefault` holding data
returns itself from `normalized()`, so the wrapper's own `hit()` stays the only
thing that writes, and the test still fails if `PhCoverage.normalized()` stops
recording.

No production code changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jt3HApCUNswAvKroUN1CsL)_