### PR TITLE
Read error lines off the spans Source already made

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -7,7 +7,6 @@ package org.eolang.parser;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.regex.Pattern;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -40,12 +39,6 @@ import org.xembly.Directives;
  * @since 0.1
  */
 final class Emit {
-
-    /**
-     * Pre-compiled line-break splitter for the source text passed to
-     * the {@link #Emit(String)} constructor.
-     */
-    private static final Pattern EOL = Pattern.compile("\\R");
 
     /**
      * Flat list of directives, appended in source order.
@@ -93,26 +86,19 @@ final class Emit {
      * Ctor.
      */
     Emit() {
-        this(new Lines(List.of()));
-    }
-
-    /**
-     * Ctor.
-     * @param source Raw EO source text (for caret-underlined error
-     *  messages — pass empty string to disable)
-     */
-    Emit(final String source) {
-        this(new Lines(List.of(Emit.EOL.split(source, -1))));
+        this(List.of());
     }
 
     /**
      * Primary ctor.
-     * @param src The source in lines
+     * @param source The source lines {@link Source} split off the text
+     *  being parsed (for caret-underlined error messages — pass an
+     *  empty list to disable)
      */
-    private Emit(final Lines src) {
+    Emit(final List<Span> source) {
         this.signature = "";
         this.sink = new ArrayList<>(0);
-        this.lines = src;
+        this.lines = new Lines(source);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -69,13 +69,13 @@ final class Eo implements Iterable<Directive> {
      */
     Iterable<Directive> directives() {
         final Globals globals = new Globals();
-        final Emit emit = new Emit(this.source);
+        final java.util.List<Span> spans = new java.util.ArrayList<>(Eo.SPANS_CAPACITY);
+        new Source(this.source).forEach(spans::add);
+        final Emit emit = new Emit(spans);
         final Stack stack = new Stack(
             (level, naming) -> Eo.checkOnClose(level, emit, naming),
             parent -> Eo.beforeChild(parent, emit)
         );
-        final java.util.List<Span> spans = new java.util.ArrayList<>(Eo.SPANS_CAPACITY);
-        new Source(this.source).forEach(spans::add);
         final Recovery recovery = new Recovery(spans);
         int idx = 0;
         while (idx < spans.size()) {

--- a/eo-parser/src/main/java/org/eolang/parser/Lines.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Lines.java
@@ -9,6 +9,11 @@ import java.util.List;
 /**
  * The source in lines, which points at the place where a parse error
  * was found by quoting the offending line under the message.
+ *
+ * <p>The lines are the {@link Span} objects {@link Source} already
+ * produced for the same text, in source order and numbered from 1, so
+ * the span of line N sits at index N-1 and carries that line's text.</p>
+ *
  * @since 0.50
  */
 final class Lines {
@@ -16,13 +21,13 @@ final class Lines {
     /**
      * The source.
      */
-    private final List<String> source;
+    private final List<Span> source;
 
     /**
      * Ctor.
      * @param lines The source in lines
      */
-    Lines(final List<String> lines) {
+    Lines(final List<Span> lines) {
         this.source = lines;
     }
 
@@ -42,7 +47,7 @@ final class Lines {
             result = String.format(
                 "%s%n%s",
                 located,
-                new MsgUnderlined(this.source.get(number - 1), pos, 1).formatted()
+                new MsgUnderlined(this.source.get(number - 1).text(), pos, 1).formatted()
             );
         }
         return result;

--- a/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LinesTest.java
@@ -19,7 +19,8 @@ final class LinesTest {
     void underlinesTheOffendingLine() {
         MatcherAssert.assertThat(
             "the line at the given number is not quoted with a caret under its position",
-            new Lines(List.of("привет мир", "второй")).underlined(1, 7, "боль"),
+            new Lines(List.of(new Span("привет мир", 1), new Span("второй", 2)))
+                .underlined(1, 7, "боль"),
             Matchers.equalTo(String.format("[1:7] error: 'боль'%nпривет мир%n       ^"))
         );
     }
@@ -28,7 +29,7 @@ final class LinesTest {
     void keepsMessageBareWhenLineIsUnknown() {
         MatcherAssert.assertThat(
             "a number past the end of the source is not answered with the bare message",
-            new Lines(List.of("")).underlined(9, 2, "ошибка"),
+            new Lines(List.of(new Span("", 1))).underlined(9, 2, "ошибка"),
             Matchers.equalTo("[9:2] error: 'ошибка'")
         );
     }


### PR DESCRIPTION
`Eo.directives()` was splitting the same source text into numbered lines twice. Once through `new Emit(this.source)`, which ran a `\R` regex over the raw string and stuffed the pieces into a `List<String>` that `Lines` held for error underlining. And once through `new Source(this.source)`, which produced the `Span` objects the walk itself consumes, each already carrying its own line text and 1-based number. Two stores of the same thing, built by two different splitters, and they didn't even agree at the edges: the regex kept a trailing empty line that `Source` drops, so on a file ending in a newline the two disagreed about how many lines the file had.

The walk now builds its spans first and hands that list to `Emit`, which passes it straight to `Lines`. `Lines` reads each line off `Span.text()` instead of keeping a parallel copy. That deletes the `\R` pattern, the `Emit(String)` constructor, and the private `Emit(Lines)` funnel that only existed to let those two constructors share a body — `Source` is now the single place that decides where a line ends.

Rendering is untouched. I ran the parser over eight sources covering LF, CRLF, files with and without a trailing newline, and errors on the last line, and diffed the emitted XMIR against the same probe built from `master`: byte-identical. `LinesTest` still passes with its spans built as `Span` rather than raw strings.

Closes #7769
