### PR TITLE
Check EoSyntax transform for null at construction, not on every parsed() call

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -97,14 +97,14 @@ public final class EoSyntax implements Syntax {
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
         this.input = ipt;
-        this.transform = transform;
+        this.transform = Objects.requireNonNull(transform, "EoSyntax has no transform");
     }
 
     @Override
     public XML parsed() throws IOException {
         final long start = System.nanoTime();
         final String text = new UncheckedText(new TextOf(this.input)).asString();
-        return Objects.requireNonNull(this.transform, "EoSyntax has no transform").apply(
+        return this.transform.apply(
             new XMLDocument(
                 new Xembler(
                     new Directives()

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -94,11 +94,19 @@ public final class EoSyntax implements Syntax {
      * Ctor.
      * @param ipt The EO program to parse
      * @param transform Transform XMIR after parsing function
-     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
+        this(Objects.requireNonNull(transform, "EoSyntax has no transform"), ipt);
+    }
+
+    /**
+     * Ctor.
+     * @param transform Transform XMIR after parsing function
+     * @param ipt The EO program to parse
+     */
+    private EoSyntax(final UnaryOperator<XML> transform, final Input ipt) {
         this.input = ipt;
-        this.transform = Objects.requireNonNull(transform, "EoSyntax has no transform");
+        this.transform = transform;
     }
 
     @Override

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -94,6 +94,7 @@ public final class EoSyntax implements Syntax {
      * Ctor.
      * @param ipt The EO program to parse
      * @param transform Transform XMIR after parsing function
+     * @checkstyle ConstructorsCodeFreeCheck (10 lines)
      */
     public EoSyntax(final Input ipt, final UnaryOperator<XML> transform) {
         this.input = ipt;

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -122,6 +122,23 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void rejectsANullTransformAtConstructionTime() {
+        Assertions.assertThrows(
+            NullPointerException.class,
+            () -> new EoSyntax(new InputOf(""), (UnaryOperator<XML>) null),
+            "EoSyntax must reject a null transform at construction, before parsed() is ever called"
+        );
+    }
+
+    @Test
+    void acceptsANonNullTransformAtConstructionTime() {
+        Assertions.assertDoesNotThrow(
+            () -> new EoSyntax(new InputOf(""), UnaryOperator.identity()),
+            "EoSyntax must accept a non-null transform at construction, but it didn't"
+        );
+    }
+
+    @Test
     void rejectsANullTrain() {
         Assertions.assertThrows(
             NullPointerException.class,


### PR DESCRIPTION
EoSyntax.parsed() null-checked the final transform field on every call, three lines away from where the field is actually set. Since transform is assigned exactly once in the constructor and never reassigned, that's a construction-time invariant being deferred to first use and re-checked on every subsequent call for no reason.

This moves the Objects.requireNonNull check into the single-argument UnaryOperator<XML> constructor, matching the pattern the two-argument Train<Shift> constructor already uses for its own null check. parsed() now just calls this.transform.apply(...) directly.

Closes #7832