### PR TITLE
fix(#7773): name the failing line number when Text throws in Lines

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Lines.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Lines.java
@@ -5,7 +5,6 @@
 package org.eolang.parser;
 
 import java.util.List;
-import java.util.Optional;
 import org.cactoos.Text;
 import org.cactoos.text.UncheckedText;
 
@@ -50,9 +49,13 @@ final class Lines {
                 )
             );
         }
-        return Optional.ofNullable(this.source.get(number - 1))
-            .map(UncheckedText::new)
-            .map(UncheckedText::asString)
-            .orElse("");
+        return new UncheckedText(
+            this.source.get(number - 1),
+            error -> {
+                throw new IllegalStateException(
+                    String.format("Failed to read line #%d", number), error
+                );
+            }
+        ).asString();
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -6,6 +6,7 @@ package org.eolang.parser;
 
 import java.util.Arrays;
 import java.util.Collections;
+import org.cactoos.Text;
 import org.cactoos.text.TextOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -92,6 +93,22 @@ final class LinesTest {
                 Matchers.containsString("500"),
                 Matchers.containsString("2")
             )
+        );
+    }
+
+    @Test
+    void namesFailingNumberWhenTextThrows() {
+        final Text broken = () -> {
+            throw new IllegalStateException("broken line");
+        };
+        final Lines lines = new Lines(Collections.singletonList(broken));
+        final Exception thrown = Assertions.assertThrows(
+            Exception.class, () -> lines.line(1)
+        );
+        MatcherAssert.assertThat(
+            "the thrown exception message must name the failing line number",
+            thrown.getMessage(),
+            Matchers.containsString("1")
         );
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -98,16 +98,18 @@ final class LinesTest {
 
     @Test
     void namesFailingNumberWhenTextThrows() {
-        final Text broken = () -> {
-            throw new IllegalStateException("broken line");
-        };
-        final Lines lines = new Lines(Collections.singletonList(broken));
-        final Exception thrown = Assertions.assertThrows(
-            Exception.class, () -> lines.line(1)
+        final Lines lines = new Lines(
+            Collections.singletonList(
+                (Text) () -> {
+                    throw new IllegalStateException("broken line");
+                }
+            )
         );
         MatcherAssert.assertThat(
             "the thrown exception message must name the failing line number",
-            thrown.getMessage(),
+            Assertions.assertThrows(
+                Exception.class, () -> lines.line(1)
+            ).getMessage(),
             Matchers.containsString("1")
         );
     }


### PR DESCRIPTION
UncheckedText erased the line number when the underlying Text threw during conversion in Lines.line(int), leaving the caller with an anonymous exception. This wraps the conversion with UncheckedText's fallback constructor so the thrown exception's message names the offending line number.

Added a test that constructs a Text throwing during asString() and asserts the exception raised by Lines.line() carries that line number.

Closes #7773