### PR TITLE
test(#7768): cover the edge cases of Lines.underlined

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -85,6 +86,45 @@ final class LinesTest {
             "the line replaced in the caller's list after construction is not the old one",
             lines.underlined(1, 0, "замена"),
             Matchers.equalTo(String.format("[1:0] error: 'замена'%nстарая%n^"))
+        );
+    }
+
+    @Test
+    void underlinesEmptyLineAtValidNumber() {
+        MatcherAssert.assertThat(
+            "a real empty line is not told apart from a number outside the source",
+            new Lines(List.of(new Span("", 1))).underlined(1, 0, "пусто"),
+            Matchers.equalTo(String.format("[1:0] error: 'пусто'%n%n"))
+        );
+    }
+
+    @Test
+    void keepsMessageBareWhenNumberIsZero() {
+        MatcherAssert.assertThat(
+            "a number below the first line is not answered with the bare message",
+            new Lines(List.of(new Span("привет", 1))).underlined(0, 3, "ноль"),
+            Matchers.equalTo("[0:3] error: 'ноль'")
+        );
+    }
+
+    @Test
+    void quotesLineWithoutCaretWhenPositionIsPastItsEnd() {
+        MatcherAssert.assertThat(
+            "a position past the end of the line is not quoted with no caret beneath it",
+            new Lines(List.of(new Span("привет", 1))).underlined(1, 10, "хвост"),
+            Matchers.equalTo(String.format("[1:10] error: 'хвост'%nпривет%n"))
+        );
+    }
+
+    @Test
+    void rejectsNullSpanAtValidNumber() {
+        final List<Span> source = new ArrayList<>(2);
+        source.add(new Span("альфа", 1));
+        source.add(null);
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new Lines(source).underlined(2, 0, "дыра"),
+            "a null span at a valid number is not refused with an exception"
         );
     }
 }


### PR DESCRIPTION
Closes #7768

The defect this issue described is already gone from `master`. `Lines.line()` used `Optional.ofNullable(...).orElse("")`, which folded a null `Text` at a valid index and an out-of-range index into the same `""`. Three merged commits removed that code entirely: #7771 folded the underlining into `Lines` and deleted the `line()` getter, #7769 changed the source from `List<Text>` to `List<Span>`, and #7772 made the constructor copy the caller's list.

What `master` does now is exactly what the issue asked for. `underlined()` reads `this.source.get(number - 1).text()` directly, so a null element surfaces as a `NullPointerException` instead of being swallowed, and an out-of-range number returns the bare message while a real empty line returns the message with the (empty) line quoted beneath it — the two are no longer indistinguishable.

So instead of a fix that no longer has anything to fix, this PR pins the behaviour down with edge cases that were not covered before:

- `underlinesEmptyLineAtValidNumber` — a genuinely empty line at a valid number is quoted, which is what tells it apart from an out-of-range number. This is the ambiguity the issue was about.
- `keepsMessageBareWhenNumberIsZero` — the lower arm of the range check; only the upper arm was tested.
- `quotesLineWithoutCaretWhenPositionIsPastItsEnd` — the line is still quoted but no caret is drawn.
- `rejectsNullSpanAtValidNumber` — a null element raises `NullPointerException` rather than folding into an empty line.

No production code is touched.
