### PR TITLE
#7751: put the const wrapper where the object it wraps is

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/const-to-dataized.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/const-to-dataized.xsl
@@ -60,7 +60,7 @@
       <xsl:attribute name="base" select="'.as-bytes'"/>
       <xsl:attribute name="name" select="$cname"/>
       <xsl:attribute name="line" select="@line"/>
-      <xsl:attribute name="pos" select="@pos + 8"/>
+      <xsl:attribute name="pos" select="@pos"/>
       <xsl:if test="@as">
         <xsl:attribute name="as" select="@as"/>
       </xsl:if>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-wrapper-position-stays-inside-the-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/const-wrapper-position-stays-inside-the-line.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/o/o[@base='.as-bytes' and @pos='9']
+input: |
+  # Sample.
+
+  [x] > main
+    number x! > @


### PR DESCRIPTION
The `.as-bytes` wrapper for a `!` marker took `@pos + 8`, a constant unrelated to where the marker sits. On `  number x! > @`, a line of 15 characters, the wrapper came out at column 17.

The column of the `!` is not recorded anywhere: `Emit.constant()` writes the attribute and nothing else, so the wrapper now takes the position of the object it wraps.

Scanning `eo-runtime/src/main/eo` for a `@pos` past the end of its line gave 16 hits before this, all const wrappers, and none after.

Closes #7751
