### PR TITLE
fix(#7775): make tab() scan the same leading span as leading()

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Span.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Span.java
@@ -54,7 +54,17 @@ final class Span {
      * @param line Line number (1-indexed)
      */
     Span(final String body, final int line) {
-        this(body, line, Span.leading(body), Span.tabbed(body));
+        this(body, line, Span.leading(body));
+    }
+
+    /**
+     * Ctor.
+     * @param body Line text
+     * @param line Line number
+     * @param leading Count of leading whitespace chars
+     */
+    private Span(final String body, final int line, final int leading) {
+        this(body, line, leading, Span.tabbed(body, leading));
     }
 
     /**
@@ -160,15 +170,11 @@ final class Span {
         return count;
     }
 
-    private static boolean tabbed(final String body) {
+    private static boolean tabbed(final String body, final int leading) {
         boolean found = false;
-        for (int idx = 0; idx < body.length(); idx = idx + 1) {
-            final char glyph = body.charAt(idx);
-            if (glyph == '\t') {
+        for (int idx = 0; idx < leading; idx = idx + 1) {
+            if (body.charAt(idx) == '\t') {
                 found = true;
-                break;
-            }
-            if (glyph != ' ') {
                 break;
             }
         }

--- a/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
@@ -159,6 +159,24 @@ final class SpanTest {
     }
 
     @Test
+    void detectsTabAfterNonSpaceNonTabWhitespace() {
+        MatcherAssert.assertThat(
+            "a tab past a form-feed that indent() already counted must still be reported",
+            new Span("\f\tfoo", 1).tab(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void ignoresNonTabWhitespaceWithNoTabPresent() {
+        MatcherAssert.assertThat(
+            "leading whitespace with no tab at all must not be reported as tabbed",
+            new Span("\ffoo", 1).tab(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void ignoresTabAfterFirstNonSpace() {
         MatcherAssert.assertThat(
             "a tab past the first non-space character is irrelevant for the indent error",


### PR DESCRIPTION
Closes #7775

`Span.tabbed()` broke its scan at the first character that was neither a space nor a tab, while `Span.leading()` counts any `Character.isWhitespace` character as leading whitespace. For a line like `"\f\tfoo"`, `leading()` counts 2 leading-whitespace characters (the form feed and the tab), but `tabbed()` stopped at the form feed before ever reaching the tab that followed it, so `tab()` came back `false` even though the tab sits squarely inside the span `leading()` already counted.

`tabbed()` now takes the precomputed `leading` count and scans exactly that span for a tab, instead of re-deriving its own stopping rule from scratch. The two methods now agree on what counts as leading whitespace.

Added tests covering a tab following a non-space, non-tab whitespace character, and the case where no tab is present at all in such leading whitespace.