### PR TITLE
Let the fast job report that there is nothing to run

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -67,7 +67,13 @@ jobs:
                   fi
                 done \
               | paste -sd, -
-          )
+          ) || true
+          # The `|| true` is what lets the guard below run at all. A step
+          # script runs under `-e -o pipefail`, so a branch that touches no
+          # `.eo` file leaves `grep` with nothing to match, `grep` exits 1,
+          # the pipeline inherits it and the assignment dies before anything
+          # reads `classes`. On the left of `||` the status is nobody's
+          # business and `classes` simply comes out empty.
           if [ -z "${classes}" ]; then
             echo 'This branch touches no .eo file that owns tests, nothing to run'
           else


### PR DESCRIPTION
Both legs of the `fast` matrix die within seconds on any branch that changes
no `.eo` file. A step script runs under `bash -e -o pipefail`, so `grep` finds
nothing to match, exits 1, the pipeline inherits it and the assignment dies —
before the guard written for exactly that case gets to run. The branches that
need least from this job were the only ones it refused.

```bash
    | paste -sd, -
) || true
```

On the left of `||` the status is nobody's business, `classes` comes out
empty, and the `if [ -z ... ]` below says so out loud. A comment beside it
explains why the `|| true` is load-bearing, so nobody tidies it away later.

Checked by running the step's own script against an empty diff, with and
without the change:

```text
--- OLD (master today), empty diff ---
exit=1
--- NEW (this branch), empty diff ---
This branch touches no .eo file that owns tests, nothing to run
exit=0
```

A range that does touch `.eo` files still comes out with its classes
(`EOboolTest,EObufferTest,EObytesTest,...`), so nothing is swallowed that
was being found before. `actionlint` is clean.

Closes #7807.
