### PR TITLE
Drop tests that duplicate a stronger sibling in ListingTest

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -9,7 +9,6 @@ import com.jcabi.xml.XMLDocument;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -31,31 +30,6 @@ final class ListingTest {
             "the text of <listing> must be equal to the source, not escaped twice",
             ListingTest.listing(source),
             Matchers.equalTo(source)
-        );
-    }
-
-    @Test
-    void dropsCharactersForbiddenInXml() {
-        MatcherAssert.assertThat(
-            "characters that XML text nodes can't hold must be dropped",
-            ListingTest.listing(
-                String.format(
-                    "[] > x%c%c%c%c",
-                    (char) 0x01,
-                    (char) 0x07,
-                    (char) 0x1F,
-                    (char) 0x7F
-                )
-            ),
-            Matchers.equalTo("[] > x")
-        );
-    }
-
-    @Test
-    void doesNotThrowExceptionOnEmptySource() {
-        Assertions.assertDoesNotThrow(
-            () -> ListingTest.listing(""),
-            "an empty source must not break the <listing> element"
         );
     }
 


### PR DESCRIPTION
ListingTest carried two tests whose behavior is already fully covered by a stronger sibling test.

doesNotThrowExceptionOnEmptySource only asserted that building a listing from an empty source does not throw, with no check on the result. buildsListingForEmptySource feeds the same empty source and asserts the resulting listing is an empty string, which already implies it built without throwing.

dropsCharactersForbiddenInXml asserted that four specific forbidden characters (0x01, 0x07, 0x1F, 0x7F) get stripped from a listing. The parameterized removesForbiddenCharacters already covers all four of those code points individually, plus ten more, via @ValueSource.

Both tests are removed, along with the now-unused Assertions import. No coverage is lost.

Closes #7834