### PR TITLE
Limit the memory a single JUnit test may take (eo.maxmem)

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -23,6 +23,14 @@
     runs to its end instead of being skipped.
     -->
     <eo.deadline>1</eo.deadline>
+    <!--
+    How much memory a single test may allocate before Maxmem terminates it
+    and reports it as skipped. The suffixes of -Xmx are understood: "2G",
+    "512M", "65536K", or plain bytes. Empty, or zero, means no limit at all
+    and no watching either, which is the default: a box with memory to
+    spare should run every test to its end.
+    -->
+    <eo.maxmem/>
   </properties>
   <dependencies>
     <dependency>
@@ -212,6 +220,7 @@
           <systemPropertyVariables>
             <eo.version>${project.version}</eo.version>
             <junit.jupiter.execution.timeout.test.method.default>${eo.deadline}s</junit.jupiter.execution.timeout.test.method.default>
+            <eo.maxmem>${eo.maxmem}</eo.maxmem>
             <eo.coverageFile>${project.build.directory}/coverage.txt</eo.coverageFile>
             <java.util.logging.config.file>
               ${project.basedir}/src/test/resources/jul.properties

--- a/eo-runtime/src/test/java/org/eolang/Consumed.java
+++ b/eo-runtime/src/test/java/org/eolang/Consumed.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import com.sun.management.ThreadMXBean;
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * How much memory the threads of a single group have taken.
+ *
+ * <p>The JVM keeps no tally of the heap that one test holds: the heap is
+ * shared by all of them at once and the collector walks it on a clock of
+ * its own. What the JVM does keep is how many bytes every thread has
+ * allocated since it started, and that is what is counted here, for the
+ * thread a test runs on and for every thread the test starts, since a new
+ * thread is born into the group of the one that made it. Garbage counts
+ * too: a test that pushes a gigabyte through the collector is as much of a
+ * danger to the build as one that holds a gigabyte to the very end.</p>
+ *
+ * <p>A thread that is already gone answers with a negative number and would
+ * take its share of the total away with it. The largest reading taken while
+ * it was still alive stays in the map instead, so a test is charged for the
+ * threads it started and left behind too. This is also why a thread about
+ * to end takes a reading of itself before it goes, rather than leaving the
+ * last word to a watcher that may look a moment too late.</p>
+ *
+ * @since 0.75.0
+ */
+final class Consumed {
+
+    /**
+     * The bean that counts bytes, empty if this JVM refuses to count them.
+     */
+    private static final Optional<ThreadMXBean> BEAN = Consumed.bean();
+
+    /**
+     * The group whose threads are counted.
+     */
+    private final ThreadGroup group;
+
+    /**
+     * The largest reading taken from every thread, by thread identifier.
+     *
+     * <p>Both the thread that runs the test and the one that watches it
+     * take readings, so the map is a concurrent one and a reading only ever
+     * replaces a smaller one: the counter of a thread never goes down, and
+     * a reading that arrives late must not undo a fresher one.</p>
+     */
+    private final Map<Long, Long> readings;
+
+    /**
+     * Ctor.
+     * @param grp The group whose threads are counted
+     */
+    Consumed(final ThreadGroup grp) {
+        this.group = grp;
+        this.readings = new ConcurrentHashMap<>(0);
+    }
+
+    /**
+     * Does this JVM count the bytes a thread allocates?
+     * @return TRUE if it does, FALSE if there is nothing to count with
+     */
+    static boolean counting() {
+        return Consumed.BEAN.isPresent();
+    }
+
+    /**
+     * How many bytes the group has allocated so far.
+     * @return Bytes allocated, or zero if this JVM does not count them
+     */
+    long bytes() {
+        this.refresh();
+        long total = 0L;
+        for (final long taken : this.readings.values()) {
+            total += taken;
+        }
+        return total;
+    }
+
+    /**
+     * Take a fresh reading from every thread of the group.
+     */
+    void refresh() {
+        final Thread[] threads = this.threads();
+        if (Consumed.counting() && threads.length > 0) {
+            final long[] ids = new long[threads.length];
+            for (int idx = 0; idx < threads.length; ++idx) {
+                ids[idx] = threads[idx].getId();
+            }
+            final long[] taken = Consumed.BEAN.get().getThreadAllocatedBytes(ids);
+            for (int idx = 0; idx < ids.length; ++idx) {
+                if (taken[idx] >= 0L) {
+                    this.readings.merge(ids[idx], taken[idx], Math::max);
+                }
+            }
+        }
+    }
+
+    private Thread[] threads() {
+        int room = 1 + this.group.activeCount() * 2;
+        Thread[] found = new Thread[room];
+        int count = this.group.enumerate(found, true);
+        while (count == found.length) {
+            room *= 2;
+            found = new Thread[room];
+            count = this.group.enumerate(found, true);
+        }
+        return Arrays.copyOf(found, count);
+    }
+
+    private static Optional<ThreadMXBean> bean() {
+        final Optional<ThreadMXBean> found;
+        final Object mbean = ManagementFactory.getThreadMXBean();
+        if (mbean instanceof ThreadMXBean bean && bean.isThreadAllocatedMemorySupported()) {
+            bean.setThreadAllocatedMemoryEnabled(true);
+            found = Optional.of(bean);
+        } else {
+            found = Optional.empty();
+        }
+        return found;
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/ConsumedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/ConsumedTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.concurrent.CountDownLatch;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Consumed}.
+ * @since 0.75.0
+ */
+@SuppressWarnings({"JTCOP.RuleAllTestsHaveProductionClass", "PMD.AvoidThreadGroup"})
+final class ConsumedTest {
+
+    @Test
+    void countsBytesOfThreadThatIsAlreadyGone() throws InterruptedException {
+        final int chunk = 8 * 1024 * 1024;
+        MatcherAssert.assertThat(
+            "The bytes of a thread must be counted while it lives and stay in the tally after it is gone, but they didnt",
+            ConsumedTest.sampled(chunk),
+            Matchers.greaterThanOrEqualTo((long) chunk)
+        );
+    }
+
+    @Test
+    void countsNothingForEmptyGroup() {
+        MatcherAssert.assertThat(
+            "A group with no threads in it must have allocated nothing, but it didnt",
+            new Consumed(new ThreadGroup("consumed-empty")).bytes(),
+            Matchers.equalTo(0L)
+        );
+    }
+
+    private static long sampled(final int chunk) throws InterruptedException {
+        final ThreadGroup group = new ThreadGroup("consumed-counts");
+        final Consumed consumed = new Consumed(group);
+        final CountDownLatch taken = new CountDownLatch(1);
+        final CountDownLatch counted = new CountDownLatch(1);
+        final byte[][] junk = new byte[1][];
+        final Thread thread = new Thread(
+            group,
+            () -> {
+                junk[0] = new byte[chunk];
+                taken.countDown();
+                try {
+                    counted.await();
+                } catch (final InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        );
+        thread.setDaemon(true);
+        thread.start();
+        taken.await();
+        consumed.refresh();
+        counted.countDown();
+        thread.join();
+        return consumed.bytes();
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/Maxmem.java
+++ b/eo-runtime/src/test/java/org/eolang/Maxmem.java
@@ -1,0 +1,111 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.lang.reflect.Method;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.junit.jupiter.api.extension.ReflectiveInvocationContext;
+
+/**
+ * A limit on the memory a single test may take.
+ *
+ * <p>A test that allocates more than the {@code eo.maxmem} bytes granted to
+ * it is terminated and reported as skipped, in the same way
+ * {@link Deadline} deals with a test that outlives {@code eo.deadline}.
+ * Without it, one greedy test takes the whole heap down with it and the
+ * build ends with {@code OutOfMemoryError} in a test that did nothing
+ * wrong, on a line that says nothing about who ate the memory.</p>
+ *
+ * <p>The limit is the number of bytes the test allocates, counted the only
+ * way a shared heap allows it to be counted per test - see
+ * {@link Consumed}. It is read from the {@code eo.maxmem} system property,
+ * which understands the suffixes of {@code -Xmx}: {@code 1G}, {@code 512M},
+ * {@code 65536K}, or plain bytes. An empty property, or a zero, means no
+ * limit at all and no watching either.</p>
+ *
+ * @since 0.75.0
+ */
+public final class Maxmem implements InvocationInterceptor {
+
+    /**
+     * How many bytes are in a kilobyte.
+     */
+    private static final long KILO = 1024L;
+
+    /**
+     * What a valid value of the property looks like.
+     */
+    private static final Pattern SIZE = Pattern.compile("(\\d+)\\s*([kKmMgG]?)[bB]?");
+
+    /**
+     * The suffixes, in the order of how many kilobytes each one is worth.
+     */
+    private static final String SUFFIXES = "kmg";
+
+    /**
+     * How many bytes a single test may allocate, zero if there is no limit.
+     */
+    private static final long LIMIT = Maxmem.limit(System.getProperty("eo.maxmem"));
+
+    @Override
+    public void interceptTestMethod(final Invocation<Void> invocation,
+        final ReflectiveInvocationContext<Method> context,
+        final ExtensionContext extension) throws Throwable {
+        new Watched(Maxmem.LIMIT).through(invocation);
+    }
+
+    @Override
+    public void interceptTestTemplateMethod(final Invocation<Void> invocation,
+        final ReflectiveInvocationContext<Method> context,
+        final ExtensionContext extension) throws Throwable {
+        new Watched(Maxmem.LIMIT).through(invocation);
+    }
+
+    /**
+     * How many bytes the property stands for.
+     * @param text What the property says, may be NULL or empty
+     * @return Bytes a test may allocate, zero if there is no limit
+     */
+    static long limit(final String text) {
+        final String trimmed;
+        if (text == null) {
+            trimmed = "";
+        } else {
+            trimmed = text.trim();
+        }
+        final long bytes;
+        if (trimmed.isEmpty()) {
+            bytes = 0L;
+        } else {
+            final Matcher matcher = Maxmem.SIZE.matcher(trimmed);
+            if (!matcher.matches()) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Can't understand '%s' as the value of eo.maxmem, try '1G' or '512M'",
+                        trimmed
+                    )
+                );
+            }
+            bytes = Long.parseLong(matcher.group(1)) * Maxmem.scale(matcher.group(2));
+        }
+        return bytes;
+    }
+
+    private static long scale(final String suffix) {
+        long scale = 1L;
+        if (!suffix.isEmpty()) {
+            final int power = 1 + Maxmem.SUFFIXES.indexOf(
+                Character.toLowerCase(suffix.charAt(0))
+            );
+            for (int idx = 0; idx < power; ++idx) {
+                scale *= Maxmem.KILO;
+            }
+        }
+        return scale;
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/MaxmemTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MaxmemTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+/**
+ * Test case for {@link Maxmem}.
+ * @since 0.75.0
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class MaxmemTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "1G, 1073741824",
+        "1g, 1073741824",
+        "2GB, 2147483648",
+        "512M, 536870912",
+        "512m, 536870912",
+        "65536K, 67108864",
+        "'  4M  ', 4194304",
+        "1024, 1024",
+        "0, 0",
+        "'', 0"
+    })
+    void readsLimitFromProperty(final String text, final long expected) {
+        MatcherAssert.assertThat(
+            String.format("Value '%s' of eo.maxmem must be read as bytes, but it wasnt", text),
+            Maxmem.limit(text),
+            Matchers.equalTo(expected)
+        );
+    }
+
+    @Test
+    void takesNoLimitFromAbsentProperty() {
+        MatcherAssert.assertThat(
+            "A property that is not set at all must mean no limit, but it didnt",
+            Maxmem.limit(null),
+            Matchers.equalTo(0L)
+        );
+    }
+
+    @Test
+    void refusesToReadNonsense() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> Maxmem.limit("plenty"),
+            "A value that is not a size must be refused loudly, but it wasnt"
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/Watched.java
+++ b/eo-runtime/src/test/java/org/eolang/Watched.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.extension.InvocationInterceptor;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * A body of a test that may allocate no more than the memory it is given.
+ *
+ * <p>The body runs in a thread of its own, born into a group of its own, so
+ * that the threads it starts land in the same group and are counted with
+ * it. While it runs, the group is asked every few milliseconds how much it
+ * has allocated. The moment the answer is over the limit, the group is
+ * interrupted and the body is abandoned where it stands: dataization gives
+ * up on the very next attribute lookup of an interrupted thread (see
+ * {@link ExInterrupted}), so the objects it was building become garbage and
+ * the heap comes back to the tests that still need it.</p>
+ *
+ * <p>A body that ends between two readings is judged all the same, on the
+ * reading it took of itself on the way out. A body that failed, though,
+ * fails the test with its own problem, whatever it ate: a broken test is
+ * worth more than a tidy skip.</p>
+ *
+ * <p>The test itself is reported as skipped rather than as failed, for the
+ * same reason {@link Deadline} reports a slow one as skipped: a budget that
+ * a box with more memory would never have reached says nothing about the
+ * code under test.</p>
+ *
+ * @since 0.75.0
+ */
+@SuppressWarnings({"PMD.AvoidThreadGroup", "PMD.AvoidCatchingGenericException"})
+final class Watched {
+
+    /**
+     * How many milliseconds pass between two readings of the appetite.
+     */
+    private static final long TICK = 50L;
+
+    /**
+     * What is said about a test that ate more than it was given.
+     */
+    private static final String MESSAGE = String.join(
+        " ",
+        "The test allocated %d bytes, which is over the %d bytes",
+        "of eo.maxmem it was given, so it was terminated"
+    );
+
+    /**
+     * How many tests have been watched, to give every group its own name.
+     */
+    private static final AtomicLong COUNT = new AtomicLong();
+
+    /**
+     * How many bytes the body may allocate, or zero if it may allocate all.
+     */
+    private final long limit;
+
+    /**
+     * Ctor.
+     * @param bytes How many bytes the body may allocate, zero for no limit
+     */
+    Watched(final long bytes) {
+        this.limit = bytes;
+    }
+
+    // @checkstyle IllegalThrowsCheck (13 lines)
+    /**
+     * Run the body and let it allocate no more than the limit.
+     *
+     * <p>A test runs on the very thread that called this method when there
+     * is no limit to keep, or when the JVM does not count what a thread
+     * allocates: watching would cost a thread and buy nothing.</p>
+     *
+     * @param body The body of the test
+     * @throws Throwable If the body fails, or if it eats too much
+     */
+    void through(final InvocationInterceptor.Invocation<Void> body) throws Throwable {
+        if (this.limit <= 0L || !Consumed.counting()) {
+            body.proceed();
+        } else {
+            this.guarded(body);
+        }
+    }
+
+    // @checkstyle IllegalThrowsCheck (30 lines)
+    private void guarded(final InvocationInterceptor.Invocation<Void> body) throws Throwable {
+        final ThreadGroup group = new ThreadGroup(
+            String.format("maxmem-%d", Watched.COUNT.incrementAndGet())
+        );
+        final AtomicReference<Throwable> failure = new AtomicReference<>();
+        final CountDownLatch done = new CountDownLatch(1);
+        final Consumed consumed = new Consumed(group);
+        final Thread thread = new Thread(
+            group,
+            () -> Watched.run(body, failure, done, consumed)
+        );
+        thread.setDaemon(true);
+        thread.start();
+        boolean over = false;
+        while (!done.await(Watched.TICK, TimeUnit.MILLISECONDS)) {
+            if (consumed.bytes() > this.limit) {
+                over = true;
+                break;
+            }
+        }
+        if (over) {
+            group.interrupt();
+            throw this.aborted(consumed.bytes());
+        }
+        final Throwable error = failure.get();
+        if (error != null) {
+            throw error;
+        }
+        if (consumed.bytes() > this.limit) {
+            throw this.aborted(consumed.bytes());
+        }
+    }
+
+    private TestAbortedException aborted(final long taken) {
+        return new TestAbortedException(
+            String.format(Watched.MESSAGE, taken, this.limit)
+        );
+    }
+
+    // @checkstyle IllegalCatchCheck (12 lines)
+    private static void run(final InvocationInterceptor.Invocation<Void> body,
+        final AtomicReference<Throwable> failure, final CountDownLatch done,
+        final Consumed consumed) {
+        try {
+            body.proceed();
+        } catch (final Throwable error) {
+            failure.set(error);
+        } finally {
+            consumed.refresh();
+            done.countDown();
+        }
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/WatchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/WatchedTest.java
@@ -1,0 +1,128 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.opentest4j.TestAbortedException;
+
+/**
+ * Test case for {@link Watched}.
+ * @since 0.75.0
+ */
+@SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+final class WatchedTest {
+
+    @Test
+    void terminatesBodyThatKeepsAllocating() {
+        MatcherAssert.assertThat(
+            "A body that never stops allocating must be terminated and interrupted, but it wasnt",
+            WatchedTest.abandoned(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void skipsBodyThatAteTooMuchAndFinished() {
+        Assertions.assertThrows(
+            TestAbortedException.class,
+            () -> new Watched(1024L * 1024L).through(
+                () -> {
+                    final byte[][] junk = new byte[1][];
+                    for (int idx = 0; idx < 16; ++idx) {
+                        junk[0] = new byte[256 * 1024];
+                    }
+                    return null;
+                }
+            ),
+            "A body that ate more than it was given must be reported as skipped, but it wasnt"
+        );
+    }
+
+    @Test
+    void letsFrugalBodyThrough() {
+        MatcherAssert.assertThat(
+            "A body that eats almost nothing must run to its end, but it didnt",
+            WatchedTest.where(64L * 1024L * 1024L),
+            Matchers.notNullValue()
+        );
+    }
+
+    @Test
+    void letsFailureOfBodyThrough() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Watched(64L * 1024L * 1024L).through(
+                () -> {
+                    throw new IllegalStateException("it broke");
+                }
+            ),
+            "A body that failed must fail the test with its own problem, but it didnt"
+        );
+    }
+
+    @Test
+    void watchesNothingWithoutLimit() {
+        MatcherAssert.assertThat(
+            "With no limit the body must run on the very thread that called it, but it didnt",
+            WatchedTest.where(0L),
+            Matchers.sameInstance(Thread.currentThread())
+        );
+    }
+
+    private static boolean abandoned() {
+        final AtomicBoolean stopped = new AtomicBoolean(false);
+        Assertions.assertThrows(
+            TestAbortedException.class,
+            () -> new Watched(1024L * 1024L).through(
+                () -> {
+                    final byte[][] junk = new byte[1][];
+                    while (!Thread.currentThread().isInterrupted()) {
+                        junk[0] = new byte[256 * 1024];
+                        WatchedTest.rest();
+                    }
+                    stopped.set(true);
+                    return null;
+                }
+            ),
+            "A body that never stops allocating must be terminated, but it wasnt"
+        );
+        return WatchedTest.awaited(stopped);
+    }
+
+    private static Thread where(final long limit) {
+        final AtomicReference<Thread> ran = new AtomicReference<>();
+        Assertions.assertDoesNotThrow(
+            () -> new Watched(limit).through(
+                () -> {
+                    ran.set(Thread.currentThread());
+                    return null;
+                }
+            ),
+            "A body that eats almost nothing must not be touched, but it was"
+        );
+        return ran.get();
+    }
+
+    private static void rest() {
+        try {
+            Thread.sleep(1L);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    private static boolean awaited(final AtomicBoolean flag) {
+        final long deadline = System.currentTimeMillis() + 500L;
+        while (!flag.get() && System.currentTimeMillis() < deadline) {
+            WatchedTest.rest();
+        }
+        return flag.get();
+    }
+}

--- a/eo-runtime/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
+++ b/eo-runtime/src/test/resources/META-INF/services/org.junit.jupiter.api.extension.Extension
@@ -1,1 +1,2 @@
 org.eolang.Deadline
+org.eolang.Maxmem

--- a/eo-runtime/src/test/resources/junit-platform.properties
+++ b/eo-runtime/src/test/resources/junit-platform.properties
@@ -3,4 +3,4 @@
 
 junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD
 junit.jupiter.extensions.autodetection.enabled = true
-junit.jupiter.extensions.autodetection.include = org.eolang.Deadline
+junit.jupiter.extensions.autodetection.include = org.eolang.Deadline, org.eolang.Maxmem


### PR DESCRIPTION
A new `eo.maxmem` property gives every test in `eo-runtime` a budget of
bytes, the way `eo.deadline` gives it a budget of seconds. A test that
goes over the budget is terminated and reported as skipped:

```
mvn test -Deo.maxmem=1G
```

The value understands the suffixes of `-Xmx` (`1G`, `512M`, `65536K`, or
plain bytes). It is **empty by default**, so nothing is watched and
nothing changes for anybody who does not ask for a budget.

## Why

The `mvn` job on master died with `OutOfMemoryError` in
[run 33040576412](https://github.com/objectionary/eo/actions/runs/33040576412/job/98412995079):
`EOdirectoryEOmadeRaceTest.makesOneDirectoryFromManyThreadsAtOnce` spent
656 seconds filling the 8G heap before the whole surefire run collapsed.
The error surfaces wherever the next allocation happens, on a line that
says nothing about who ate the memory.

Two things let that test run unbounded, and this PR fixes the second:

1. `eo.deadline` is wired to
   `junit.jupiter.execution.timeout.test.method.default`, which JUnit
   applies to `@Test` methods only. `@RepeatedTest` and
   `@ParameterizedTest` are test *templates* and are not covered by it,
   so the ten repetitions of that race test had no deadline at all. That
   gap is left alone here (raising it to
   `junit.jupiter.execution.timeout.default` would suddenly put a
   1-second deadline on every parameterized test in the module).
2. Nothing bounded the memory. Now `eo.maxmem` does, and it covers
   templates as well as plain `@Test` methods.

## How

`org.eolang.Maxmem` is a JUnit `InvocationInterceptor`, registered next
to `org.eolang.Deadline` through `META-INF/services` and
`junit-platform.properties`. For each test method and test template
method it hands the body to `Watched`, which:

- runs it on a thread of its own, born into a thread group of its own,
  so that the threads the test starts are counted with it (this is what
  catches the race test, whose allocations happen in `Together` worker
  threads, not on the test thread);
- asks `Consumed` every 50ms how many bytes that group has allocated;
- on going over the budget, interrupts the group and abandons the body:
  dataization gives up on the next attribute lookup of an interrupted
  thread (`ExInterrupted`), so the objects it was building become
  garbage and the heap comes back to the tests that still need it;
- reports the test as skipped, through `TestAbortedException`, for the
  same reason `Deadline` reports a slow test as skipped.

A body that ends between two readings is judged on the reading it takes
of itself on the way out. A body that *failed* still fails the test with
its own problem, whatever it ate — a real failure is never hidden behind
a skip.

`Consumed` counts bytes allocated per thread (`ThreadMXBean
.getThreadAllocatedBytes`), which is the only per-test figure a shared
heap offers; garbage counts too, since a test that pushes a gigabyte
through the collector is as much of a danger to the build as one that
holds a gigabyte to the end. On a JVM that does not publish the counter,
the whole mechanism stays idle and no thread is created.

## What it does to the suite

Running the whole `eo-runtime` suite locally with
`-Deo.deadline=2 -Deo.maxmem=1G` (the settings of `mvn.yml` plus a
budget) terminates 14 tests:

| test | verdict |
| --- | --- |
| `EOdirectoryEOmadeRaceTest.makesOneDirectoryFromManyThreadsAtOnce` (all 10) | the runaway from the failing job; the class now finishes in 17s instead of exhausting the heap |
| `PhTerminatorTest.keepsTheReasonOfAnOutOfRangeDecimalConversion` (3) | genuinely wants more than 1G; passes at 6G |
| `EObytesEOconcatTest.failsCleanlyInsteadOfOverflowingArraySize` | unbounded by design, still over budget at 6G |

No workflow is changed here, because picking a number is a trade: any
budget small enough to catch the runaway also skips that `concat` test.
Say the word and I will wire `mvn.yml` to whatever value you prefer.

## Tests

`MaxmemTest`, `WatchedTest` and `ConsumedTest` cover the parsing of the
property, the termination and interruption of a greedy body, the
skipping of one that finished over budget, the pass-through of a
failure, and the zero-overhead path when no budget is set. Verified with
`mvn -Pqulice verify` on `eo-runtime` (green) and by running the module
with and without a budget.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHXdcnJW5p2yjc8w7GLq3K)_