### PR TITLE
Remove stale @todo puzzle in Comments.java

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Comments.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Comments.java
@@ -2,10 +2,6 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-// @todo #7588:30min No production caller resolves to Comments#seal anymore
-//  since it was moved into Globals#seal(Emit, Span); only CommentsTest still
-//  exercises it. Delete this class and CommentsTest once that test's cases
-//  are confirmed to be covered by GlobalsTest.
 package org.eolang.parser;
 
 import java.util.List;


### PR DESCRIPTION
Closes #7817.

The puzzle told us to delete `Comments` and `CommentsTest` once `Comments#seal` had "moved into `Globals#seal(Emit, Span)`" and no production caller was left. So I went looking for that overload and for the callers it supposedly orphaned.

Neither claim survives contact with the code. `Globals` has no `seal(Emit, Span)` method — only a no-arg `seal()` that flips a boolean flag and does nothing else. Nothing was ever moved there. Meanwhile `Comments.seal(Globals, Emit, Span)` is called directly by eight production classes: `LnReversed`, `LnMethod`, `LnPipe`, `LnOnlyPhi`, `LnApplication`, `LnMeta`, `LnVoid` (twice), and `LnFormation`. This is not dead code shadowed by a migration — it's the only place that flushes the top comment block into `/object/comments`, exercised on every parse that has a header comment.

Had I followed the puzzle literally and deleted the class, the build would have failed with eight missing-method compile errors, and the header-comment feature (§3.3/§6.4) would have had no implementation left at all. So this PR does the one thing the puzzle actually asks for once its premise is checked: removes the stale `@todo` comment itself. `Comments` and `CommentsTest` are untouched.