### PR TITLE
Say what callers were seen putting into a void

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answer.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answer.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.inference;
 
+import java.util.Collection;
+import java.util.Collections;
+
 /**
  * What one object of the program turns out to be.
  *
@@ -17,6 +20,14 @@ package org.eolang.inference;
  * colours an object green while the printed number counts it among the ones
  * we know nothing about is worse than either alone, and the only way to be
  * sure that cannot happen is for both to read the same answer.</p>
+ *
+ * <p>An object that settled on nothing better than somebody else's void
+ * carries what the program was seen putting into that void as well. It is
+ * evidence and not an answer — the callers of today do not oblige the one
+ * written tomorrow — but a reader told that their object is whatever
+ * {@code Φ.bool.and.x} turns out to be has nowhere to go next, and a reader
+ * told that {@code Φ.true} and {@code Φ.false} have both been put there has.
+ * The rung is untouched by it.</p>
  *
  * @since 0.70.0
  */
@@ -33,6 +44,11 @@ final class Answer {
     private final int climbed;
 
     /**
+     * What the program was seen putting into the void it is rooted at.
+     */
+    private final Collection<Type> witnesses;
+
+    /**
      * Ctor.
      * @param where The object this one settled on, which is the object itself
      *  when the walk went nowhere
@@ -40,8 +56,22 @@ final class Answer {
      *  left to find out
      */
     Answer(final String where, final int rung) {
+        this(where, rung, Collections.emptyList());
+    }
+
+    /**
+     * Ctor.
+     * @param where The object this one settled on, which is the object itself
+     *  when the walk went nowhere
+     * @param rung The rung it stands on, from nothing at all up to nothing
+     *  left to find out
+     * @param seen What the program was seen putting into the void it is
+     *  rooted at, empty when it is rooted at none or nobody fills it
+     */
+    Answer(final String where, final int rung, final Collection<Type> seen) {
         this.settled = where;
         this.climbed = rung;
+        this.witnesses = seen;
     }
 
     /**
@@ -58,5 +88,13 @@ final class Answer {
      */
     int rung() {
         return this.climbed;
+    }
+
+    /**
+     * What the program was seen putting into the void it is rooted at.
+     * @return The types, empty when nobody was seen filling it
+     */
+    Collection<Type> seen() {
+        return this.witnesses;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Answered.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answered.java
@@ -57,7 +57,7 @@ final class Answered {
         final Pairs pairs = new Pairs(new XMLDocument(this.tables.resolve("links.xml")));
         final Answers answers = new Answers(
             new Ungrouped(given, Collections.emptyMap()).rows(),
-            new HashSet<>(given.xpath("//attr[@void='true']/@type")),
+            new Seen(given).all(),
             new HashSet<>(pairs.certain()),
             new Ends(pairs.all()).names()
         );

--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -35,6 +35,12 @@ import java.util.Map;
  * already worked out on the way to the rung. Whoever counts the program and
  * whoever shows it to somebody read the same one.</p>
  *
+ * <p>A name rooted at a void goes back with what {@link Seen} found in that
+ * void besides. Nothing in the walk reads it and no rung moves because of it:
+ * a void filled with a {@code number} at every call site is still a void, and
+ * saying otherwise would turn the habits of today's callers into a promise
+ * nobody made.</p>
+ *
  * @since 0.69.0
  */
 final class Answers {
@@ -45,9 +51,9 @@ final class Answers {
     private final Map<String, Collection<Map<String, String>>> table;
 
     /**
-     * The locator of every void.
+     * Every void, with what the program was seen putting into it.
      */
-    private final Collection<String> hollows;
+    private final Map<String, Collection<Type>> hollows;
 
     /**
      * The objects the table answers by itself.
@@ -63,14 +69,15 @@ final class Answers {
      * Ctor.
      * @param rows The rows of the provides table, by the locator of their
      *  owner, from {@link Ungrouped}
-     * @param voids The locator of every void
+     * @param voids Every void, with what the program was seen putting into
+     *  it, from {@link Seen}
      * @param answered The objects the table answers by itself, from
      *  {@link Pairs}
      * @param names Every chain of copies, walked to its end
      */
     Answers(
         final Map<String, Collection<Map<String, String>>> rows,
-        final Collection<String> voids,
+        final Map<String, Collection<Type>> voids,
         final Collection<String> answered,
         final Map<String, String> names
     ) {
@@ -88,17 +95,18 @@ final class Answers {
      */
     Answer of(final String locator, final int filled) {
         final String end = this.ends.getOrDefault(locator, locator);
-        final int rung;
+        final String root = this.root(end);
+        final Answer found;
         if (this.ground.contains(end)) {
-            rung = 4;
+            found = new Answer(end, 4);
         } else if (this.table.containsKey(end)) {
-            rung = this.depth(end, this.voids(end) - filled);
-        } else if (this.rooted(end)) {
-            rung = 1;
+            found = new Answer(end, this.depth(end, this.voids(end) - filled));
+        } else if (root.isEmpty()) {
+            found = new Answer(end, 0);
         } else {
-            rung = 0;
+            found = new Answer(end, 1, this.hollows.get(root));
         }
-        return new Answer(end, rung);
+        return found;
     }
 
     private int depth(final String type, final int free) {
@@ -133,12 +141,12 @@ final class Answers {
         return found;
     }
 
-    private boolean rooted(final String locator) {
-        boolean found = false;
+    private String root(final String locator) {
+        String found = "";
         String walked = locator;
         while (!walked.isEmpty()) {
-            if (this.hollows.contains(walked)) {
-                found = true;
+            if (this.hollows.containsKey(walked)) {
+                found = walked;
                 break;
             }
             if (!walked.contains(".")) {

--- a/eo-inference/src/main/java/org/eolang/inference/Pieces.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pieces.java
@@ -22,6 +22,12 @@ import org.xembly.Directives;
  * where it can be tested, and leaves the page nothing harder to do than
  * putting a class on a span.</p>
  *
+ * <p>A mark carries what the tables said about every object under it, so that
+ * a reader hovering over a word is told the same thing the tables hold: the
+ * name it goes by, what it settled on, and, where it settled on nothing better
+ * than somebody else's void, what the program was seen putting into that
+ * void.</p>
+ *
  * <p>A chain of dispatches is the awkward case. {@code first.as-bytes.size}
  * is three objects and the XMIR gives all three the same column, because each
  * one is written where the chain ends rather than where it begins. So a chain
@@ -182,10 +188,21 @@ final class Pieces {
                 .attr("label", object.label())
                 .attr("band", Pieces.band(object.answer()))
                 .attr("where", object.answer().where())
-                .attr("loc", object.loc())
-                .up();
+                .attr("loc", object.loc());
+            Pieces.witnessed(dirs, object.answer().seen());
+            dirs.up();
         }
         return dirs.add("text").set(text).up().up();
+    }
+
+    private static void witnessed(final Directives dirs, final Collection<Type> seen) {
+        if (!seen.isEmpty()) {
+            dirs.add("seen");
+            for (final Type witness : seen) {
+                dirs.append(witness.directives());
+            }
+            dirs.up();
+        }
     }
 
     private static String band(final Answer answer) {

--- a/eo-inference/src/main/java/org/eolang/inference/Seen.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Seen.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What callers were seen putting into every void of a program.
+ *
+ * <p>{@link Witnessed} writes this down, void by void, and here it is read
+ * back. A void that nobody fills is still a void and still belongs in the
+ * answer, so every one of them is listed, with an empty choice where the
+ * table says nothing.</p>
+ *
+ * <p>The choice is flattened as it is read. A void filled from one place
+ * carries its type on its own, a void filled from several carries a
+ * {@code union} of them, and to whoever asks what went in the difference
+ * between the two is no difference at all.</p>
+ *
+ * <p>This is evidence and never a contract, exactly as {@link Witnessed}
+ * says: nothing may work out the type of a void from what is read here.
+ * It is read so that a reader who is told an object is whatever
+ * {@code Φ.bool.and.x} turns out to be can also be told what the program was
+ * seen putting there.</p>
+ *
+ * @since 0.70.0
+ */
+final class Seen {
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * Ctor.
+     * @param provides The provides table
+     */
+    Seen(final XML provides) {
+        this.given = provides;
+    }
+
+    /**
+     * What was seen going into every void.
+     * @return The witnesses, by the locator of the void
+     */
+    Map<String, Collection<Type>> all() {
+        final Map<String, Collection<Type>> found = new LinkedHashMap<>(0);
+        for (final XML hollow : this.given.nodes("//attr[@void='true']")) {
+            found.put(hollow.xpath("@type").get(0), Seen.members(hollow));
+        }
+        return found;
+    }
+
+    private static Collection<Type> members(final XML hollow) {
+        final Collection<Type> found = new ArrayList<>(0);
+        for (final String loc : hollow.xpath("witnessed/ref/@loc|witnessed/union/ref/@loc")) {
+            found.add(new Ref(loc));
+        }
+        if (!hollow.nodes("witnessed/data|witnessed/union/data").isEmpty()) {
+            found.add(new Data());
+        }
+        if (!hollow.nodes("witnessed/unknown").isEmpty()) {
+            found.add(new Unknown());
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
@@ -79,12 +79,34 @@ SPDX-License-Identifier: MIT
             <xsl:value-of select="@where"/>
           </code>
           <xsl:text> turns out to be</xsl:text>
+          <xsl:apply-templates select="seen"/>
         </xsl:when>
         <xsl:otherwise>
           <xsl:text> — we know nothing about it</xsl:text>
         </xsl:otherwise>
       </xsl:choose>
     </span>
+  </xsl:template>
+  <xsl:template match="seen">
+    <xsl:text>, and callers were seen putting </xsl:text>
+    <xsl:for-each select="*">
+      <xsl:if test="position() &gt; 1">
+        <xsl:text>, </xsl:text>
+      </xsl:if>
+      <xsl:apply-templates select="."/>
+    </xsl:for-each>
+    <xsl:text> in it</xsl:text>
+  </xsl:template>
+  <xsl:template match="seen/ref">
+    <code>
+      <xsl:value-of select="@loc"/>
+    </code>
+  </xsl:template>
+  <xsl:template match="seen/data">
+    <xsl:text>a datum</xsl:text>
+  </xsl:template>
+  <xsl:template match="seen/unknown">
+    <xsl:text>too many things to name</xsl:text>
   </xsl:template>
   <xsl:template name="style">
     <style>

--- a/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
@@ -31,7 +31,7 @@ final class AnswersTest {
         MatcherAssert.assertThat(
             "a copy of an oak must answer that it is an oak, but it named something else",
             new Answers(
-                rows, Collections.emptyList(), Collections.emptyList(), chain
+                rows, Collections.emptyMap(), Collections.emptyList(), chain
             ).of("Φ.grove.α0", 0).where(),
             Matchers.equalTo("Φ.oak")
         );
@@ -51,7 +51,7 @@ final class AnswersTest {
         MatcherAssert.assertThat(
             "an inc whose void nobody filled cannot be known whole, but it was",
             new Answers(
-                rows, Collections.emptyList(), Collections.emptyList(),
+                rows, Collections.emptyMap(), Collections.emptyList(),
                 Collections.emptyMap()
             ).of("Φ.inc", 0).rung(),
             Matchers.equalTo(2)
@@ -63,7 +63,7 @@ final class AnswersTest {
         MatcherAssert.assertThat(
             "an object no table mentions must answer with itself, but it named something else",
             new Answers(
-                Collections.emptyMap(), Collections.emptyList(),
+                Collections.emptyMap(), Collections.emptyMap(),
                 Collections.emptyList(), Collections.emptyMap()
             ).of("Φ.nowhere", 0).where(),
             Matchers.equalTo("Φ.nowhere")

--- a/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
@@ -86,6 +86,29 @@ final class PiecesTest {
         );
     }
 
+    @Test
+    void saysWhatCallersWereSeenPassing() {
+        MatcherAssert.assertThat(
+            "an amber mark must say what turned up in the void, but it didnt",
+            PiecesTest.drawn(
+                "[if] > bool",
+                Collections.singletonList(
+                    new Written(
+                        "Φ.bool.if", 1, "if",
+                        new Answer(
+                            "Φ.bool.if", 1,
+                            Arrays.asList(new Ref("Φ.true"), new Ref("Φ.false"))
+                        )
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/line/bit/told/seen/ref[@loc='Φ.true']",
+                "/line/bit/told/seen/ref[@loc='Φ.false']"
+            )
+        );
+    }
+
     private static String drawn(final String line, final Collection<Written> written) {
         return new Xembler(
             new Directives()

--- a/eo-inference/src/test/java/org/eolang/inference/SeenTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/SeenTest.java
@@ -1,0 +1,78 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link Seen}.
+ * @since 0.70.0
+ */
+final class SeenTest {
+
+    @Test
+    void readsBackEveryTypeACallerWasSeenPassing() {
+        MatcherAssert.assertThat(
+            "the two types the table witnesses must both come back, but they didnt",
+            new Xembler(
+                SeenTest.drawn(
+                    "<provides><type id='Φ.bool.and'><attr name='x' type='Φ.bool.and.x'",
+                    " void='true'><witnessed><union><ref loc='Φ.true'/>",
+                    "<ref loc='Φ.false'/></union></witnessed></attr></type></provides>"
+                )
+            ).xmlQuietly(),
+            XhtmlMatchers.hasXPaths(
+                "/seen/ref[@loc='Φ.true']",
+                "/seen/ref[@loc='Φ.false']"
+            )
+        );
+    }
+
+    @Test
+    void saysThatADatumWentIn() {
+        MatcherAssert.assertThat(
+            "a void filled with bytes must own up to it, but it didnt",
+            new Xembler(
+                SeenTest.drawn(
+                    "<provides><type id='Φ.bool.and'><attr name='x' type='Φ.bool.and.x'",
+                    " void='true'><witnessed><data/></witnessed></attr></type></provides>"
+                )
+            ).xmlQuietly(),
+            XhtmlMatchers.hasXPath("/seen/data")
+        );
+    }
+
+    @Test
+    void keepsAVoidNobodyFillsInTheAnswer() {
+        MatcherAssert.assertThat(
+            "a void with no witnesses must still be listed, but it was left out",
+            new Seen(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.bool.and'><attr name='x'",
+                        " type='Φ.bool.and.x' void='true'/></type></provides>"
+                    )
+                )
+            ).all(),
+            Matchers.hasKey("Φ.bool.and.x")
+        );
+    }
+
+    private static Directives drawn(final String... lines) {
+        final Directives dirs = new Directives().add("seen");
+        for (final Type witness
+            : new Seen(new XMLDocument(String.join("", lines))).all().get("Φ.bool.and.x")) {
+            dirs.append(witness.directives());
+        }
+        return dirs.up();
+    }
+}


### PR DESCRIPTION
An amber mark on a page names the void an object is waiting on and stops
there. That tells a reader where the answer is missing and nothing at all
about where to go looking for it, which is the wrong half to keep quiet
about: the tables have known the other half all along. `Witnessed` records
what every application puts into every void, and until now nobody read it
back.

`Seen` reads that half of `provides.xml` into the types of each void, and
`Answers` hands them along with a rooted answer:

```java
} else if (root.isEmpty()) {
    found = new Answer(end, 0);
} else {
    found = new Answer(end, 1, this.hollows.get(root));
}
```

So the popover now says `x is whatever Φ.bool.and.x turns out to be, and
callers were seen putting Φ.false, Φ.true, Φ.bool, Φ.bool.and, Φ.number.eq
in it`. A void filled with bytes says "a datum", and one over the cap says
"too many things to name" — the same three shapes the table itself writes.

This is evidence and never a contract, exactly as `Witnessed` says. Nothing
in the walk reads it, no rung moves because of it, and the three bands come
out byte-identical: 50638 objects, 75.6% named, 23.3% rooted at a void, 1.0%
nothing known, depth 65.8%. Of the 10749 amber marks eo-runtime draws, 6222
now carry witnesses.

Closes #7802.
