### PR TITLE
Answer a call site with the receiver it hands over

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -36,13 +36,6 @@ import java.util.Map;
  * and not by an argument written to the right of the name.</p>
  *
  * @since 0.69.0
- * @todo #7491:45min Substitute a receiver filling into an answer, the way
- *  {@link Filled} already substitutes an argument. {@link Dispatched} asks
- *  this class about arguments alone, through the ctor that leaves the
- *  receivers empty, because it is handed the arguments of the program and no
- *  XMIR to read a receiver off. Once it has them, the {@code plus} of
- *  {@code ^} inside a formation could be answered with the type of whoever
- *  dispatched on it rather than left rooted at the void.
  */
 final class Bound {
 
@@ -65,20 +58,6 @@ final class Bound {
      * What the types certainly have.
      */
     private final Provided owned;
-
-    /**
-     * Ctor, for the callers that ask only about arguments.
-     * @param arguments The arguments of every application, from {@link Given}
-     * @param links The pairs, each name against the one it is a copy of
-     * @param provided What the types certainly have
-     */
-    Bound(
-        final Map<String, List<String>> arguments,
-        final Map<String, String> links,
-        final Provided provided
-    ) {
-        this(arguments, Collections.emptyMap(), links, provided);
-    }
 
     /**
      * Ctor.

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -48,6 +48,11 @@ final class Dispatched {
     private final Map<String, List<String>> args;
 
     /**
+     * What every dispatch takes its attribute from, from {@link Xmirs}.
+     */
+    private final Map<String, String> receivers;
+
+    /**
      * The locator of every void this pass may look into.
      */
     private final Collection<String> hollows;
@@ -57,6 +62,7 @@ final class Dispatched {
      * @param provides The provides table
      * @param dispatches Every dispatch of the program
      * @param arguments The arguments of every application, from {@link Given}
+     * @param taken What every dispatch takes its attribute from
      * @param voids The locator of every void this pass may look into, empty
      *  when it may look into none
      */
@@ -64,11 +70,13 @@ final class Dispatched {
         final XML provides,
         final Collection<XML> dispatches,
         final Map<String, List<String>> arguments,
+        final Map<String, String> taken,
         final Collection<String> voids
     ) {
         this.given = provides;
         this.all = dispatches;
         this.args = arguments;
+        this.receivers = taken;
         this.hollows = voids;
     }
 
@@ -81,7 +89,9 @@ final class Dispatched {
     Map<String, String> answers(final Map<String, String> pairs) {
         final Map<String, String> names = new Ends(pairs).names();
         final Provided owned = new Provided(this.given, names, this.hollows);
-        final Filled filled = new Filled(this.args, pairs, owned);
+        final Filled filled = new Filled(
+            pairs, owned, new Bound(this.args, this.receivers, pairs, owned).all()
+        );
         final Map<String, String> found = new HashMap<>(0);
         for (final XML dispatch : this.all) {
             final String made = dispatch.xpath("@loc").get(0);

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -50,25 +49,12 @@ final class Filled {
 
     /**
      * Ctor.
-     * @param arguments The arguments of every application, from {@link Given}
      * @param links The pairs, each name against the one it is a copy of
      * @param provided The provides table, by the name a type goes by
+     * @param bound What every application and every dispatch fills, from
+     *  {@link Bound}
      */
     Filled(
-        final Map<String, List<String>> arguments,
-        final Map<String, String> links,
-        final Provided provided
-    ) {
-        this(links, provided, new Bound(arguments, links, provided).all());
-    }
-
-    /**
-     * Ctor.
-     * @param links The pairs, each name against the one it is a copy of
-     * @param provided The provides table, by the name a type goes by
-     * @param bound What every application fills, from {@link Bound}
-     */
-    private Filled(
         final Map<String, String> links,
         final Provided provided,
         final Map<String, Map<String, String>> bound

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -76,10 +76,12 @@ public final class Resolved implements Clue {
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Pairs written = new Pairs(new XMLDocument(links));
         final Map<String, String> pairs = new Settled(
-            new Dispatched(given, dispatches, args, voids)
+            new Dispatched(given, dispatches, args, world.receivers(), voids)
         ).from(
             new Settled(
-                new Dispatched(given, dispatches, args, Collections.emptyList())
+                new Dispatched(
+                    given, dispatches, args, world.receivers(), Collections.emptyList()
+                )
             ).from(written.all())
         );
         final Map<String, Type> rows = new Refs(

--- a/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
@@ -38,7 +38,7 @@ final class BoundTest {
         MatcherAssert.assertThat(
             "the second application of a chain must fill the void the first one left empty",
             new Bound(
-                args, pairs,
+                args, Collections.emptyMap(), pairs,
                 new Provided(
                     rows, Collections.emptyMap(),
                     Collections.emptyList(), Collections.emptyMap()

--- a/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
@@ -29,15 +29,18 @@ final class FilledTest {
                 Map.of("void", "true", "type", "Φ.node")
             )
         );
+        final Provided owned = new Provided(
+            rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+        );
         MatcherAssert.assertThat(
             "an exact fill of the whole answer must win over a fill of one of its prefixes",
             new Filled(
-                Map.of("app", List.of("value-x", "value-foo")),
                 Map.of("app", "form"),
-                new Provided(
-                    rows, Collections.emptyMap(),
-                    Collections.emptyList(), Collections.emptyMap()
-                )
+                owned,
+                new Bound(
+                    Map.of("app", List.of("value-x", "value-foo")),
+                    Collections.emptyMap(), Map.of("app", "form"), owned
+                ).all()
             ).instead("Φ.node.x", "app"),
             Matchers.equalTo("value-x")
         );
@@ -54,15 +57,18 @@ final class FilledTest {
             )
         );
         rows.put("long-fill", List.of(Map.of("name", "y", "type", "Φ.result")));
+        final Provided owned = new Provided(
+            rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+        );
         MatcherAssert.assertThat(
             "the more specific (longer) filled prefix must win, not whichever the map yields first",
             new Filled(
-                Map.of("app", List.of("short-fill", "long-fill")),
                 Map.of("app", "form"),
-                new Provided(
-                    rows, Collections.emptyMap(),
-                    Collections.emptyList(), Collections.emptyMap()
-                )
+                owned,
+                new Bound(
+                    Map.of("app", List.of("short-fill", "long-fill")),
+                    Collections.emptyMap(), Map.of("app", "form"), owned
+                ).all()
             ).instead("Φ.node.x.y", "app"),
             Matchers.equalTo("Φ.result")
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caller-says-what-the-receiver-holds.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caller-says-what-the-receiver-holds.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Inside the body of `halved` there is nothing to say about `^` but the void
+# declared for it, since every caller may hand over something different. At a
+# call site there is: `42.halved` says the receiver is a number, so what the
+# body reads through `^` can be followed from there. The answer in the body
+# stays rooted at the void and the answer at the call site does not, which is
+# the same substitution an argument already gets.
+eo:
+  app.eo: |
+    [] > app
+      42.halved.as-bytes > @
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+      [x] > plus
+        x > @
+      [^] > halved
+        ^.plus 0 > @
+links:
+  - "/links/type[@id='Φ.number.halved.φ']/ref[@loc='Φ.number.halved.ρ.plus']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.number.plus.x.as-bytes']"


### PR DESCRIPTION
Closes #7739, and removes the puzzle text from `Bound`.

`Filled` substitutes what an application put into a void, so a question asked of a copy is answered with the argument rather than with the void it landed in. Since #7491 a dispatch fills a void too — the receiver one — but those fillings never reached here, because `Dispatched` built its `Bound` without them.

Inside a body there is still nothing to say about `^` but the void declared for it, since every caller may hand over something different. At a call site there is. Taking `42.halved.as-bytes` against

```
[as-bytes] > number
  as-bytes > @
  [x] > plus
    x > @
  [^] > halved
    ^.plus 0 > @
```

the answer was `Φ.number.halved.ρ.plus.as-bytes` — rooted at a receiver that the very same `links.xml` row already described as a number, two elements away:

```xml
<type id="Φ.app.φ.ρ">
  <ref loc="Φ.number.halved">
    <bind void="Φ.number.halved.ρ"><ref loc="Φ.app.φ.ρ.ρ"/></bind>
```

It is now `Φ.number.plus.x.as-bytes`, while the body keeps its honest `Φ.number.halved.ρ.plus`.

Measured over eo-runtime, 50,638 objects, master against this branch:

| rung | master | here |
| --- | --- | --- |
| nothing at all | 526 | 526 |
| a name rooted at a void | 12,134 | 11,808 |
| a formation, voids still free | 3,714 | 3,727 |
| a formation, nothing left free | 23,902 | 24,215 |
| nothing left to find out | 10,362 | 10,362 |
| **named** | **75.0%** | **75.6%** |
| **depth** | **65.5%** | **65.8%** |

326 objects move up a rung and none move down. It is a smaller number than the 429 #7743 gave up, and it should be: this recovers only what a caller was actually seen to hand over, and a formation nobody dispatches on keeps its void.

`Filled` no longer knows how to build a `Bound`. It takes the fillings it is to use, which leaves it a single constructor of three arguments — no suppression needed for the fourth — and puts the choice of what fills what in the one place that already knows both. One pack describes the behaviour.
