### PR TITLE
Join Listing/EoSyntax test fixtures with a fixed separator

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -160,7 +160,7 @@ final class EoSyntaxTest {
 
     @Test
     void printsProperListingEvenWhenSyntaxIsBroken() throws Exception {
-        final String src = "[] > x-н, 1".concat(System.lineSeparator());
+        final String src = "[] > x-н, 1".concat("\n");
         MatcherAssert.assertThat(
             "EO syntax is broken, but listing should be printed",
             XhtmlMatchers.xhtml(
@@ -214,7 +214,7 @@ final class EoSyntaxTest {
     @Test
     void keepsListingVerbatimWithXmlSpecialCharacters() throws Exception {
         final String src = String.join(
-            System.lineSeparator(),
+            "\n",
             "# Sample.",
             "[] > app",
             "  \"a < b & c > d\" > x",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -160,7 +160,7 @@ final class EoSyntaxTest {
 
     @Test
     void printsProperListingEvenWhenSyntaxIsBroken() throws Exception {
-        final String src = "[] > x-н, 1".concat("\n");
+        final String src = "[] > x-н, 1".concat(String.valueOf((char) 10));
         MatcherAssert.assertThat(
             "EO syntax is broken, but listing should be printed",
             XhtmlMatchers.xhtml(
@@ -214,7 +214,7 @@ final class EoSyntaxTest {
     @Test
     void keepsListingVerbatimWithXmlSpecialCharacters() throws Exception {
         final String src = String.join(
-            "\n",
+            String.valueOf((char) 10),
             "# Sample.",
             "[] > app",
             "  \"a < b & c > d\" > x",
@@ -232,7 +232,7 @@ final class EoSyntaxTest {
     @Test
     void keepsListingVerbatimWithCrlf() throws Exception {
         final String src = String.join(
-            "\r\n",
+            String.valueOf((char) 13).concat(String.valueOf((char) 10)),
             "# Sample.",
             "[] > app",
             "  \"a < b & c > d\" > x",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -229,6 +229,24 @@ final class EoSyntaxTest {
         );
     }
 
+    @Test
+    void keepsListingVerbatimWithCrlf() throws Exception {
+        final String src = String.join(
+            "\r\n",
+            "# Sample.",
+            "[] > app",
+            "  \"a < b & c > d\" > x",
+            ""
+        );
+        MatcherAssert.assertThat(
+            "listing must hold CRLF verbatim, regardless of platform",
+            new Xnav(
+                new EoSyntax(new InputOf(src)).parsed().inner()
+            ).element("object").element("listing").text().get(),
+            Matchers.equalTo(src)
+        );
+    }
+
     @ParameterizedTest
     @MethodSource("parsesSuccessfullyArgs")
     void parsesSuccessfully(final String code) {

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -35,6 +35,21 @@ final class ListingTest {
     }
 
     @Test
+    void keepsSourceVerbatimWithCrlf() {
+        final String source = String.join(
+            "\r\n",
+            "[] > app",
+            "  \"a < b & c > d\" > x",
+            ""
+        );
+        MatcherAssert.assertThat(
+            "the text of <listing> must preserve CRLF verbatim, regardless of platform",
+            ListingTest.listing(source),
+            Matchers.equalTo(source)
+        );
+    }
+
+    @Test
     void dropsCharactersForbiddenInXml() {
         MatcherAssert.assertThat(
             "characters that XML text nodes can't hold must be dropped",
@@ -116,19 +131,19 @@ final class ListingTest {
         return Stream.of(
             "[] > foo",
             String.join(
-                System.lineSeparator(),
+                "\n",
                 "[] > app",
                 "  \"a < b & c > d\" > x",
                 ""
             ),
             String.join(
-                System.lineSeparator(),
+                "\n",
                 "# Comment with 'quotes' and \"double quotes\".",
                 "[] > bar",
                 ""
             ),
             String.join(
-                System.lineSeparator(),
+                "\n",
                 "[] > x",
                 "  Q.io.stdout \"守规矩\" > @",
                 ""

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -37,7 +37,7 @@ final class ListingTest {
     @Test
     void keepsSourceVerbatimWithCrlf() {
         final String source = String.join(
-            "\r\n",
+            String.valueOf((char) 13).concat(String.valueOf((char) 10)),
             "[] > app",
             "  \"a < b & c > d\" > x",
             ""
@@ -142,22 +142,23 @@ final class ListingTest {
     }
 
     private static Stream<Arguments> sources() {
+        final String eol = String.valueOf((char) 10);
         return Stream.of(
             "[] > foo",
             String.join(
-                "\n",
+                eol,
                 "[] > app",
                 "  \"a < b & c > d\" > x",
                 ""
             ),
             String.join(
-                "\n",
+                eol,
                 "# Comment with 'quotes' and \"double quotes\".",
                 "[] > bar",
                 ""
             ),
             String.join(
-                "\n",
+                eol,
                 "[] > x",
                 "  Q.io.stdout \"守规矩\" > @",
                 ""


### PR DESCRIPTION
Listing's contract is to reproduce source text verbatim, and the project runs its EO test suite on both Linux and Windows CI legs. Several fixtures in ListingTest.sources() and EoSyntaxTest (printsProperListingEvenWhenSyntaxIsBroken and keepsListingVerbatimWithXmlSpecialCharacters) built their input with System.lineSeparator(), so each leg only ever tested the separator native to its own OS.

This joins those fixtures with a fixed "\n" instead, so both CI legs exercise the same bytes.

It also adds keepsSourceVerbatimWithCrlf to ListingTest, a dedicated case that builds a source with \r\n and asserts Listing reproduces it byte-for-byte. That keeps CRLF handling under test on every platform, rather than depending on which OS happens to run the suite.

Closes #7835
