### PR TITLE
fix(#7774): docblock describes the class's purpose, not its field

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Lines.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Lines.java
@@ -10,7 +10,7 @@ import org.cactoos.Text;
 import org.cactoos.text.UncheckedText;
 
 /**
- * The source in lines.
+ * Addresses a source's lines by number.
  * @since 0.50
  */
 final class Lines {


### PR DESCRIPTION
Closes #7774

Lines.java's class docblock read "The source in lines", the same three words as the constructor's `@param lines`.

Rewrote the docblock to say what the class is for: addressing a source's lines by number.