### PR TITLE
Write the inference pages where a person looks for them

### DIFF
--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -103,16 +103,18 @@ mark says what the tables hold about it, and an amber one names what the
 program was seen putting into the void besides.
 
 Off by default, since the tables are what the compiler needs and the pages are
-for a person:
+for a person. The goal runs in whichever module uses the plugin, so this is
+the shortest way to the pages of eo-runtime:
 
 ```bash
-mvn install -Deo.inferenceReport
+mvn -pl eo-runtime process-sources -Deo.inferenceReport
+open eo-runtime/target/site/inference/index.html
 ```
 
-The pages land in `target/site/inference/`, beside the coverage report and
-every other generated page a person opens. They are not written into
-`target/eo/`, which is the compiler's scratch space, however much the tables
-they are made from live there.
+They land in the `target/site/inference/` of the module they describe, beside
+the coverage report and every other generated page a person opens. They are
+not written into `target/eo/`, which is the compiler's scratch space, however
+much the tables they are made from live there.
 
 A property and not a profile, though coverage next door is turned on with
 `-Pjacoco`. A profile is what you need to add an execution to a build, and

--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -93,6 +93,32 @@ empty row for every object would leave all four exactly where they are:
   9728  nothing left to find out
 ```
 
+## What it draws
+
+The three numbers say how much of a program we understand without saying which
+part. A page per source file says both, with the author's own source on it and
+a mark on every object: green where we can name the formation, amber where the
+answer is somebody else's void, red where there is nothing. Hovering over a
+mark says what the tables hold about it, and an amber one names what the
+program was seen putting into the void besides.
+
+Off by default, since the tables are what the compiler needs and the pages are
+for a person:
+
+```bash
+mvn install -Deo.inferenceReport
+```
+
+The pages land in `target/site/inference/`, beside the coverage report and
+every other generated page a person opens. They are not written into
+`target/eo/`, which is the compiler's scratch space, however much the tables
+they are made from live there.
+
+A property and not a profile, though coverage next door is turned on with
+`-Pjacoco`. A profile is what you need to add an execution to a build, and
+there is nothing to add here: the goal already runs, and one flag decides
+whether it writes.
+
 ## How it works
 
 Every rule is a `Clue`: it reads the program and writes down one kind of fact.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -13,6 +13,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -43,6 +44,12 @@ import org.eolang.parser.TrFull;
  * dictionary to be read: a row saying that {@code Φ.app.t.next} has nothing
  * means something to a human as it stands. It also makes the tables of many
  * files one table, since no two files can name the same locator.</p>
+ *
+ * <p>The pages a reader looks at go nowhere near those three directories.
+ * They are written under {@code target/site}, beside the coverage report and
+ * every other generated page a person opens, because {@code target/eo} is the
+ * compiler's scratch space — a numbered pipeline of intermediate XMIR nobody
+ * opens on purpose — and a thing meant to be opened does not belong in it.</p>
  *
  * <p>Two things happen to a file before any rule looks at it. First, every
  * composite base is split into one object per dispatch step: the parser rolls
@@ -75,9 +82,10 @@ final class Inferring implements Step {
     private final Path tables;
 
     /**
-     * Whether to write the pages a reader looks at, beside the tables.
+     * The directory for the pages a reader looks at, empty when nobody asked
+     * for them.
      */
-    private final boolean shown;
+    private final Path pages;
 
     /**
      * Ctor.
@@ -87,7 +95,7 @@ final class Inferring implements Step {
      * @param rows The directory for the tables
      */
     Inferring(final Path parsed, final Path pre, final Path rows) {
-        this(parsed, pre, rows, false);
+        this(parsed, pre, rows, Paths.get(""));
     }
 
     /**
@@ -96,13 +104,14 @@ final class Inferring implements Step {
      *  after its canonical pipeline (see {@code org.eolang.parser.Canonical})
      * @param pre The directory for the prepared XMIR files
      * @param rows The directory for the tables
-     * @param report Whether to write the pages a reader looks at
+     * @param site The directory for the pages a reader looks at, empty when
+     *  nobody asked for them
      */
-    Inferring(final Path parsed, final Path pre, final Path rows, final boolean report) {
+    Inferring(final Path parsed, final Path pre, final Path rows, final Path site) {
         this.input = parsed;
         this.prepared = pre;
         this.tables = rows;
-        this.shown = report;
+        this.pages = site;
     }
 
     @Override
@@ -117,11 +126,10 @@ final class Inferring implements Step {
                 ready, this.tables
             );
             this.measured();
-            if (this.shown) {
-                final Path pages = this.tables.resolve("report");
+            if (!this.pages.toString().isEmpty()) {
                 Logger.info(
                     this, "Wrote %d page(s) to look at, they are in %[file]s",
-                    new Report(this.prepared, this.tables).written(pages), pages
+                    new Report(this.prepared, this.tables).written(this.pages), this.pages
                 );
             }
         } else {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
@@ -6,6 +6,8 @@ package org.eolang.maven;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -40,7 +42,9 @@ import org.apache.maven.plugins.annotations.Parameter;
  *
  * <p>The XMIR prepared for the rules is saved in {@link #prepared} and the
  * tables in {@link #tables}, a document each. Not one of them fails the
- * build.</p>
+ * build. The pages a reader opens are not part of that scratch space and go
+ * to {@link #pages}, under {@code target/site}, where the coverage report
+ * already is.</p>
  *
  * @since 0.67.0
  */
@@ -76,10 +80,23 @@ public final class MjInference extends MjSafe {
      *
      * <p>Off by default. The tables are what the compiler needs and the pages
      * are for a person, so they are written when somebody asks and not on
-     * every build.</p>
+     * every build. A property rather than a profile, though coverage next
+     * door is reached for with {@code -Pjacoco}: a profile is what you need
+     * to add an execution to a build, and there is nothing to add here — the
+     * goal already runs and one flag decides whether it writes.</p>
      */
     @Parameter(property = "eo.inferenceReport", required = true, defaultValue = "false")
     private boolean report;
+
+    /**
+     * The directory where the pages are written.
+     */
+    @Parameter(
+        property = "eo.inferenceReportDir",
+        required = true,
+        defaultValue = "${project.build.directory}/site/inference"
+    )
+    private File pages;
 
     /**
      * Ctor.
@@ -95,8 +112,18 @@ public final class MjInference extends MjSafe {
                 this.targetDir.toPath().resolve(Parsing.DIR),
                 this.prepared.toPath(),
                 this.tables.toPath(),
-                this.report
+                this.wanted()
             )
         ).exec();
+    }
+
+    private Path wanted() {
+        final Path found;
+        if (this.report) {
+            found = this.pages.toPath();
+        } else {
+            found = Paths.get("");
+        }
+        return found;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -125,6 +125,43 @@ final class InferringTest {
     }
 
     @Test
+    void writesThePagesWhereItIsTold(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("plot")).resolve("shrub.xmir"),
+            new EoSyntax(
+                String.join(System.lineSeparator(), "[] > shrub", "  [] > twig", "")
+            ).parsed().toString()
+        );
+        new Inferring(
+            temp.resolve("plot"), temp.resolve("pre"), temp.resolve("rows"),
+            temp.resolve("site").resolve("inference")
+        ).exec();
+        MatcherAssert.assertThat(
+            "the pages must land in the directory they were given, but they went elsewhere",
+            Files.exists(
+                temp.resolve("site").resolve("inference").resolve("index.html")
+            ),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void writesNoPagesWhenNobodyAsksForThem(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("plot")).resolve("fern.xmir"),
+            new EoSyntax(
+                String.join(System.lineSeparator(), "[] > fern", "  [] > frond", "")
+            ).parsed().toString()
+        );
+        new Inferring(temp.resolve("plot"), temp.resolve("pre"), temp.resolve("rows")).exec();
+        MatcherAssert.assertThat(
+            "a build nobody asked a report of must write no pages, but it wrote some",
+            Files.exists(temp.resolve("rows").resolve("report")),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void keepsFoldersOfProgram(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("tree").resolve("one")).resolve("leaf.xmir"),


### PR DESCRIPTION
The report was written to `target/eo/6-inference/report/`, beside the tables
it is made from. That was the obvious spot while it was being built, but
`target/eo/` is the compiler's scratch space — a numbered pipeline of
intermediate XMIR nobody opens on purpose — and a thing meant to be opened
belongs where the other things meant to be opened are.

It now goes to `target/site/inference/`, beside the coverage report, named by
a new `eo.inferenceReportDir` on `MjInference`. `Inferring` takes the
directory instead of a flag, with an empty path standing for nobody having
asked:

```java
if (!this.pages.toString().isEmpty()) {
    Logger.info(
        this, "Wrote %d page(s) to look at, they are in %[file]s",
        new Report(this.prepared, this.tables).written(this.pages), this.pages
    );
}
```

On the question the issue asked to settle: turning it on stays a **property**
and does not become a profile. A profile is what you need in order to add an
execution to a build, and there is nothing to add here — the goal already
runs, and one flag decides whether it writes. `mvn install -Deo.inferenceReport`
is the whole of it.

The eo-inference README now has a section on the report — what it draws, how
to turn it on, where it lands, and why it is a property — which it did not
have before.

Verified against a full eo-runtime build: `Wrote 171 page(s) to look at, they
are in eo-runtime/target/site/inference`, and `target/eo/6-inference/` is back
to the three tables and nothing else.

Closes #7801.
