### PR TITLE
Complete probed package only when it is actually pulled

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Probing.java
@@ -17,6 +17,15 @@ import org.cactoos.list.ListOf;
  * Goes through all {@code probe} and {@code also} metas in XMIR files,
  * tries to locate the objects pointed by {@code probe} in Objectionary,
  * and if found, registers them in the catalog.
+ *
+ * <p>When a probed object has no source of its own, the package it belongs
+ * to is completed from the remote index, since a package that arrives from
+ * the registry has to arrive as a whole. A package that the project's own
+ * sources provide is not completed: a sibling that the index still lists,
+ * but no local source names, is a leftover of an older release and not a
+ * missing member of the local package, so {@link Pulling} must not fetch
+ * it.</p>
+ *
  * @since 0.61.0
  */
 final class Probing implements Step {
@@ -101,25 +110,35 @@ final class Probing implements Step {
         return new Threaded<>(
             unprobed,
             tojo -> {
-                final Path src = tojo.xmir();
-                final Collection<String> objects = new ListOf<>(new Probes(src));
-                if (!objects.isEmpty()) {
-                    Logger.debug(this, "Probing object(s): %s", objects);
-                }
-                int count = 0;
-                for (final String object : objects) {
-                    if (!this.objectionary.contains(object)) {
-                        continue;
-                    }
-                    ++count;
-                    this.tojos.add(object).withDiscoveredAt(src);
-                    probed.put(object, true);
-                    this.complete(object, src, completed);
-                }
+                final int count = this.register(tojo.xmir(), probed, completed);
                 tojo.withProbed(count);
                 return count;
             }
         ).total();
+    }
+
+    private int register(
+        final Path src,
+        final Map<String, Boolean> probed,
+        final Set<String> completed
+    ) throws IOException {
+        final Collection<String> objects = new ListOf<>(new Probes(src));
+        if (!objects.isEmpty()) {
+            Logger.debug(this, "Probing object(s): %s", objects);
+        }
+        int count = 0;
+        for (final String object : objects) {
+            if (!this.objectionary.contains(object)) {
+                continue;
+            }
+            ++count;
+            final TjForeign added = this.tojos.add(object).withDiscoveredAt(src);
+            probed.put(object, true);
+            if (added.sourceless()) {
+                this.complete(object, src, completed);
+            }
+        }
+        return count;
     }
 
     private void complete(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
@@ -156,6 +156,17 @@ final class TjForeign {
     }
 
     /**
+     * Checks if the tojo has no source of its own, meaning that it is one of
+     * the objects {@link Pulling} is going to fetch from the remote
+     * objectionary.
+     * @return True if there is neither {@code .eo} nor {@code .xmir} on disk
+     */
+    boolean sourceless() {
+        return !this.delegate.exists(TjsForeign.Attribute.EO.getKey())
+            && !this.delegate.exists(TjsForeign.Attribute.XMIR.getKey());
+    }
+
+    /**
      * Checks if tojo was discovered as a dependency of another object,
      * rather than registered directly as a user source.
      * @return True if discovered, false otherwise

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -43,8 +43,8 @@ final class ProbingTest {
     @Test
     void completesPartiallyProbedPackage(@TempDir final Path temp) throws IOException {
         final TjsForeign tojos = new TjsForeign();
-        tojos.add("test").withXmir(ProbingTest.caller(temp));
-        new Probing(tojos, ProbingTest.tuples(), true).exec();
+        tojos.add("test").withXmir(this.caller(temp));
+        new Probing(tojos, this.tuples(), true).exec();
         MatcherAssert.assertThat(
             "Probe should have registered the siblings that were never probed directly",
             tojos.contains("tuple.eachi") && tojos.contains("tuple.withouti"),
@@ -57,9 +57,9 @@ final class ProbingTest {
         @TempDir final Path temp
     ) throws IOException {
         final TjsForeign tojos = new TjsForeign();
-        tojos.add("test").withXmir(ProbingTest.caller(temp));
+        tojos.add("test").withXmir(this.caller(temp));
         tojos.add("tuple.each").withSource(temp.resolve("tuple").resolve("each.eo"));
-        new Probing(tojos, ProbingTest.tuples(), true).exec();
+        new Probing(tojos, this.tuples(), true).exec();
         MatcherAssert.assertThat(
             "Probe should not register the siblings of a package that is on disk already",
             tojos.contains("tuple.eachi") || tojos.contains("tuple.withouti"),
@@ -125,7 +125,7 @@ final class ProbingTest {
         );
     }
 
-    private static Path caller(final Path temp) throws IOException {
+    private Path caller(final Path temp) throws IOException {
         final Path xmir = temp.resolve("test.xmir");
         Files.write(
             xmir,
@@ -142,7 +142,7 @@ final class ProbingTest {
         return xmir;
     }
 
-    private static Objectionary tuples() {
+    private Objectionary tuples() {
         return new OyIndexed(
             new Objectionary.Fake(),
             new ObjectsIndex(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -42,31 +42,9 @@ final class ProbingTest {
 
     @Test
     void completesPartiallyProbedPackage(@TempDir final Path temp) throws IOException {
-        final Path xmir = temp.resolve("test.xmir");
-        Files.write(
-            xmir,
-            new EoSyntax(
-                String.join(
-                    System.lineSeparator(),
-                    "+package foo",
-                    "",
-                    "[] > test",
-                    "  Q.tuple.each > @"
-                )
-            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
-        );
         final TjsForeign tojos = new TjsForeign();
-        tojos.add("test").withXmir(xmir);
-        new Probing(
-            tojos,
-            new OyIndexed(
-                new Objectionary.Fake(),
-                new ObjectsIndex(
-                    () -> new SetOf<>("tuple.each", "tuple.eachi", "tuple.withouti")
-                )
-            ),
-            true
-        ).exec();
+        tojos.add("test").withXmir(ProbingTest.caller(temp));
+        new Probing(tojos, ProbingTest.tuples(), true).exec();
         MatcherAssert.assertThat(
             "Probe should have registered the siblings that were never probed directly",
             tojos.contains("tuple.eachi") && tojos.contains("tuple.withouti"),
@@ -78,32 +56,10 @@ final class ProbingTest {
     void doesNotCompletePackageThatLocalSourcesProvide(
         @TempDir final Path temp
     ) throws IOException {
-        final Path xmir = temp.resolve("test.xmir");
-        Files.write(
-            xmir,
-            new EoSyntax(
-                String.join(
-                    System.lineSeparator(),
-                    "+package foo",
-                    "",
-                    "[] > test",
-                    "  Q.tuple.each > @"
-                )
-            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
-        );
         final TjsForeign tojos = new TjsForeign();
-        tojos.add("test").withXmir(xmir);
+        tojos.add("test").withXmir(ProbingTest.caller(temp));
         tojos.add("tuple.each").withSource(temp.resolve("tuple").resolve("each.eo"));
-        new Probing(
-            tojos,
-            new OyIndexed(
-                new Objectionary.Fake(),
-                new ObjectsIndex(
-                    () -> new SetOf<>("tuple.each", "tuple.eachi", "tuple.withouti")
-                )
-            ),
-            true
-        ).exec();
+        new Probing(tojos, ProbingTest.tuples(), true).exec();
         MatcherAssert.assertThat(
             "Probe should not register the siblings of a package that is on disk already",
             tojos.contains("tuple.eachi") || tojos.contains("tuple.withouti"),
@@ -166,6 +122,32 @@ final class ProbingTest {
             "Probe should not register any objects when offline",
             tojos.size(),
             Matchers.equalTo(1)
+        );
+    }
+
+    private static Path caller(final Path temp) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "+package foo",
+                    "",
+                    "[] > test",
+                    "  Q.tuple.each > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        return xmir;
+    }
+
+    private static Objectionary tuples() {
+        return new OyIndexed(
+            new Objectionary.Fake(),
+            new ObjectsIndex(
+                () -> new SetOf<>("tuple.each", "tuple.eachi", "tuple.withouti")
+            )
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProbingTest.java
@@ -75,6 +75,43 @@ final class ProbingTest {
     }
 
     @Test
+    void doesNotCompletePackageThatLocalSourcesProvide(
+        @TempDir final Path temp
+    ) throws IOException {
+        final Path xmir = temp.resolve("test.xmir");
+        Files.write(
+            xmir,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "+package foo",
+                    "",
+                    "[] > test",
+                    "  Q.tuple.each > @"
+                )
+            ).parsed().toString().getBytes(StandardCharsets.UTF_8)
+        );
+        final TjsForeign tojos = new TjsForeign();
+        tojos.add("test").withXmir(xmir);
+        tojos.add("tuple.each").withSource(temp.resolve("tuple").resolve("each.eo"));
+        new Probing(
+            tojos,
+            new OyIndexed(
+                new Objectionary.Fake(),
+                new ObjectsIndex(
+                    () -> new SetOf<>("tuple.each", "tuple.eachi", "tuple.withouti")
+                )
+            ),
+            true
+        ).exec();
+        MatcherAssert.assertThat(
+            "Probe should not register the siblings of a package that is on disk already",
+            tojos.contains("tuple.eachi") || tojos.contains("tuple.withouti"),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void avoidsDuplicateTojoForAnOrgEolangPrefixedReference(
         @TempDir final Path temp
     ) throws IOException {


### PR DESCRIPTION
Closes #7844

`Probing.complete()` completed the package of every probed object from the remote index, without asking whether the project's own sources were already providing that package. Once any probe was found in Objectionary, every `objectionary.children(pkg)` sibling got registered as a tojo, and `Pulling.exec()` downloaded each registered tojo that has no source.

That is wrong when the local tree is the newer copy of the same package the index publishes. In `objectionary/home`, probing any `string` member registered the whole `string` package from `objectionary.lst` — including `objects/string/{as-char,as-decimal,as-fixed,as-hex,low-cased,up-cased}.eo`, none of which exists locally any more and none of which any local source names. They were pulled anyway, so a 0.63.0 build silently ingested 0.62.1 sources: they failed to parse under the current parser, and under the `merge` goal the hoisted test name `can-convert-already-lower-cased-text` from `string.low-cased` collided with the one in the local `string/english.eo`.

## Changes

- `TjForeign.sourceless()` — new predicate, true when a tojo has neither `.eo` nor `.xmir`, i.e. when it is one of the objects `Pulling` will fetch (the same condition as `TjsForeign.withoutSources()`, asked of a single tojo).
- `Probing` — `complete()` is now called only for a probed object that is `sourceless()`. The completion added in #6175 is only needed for a package arriving from the registry; a package whose members are on disk needs no completion, and a sibling that no local source names is not a missing member of it.
- `Probing.register()` — the body of the `Threaded` lambda moved into a private method, to keep the lambda within the allowed length.
- `ProbingTest.doesNotCompletePackageThatLocalSourcesProvide()` — new test: when `tuple.each` is registered with a local source, probing it no longer registers `tuple.eachi` and `tuple.withouti`. It fails without the guard.

The existing `completesPartiallyProbedPackage` and `avoidsDuplicateTojoForAnOrgEolangPrefixedReference` tests still pass, so completion of a genuinely remote package is unaffected.

## Verification

- `mvn -pl eo-maven-plugin surefire:test -Dtest=ProbingTest,MjProbeTest,MjPullTest,ProbesTest,TjsForeignTest` — 45 tests, all green.
- `mvn -Pqulice -pl eo-maven-plugin qulice:check` — clean.
- Full `eo-maven-plugin` test suite run locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CZtdktDJ6WXgPnReD41c3A)_