### PR TITLE
fix(#7767): report a line number that doesn't exist

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Lines.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Lines.java
@@ -30,18 +30,29 @@ final class Lines {
 
     /**
      * Get the line by number.
-     * @param number The line number
+     *
+     * <p>Lines are numbered from 1. A number outside that range is a
+     * mistake by the caller, not an empty line, so an
+     * {@link IndexOutOfBoundsException} naming the number and the size of
+     * the source is thrown, instead of folding it into {@code ""} — which
+     * a caller could not tell apart from a real, empty line at a valid
+     * number.</p>
+     *
+     * @param number The line number, from 1 to the number of lines
      * @return The line
      */
     String line(final int number) {
-        final Optional<String> result;
         if (number < 1 || number > this.source.size()) {
-            result = Optional.empty();
-        } else {
-            result = Optional.ofNullable(this.source.get(number - 1))
-                .map(UncheckedText::new)
-                .map(UncheckedText::asString);
+            throw new IndexOutOfBoundsException(
+                String.format(
+                    "Line #%d doesn't exist, the source has %d line(s), numbered from 1",
+                    number, this.source.size()
+                )
+            );
         }
-        return result.orElse("");
+        return Optional.ofNullable(this.source.get(number - 1))
+            .map(UncheckedText::new)
+            .map(UncheckedText::asString)
+            .orElse("");
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -56,33 +56,36 @@ final class LinesTest {
     @ParameterizedTest
     @ValueSource(ints = {-1, 0, 3, 500, Integer.MAX_VALUE})
     void rejectsANumberThatIsNotALine(final int number) {
+        final Lines lines = new Lines(
+            Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
+        );
         Assertions.assertThrows(
             IndexOutOfBoundsException.class,
-            () -> new Lines(
-                Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
-            ).line(number),
+            () -> lines.line(number),
             "a number outside the range of lines must be reported, not folded into an empty string"
         );
     }
 
     @Test
     void rejectsAnyNumberWhenThereAreNoLines() {
+        final Lines lines = new Lines(Collections.emptyList());
         Assertions.assertThrows(
             IndexOutOfBoundsException.class,
-            () -> new Lines(Collections.emptyList()).line(1),
+            () -> lines.line(1),
             "an empty source must have no line 1"
         );
     }
 
     @Test
     void namesTheNumberAndTheSizeWhenItRejects() {
+        final Lines lines = new Lines(
+            Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
+        );
         MatcherAssert.assertThat(
             "the message must name the number asked for and how many lines there are",
             Assertions.assertThrows(
                 IndexOutOfBoundsException.class,
-                () -> new Lines(
-                    Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
-                ).line(500),
+                () -> lines.line(500),
                 "a number outside the range of lines must be reported"
             ).getMessage(),
             Matchers.allOf(

--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.cactoos.text.TextOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * Test case for {@link Lines}.
+ * @since 0.50
+ */
+final class LinesTest {
+
+    @Test
+    void readsTheFirstLine() {
+        MatcherAssert.assertThat(
+            "line 1 must be the first line of the source",
+            new Lines(
+                Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
+            ).line(1),
+            Matchers.equalTo("alpha")
+        );
+    }
+
+    @Test
+    void readsTheLastLine() {
+        MatcherAssert.assertThat(
+            "the highest valid number must be the last line",
+            new Lines(
+                Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
+            ).line(2),
+            Matchers.equalTo("beta")
+        );
+    }
+
+    @Test
+    void readsAGenuinelyEmptyLine() {
+        MatcherAssert.assertThat(
+            "an empty line at a valid number must come back as an empty string",
+            new Lines(
+                Arrays.asList(new TextOf("alpha"), new TextOf(""))
+            ).line(2),
+            Matchers.equalTo("")
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {-1, 0, 3, 500, Integer.MAX_VALUE})
+    void rejectsANumberThatIsNotALine(final int number) {
+        Assertions.assertThrows(
+            IndexOutOfBoundsException.class,
+            () -> new Lines(
+                Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
+            ).line(number),
+            "a number outside the range of lines must be reported, not folded into an empty string"
+        );
+    }
+
+    @Test
+    void rejectsAnyNumberWhenThereAreNoLines() {
+        Assertions.assertThrows(
+            IndexOutOfBoundsException.class,
+            () -> new Lines(Collections.emptyList()).line(1),
+            "an empty source must have no line 1"
+        );
+    }
+
+    @Test
+    void namesTheNumberAndTheSizeWhenItRejects() {
+        MatcherAssert.assertThat(
+            "the message must name the number asked for and how many lines there are",
+            Assertions.assertThrows(
+                IndexOutOfBoundsException.class,
+                () -> new Lines(
+                    Arrays.asList(new TextOf("alpha"), new TextOf("beta"))
+                ).line(500),
+                "a number outside the range of lines must be reported"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("500"),
+                Matchers.containsString("2")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #7767

## What was wrong

`Lines.line(int)` mapped an out-of-range `number` to `Optional.empty()` and then unwrapped it to `""`:

```java
if (number < 1 || number > this.source.size()) {
    result = Optional.empty();
} else {
    ...
}
return result.orElse("");
```

`""` is indistinguishable from a real, empty line at a valid number, so a caller asking for line 500 of a 10-line source got a silent success and carried the mistake on as data.

## What changed

`eo-parser/src/main/java/org/eolang/parser/Lines.java` — an out-of-range number now raises an `IndexOutOfBoundsException` naming both the number asked for and how many lines the source actually has:

```
Line #500 doesn't exist, the source has 2 line(s), numbered from 1
```

Unchanged: lines are still numbered from 1, and a genuinely empty line at a valid number still comes back as `""`.

### Scope

Tolerating a `null` element at a *valid* index is a separate report (#7768), so the `Optional.ofNullable(...).orElse("")` around the element read is deliberately left as it is here. This PR only stops the out-of-range case from masquerading as data.

`Lines` has no production callers today — it is only referenced from its own file — so nothing in the parser changes behaviour as a result. The `@throws` tag was folded into the method's prose because `JavadocThrowsCheck` requires the exception to be declared in the signature, which is not appropriate for an unchecked one.

## Tests

The class had no test at all; this adds `LinesTest` with 10 cases:

| test | what it pins |
| --- | --- |
| `readsTheFirstLine` / `readsTheLastLine` | valid numbers still read the right line |
| `readsAGenuinelyEmptyLine` | an empty line at a valid number is still `""` |
| `rejectsANumberThatIsNotALine` | `-1`, `0`, `3`, `500`, `Integer.MAX_VALUE` all throw (5 cases) |
| `rejectsAnyNumberWhenThereAreNoLines` | an empty source has no line 1 |
| `namesTheNumberAndTheSizeWhenItRejects` | the message carries both the number and the size |

Verified against the unfixed `Lines.java`: 7 of the 10 fail ("Expected `IndexOutOfBoundsException` to be thrown, but nothing was thrown"); the three read tests pass either way, as they should.

`mvn -pl eo-parser test -PskipITs` → **1429** tests, 0 failures, 6 skipped, against **1419** / 0 / 6 on unmodified `master` at the same commit — exactly the 10 new cases, with a per-class diff confirming no other test class changed.
`mvn -pl eo-parser -DskipTests -DskipITs -Pqulice verify` → BUILD SUCCESS.

---
_Generated by [Claude Code](https://claude.ai/code/session_018nXep6pc4gb3rAoBvbHG67)_