### PR TITLE
fix(#7695): compare bytes by content, never by the wrapper's delegate

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/BytesOf.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesOf.java
@@ -10,6 +10,16 @@ import java.util.Arrays;
 
 /**
  * Bytes.
+ *
+ * <p>Equality is value-based: two {@link Bytes} are equal when they hold
+ * the same byte sequence, no matter how each of them was built. Neither
+ * {@link BytesOf#equals(Object)} nor {@link BytesOf#hashCode()} may be
+ * delegated to the wrapped object, because {@link Bytes} is a public
+ * interface and an implementation of it is free to inherit the
+ * identity-based {@link Object#equals(Object)}. Delegating to such an
+ * object made equality asymmetric against {@link BytesRaw} and put
+ * unequal hash codes on equal byte sequences.</p>
+ *
  * @since 0.1.0
  */
 public final class BytesOf implements Bytes {
@@ -132,11 +142,19 @@ public final class BytesOf implements Bytes {
 
     @Override
     public boolean equals(final Object other) {
-        return this.bytes.equals(other);
+        final boolean result;
+        if (this == other) {
+            result = true;
+        } else if (other instanceof Bytes seq) {
+            result = Arrays.equals(this.take(), seq.take());
+        } else {
+            result = false;
+        }
+        return result;
     }
 
     @Override
     public int hashCode() {
-        return this.bytes.hashCode();
+        return Arrays.hashCode(this.take());
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -4,6 +4,9 @@
  */
 package org.eolang;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -212,5 +215,132 @@ final class BytesOfTest {
             ),
             "'xor' of operands with different lengths should fail with ExFailure, but it didn't"
         );
+    }
+
+    @Test
+    void staysEqualToRawBytesOfTheSameContent() {
+        MatcherAssert.assertThat(
+            "a wrapper around a foreign Bytes must equal the raw bytes of the same content",
+            new BytesOf(new BytesOfTest.PlainBytes(new byte[] {(byte) 0x01})),
+            Matchers.equalTo(new BytesOf(new byte[] {(byte) 0x01}))
+        );
+    }
+
+    @Test
+    void keepsEqualitySymmetricWithForeignBytes() {
+        final Bytes wrapped = new BytesOf(new BytesOfTest.PlainBytes(new byte[] {(byte) 0x01}));
+        final Bytes raw = new BytesOf(new byte[] {(byte) 0x01});
+        MatcherAssert.assertThat(
+            "equality must hold in both directions, not only from the raw side",
+            wrapped.equals(raw),
+            Matchers.equalTo(raw.equals(wrapped))
+        );
+    }
+
+    @Test
+    void hashesForeignBytesByContent() {
+        MatcherAssert.assertThat(
+            "equal byte sequences must carry equal hash codes, however each was built",
+            new BytesOf(new BytesOfTest.PlainBytes(new byte[] {(byte) 0x01})).hashCode(),
+            Matchers.equalTo(new BytesOf(new byte[] {(byte) 0x01}).hashCode())
+        );
+    }
+
+    @Test
+    void collapsesEqualBytesInAHashSet() {
+        final Set<Bytes> set = new HashSet<>(0);
+        set.add(new BytesOf(new BytesOfTest.PlainBytes(new byte[] {(byte) 0x01})));
+        set.add(new BytesOf(new byte[] {(byte) 0x01}));
+        MatcherAssert.assertThat(
+            "two Bytes of the same content must occupy one slot of a HashSet",
+            set,
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void staysUnequalToBytesOfOtherContent() {
+        MatcherAssert.assertThat(
+            "bytes of different content must not be equal",
+            new BytesOf(new BytesOfTest.PlainBytes(new byte[] {(byte) 0x01})),
+            Matchers.not(Matchers.equalTo(new BytesOf(new byte[] {(byte) 0x02})))
+        );
+    }
+
+    @Test
+    void staysUnequalToAnObjectThatIsNotBytes() {
+        MatcherAssert.assertThat(
+            "an object that is not Bytes must not be equal to Bytes",
+            new BytesOf(new byte[] {(byte) 0x01}),
+            Matchers.not(Matchers.equalTo("not bytes"))
+        );
+    }
+
+    /**
+     * A legal {@link Bytes} that deliberately inherits the identity-based
+     * {@link Object#equals(Object)}, as any implementation of the public
+     * interface is free to do.
+     * @since 0.1.0
+     */
+    private static final class PlainBytes implements Bytes {
+
+        /**
+         * Data.
+         */
+        private final byte[] data;
+
+        PlainBytes(final byte[] bytes) {
+            this.data = Arrays.copyOf(bytes, bytes.length);
+        }
+
+        @Override
+        public Bytes not() {
+            return new BytesOf(this.data).not();
+        }
+
+        @Override
+        public Bytes and(final Bytes other) {
+            return new BytesOf(this.data).and(other);
+        }
+
+        @Override
+        public Bytes or(final Bytes other) {
+            return new BytesOf(this.data).or(other);
+        }
+
+        @Override
+        public Bytes xor(final Bytes other) {
+            return new BytesOf(this.data).xor(other);
+        }
+
+        @Override
+        public Bytes shift(final int bits) {
+            return new BytesOf(this.data).shift(bits);
+        }
+
+        @Override
+        public Bytes sshift(final int bits) {
+            return new BytesOf(this.data).sshift(bits);
+        }
+
+        @Override
+        public Double asNumber() {
+            return new BytesOf(this.data).asNumber();
+        }
+
+        @Override
+        public <T extends Number> T asNumber(final Class<T> type) {
+            return new BytesOf(this.data).asNumber(type);
+        }
+
+        @Override
+        public String asString() {
+            return new BytesOf(this.data).asString();
+        }
+
+        @Override
+        public byte[] take() {
+            return Arrays.copyOf(this.data, this.data.length);
+        }
     }
 }


### PR DESCRIPTION
Closes #7695

## What was wrong

`BytesOf.equals` and `BytesOf.hashCode` delegated straight to the wrapped object:

```java
public boolean equals(final Object other) {
    return this.bytes.equals(other);
}
```

`Bytes` is a **public** interface, so an implementation of it is free to inherit the identity-based `Object.equals`. Wrapping such an object broke the Java equality contract against `BytesRaw`, which compares `take()` contents:

```java
final Bytes plain = new PlainBytes(new byte[] {1});   // inherits Object.equals
final Bytes wrapped = new BytesOf(plain);
final Bytes raw = new BytesOf(new byte[] {1});

wrapped.equals(raw);   // false
raw.equals(wrapped);   // true   <- not symmetric
```

Their hash codes differed too, so callers could not safely put `Bytes` into a `HashSet` or a `HashMap`, and equality depended on construction history instead of byte content.

## What changed

`eo-runtime/src/main/java/org/eolang/BytesOf.java` — `equals` and `hashCode` now work on this object's own `take()` contents, mirroring `BytesRaw`:

```java
public boolean equals(final Object other) {
    final boolean result;
    if (this == other) {
        result = true;
    } else if (other instanceof Bytes seq) {
        result = Arrays.equals(this.take(), seq.take());
    } else {
        result = false;
    }
    return result;
}

public int hashCode() {
    return Arrays.hashCode(this.take());
}
```

plus a docblock recording why these two must not be delegated.

**`BytesOf(byte[])` behaviour is unchanged.** That constructor wraps a `BytesRaw`, whose `equals` already compared `Arrays.equals(this.data, other.take())` — the same contents this now compares directly. Only the `BytesOf(Bytes)` path, the one in the report, changes.

## Tests

Six tests added to `BytesOfTest`, backed by a `PlainBytes` fixture that implements every `Bytes` method but deliberately inherits `Object.equals`, exactly as the issue describes:

| test | what it pins |
| --- | --- |
| `staysEqualToRawBytesOfTheSameContent` | a wrapper around a foreign `Bytes` equals the raw bytes of the same content |
| `keepsEqualitySymmetricWithForeignBytes` | both directions of `equals` agree |
| `hashesForeignBytesByContent` | equal sequences carry equal hash codes |
| `collapsesEqualBytesInAHashSet` | the two occupy one `HashSet` slot |
| `staysUnequalToBytesOfOtherContent` | different content stays unequal |
| `staysUnequalToAnObjectThatIsNotBytes` | a non-`Bytes` object stays unequal |

Verified against the unfixed `BytesOf.java`: the first four fail; with the fix all 38 `BytesOfTest` tests pass.

`mvn -pl eo-runtime -DskipTests -DskipITs -Pqulice verify` → BUILD SUCCESS.
`mvn -pl eo-runtime test -PskipITs -Deo.transpileTests=false` → 627 tests; the only failures are `MainTest.printsVersion` and 10 `SyscallTest` port-allocation errors ("Couldn't find a free TCP port in 20000-29999"), which fail identically on unmodified `master` in this sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nXep6pc4gb3rAoBvbHG67)_