### PR TITLE
Let stdin.all-lines reach the end of the stream

### DIFF
--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -30,6 +30,15 @@ import org.cactoos.Proc;
  * file descriptor 0, and neither the exec plugin nor {@code Farea} can give
  * a process an input of its own.</p>
  *
+ * <p>That JVM is given a stack of its own too. Dataizing an EO object walks
+ * the whole chain of its nested objects on the Java stack, and a recursive
+ * object adds its own chain on every step, so the depth grows with the
+ * input and not with the length of the program. Every other JVM this
+ * project starts to run EO is handed the same flag, {@code JarIT} and the
+ * {@code argLine} of both Surefire and Failsafe among them; on the default
+ * stack a snippet reading a few hundred lines already dies with a
+ * {@link StackOverflowError}.</p>
+ *
  * @since 0.56.3
  */
 final class EoSourceRun implements Proc<Object> {
@@ -38,20 +47,6 @@ final class EoSourceRun implements Proc<Object> {
      * Name of the file the forked program reads its standard input from.
      */
     private static final String STDIN = "stdin.txt";
-
-    /**
-     * How much stack the forked JVM gets.
-     *
-     * <p>Dataizing an EO object walks the whole chain of its nested
-     * objects on the Java stack, and a recursive object adds its own chain
-     * on every step, so the depth grows with the input and not with the
-     * length of the program. Every other JVM this project starts to run EO
-     * is given a stack of its own for that reason, {@code JarIT} and the
-     * {@code argLine} of both Surefire and Failsafe among them; on the
-     * default stack a snippet reading a few hundred lines already dies
-     * with a {@link StackOverflowError}.</p>
-     */
-    private static final String STACK = "-Xss64M";
 
     /**
      * Name of the file the dependency plugin writes the classpath into.
@@ -159,7 +154,7 @@ final class EoSourceRun implements Proc<Object> {
         final List<String> line = new ArrayList<>(
             java.util.Arrays.asList(
                 ProcessHandle.current().info().command().orElse("java"),
-                EoSourceRun.STACK,
+                "-Xss64M",
                 "-cp",
                 String.format(
                     "%s%s%s",

--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -40,6 +40,20 @@ final class EoSourceRun implements Proc<Object> {
     private static final String STDIN = "stdin.txt";
 
     /**
+     * How much stack the forked JVM gets.
+     *
+     * <p>Dataizing an EO object walks the whole chain of its nested
+     * objects on the Java stack, and a recursive object adds its own chain
+     * on every step, so the depth grows with the input and not with the
+     * length of the program. Every other JVM this project starts to run EO
+     * is given a stack of its own for that reason, {@code JarIT} and the
+     * {@code argLine} of both Surefire and Failsafe among them; on the
+     * default stack a snippet reading a few hundred lines already dies
+     * with a {@link StackOverflowError}.</p>
+     */
+    private static final String STACK = "-Xss64M";
+
+    /**
      * Name of the file the dependency plugin writes the classpath into.
      */
     private static final String CLASSPATH = "target/cp.txt";
@@ -145,6 +159,7 @@ final class EoSourceRun implements Proc<Object> {
         final List<String> line = new ArrayList<>(
             java.util.Arrays.asList(
                 ProcessHandle.current().info().command().orElse("java"),
+                EoSourceRun.STACK,
                 "-cp",
                 String.format(
                     "%s%s%s",

--- a/eo-integration-tests/src/test/resources/snippets/reads-via-independent-console-calls.yaml
+++ b/eo-integration-tests/src/test/resources/snippets/reads-via-independent-console-calls.yaml
@@ -12,10 +12,11 @@ eo: |
   +package snippets
 
   [] > reads-via-independent-console-calls
-    stdout > @
-      "%s%s".printf
-        *
-          string c1
-          string c2
-    console.read 6 > c1
-    console.read 5 > c2
+    seq > @
+      *
+        stdout
+          string
+            console.read 6
+        stdout
+          string
+            console.read 5

--- a/eo-runtime/src/main/eo/stdin.eo
+++ b/eo-runtime/src/main/eo/stdin.eo
@@ -20,6 +20,15 @@
 # the current line's own multi-byte read, since neither was otherwise forced
 # until the whole recursion bottomed out at the final `string`.
 #
+# That next probe is named through the root `stdin` and not through the
+# receiver, because an attribute answers with the very same object every
+# time it is taken: a probe taken twice from one `stdin` is one probe,
+# holding the one lookahead byte it has already read and the one line it has
+# already assembled. Through the receiver the recursion would see that same
+# line and that same `eof` at every level and never end, while the root
+# names a `stdin` of its own, whose probe reads the next byte of the stream
+# where the previous probe left off.
+#
 # Reading from the console cannot be exercised by a `++>` test, since
 # `console.read` reaches the process's real file descriptor 0 through
 # `posix`/`win32` and neither can be substituted in EO. The
@@ -42,7 +51,7 @@
         seq *
           scan.line
           ^.rec-read
-            ^.^.line-or-eof
+            stdin.line-or-eof
             is-first.if
               buffer.concat scan.line
               concat.


### PR DESCRIPTION
Fixes the `codecov` build on `master` ([run 32988400153](https://github.com/objectionary/eo/actions/runs/32988400153/job/98240006756)), where `SnippetIT` failed on four snippets. The snippet ITs run only on `master` (`mvn.yml` and `fast.yml` both pass `-PskipITs`), so nothing caught these on the pull requests that introduced the snippets.

### `stdin.all-lines` never ended

`reads-all-lines`, `reads-line-without-carriage-return` and `reads-nothing-from-blank-stdin` all died with a `StackOverflowError`, whatever their input — a single `"\n"` included.

`all-lines` took the next `line-or-eof` probe of its recursion through the receiver, as `^.^.line-or-eof`. An attribute answers with the very same object every time it is taken, so every level of the recursion shared one probe, holding the one lookahead byte it had already read and the one line it had already assembled. `eof` stayed `false` for ever and the recursion ran until it ran out of stack, or, given a bigger stack, out of heap.

The probe is now named through the root `stdin`, which answers with a `stdin` of its own, so each level reads the stream where the previous level stopped. Measured against the compiled runtime, before and after, on the `reads-nothing-from-blank-stdin` snippet that brackets what it read between `<` and `>`:

| stdin | before | after |
| --- | --- | --- |
| empty | brackets, empty | brackets, empty |
| a lone newline | `OutOfMemoryError` | brackets, empty |
| `one`, `two`, `three`, one per line | `OutOfMemoryError` | the three lines, newline-separated |
| `日本語` and a CRLF | `OutOfMemoryError` | `日本語`, no carriage return |

### `reads-via-independent-console-calls` printed its reads backwards

It expected `HelloWorld!` and printed `World!Hello`: both `console.read` calls were handed to `printf` as arguments, and `printf` dataizes them right to left, so the second read took the first five bytes. The reads now run inside a `seq`, the way the docblock of `console` itself writes independent reads. The snippet still proves what it was added for — that unchained `console.read` calls continue on the same descriptor — without depending on the evaluation order of `printf`.

### The forked JVM had the default stack

`EoSourceRun` runs a stdin snippet in a JVM of its own and was the only JVM in the repository that runs EO without a stack of its own; `JarIT` passes `-Xss64M` and the `argLine` of both Surefire and Failsafe passes `-Xss512M`. Dataization depth grows with the input, so on the default 1M stack `all-lines` overflows at a few hundred lines even now that it terminates. The fork now gets `-Xss64M`, as `JarIT` does.

### Verification

Locally, against the compiled runtime:

- `mvn verify -pl eo-integration-tests -Dit.test=SnippetIT` — `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0`, was `Failures: 4`.
- `mvn install -pl eo-runtime` — the 2507 unit tests pass, and the `MjFormat` canonical check accepts `stdin.eo`. Two pre-existing failures are unrelated to this change and caused by the sandbox: `MainTest.printsVersion` trips on the `JAVA_TOOL_OPTIONS` banner, and `SyscallTest$PosixSocketTest` cannot open sockets.
- `mvn verify -PskipTests -Pqulice -pl eo-integration-tests,eo-runtime` — passes.