### PR TITLE
Move the Xembly cursor back up after <listing>

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -25,6 +25,11 @@ import org.xembly.Directives;
  * characters at all and would make the document not well-formed;
  * Xembly says nothing about them.</p>
  *
+ * <p>The directives leave the cursor on {@code /object}, not inside the
+ * {@code <listing>} they add, so that whatever the caller appends next
+ * becomes a sibling of {@code <listing>} even without an absolute
+ * {@code xpath()} reset of its own.</p>
+ *
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
@@ -58,6 +63,7 @@ final class Listing implements Iterable<Directive> {
             .strict(1)
             .add("listing")
             .set(Listing.FORBIDDEN.matcher(this.source).replaceAll(""))
+            .up()
             .iterator();
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -5,6 +5,7 @@
 package org.eolang.parser;
 
 import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
@@ -109,6 +110,20 @@ final class ListingTest {
             ),
             ListingTest.listing(source),
             Matchers.equalTo(source)
+        );
+    }
+
+    @Test
+    void leavesCursorOnObjectForTheNextSibling() {
+        MatcherAssert.assertThat(
+            "what the caller appends after <listing> must be its sibling under /object",
+            new Xembler(
+                new Directives()
+                    .add("object").up()
+                    .append(new Listing("[] > foo"))
+                    .add("metas")
+            ).xmlQuietly(),
+            XhtmlMatchers.hasXPath("/object/metas")
         );
     }
 


### PR DESCRIPTION
Listing.iterator() ended its directive chain on set(), so once the directives were applied the Xembly cursor sat inside the <listing> element it had just added. Nothing broke today only because EoSyntax.parsed() follows the append with an absolute xpath("/object") that resets the cursor no matter where Listing left it.

The fix is one trailing up(). The cursor now comes back to /object, which is where the caller was when it appended the directives, so a sibling of <listing> added with relative navigation lands under /object instead of inside the listing text. This is the same self-contained navigation Emit.comment already does with its matching push()/up()/up()/pop() pair.

The new test in ListingTest appends Listing and then adds a <metas> element relatively, asserting it shows up at /object/metas. Without the up() it would be at /object/listing/metas.

Closes #7830
