### PR TITLE
Give Lines a reason to exist beyond storage

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -57,7 +57,7 @@ final class Emit {
      * lookup). Empty when no source is wired through — in that case
      * {@link #error} falls back to the bare {@code [L:P] message} form.
      */
-    private final List<String> lines;
+    private final Lines lines;
 
     /**
      * The atom signature owed to an open {@code <o>} as its {@code λ}
@@ -93,7 +93,7 @@ final class Emit {
      * Ctor.
      */
     Emit() {
-        this(List.of());
+        this(new Lines(List.of()));
     }
 
     /**
@@ -102,14 +102,14 @@ final class Emit {
      *  messages — pass empty string to disable)
      */
     Emit(final String source) {
-        this(List.of(Emit.EOL.split(source, -1)));
+        this(new Lines(List.of(Emit.EOL.split(source, -1))));
     }
 
     /**
      * Primary ctor.
-     * @param src Pre-split source lines
+     * @param src The source in lines
      */
-    private Emit(final List<String> src) {
+    private Emit(final Lines src) {
         this.signature = "";
         this.sink = new ArrayList<>(0);
         this.lines = src;
@@ -292,7 +292,7 @@ final class Emit {
             dirs.attr("lossy", "");
         }
         this.append(
-            dirs.set(this.formatted(line, pos, message))
+            dirs.set(this.lines.underlined(line, pos, message))
                 .up().up()
                 .pop()
         );
@@ -561,20 +561,5 @@ final class Emit {
         while (iterator.hasNext()) {
             this.sink.add(iterator.next());
         }
-    }
-
-    private String formatted(final int line, final int pos, final String message) {
-        final String located = new MsgLocated(line, pos, message).formatted();
-        final String result;
-        if (line >= 1 && line <= this.lines.size()) {
-            result = String.format(
-                "%s%n%s",
-                located,
-                new MsgUnderlined(this.lines.get(line - 1), pos, 1).formatted()
-            );
-        } else {
-            result = located;
-        }
-        return result;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Lines.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Lines.java
@@ -5,12 +5,10 @@
 package org.eolang.parser;
 
 import java.util.List;
-import java.util.Optional;
-import org.cactoos.Text;
-import org.cactoos.text.UncheckedText;
 
 /**
- * The source in lines.
+ * The source in lines, which points at the place where a parse error
+ * was found by quoting the offending line under the message.
  * @since 0.50
  */
 final class Lines {
@@ -18,41 +16,35 @@ final class Lines {
     /**
      * The source.
      */
-    private final List<Text> source;
+    private final List<String> source;
 
     /**
      * Ctor.
      * @param lines The source in lines
      */
-    Lines(final List<Text> lines) {
+    Lines(final List<String> lines) {
         this.source = lines;
     }
 
     /**
-     * Get the line by number.
-     *
-     * <p>Lines are numbered from 1. A number outside that range is a
-     * mistake by the caller, not an empty line, so an
-     * {@link IndexOutOfBoundsException} naming the number and the size of
-     * the source is thrown, instead of folding it into {@code ""} — which
-     * a caller could not tell apart from a real, empty line at a valid
-     * number.</p>
-     *
-     * @param number The line number, from 1 to the number of lines
-     * @return The line
+     * The message with the offending line and a caret beneath it.
+     * @param number The line number, 1-indexed
+     * @param pos The position in the line, 0-indexed
+     * @param message The message
+     * @return The message, quoted when the line is known
      */
-    String line(final int number) {
+    String underlined(final int number, final int pos, final String message) {
+        final String located = new MsgLocated(number, pos, message).formatted();
+        final String result;
         if (number < 1 || number > this.source.size()) {
-            throw new IndexOutOfBoundsException(
-                String.format(
-                    "Line #%d doesn't exist, the source has %d line(s), numbered from 1",
-                    number, this.source.size()
-                )
+            result = located;
+        } else {
+            result = String.format(
+                "%s%n%s",
+                located,
+                new MsgUnderlined(this.source.get(number - 1), pos, 1).formatted()
             );
         }
-        return Optional.ofNullable(this.source.get(number - 1))
-            .map(UncheckedText::new)
-            .map(UncheckedText::asString)
-            .orElse("");
+        return result;
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -4,15 +4,10 @@
  */
 package org.eolang.parser;
 
-import java.util.Arrays;
-import java.util.Collections;
-import org.cactoos.text.TextOf;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link Lines}.
@@ -21,77 +16,20 @@ import org.junit.jupiter.params.provider.ValueSource;
 final class LinesTest {
 
     @Test
-    void readsTheFirstLine() {
+    void underlinesTheOffendingLine() {
         MatcherAssert.assertThat(
-            "line 1 must be the first line of the source",
-            new Lines(
-                Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
-            ).line(1),
-            Matchers.equalTo("alpha")
+            "the line at the given number is not quoted with a caret under its position",
+            new Lines(List.of("привет мир", "второй")).underlined(1, 7, "боль"),
+            Matchers.equalTo(String.format("[1:7] error: 'боль'%nпривет мир%n       ^"))
         );
     }
 
     @Test
-    void readsTheLastLine() {
+    void keepsMessageBareWhenLineIsUnknown() {
         MatcherAssert.assertThat(
-            "the highest valid number must be the last line",
-            new Lines(
-                Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
-            ).line(2),
-            Matchers.equalTo("beta")
-        );
-    }
-
-    @Test
-    void readsAGenuinelyEmptyLine() {
-        MatcherAssert.assertThat(
-            "an empty line at a valid number must come back as an empty string",
-            new Lines(
-                Arrays.asList(new TextOf("alpha"), new TextOf(""))
-            ).line(2),
-            Matchers.equalTo("")
-        );
-    }
-
-    @ParameterizedTest
-    @ValueSource(ints = {-1, 0, 3, 500, Integer.MAX_VALUE})
-    void rejectsANumberThatIsNotALine(final int number) {
-        final Lines lines = new Lines(
-            Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
-        );
-        Assertions.assertThrows(
-            IndexOutOfBoundsException.class,
-            () -> lines.line(number),
-            "a number outside the range of lines must be reported, not folded into an empty string"
-        );
-    }
-
-    @Test
-    void rejectsAnyNumberWhenThereAreNoLines() {
-        final Lines lines = new Lines(Collections.emptyList());
-        Assertions.assertThrows(
-            IndexOutOfBoundsException.class,
-            () -> lines.line(1),
-            "an empty source must have no line 1"
-        );
-    }
-
-    @Test
-    void namesTheNumberAndTheSizeWhenItRejects() {
-        final Lines lines = new Lines(
-            Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
-        );
-        MatcherAssert.assertThat(
-            "the message must name the number asked for and how many lines there are",
-            Assertions.assertThrows(
-                IndexOutOfBoundsException.class,
-                () -> lines.line(500),
-                "a number outside the range of lines must be reported"
-            ).getMessage(),
-            Matchers.allOf(
-                Matchers.containsString("500"),
-                Matchers.containsString("2")
-            )
+            "a number past the end of the source is not answered with the bare message",
+            new Lines(List.of("")).underlined(9, 2, "ошибка"),
+            Matchers.equalTo("[9:2] error: 'ошибка'")
         );
     }
 }


### PR DESCRIPTION
`Lines` held a list of source lines and handed them back one at a time through `line(int)`. Nothing in the codebase called it, and the one place that actually needed a source line — `Emit` — kept its own `List<String>` and repeated the same 1-indexed bounds check and `get(number - 1)` lookup inline, in a private `formatted` method.

So the class stored data for nobody while its real behavior lived somewhere else. This moves that behavior in: `Lines` now answers `underlined(number, pos, message)`, returning the located message with the offending line and a caret beneath it, or the bare `[L:P] error: '...'` form when the number falls outside the source. `Emit` holds a `Lines` and delegates; its private `formatted` is gone, and so are the `Optional`, `Text` and `UncheckedText` imports that only existed to serve the old getter.

The rendering is unchanged — the branches are the same ones, inverted — so the existing `eo-typos` fixtures that assert the exact error text still describe the output. `Lines` had no test file before; it has one now covering both the quoted and the bare form.

Closes #7771
