### PR TITLE
Keep errno readable across the strerror lookup

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/Errno.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/Errno.java
@@ -17,7 +17,8 @@ import org.eolang.Phi;
  * <p>libc reports a failure by returning {@code -1} and leaving the real cause
  * in {@code errno}. This object reads {@code errno} straight away through
  * {@link Native#getLastError()}, which JNA captures the instant the native call
- * returns, and turns it into a human-readable message with {@code strerror}.
+ * returns, and turns it into a human-readable message through {@link Strerror},
+ * which keeps the number readable for the {@code errno} syscall that comes next.
  * That is why the wrapper builds it immediately after the call, before any other
  * native call can overwrite the value. On success it stays an empty
  * {@link PhDefault}, exactly what the wrappers put there before.</p>
@@ -44,7 +45,7 @@ final class Errno implements Supplier<Phi> {
         final Phi output;
         if (this.code == -1) {
             output = new Data.ToPhi(
-                CStdLib.INSTANCE.strerror(Native.getLastError())
+                new Strerror(Native.getLastError()).it()
             );
         } else {
             output = new PhDefault();

--- a/eo-runtime/src/main/java/org/eolang/posix/Strerror.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/Strerror.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import com.sun.jna.Native;
+import java.util.function.IntFunction;
+
+/**
+ * The human-readable message of an OS error code, taken without losing the
+ * error the failing call has left behind.
+ *
+ * <p>Looking a message up is a native call of its own, and JNA remembers the
+ * {@code errno} of the call it made last: {@code strerror} therefore overwrites
+ * the very number the program is about to read through {@link ErrnoSyscall}.
+ * It really does — the first lookup in the process makes libc probe the message
+ * catalogs of the current locale, they are not there, and {@code ENOENT} lands
+ * where {@code EEXIST} was. Every later lookup finds the catalog answer cached
+ * and leaves {@code errno} alone, so the loss hits whichever failing call in
+ * the process happens to be the first one, and nobody else. This object reads
+ * the number before the lookup and puts it back after, making the translation
+ * invisible to the program.</p>
+ *
+ * @since 0.75
+ */
+final class Strerror {
+
+    /**
+     * Where a message comes from, by error code.
+     */
+    private final IntFunction<String> messages;
+
+    /**
+     * The code to translate.
+     */
+    private final int errno;
+
+    /**
+     * Ctor.
+     * @param code The code to translate
+     */
+    Strerror(final int code) {
+        this(CStdLib.INSTANCE::strerror, code);
+    }
+
+    /**
+     * Ctor.
+     * @param source Where a message comes from, by error code
+     * @param code The code to translate
+     */
+    Strerror(final IntFunction<String> source, final int code) {
+        this.messages = source;
+        this.errno = code;
+    }
+
+    /**
+     * The message.
+     * @return The error as a human-readable string
+     */
+    String it() {
+        final int last = Native.getLastError();
+        final String result = this.messages.apply(this.errno);
+        Native.setLastError(last);
+        return result;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/posix/StrerrorSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StrerrorSyscall.java
@@ -33,7 +33,7 @@ public final class StrerrorSyscall implements Syscall {
     public Phi make(final Phi... params) {
         final int errno = new Int("the 'errno' argument of strerror", params[0]).it();
         final Phi result = this.posix.take("return").copy();
-        result.put(0, new Data.ToPhi(CStdLib.INSTANCE.strerror(errno)));
+        result.put(0, new Data.ToPhi(new Strerror(errno).it()));
         result.put(1, new PhDefault());
         return result;
     }

--- a/eo-runtime/src/test/java/org/eolang/posix/StrerrorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/StrerrorTest.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import com.sun.jna.Native;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Strerror}.
+ *
+ * <p>The number 17 below is {@code EEXIST}, the error a failing exclusive
+ * creation leaves behind on every platform we support.</p>
+ *
+ * @since 0.75
+ */
+final class StrerrorTest {
+
+    @Test
+    void translatesTheCode() {
+        MatcherAssert.assertThat(
+            "the message of the code asked for must come back",
+            new Strerror(code -> String.format("error #%d", code), 17).it(),
+            Matchers.equalTo("error #17")
+        );
+    }
+
+    @Test
+    void keepsTheLastErrorWhenTheLookupSpoilsIt() {
+        Native.setLastError(17);
+        new Strerror(
+            code -> {
+                Native.setLastError(2);
+                return "spoiled";
+            },
+            17
+        ).it();
+        MatcherAssert.assertThat(
+            "the error of the failing call must survive a lookup that spoils it",
+            Native.getLastError(),
+            Matchers.equalTo(17)
+        );
+    }
+
+    @Test
+    void namesTheErrorThroughTheRealLibrary() {
+        MatcherAssert.assertThat(
+            "libc must name the error",
+            new Strerror(17).it(),
+            Matchers.not(Matchers.emptyString())
+        );
+    }
+
+    @Test
+    void keepsTheLastErrorThroughTheRealLibrary() {
+        Native.setLastError(17);
+        new Strerror(17).it();
+        MatcherAssert.assertThat(
+            "the error of the failing call must survive the lookup in libc",
+            Native.getLastError(),
+            Matchers.equalTo(17)
+        );
+    }
+}


### PR DESCRIPTION
The `codecov` build on `master` ([run 33046736636](https://github.com/objectionary/eo/actions/runs/33046736636/job/98432447936)) failed on one assertion:

```text
EOposixTest.can_report_eexist_when_creating_an_existing_file_exclusively:1269 expected: [true] but was: [false]
```

## What was wrong

`posix.eo` opens `/dev/null` with `O_CREAT|O_EXCL`, which must fail with `EEXIST` (17), and then reads the reason through a second syscall, `posix "errno"`. It read 2 (`ENOENT`) instead.

The syscall wrapper turns a failure into a message right away — `OpenSyscall` builds `Errno`, which calls `strerror`. That lookup is a native call of its own, and JNA remembers the `errno` of the call it made *last*, so the lookup overwrites the very number `ErrnoSyscall` is about to read. It really does overwrite it: the first `strerror` in the process makes libc probe the message catalogs of the current locale, they are not there, and `ENOENT` lands where `EEXIST` was. Every later lookup finds the catalog answer cached and leaves `errno` alone.

Measured with JNA 5.19.1 on `ubuntu-24.04`, opening `/dev/null` exclusively three times in one JVM:

```text
round 0: saved=17 msg=File exists lastError now=2
round 1: saved=17 msg=File exists lastError now=17
round 2: saved=17 msg=File exists lastError now=17
```

So exactly one failing call per JVM lost its reason — whichever came first. That is why the test failed here and passed in the run before, and why the same `master` commit is green in `mvn.yml`: with tests running concurrently, which assertion draws the first lookup is a race.

The same loss reaches production objects, not only this test. `directory.retried`, `directory.made`, and `file.touched` all compare `errno` against `eexist` after a failing exclusive create or `mkdir`; when the number is gone, `directory.retried` raises `Can't create a unique file in %s, OS error 2` instead of trying the next candidate.

## What changed

A new `Strerror` reads the number before the lookup and puts it back after (`Native.setLastError`), making the translation invisible to whatever reads `errno` next. Both callers of `strerror` in the package — `Errno` and `StrerrorSyscall` — go through it, so `socket.eo`, which asks for a message and then keeps going, no longer disturbs the error state either.

`StrerrorTest` covers it: one test hands `Strerror` a lookup that deliberately spoils the last error and asserts it survives (deterministic, whatever the test order), the others check the real libc path and the message itself.

The win32 counterpart reads `errno` live through `Msvcrt._errno()` rather than from JNA's memory, so it is a different path; I left it alone, since I have no Windows runner to confirm anything about it here.

## How it was checked

On `ubuntu-24.04`, JDK 21:

- `mvn -pl eo-runtime test -Dtest=EOposixTest,StrerrorTest,StrerrorSyscallTest,EOdirectoryEOmadeRaceTest,EOmktempTest` — 45 tests, 0 failures, including the assertion that failed in CI.
- With the restore taken back out, `StrerrorTest` fails 2 of its 4 tests — the regression is reproduced, then fixed.
- `mvn -Pqulice -Deo.skip -pl eo-runtime clean process-classes qulice:check` — 233 files against 1014 rules, no complaints.