### PR TITLE
fix(#7779): split the source into spans only once

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Source.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Source.java
@@ -5,8 +5,11 @@
 package org.eolang.parser;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
 
 /**
  * EO source text as an iterable of {@link Span}.
@@ -26,41 +29,42 @@ import java.util.List;
 final class Source implements Iterable<Span> {
 
     /**
-     * Raw source text (already decoded; UTF-8 is the caller's contract).
+     * All spans of the source, in source order: split once, on the first
+     * iteration, and reused by every iteration after it.
      */
-    private final String text;
+    private final Unchecked<List<Span>> lines;
 
     /**
      * Ctor.
      * @param raw The full source text
      */
     Source(final String raw) {
-        this.text = raw;
+        this.lines = new Unchecked<>(new Sticky<>(() -> Source.spans(raw)));
     }
 
     @Override
     public Iterator<Span> iterator() {
-        return this.spans().iterator();
+        return this.lines.value().iterator();
     }
 
-    private List<Span> spans() {
-        final List<Span> out = new ArrayList<>(this.text.length() / 32 + 1);
-        final int len = this.text.length();
+    private static List<Span> spans(final String text) {
+        final List<Span> out = new ArrayList<>(text.length() / 32 + 1);
+        final int len = text.length();
         int start = 0;
         int number = 1;
         int pos = 0;
         while (pos < len) {
-            final char glyph = this.text.charAt(pos);
+            final char glyph = text.charAt(pos);
             if (glyph == '\n') {
-                out.add(new Span(this.text.substring(start, pos), number));
+                out.add(new Span(text.substring(start, pos), number));
                 number = number + 1;
                 pos = pos + 1;
                 start = pos;
             } else if (glyph == '\r') {
-                out.add(new Span(this.text.substring(start, pos), number));
+                out.add(new Span(text.substring(start, pos), number));
                 number = number + 1;
                 pos = pos + 1;
-                if (pos < len && this.text.charAt(pos) == '\n') {
+                if (pos < len && text.charAt(pos) == '\n') {
                     pos = pos + 1;
                 }
                 start = pos;
@@ -69,8 +73,8 @@ final class Source implements Iterable<Span> {
             }
         }
         if (start < len) {
-            out.add(new Span(this.text.substring(start, len), number));
+            out.add(new Span(text.substring(start, len), number));
         }
-        return out;
+        return Collections.unmodifiableList(out);
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/SourceTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SourceTest.java
@@ -5,9 +5,11 @@
 package org.eolang.parser;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -125,6 +127,44 @@ final class SourceTest {
                 )
             ),
             Matchers.contains("alpha", "beta", "gamma")
+        );
+    }
+
+    @Test
+    void reusesTheSameSpansOnEveryIteration() {
+        final Source source = new Source(
+            SourceTest.join(SourceTest.newline(), "alpha", "beta", "gamma")
+        );
+        MatcherAssert.assertThat(
+            "a second iteration must hand back the very same span objects, not fresh ones",
+            SourceTest.collect(source),
+            Matchers.contains(SourceTest.collect(source).toArray(new Span[0]))
+        );
+    }
+
+    @Test
+    void iteratesTwiceOverTheSameInstance() {
+        final Source source = new Source(
+            SourceTest.join(SourceTest.newline(), "alpha", "beta")
+        );
+        SourceTest.texts(source);
+        MatcherAssert.assertThat(
+            "iterating an already-iterated source must still yield all of its lines",
+            SourceTest.texts(source),
+            Matchers.contains("alpha", "beta")
+        );
+    }
+
+    @Test
+    void forbidsRemovalThroughTheIterator() {
+        final Iterator<Span> iter = new Source(
+            SourceTest.join(SourceTest.newline(), "alpha", "beta")
+        ).iterator();
+        iter.next();
+        Assertions.assertThrows(
+            UnsupportedOperationException.class,
+            iter::remove,
+            "the iterator must not let a caller drop a span from the source"
         );
     }
 


### PR DESCRIPTION
Closes #7779

## What was wrong

`Source.iterator()` called `this.spans()` on every invocation. That method allocates a fresh `ArrayList` and walks the entire source string character by character, so:

- iterating the same `Source` twice re-split the whole text from scratch;
- the second iteration handed back *different* `Span` objects for the same lines;
- this contradicted `Span`'s own docblock, which states its value is "computed once, at construction time, and does not mutate" — while the `Source` producing those spans recomputed its whole list each time.

## What changed

`eo-parser/src/main/java/org/eolang/parser/Source.java`:

- the span list is now held in a `Sticky` scalar, so the split runs at most once per `Source` and every later iteration reuses the same list;
- `spans` became `static` — it no longer needs the instance, only the raw text;
- the list is wrapped in `Collections.unmodifiableList`, so an iterator cannot drop a span from the source.

The `Sticky` + `Unchecked` shape keeps the constructor code-free, which is what `ConstructorsCodeFreeCheck` requires; it mirrors `Transpilation.java:164` in `eo-maven-plugin`.

Splitting behaviour is untouched: LF, CRLF, bare CR, blank lines, a final line without a terminator, and 1-based numbering all behave exactly as before.

## Tests

Three tests added to `SourceTest`:

| test | what it pins |
| --- | --- |
| `reusesTheSameSpansOnEveryIteration` | a second iteration yields the *same* `Span` instances (`Span` has no `equals`, so the matcher compares by identity — this only passes if the list is cached) |
| `iteratesTwiceOverTheSameInstance` | an already-iterated `Source` still yields all its lines |
| `forbidsRemovalThroughTheIterator` | `Iterator.remove` throws `UnsupportedOperationException` |

Verified locally against the unfixed `Source.java`: `reusesTheSameSpansOnEveryIteration` and `forbidsRemovalThroughTheIterator` both fail, so they genuinely catch the reported defect.

`mvn -pl eo-parser test -PskipITs` → 1422 tests, 0 failures (1419 before, +3 new).
`mvn -pl eo-parser -DskipTests -DskipITs -Pqulice verify` → BUILD SUCCESS.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nXep6pc4gb3rAoBvbHG67)_