### PR TITLE
Add MsgUnderlinedTest and fix its underline length clamp

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/MsgUnderlined.java
+++ b/eo-parser/src/main/java/org/eolang/parser/MsgUnderlined.java
@@ -72,7 +72,7 @@ final class MsgUnderlined {
             result = String.format(
                 "%s%s",
                 MsgUnderlined.repeat(" ", this.from),
-                MsgUnderlined.repeat("^", Math.min(this.length, this.origin.length()))
+                MsgUnderlined.repeat("^", Math.min(this.length, this.origin.length() - this.from))
             );
         }
         return result;

--- a/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link MsgUnderlined}.
+ * @since 0.50
+ */
+final class MsgUnderlinedTest {
+
+    @Test
+    void underlinesWholeLineWhenFromIsNegative() {
+        MatcherAssert.assertThat(
+            "a negative from must underline every character of the origin",
+            new MsgUnderlined("hello", -1, 3).formatted(),
+            Matchers.equalTo(String.format("hello%n^^^^^"))
+        );
+    }
+
+    @Test
+    void clampsCaretRunToLineLengthRemainingAfterFrom() {
+        MatcherAssert.assertThat(
+            "a length reaching past the line end must be clamped to what remains from position",
+            new MsgUnderlined("0123456789", 8, 5).formatted(),
+            Matchers.equalTo(String.format("0123456789%n        ^^"))
+        );
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
@@ -31,4 +31,13 @@ final class MsgUnderlinedTest {
             Matchers.equalTo(String.format("0123456789%n        ^^"))
         );
     }
+
+    @Test
+    void leavesUnderlineEmptyWhenFromReachesLineEnd() {
+        MatcherAssert.assertThat(
+            "a from at the line length must draw no caret since no position is left to underline",
+            new MsgUnderlined("abc", 3, 2).formatted(),
+            Matchers.equalTo(String.format("abc%n"))
+        );
+    }
 }


### PR DESCRIPTION
MsgUnderlined had no test of its own, so two of its branches went unexercised: the from < 0 whole-line underline, and the length clamp.

The clamp itself was wrong: it capped the caret run against the full line length instead of what remains from the given position, so a caret run could still be requested to extend past the end of the line for any from > 0. It never surfaced because the only caller always passes length = 1.

This adds MsgUnderlinedTest covering the negative-from branch, the clamp with a length that overruns the remaining line, and the case where from lands exactly at the line end, and fixes the clamp to use origin.length() - from instead of origin.length().

Closes #7833