### PR TITLE
fix(#7760): split the hashes table on CRLF as well as on LF

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ChText.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ChText.java
@@ -29,6 +29,13 @@ import org.cactoos.text.TextOf;
  * be83d9adda4b7c9e670e625fe951c80f3ead4177, 0.28.9
  * }</pre></p>
  *
+ * <p>Lines may be terminated by {@code \n} or by {@code \r\n}. The
+ * carriage return has to be consumed by the split, because each line is
+ * then matched with a regular expression that must consume the whole line
+ * and {@code .} does not match a {@code \r}. A table written on Windows —
+ * such as the built-in fallback of {@link CommitHashesText}, joined with
+ * {@link System#lineSeparator()} — would otherwise match no tag at all.</p>
+ *
  * @since 0.28.11
  */
 final class ChText implements CommitHash {
@@ -95,7 +102,7 @@ final class ChText implements CommitHash {
                                     t -> t.asString().matches(
                                         String.format("^.+\\s\\Q%s\\E$", this.tag)
                                     ),
-                                    new Split(new TextOf(this.source), "\\n")
+                                    new Split(new TextOf(this.source), "\\r?\\n")
                                 ),
                                 () -> {
                                     throw new HashNotFoundException(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ChTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ChTextTest.java
@@ -143,6 +143,38 @@ final class ChTextTest {
     }
 
     @Test
+    void readsCorrectHashFromWindowsLineEndings() {
+        MatcherAssert.assertThat(
+            "a table whose lines end with CRLF must still yield the hash of the requested tag",
+            new ChText(
+                () -> String.join(
+                    ChTextTest.crnl(),
+                    "5fe5ad8d21dbe418038fa4c86e096fb037f290a9 0.23.15",
+                    "15c85d7f8cffe15b0deba96e90bdac98a76293bb 0.23.17"
+                ),
+                "0.23.15"
+            ).value(),
+            Matchers.equalTo("5fe5ad8d21dbe418038fa4c86e096fb037f290a9")
+        );
+    }
+
+    @Test
+    void readsLastHashFromWindowsLineEndings() {
+        MatcherAssert.assertThat(
+            "the last line of a CRLF table must be matched as well as the first one",
+            new ChText(
+                () -> String.join(
+                    ChTextTest.crnl(),
+                    "5fe5ad8d21dbe418038fa4c86e096fb037f290a9 0.23.15",
+                    "15c85d7f8cffe15b0deba96e90bdac98a76293bb 0.23.17"
+                ),
+                "0.23.17"
+            ).value(),
+            Matchers.equalTo("15c85d7f8cffe15b0deba96e90bdac98a76293bb")
+        );
+    }
+
+    @Test
     void executesNotAtTagMatchesHash() {
         final AtomicInteger count = new AtomicInteger(0);
         new ChText(
@@ -179,5 +211,9 @@ final class ChTextTest {
             count.get(),
             Matchers.equalTo(2)
         );
+    }
+
+    private static String crnl() {
+        return new String(new char[] {(char) 13, (char) 10});
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CommitHashesTextTest.java
@@ -33,6 +33,22 @@ final class CommitHashesTextTest {
     }
 
     @Test
+    void findsEveryTagOfTheFallbackTable() {
+        MatcherAssert.assertThat(
+            "ChText must find a tag in the built-in fallback table, whatever the platform's line separator is",
+            new ChText(
+                new CommitHashesText(
+                    () -> {
+                        throw new SSLException("handshake failed");
+                    }
+                )::asString,
+                "0.23.15"
+            ).value(),
+            Matchers.equalTo("5fe5ad8d21dbe418038fa4c86e096fb037f290a9")
+        );
+    }
+
+    @Test
     void propagatesAFailureThatIsNotAnIoError() {
         Assertions.assertThrows(
             IllegalStateException.class,


### PR DESCRIPTION
Closes #7760

## What was wrong

`CommitHashesText.FALLBACK` joins its built-in tag table with `System.lineSeparator()`, while `ChText.inside()` split that text on `\n` alone.

Where the separator is `\r\n`, every line keeps a trailing `\r` after the split. Each line is then tested with `String.matches`, which must consume the *whole* line, and `.` does not match a carriage return — so no line ever matched. `ChText` threw `HashNotFoundException`, and `ChRemote` turned it into:

```
Tag '0.23.15' doesn't exist or the list of all tags was not loaded correctly
```

On Windows the fallback table was therefore dead code: an offline build failed, and the message blamed a tag that was sitting right there in the table.

## What changed

`eo-maven-plugin/src/main/java/org/eolang/maven/ChText.java` — one line:

```diff
-new Split(new TextOf(this.source), "\\n")
+new Split(new TextOf(this.source), "\\r?\\n")
```

plus a docblock note recording why the carriage return has to be consumed by the split.

### Why this side and not the other

The issue offers two options: join `FALLBACK` with `\n`, or split on `\r?\n`. I took the splitter for two reasons:

1. **It is the only one qulice permits.** Joining with a literal `"\n"` trips `ProhibitLineSeparatorInStringsCheck` ("OS-dependent line separator in string literal, use `System.lineSeparator()`"). That check is presumably why the table was written with `System.lineSeparator()` in the first place.
2. **It covers strictly more cases.** `ChText(Path, String)` also reads a user-supplied offline `tags.txt`. If that file was written on Windows, changing how `FALLBACK` is joined would not have helped it; fixing the splitter does.

`CommitHashesText` is left untouched.

## Tests

| test | what it pins |
| --- | --- |
| `ChTextTest.readsCorrectHashFromWindowsLineEndings` | a tag on a CRLF-terminated line is found |
| `ChTextTest.readsLastHashFromWindowsLineEndings` | the final line of a CRLF table is matched too |
| `CommitHashesTextTest.findsEveryTagOfTheFallbackTable` | end-to-end: `ChText` reading the real built-in fallback table after a transport failure — the exact path from the issue report |

Verified against the unfixed `ChText.java`: `readsCorrectHashFromWindowsLineEndings` fails with precisely the reported `HashNotFoundException: Git SHA not found for the '0.23.15' tag`.

`mvn -pl eo-maven-plugin -DskipTests -DskipITs -Pqulice verify` → BUILD SUCCESS.
`mvn -pl eo-maven-plugin test -PskipITs` → 755 tests; the only 2 failures are `OyRemoteTest.checksPresenceOfDirectory` / `checksPresenceOfDirectoryWithNarrowHash`, which need live access to objectionary.com and fail identically on unmodified `master` in this sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nXep6pc4gb3rAoBvbHG67)_