### PR TITLE
Rename Lines to Rows to stop implying List<Line>

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -50,7 +50,7 @@ final class Emit {
      * lookup). Empty when no source is wired through — in that case
      * {@link #error} falls back to the bare {@code [L:P] message} form.
      */
-    private final Lines lines;
+    private final Rows lines;
 
     /**
      * The atom signature owed to an open {@code <o>} as its {@code λ}
@@ -98,7 +98,7 @@ final class Emit {
     Emit(final List<Span> source) {
         this.signature = "";
         this.sink = new ArrayList<>(0);
-        this.lines = new Lines(source);
+        this.lines = new Rows(source);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Rows.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Rows.java
@@ -8,16 +8,16 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * The source in lines, which points at the place where a parse error
- * was found by quoting the offending line under the message.
+ * Raw source text addressed by row number, which points at the place where
+ * a parse error was found by quoting the offending line under the message.
  *
- * <p>The lines are the {@link Span} objects {@link Source} already
+ * <p>The rows are the {@link Span} objects {@link Source} already
  * produced for the same text, in source order and numbered from 1, so
- * the span of line N sits at index N-1 and carries that line's text.</p>
+ * the span of row N sits at index N-1 and carries that row's text.</p>
  *
  * @since 0.50
  */
-final class Lines {
+final class Rows {
 
     /**
      * The source.
@@ -28,7 +28,7 @@ final class Lines {
      * Ctor.
      * @param lines The source in lines
      */
-    Lines(final List<Span> lines) {
+    Rows(final List<Span> lines) {
         this.source = new ArrayList<>(lines);
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/RowsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RowsTest.java
@@ -11,16 +11,16 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link Lines}.
+ * Test case for {@link Rows}.
  * @since 0.50
  */
-final class LinesTest {
+final class RowsTest {
 
     @Test
     void underlinesTheOffendingLine() {
         MatcherAssert.assertThat(
             "the line at the given number is not quoted with a caret under its position",
-            new Lines(List.of(new Span("привет мир", 1), new Span("второй", 2)))
+            new Rows(List.of(new Span("привет мир", 1), new Span("второй", 2)))
                 .underlined(1, 7, "боль"),
             Matchers.equalTo(String.format("[1:7] error: 'боль'%nпривет мир%n       ^"))
         );
@@ -30,7 +30,7 @@ final class LinesTest {
     void keepsMessageBareWhenLineIsUnknown() {
         MatcherAssert.assertThat(
             "a number past the end of the source is not answered with the bare message",
-            new Lines(List.of(new Span("", 1))).underlined(9, 2, "ошибка"),
+            new Rows(List.of(new Span("", 1))).underlined(9, 2, "ошибка"),
             Matchers.equalTo("[9:2] error: 'ошибка'")
         );
     }
@@ -39,7 +39,7 @@ final class LinesTest {
     void ignoresLineAppendedAfterConstruction() {
         final List<Span> source = new ArrayList<>(1);
         source.add(new Span("первый", 1));
-        final Lines lines = new Lines(source);
+        final Rows lines = new Rows(source);
         source.add(new Span("второй", 2));
         MatcherAssert.assertThat(
             "a line appended to the caller's list after construction is not left out",
@@ -53,7 +53,7 @@ final class LinesTest {
         final List<Span> source = new ArrayList<>(2);
         source.add(new Span("первый", 1));
         source.add(new Span("второй", 2));
-        final Lines lines = new Lines(source);
+        final Rows lines = new Rows(source);
         source.remove(1);
         MatcherAssert.assertThat(
             "a line removed from the caller's list after construction is not still quoted",
@@ -66,7 +66,7 @@ final class LinesTest {
     void keepsLinesWhenCallerListIsCleared() {
         final List<Span> source = new ArrayList<>(1);
         source.add(new Span("осталась", 1));
-        final Lines lines = new Lines(source);
+        final Rows lines = new Rows(source);
         source.clear();
         MatcherAssert.assertThat(
             "a line is not quoted after the caller's list was emptied",
@@ -79,7 +79,7 @@ final class LinesTest {
     void ignoresLineReplacedAfterConstruction() {
         final List<Span> source = new ArrayList<>(1);
         source.add(new Span("старая", 1));
-        final Lines lines = new Lines(source);
+        final Rows lines = new Rows(source);
         source.set(0, new Span("новая", 1));
         MatcherAssert.assertThat(
             "the line replaced in the caller's list after construction is not the old one",


### PR DESCRIPTION
Lines.java held a List<Text> of raw source rows, but the plural of Line (a functional interface for a classified source line, unrelated in shape and purpose) made it read as a collection of Line objects.

This renames the class to Rows and updates its javadoc to describe what it actually stores: raw source text addressed by row number. No callers reference the class outside its own file, so the rename is self-contained.

Closes #7770.