### PR TITLE
fix(#7741): let the comment block keep the blank line it demands

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -43,7 +43,7 @@ final class Blanks {
      */
     static void checkPlain(final Span span, final Globals globals, final Emit emit) {
         Blanks.enterAfterMeta(span, globals, emit);
-        if (globals.pendingBlanks() > 0) {
+        if (globals.pendingBlanks() > 0 && !Comments.afterBlock(globals)) {
             emit.error(
                 span.line(), span.indent(),
                 "blank line not allowed between non-master siblings"

--- a/eo-parser/src/main/java/org/eolang/parser/Comments.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Comments.java
@@ -28,6 +28,24 @@ final class Comments {
     }
 
     /**
+     * Is the blank line the parser is holding the one R-6.5.2 demands
+     * after the top comment block?
+     *
+     * <p>That blank belongs to the comment block, not to the object
+     * that follows it, so R-6.5.4 must not read it as a blank between
+     * two plain siblings. A master object never notices the
+     * difference, being exempt from R-6.5.4 anyway; a plain one is
+     * not exempt, and without this the first object of a documented
+     * file is rejected unless it happens to be a formation.</p>
+     *
+     * @param globals Global parser state
+     * @return TRUE if the block is still pending, so the blank is its own
+     */
+    static boolean afterBlock(final Globals globals) {
+        return !globals.sealed() && !globals.pendingComments().isEmpty();
+    }
+
+    /**
      * Flush the pending top comment block, if any, and close the header
      * zone.
      *

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/documented-non-formation-is-accepted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/documented-non-formation-is-accepted.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7741: the blank line R-6.5.2 demands after the top comment block belongs
+# to the block, not to the object that follows it, so R-6.5.4 must not read
+# it as a blank between two plain siblings. A formation was exempt anyway;
+# an application was not, and got rejected for being documented.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/comments/comment[contains(text(),'Doc')]
+  - //o[@base='Φ.number' and @name='foo']
+input: |
+  # Doc.
+
+  42 > foo


### PR DESCRIPTION
Fixes #7741.

The blank line R-6.5.2 demands after the top comment block was charged a second time as an R-6.5.4 blank between plain siblings, so a documented top-level object parsed only when it happened to be a formation. `# Doc.` + blank + `42 > foo` was rejected; the same line without the comment block, or after a meta header, was fine. `Blanks.checkPlain` now leaves that blank alone while the block is still unflushed, and `Comments.seal` keeps doing its own R-6.5.2 check right after, so a missing blank is still reported.

The visible consequence was the printer: `[x] > foo` with `x > @` prints as `I > foo` under its doc comment, correctly per R-3.16, and that output did not reparse.

The new YAML pack fails against `master` and passes here. `EoSyntaxTest`: 637 run, 0 failed. A print-parse-print round trip over all 171 `.eo` sources of `eo-runtime` is unchanged.
