### PR TITLE
One rest() for every nap WatchedTest takes

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/WatchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/WatchedTest.java
@@ -94,7 +94,7 @@ final class WatchedTest {
                     final byte[][] junk = new byte[1][];
                     while (!Thread.currentThread().isInterrupted()) {
                         junk[0] = new byte[256 * 1024];
-                        WatchedTest.rest();
+                        WatchedTest.rest(1L);
                     }
                     stopped.set(true);
                     return null;
@@ -110,7 +110,7 @@ final class WatchedTest {
         final Thread watcher = Thread.currentThread();
         final Thread bell = new Thread(
             () -> {
-                WatchedTest.nap();
+                WatchedTest.rest(100L);
                 watcher.interrupt();
             }
         );
@@ -121,7 +121,7 @@ final class WatchedTest {
             () -> new Watched(64L * 1024L * 1024L).through(
                 () -> {
                     while (!Thread.currentThread().isInterrupted()) {
-                        WatchedTest.rest();
+                        WatchedTest.rest(1L);
                     }
                     stopped.set(true);
                     return null;
@@ -146,17 +146,9 @@ final class WatchedTest {
         return ran.get();
     }
 
-    private static void nap() {
+    private static void rest(final long millis) {
         try {
-            Thread.sleep(100L);
-        } catch (final InterruptedException ex) {
-            Thread.currentThread().interrupt();
-        }
-    }
-
-    private static void rest() {
-        try {
-            Thread.sleep(1L);
+            Thread.sleep(millis);
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
         }
@@ -165,7 +157,7 @@ final class WatchedTest {
     private static boolean awaited(final AtomicBoolean flag) {
         final long deadline = System.currentTimeMillis() + 500L;
         while (!flag.get() && System.currentTimeMillis() < deadline) {
-            WatchedTest.rest();
+            WatchedTest.rest(1L);
         }
         return flag.get();
     }


### PR DESCRIPTION
A follow-up to #7816, which merged before this landed on the branch.

The test #7816 added to `WatchedTest` needed a longer sleep than the file's `rest()` helper gave it,
and took a second copy of the same `try { Thread.sleep } catch { interrupt }` to get it. The helper
now takes the milliseconds instead, so there is one of them again — and the `statics` count the
`counts` job reported on #7816 goes back down by one.

Test-only, no production code touched, no behaviour changed.

## Checks

* `mvn test -pl :eo-runtime -Dtest=WatchedTest,MaxmemTest,ConsumedTest` — 20/20, `WatchedTest` 6/6.
* `mvn -Pqulice -pl :eo-runtime qulice:check` — passes.

Both run on this branch rebased onto the current `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2cs47MwSLGzA3Dk9ExssY


---
_Generated by [Claude Code](https://claude.ai/code/session_01V2cs47MwSLGzA3Dk9ExssY)_