### PR TITLE
#7750: keep the arguments of an object whose head is `^`

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -211,6 +211,7 @@
         <xsl:attribute name="pos" select="@pos - 1"/>
         <xsl:attribute name="base" select="'ξ'"/>
       </o>
+      <xsl:apply-templates select="o"/>
     </o>
   </xsl:template>
   <xsl:template match="o[@base!='ξ' and @base!='ρ' and @base!=$eo:empty and @base!=$eo:bottom]" mode="no-dots">

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/rho-head-keeps-its-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/rho-head-keeps-its-arguments.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/o/o[@base='ξ.ρ' and @name='z']/o[@as='α0' and @base='Φ.number']
+input: |
+  [] > main
+    ^ 1 > z


### PR DESCRIPTION
The template for a bare `^` head rebuilt the element and never copied its `o` children, so every argument was dropped without a word.

`^ 1 > z` came out as `<o base="ξ.ρ" name="z"/>` with no arguments, while `$.^ 1 > z`, the same object written differently, kept them.

Closes #7750
