### PR TITLE
fix(posix): skip the real-libc strerror tests on Windows

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/posix/StrerrorTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/StrerrorTest.java
@@ -8,12 +8,18 @@ import com.sun.jna.Native;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 /**
  * Test case for {@link Strerror}.
  *
  * <p>The number 17 below is {@code EEXIST}, the error a failing exclusive
  * creation leaves behind on every platform we support.</p>
+ *
+ * <p>The tests that go through the real library are off on Windows, where
+ * there is no {@code libc} to load and {@link CStdLib} cannot be built at
+ * all.</p>
  *
  * @since 0.75
  */
@@ -46,6 +52,7 @@ final class StrerrorTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void namesTheErrorThroughTheRealLibrary() {
         MatcherAssert.assertThat(
             "libc must name the error",
@@ -55,6 +62,7 @@ final class StrerrorTest {
     }
 
     @Test
+    @DisabledOnOs(OS.WINDOWS)
     void keepsTheLastErrorThroughTheRealLibrary() {
         Native.setLastError(17);
         new Strerror(17).it();


### PR DESCRIPTION
The Windows build broke in [run 33059001942](https://github.com/objectionary/eo/actions/runs/33059001942/job/98472936263):

```
[ERROR]   StrerrorTest.keepsTheLastErrorThroughTheRealLibrary:60 » UnsatisfiedLink Unable to load library 'c'
[ERROR]   StrerrorTest.namesTheErrorThroughTheRealLibrary:50 » NoClassDefFound Could not initialize class org.eolang.posix.CStdLib
```

`StrerrorTest` came in with a300e579. Two of its four cases construct `new Strerror(17)`, which resolves messages through `CStdLib.INSTANCE`; that constant loads the library named `c`, which Windows does not have, so JNA fails to link and `CStdLib` never initializes.

This turns those two cases off on Windows with `@DisabledOnOs(OS.WINDOWS)` — the same treatment every other syscall-touching test in `org.eolang.posix` already gets (`GettimeofdaySyscallTest`, `WriteSyscallTest`, `RecvSyscallTest`, `SendSyscallTest`, `InetAddrSyscallTest`). The two cases that feed `Strerror` a fake source of messages exercise the errno-preserving logic itself and keep running on every platform, so the behaviour the original commit added stays covered everywhere.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rbduy98kkwgTYSB6SPxGNB)_