### PR TITLE
Carry the deadline's interrupt over to the watched test body

### DIFF
--- a/.github/workflows/ec2.yml
+++ b/.github/workflows/ec2.yml
@@ -64,7 +64,7 @@ jobs:
       - uses: JesseTG/rm@v1.0.3
         with:
           path: ~/.m2/repository/org/eolang
-      - run: mvn -ntp --errors --batch-mode '-Deo.coverageTracking=true' '-Deo.deadline=120' '-Deo.eo.maxmem=4G' '-Dheap-size=48G' -Psite -Pjacoco clean install site
+      - run: mvn -ntp --errors --batch-mode '-Deo.coverageTracking=true' '-Deo.deadline=120' '-Deo.maxmem=4G' '-Dheap-size=48G' -Psite -Pjacoco clean install site
   terminate-instance:
     needs:
       - start-instance

--- a/eo-runtime/src/test/java/org/eolang/Watched.java
+++ b/eo-runtime/src/test/java/org/eolang/Watched.java
@@ -28,6 +28,16 @@ import org.opentest4j.TestAbortedException;
  * fails the test with its own problem, whatever it ate: a broken test is
  * worth more than a tidy skip.</p>
  *
+ * <p>The watching thread is the one JUnit runs the test on, so it is also
+ * the one JUnit interrupts when the test outlives {@code eo.deadline}: the
+ * timeout of a test is scheduled against the thread that enters the
+ * interceptor, not against the thread the body ends up on. That interrupt
+ * therefore has to be carried over to the group by hand. Without it the
+ * deadline stops watching and nothing else, the body is left running on a
+ * thread nobody waits for any more, and a suite where many tests outlive
+ * their second ends up with as many runaway threads, all of them
+ * allocating, until the heap is gone.</p>
+ *
  * <p>The test itself is reported as skipped rather than as failed, for the
  * same reason {@link Deadline} reports a slow one as skipped: a budget that
  * a box with more memory would never have reached says nothing about the
@@ -89,7 +99,7 @@ final class Watched {
         }
     }
 
-    // @checkstyle IllegalThrowsCheck (30 lines)
+    // @checkstyle IllegalThrowsCheck (37 lines)
     private void guarded(final InvocationInterceptor.Invocation<Void> body) throws Throwable {
         final ThreadGroup group = new ThreadGroup(
             String.format("maxmem-%d", Watched.COUNT.incrementAndGet())
@@ -104,11 +114,16 @@ final class Watched {
         thread.setDaemon(true);
         thread.start();
         boolean over = false;
-        while (!done.await(Watched.TICK, TimeUnit.MILLISECONDS)) {
-            if (consumed.bytes() > this.limit) {
-                over = true;
-                break;
+        try {
+            while (!done.await(Watched.TICK, TimeUnit.MILLISECONDS)) {
+                if (consumed.bytes() > this.limit) {
+                    over = true;
+                    break;
+                }
             }
+        } catch (final InterruptedException ex) {
+            group.interrupt();
+            throw ex;
         }
         if (over) {
             group.interrupt();

--- a/eo-runtime/src/test/java/org/eolang/WatchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/WatchedTest.java
@@ -29,6 +29,15 @@ final class WatchedTest {
     }
 
     @Test
+    void stopsBodyWhenTheWatcherIsInterrupted() {
+        MatcherAssert.assertThat(
+            "A body must be stopped when the thread watching it is interrupted, but it wasnt",
+            WatchedTest.interrupted(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
     void skipsBodyThatAteTooMuchAndFinished() {
         Assertions.assertThrows(
             TestAbortedException.class,
@@ -96,6 +105,33 @@ final class WatchedTest {
         return WatchedTest.awaited(stopped);
     }
 
+    private static boolean interrupted() {
+        final AtomicBoolean stopped = new AtomicBoolean(false);
+        final Thread watcher = Thread.currentThread();
+        final Thread bell = new Thread(
+            () -> {
+                WatchedTest.nap();
+                watcher.interrupt();
+            }
+        );
+        bell.setDaemon(true);
+        bell.start();
+        Assertions.assertThrows(
+            InterruptedException.class,
+            () -> new Watched(64L * 1024L * 1024L).through(
+                () -> {
+                    while (!Thread.currentThread().isInterrupted()) {
+                        WatchedTest.rest();
+                    }
+                    stopped.set(true);
+                    return null;
+                }
+            ),
+            "The interrupt of the watching thread must be reported, but it wasnt"
+        );
+        return WatchedTest.awaited(stopped);
+    }
+
     private static Thread where(final long limit) {
         final AtomicReference<Thread> ran = new AtomicReference<>();
         Assertions.assertDoesNotThrow(
@@ -108,6 +144,14 @@ final class WatchedTest {
             "A body that eats almost nothing must not be touched, but it was"
         );
         return ran.get();
+    }
+
+    private static void nap() {
+        try {
+            Thread.sleep(100L);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
     }
 
     private static void rest() {


### PR DESCRIPTION
Fixes the `codecov` build failure in [run 33072282426](https://github.com/objectionary/eo/actions/runs/33072282426/job/98517406290).

## What broke

`mvn install -Deo.coverageTracking=true` on `master` stopped after 338 of ~2600 tests with:

```
Exception in thread "pool-1-thread-2" java.lang.OutOfMemoryError: Java heap space
[ERROR]   TestEngine with ID 'junit-jupiter' failed to execute tests
```

The `OutOfMemoryError` took the whole engine down, which is why the tail of the log is a wall of
`RunListenerAdapter ... this.testPlan is null` — collateral from the launcher having already finished
while the ForkJoin workers kept reporting.

## Why

`Maxmem` (the `eo.maxmem` interceptor added in #7788, switched on with `256M` in ce487e66) runs every
test body on a thread of its own, inside a group of its own, and then waits for that thread on the
thread JUnit called the interceptor on:

```java
thread.start();
while (!done.await(Watched.TICK, TimeUnit.MILLISECONDS)) { ... }
```

A test's deadline is scheduled against the thread that *enters* the interceptor, not against the
thread the body ends up on — `SeparateThreadTimeoutInvocation` (this repo sets
`junit.jupiter.execution.timeout.thread.mode.default = SEPARATE_THREAD`) cancels the future of the
thread it started, and that thread is the waiter above. So when a test outlived its
`eo.deadline` second:

* the waiter left `done.await` with an `InterruptedException`, JUnit turned it into a
  `TimeoutException`, `Deadline` turned that into an abort, and the test was reported as skipped —
  all of which looked right;
* the body thread was never touched. It kept computing on a thread nobody was waiting for any more.

That run skipped 110 tests before it died; a healthy full run skips 522. Each one left a runaway
daemon thread behind, all of them allocating, until the 8G heap was gone.

## The fix

`Watched` now hands the interrupt to the group before it gives up on the wait, so the body stops at
its next attribute lookup through `ExInterrupted` — exactly what already happens when a test eats
more than `eo.maxmem`:

```java
} catch (final InterruptedException ex) {
    group.interrupt();
    throw ex;
}
```

Nothing else changes: the test is still reported as skipped, with the same message, on the same path.

Also in this PR: `ec2.yml` passed `-Deo.eo.maxmem=4G`, which sets a property nobody reads and left
that job on the `256M` default. It now passes `-Deo.maxmem=4G`.

## Checks

A throwaway probe test (a body that loops until interrupted, plus a `@Timeout(30)` observer that
reports on it 5s later), run with `-Deo.deadline=1 -Deo.maxmem=256M`:

| | verdict |
| --- | --- |
| before | `stopped=false, ticks=3573 -> 4471` — the body was still running 4s after being skipped |
| after | `PROBE leaking body stopped at 897 ticks` / `stopped=true, ticks=897 -> 897` |

The full module, `mvn test -pl :eo-runtime -Deo.coverageTracking=true`:

* before: the engine died mid-run, `OutOfMemoryError`, 338 tests reported;
* after: the engine ran to the end — `Tests run: 2613, Failures: 1, Errors: 10, Skipped: 522`, no
  `OutOfMemoryError` anywhere in the log.

The one failure and ten errors left are artifacts of the sandbox I ran in, not of this change:
`MainTest.printsVersion` picks up the container's `JAVA_TOOL_OPTIONS` banner on stdout, and the ten
`SyscallTest` errors are `ephpo` finding no free TCP port in `20000-29999`.

`WatchedTest` gains `stopsBodyWhenTheWatcherIsInterrupted`, which interrupts the watching thread by
hand and asserts the body stops; the class passes 6/6. `mvn -Pqulice -pl :eo-runtime qulice:check`
passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2cs47MwSLGzA3Dk9ExssY


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2cs47MwSLGzA3Dk9ExssY)_