### PR TITLE
Replace the `failure` object with the `I` glyph

### DIFF
--- a/eo-runtime/src/main/eo/number/as-decimal.eo
+++ b/eo-runtime/src/main/eo/number/as-decimal.eo
@@ -53,10 +53,7 @@
               digits m
               "-".as-bytes.concat
                 digits m
-            |
-              as-i64.
-                n.times -1
-                T message > [message] >> failure
+            | ((n.times -1).as-i64 I)
             [^ n] >> digits
               if. > @
                 n.lt ^.ten
@@ -66,11 +63,11 @@
                   ^.digits q
                   as-char.
                     plus. (n.minus (q.times ^.ten)).as-number 48
-              n.div ^.ten failure > bits!
+              n.div ^.ten I > bits!
               i64 bits > q
-            | (n.as-i64 failure)
+            | (n.as-i64 I)
   ^ > n
-  10.as-i64 failure > ten!
+  10.as-i64 I > ten!
   n.abs.floor > truncated
 
   eq. ++> can-drop-the-sign-of-a-negative-below-one

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -111,7 +111,6 @@
           minus.
             code from
             48
-  T message > [message] >> failure
   if. > [^ i] >> flags-end
     i.gte
       number span
@@ -179,7 +178,7 @@
           truncated.
             string text
             number ^.precision
-            failure
+            I
           text
       |
         seq *
@@ -211,7 +210,7 @@
             precise.as-bool.if
               number precision
               6
-            failure
+            I
           if.
             78-.eq conv
             capped (bytes datum).as-hex
@@ -242,7 +241,7 @@
       padded-zeros.
         string value
         number width
-        failure
+        I
     positional.as-bool.if > flags!
       as-number.
         plus.
@@ -280,7 +279,7 @@
           string value
           number width
           " "
-          failure
+          I
       zero.as-bool.if
         filled
         as-bytes.
@@ -288,7 +287,7 @@
             string value
             number width
             " "
-            failure
+            I
     and. > positional!
       gt.
         number dollar


### PR DESCRIPTION
`printf.eo` and `as-decimal.eo` both carried a hand-made one-attribute
formation:

```eo
T message > [message] >> failure
```

It existed only to sit in the fallback position of `truncated`, `padded-left`,
`padded-right`, `padded-zeros`, `as-fixed`, `as-i64` and `div`, so the built-in
`I` glyph now goes there instead and the object is gone.

Every one of those fallbacks is unreachable from `printf` and `as-decimal`:
widths and precisions come out of `digits-value`, which only ever yields a
finite non-negative integer, and the magnitudes handed to `as-i64` are
range-checked against `2^63` before the conversion. So the two objects differ
only in what would happen on a branch neither one takes — `failure` terminated
with the message, `I` hands the message back — and `printf` and `as-decimal`
format exactly as before.

In `as-decimal.eo` the canonical formatter collapsed the vertical `as-i64.`
application into `| ((n.times -1).as-i64 I)`, since it now fits on one line.

Follow-up: objectionary/lints#1317 asks for a lint that catches such hand-made
identity objects and suggests `I`.