### PR TITLE
fix(#7747): round u64.as-number once, not twice

### DIFF
--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -3,6 +3,11 @@
 # interpreted without a sign. Addition, subtraction and multiplication
 # share the bit pattern of their signed `i64` counterparts, while
 # comparisons and division are made unsigned.
+# `as-number` rounds exactly once. Above `2^63` the eight bytes are
+# shifted right by one bit, the bit that falls off is put back as the
+# lowest bit of the shifted value, and the result is doubled. That
+# lowest bit keeps the shifted value odd whenever something was
+# discarded, so it can never sit on a tie and be rounded the wrong way.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -12,15 +17,19 @@
 
 [as-bytes] > u64
   as-bytes > @
-  plus. > [^] > as-number
+  if. > [^] > as-number
+    eq.
+      ^.as-bytes.and 80-00-00-00-00-00-00-00
+      80-00-00-00-00-00-00-00
+    times.
+      as-number.
+        i64
+          or.
+            ^.as-bytes.right 1
+            ^.as-bytes.and 00-00-00-00-00-00-00-01
+      2
     as-number.
       i64 ^.as-bytes
-    if.
-      eq.
-        ^.as-bytes.and 80-00-00-00-00-00-00-00
-        80-00-00-00-00-00-00-00
-      1.8446744073709552e19
-      0
   as-bytes.xor 80-00-00-00-00-00-00-00 > flip
   gt. > [^ x] > gt
     i64 ^.flip
@@ -81,9 +90,29 @@
     00-00-00-00-00-00-00-2A.as-u64.as-number
     42
 
+  eq. ++> can-convert-a-value-just-above-two-to-the-63rd
+    80-00-00-00-00-00-04-01.as-u64.as-number
+    9.223372036854778e18
+
+  eq. ++> can-convert-a-value-just-below-two-to-the-63rd
+    7F-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
+    9.223372036854776e18
+
+  eq. ++> can-convert-a-value-with-two-high-bits-to-a-number
+    C0-00-00-00-00-00-04-01.as-u64.as-number
+    1.3835058055282166e19
+
+  eq. ++> can-convert-the-maximum-to-a-number
+    FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
+    1.8446744073709552e19
+
   gt. ++> can-convert-to-an-unsigned-number
     FF-FF-FF-FF-FF-FF-FF-FF.as-u64.as-number
     0
+
+  eq. ++> can-convert-two-to-the-63rd-to-a-number
+    80-00-00-00-00-00-00-00.as-u64.as-number
+    9.223372036854776e18
 
   eq. ++> can-equal-the-same-u64
     00-00-00-00-00-00-00-2A.as-u64


### PR DESCRIPTION
Closes #7747

## What was wrong

`as-number` read the eight bytes as an `i64` and then added `2^64` when the top bit was set. **Both** steps round:

- `i64.as-number` rounds the signed reading into the binade below `2^63`, spacing 1024;
- the `plus` rounds that sum into the binade above `2^63`, spacing 2048.

The second rounding cannot recover what the first one dropped. Over 207 000 checked values at or above `2^63`, **34 139** came out wrong, each by one ULP.

## A note on the suggested fix

The issue suggests: "shift the eight bytes right by one bit, convert that, double it and add back the low bit." That still rounds twice — `(double)(v >>> 1)` rounds, and doubling preserves the error. It is much better (46 wrong out of the same 207 000 instead of 34 139) but **still wrong for the very value the issue cites**:

| | `80-00-00-00-00-00-04-01` (`2^63 + 1025`) |
| --- | --- |
| correctly rounded | `9.223372036854778e18` |
| current code | `9.223372036854776e18` ❌ |
| shift + double + add low bit | `9.223372036854776e18` ❌ |
| this PR | `9.223372036854778e18` ✅ |

## What changed

The low bit is **OR-ed into** the shifted value rather than added afterwards — round-to-odd:

```
  if. > [^] > as-number
    eq.
      ^.as-bytes.and 80-00-00-00-00-00-00-00
      80-00-00-00-00-00-00-00
    times.
      as-number.
        i64
          or.
            ^.as-bytes.right 1
            ^.as-bytes.and 00-00-00-00-00-00-00-01
      2
    as-number.
      i64 ^.as-bytes
```

Why this rounds exactly once:

- `v >>> 1` always fits below `2^63`, so the `i64` reading of it is a single correctly-rounded conversion;
- OR-ing the discarded bit back in as the lowest bit keeps the shifted value **odd whenever something was discarded**, so it can never sit exactly on a rounding tie and be sent the wrong way by round-half-to-even;
- doubling is exact (a power-of-two scale).

Below `2^63` the `i64` reading is already correctly rounded, so that branch is used unchanged — round-to-odd must *not* be applied there, since it would make small odd values inexact (`43` would come out as `42`).

## Verification

Modelled all three algorithms against exact rational rounding over **635 000** values — every tie point and its neighbours in `[2^63, 2^64)`, the top of the range, uniform random samples, and values below `2^63` for the other branch. Result: **0 wrong**, where the current code is wrong on ~16% of values above `2^63`.

Five tests added to `u64.eo`:

| test | value | pins |
| --- | --- | --- |
| `can-convert-a-value-just-above-two-to-the-63rd` | `80-…-04-01` | the reported case; **fails on master** |
| `can-convert-a-value-with-two-high-bits-to-a-number` | `C0-…-04-01` | a second binade; **fails on master** |
| `can-convert-a-value-just-below-two-to-the-63rd` | `7F-…-FF` | the untouched branch stays exact |
| `can-convert-two-to-the-63rd-to-a-number` | `80-…-00` | the boundary itself |
| `can-convert-the-maximum-to-a-number` | `FF-…-FF` | the top of the range |

Verified against the unfixed `u64.eo`: the first two fail (`expected: <true> but was: <false>`), and both pass here.

`mvn -pl eo-runtime test -PskipITs -Dtest=EOu64Test` → 30 run, 0 failures (3 pre-existing division skips).
`mvn -pl eo-runtime test -PskipITs` (full, EO tests transpiled) → 2575 tests, 2 failures + 10 errors — byte-identical to the 2 failures + 10 errors that unmodified `master` produces in this sandbox (`MainTest.printsVersion`, an `EOposixTest` O_EXCL case that only fails under parallel execution as root, and 10 `SyscallTest` "couldn't find a free TCP port" errors).

---
_Generated by [Claude Code](https://claude.ai/code/session_018nXep6pc4gb3rAoBvbHG67)_