### PR TITLE
Fix Listing docblock: Xembly doesn't refuse U+FFFE/U+FFFF

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -16,16 +16,23 @@ import org.xembly.Directives;
  *
  * <p>The text is set as is, without any manual escaping: the XML writer
  * escapes it exactly once, so the text value of {@code /object/listing}
- * equals the source. The characters of the XML 1.1 restricted set are
- * dropped first, because {@link Directives#set(Object)} refuses them and
- * throws, whatever version the writer emits later.</p>
+ * equals the source. A few characters are dropped first, for two
+ * different reasons. The XML 1.1 restricted set — {@code 0x00-0x08},
+ * {@code 0x0B-0x0C}, {@code 0x0E-0x1F}, {@code 0x7F-0x84} and
+ * {@code 0x86-0x9F} — goes because {@link Directives#set(Object)}
+ * refuses those and throws, whatever version the writer emits later.
+ * {@code U+FFFE} and {@code U+FFFF} go because they are not XML
+ * characters at all and would make the document not well-formed;
+ * Xembly says nothing about them.</p>
  *
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
 
     /**
-     * Characters that Xembly refuses to put inside an XML text node.
+     * Characters that must not reach an XML text node: the XML 1.1
+     * restricted set, which Xembly refuses, plus {@code U+FFFE} and
+     * {@code U+FFFF}, which are not XML characters.
      */
     private static final Pattern FORBIDDEN = Pattern.compile(
         "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"


### PR DESCRIPTION
The class docblock and the `FORBIDDEN` field comment in `Listing.java` attributed the whole restricted-character set — including `U+FFFE` and `U+FFFF` — to `Directives#set(Object)` refusing them and throwing.

That's only true for the XML 1.1 restricted set (`0x00-0x08`, `0x0B-0x0C`, `0x0E-0x1F`, `0x7F-0x84`, `0x86-0x9F`), which is exactly what Xembly's `Arg.legal` checks. `U+FFFE` and `U+FFFF` aren't in that check at all; they're dropped separately because they aren't valid XML characters and would make the emitted document not well-formed.

This updates both comments to say so, so a reader chasing "why does Xembly refuse `U+FFFE`" isn't sent down the wrong path.

No behavioral change — comment-only.