### PR TITLE
Publish the inference report to gh-pages

### DIFF
--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: inference
+run-name: "inference report publication"
+'on':
+  push:
+    tags:
+      - '*'
+  workflow_dispatch:
+concurrency:
+  group: inference-${{ github.ref }}
+  cancel-in-progress: false
+jobs:
+  inference:
+    if: github.repository_owner == 'objectionary'
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'temurin'
+          java-version: 26
+      - uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk-26-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-26-maven-
+      - uses: JesseTG/rm@v1.0.3
+        with:
+          path: ~/.m2/repository/org/eolang
+      # One pass over the whole reactor, with the flag on, so the goal writes
+      # the pages while eo-runtime is being built rather than inferring the
+      # same program twice.
+      - run: mvn install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip '-Deo.inferenceReport'
+      # The pages are of eo-runtime, the only program here big enough to have
+      # red spots worth hunting. `clean` is true so that the page of an .eo
+      # file somebody deleted goes away with it, and it touches nothing
+      # outside `inference` because `target-folder` scopes it.
+      - uses: JamesIves/github-pages-deploy-action@v4.9.0
+        with:
+          branch: gh-pages
+          folder: eo-runtime/target/site/inference
+          target-folder: inference
+          clean: true

--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -102,9 +102,13 @@ answer is somebody else's void, red where there is nothing. Hovering over a
 mark says what the tables hold about it, and an amber one names what the
 program was seen putting into the void besides.
 
-Off by default, since the tables are what the compiler needs and the pages are
-for a person. The goal runs in whichever module uses the plugin, so this is
-the shortest way to the pages of eo-runtime:
+The pages of eo-runtime are published at
+[www.eolang.org/inference](https://www.eolang.org/inference/), rebuilt on every
+tag, so looking at them needs nothing installed.
+
+Building them is off by default, since the tables are what the compiler needs
+and the pages are for a person. The goal runs in whichever module uses the
+plugin, so this is the shortest way to the pages of a working copy:
 
 ```bash
 mvn -pl eo-runtime process-sources -Deo.inferenceReport


### PR DESCRIPTION
The report was built by a flag and read by whoever ran the build. Asking why a
spot is red meant cloning the repo, installing four modules and waiting three
minutes, which is not really asking.

A new workflow pushes the pages of eo-runtime to `gh-pages`, so they land at
[www.eolang.org/inference](https://www.eolang.org/inference/) — the same way
`eo-maven-plugin-site.yml` and `objectionary.yml` already publish theirs:

```yaml
      - uses: JamesIves/github-pages-deploy-action@v4.9.0
        with:
          branch: gh-pages
          folder: eo-runtime/target/site/inference
          target-folder: inference
          clean: true
```

One `mvn install` with the flag on, so the goal writes the pages while
eo-runtime is being built instead of inferring the same program twice.
`clean: true` follows `objectionary.yml`, so the page of an `.eo` file somebody
deleted goes away with it, and `target-folder` keeps that scoped to `inference`
alone.

**On tags and on the button, not on every push to master**, which is what both
neighbours already do. The report of eo-runtime is 172 files and 8.4 MB, and
`gh-pages` is about three gigabytes already — the comment at the top of
`fast.yml` says so and asks for a shallow clone because of it. A publish per
master push would add a quarter of a gigabyte on a busy day; a publish per tag
adds a few megabytes a week, and `workflow_dispatch` covers wanting it sooner.

Verified locally that the build this workflow runs produces what it deploys:
171 pages plus an index, 8.4 MB, every relative link resolving, and the index
tally summing to exactly the 50,918 objects the goal prints. `actionlint` and
`markdownlint` are both clean.

The eo-inference README now carries the URL beside the command that builds the
same pages from a working copy.

Closes #7821.
