### PR TITLE
fix(#7744): read nonProxyHosts without regard to case

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MvnProxy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MvnProxy.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 /**
  * One active proxy of Maven settings, carrying the excluded hosts that a
@@ -51,14 +52,19 @@ final class MvnProxy {
      * Whether the given host is excluded from this proxy by its
      * {@code nonProxyHosts} pattern, the same {@code |}-separated,
      * {@code *}-wildcard glob syntax the JDK's own {@code http.nonProxyHosts}
-     * property uses.
+     * property uses, read without regard to case: host names are
+     * case-insensitive, and the JDK matches them that way, so a host the user
+     * excluded stays excluded however it is capitalised in a repository URL.
      * @param host The host a request is bound for
      * @return True when the host must be reached directly
      */
     boolean excludes(final String host) {
         final String hosts = this.origin.getNonProxyHosts();
         return hosts != null && Arrays.stream(hosts.split("\\|")).anyMatch(
-            pattern -> host.matches(pattern.trim().replace(".", "\\.").replace("*", ".*"))
+            pattern -> Pattern.compile(
+                pattern.trim().replace(".", "\\.").replace("*", ".*"),
+                Pattern.CASE_INSENSITIVE
+            ).matcher(host).matches()
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MvnProxyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MvnProxyTest.java
@@ -28,6 +28,19 @@ final class MvnProxyTest {
     }
 
     @Test
+    void excludesAHostWrittenInAnotherCase() {
+        final org.apache.maven.settings.Proxy origin = new org.apache.maven.settings.Proxy();
+        origin.setHost("prox.eolang.org");
+        origin.setPort(8080);
+        origin.setNonProxyHosts("localhost|*.internal.example.com");
+        MatcherAssert.assertThat(
+            "A host name is case-insensitive, so its capitals must not send it through the proxy",
+            new MvnProxy(origin).excludes("Build.Internal.EXAMPLE.com"),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void doesNotExcludeAHostAbsentFromNonProxyHosts() {
         final org.apache.maven.settings.Proxy origin = new org.apache.maven.settings.Proxy();
         origin.setHost("prox.eolang.org");


### PR DESCRIPTION
Fixes #7744.

`excludes` compiled the `nonProxyHosts` glob into a case-sensitive regex, so `*.example.com` excluded `www.example.com` and sent `WWW.Example.COM` through the proxy. Host names are case-insensitive, and the JDK's own `http.nonProxyHosts`, which this method's javadoc claims parity with, matches them that way: I ran both against the same grid in one JVM and the two answers differed on every capitalised row.

`Pattern.CASE_INSENSITIVE` is all it takes. The new test fails against `master` and passes here. `MvnProxyTest`: 3 run, 0 failed.

The same line is also more lenient than the JDK about spaces around `|` (`localhost | *.corp` excludes `host.corp` here, and does not in the JDK). I left that alone: it forgives a settings file the JDK would punish, and tightening it would break users who rely on it. Happy to change it if you would rather have exact parity.
