### PR TITLE
Build a fresh canonical pipeline per EoSyntax instance

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -38,7 +38,7 @@ public final class EoSyntax implements Syntax {
     /**
      * Transform XMIR after parsing.
      */
-    private final UnaryOperator<XML> transform;
+    final UnaryOperator<XML> transform;
 
     /**
      * Ctor.
@@ -66,6 +66,7 @@ public final class EoSyntax implements Syntax {
      * {@code Φ} package. Use a {@link Canonical} built with a list of
      * objects to make the pipeline resolve same-package references
      * automatically (see {@code add-default-package.xsl}).</p>
+     *
      * @param ipt The EO program to parse
      */
     public EoSyntax(final Input ipt) {

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -31,17 +31,6 @@ import org.xembly.Xembler;
 public final class EoSyntax implements Syntax {
 
     /**
-     * Canonical XSL pipeline applied to the raw parser output.
-     *
-     * <p>This one is not aware of any objects, so bare references are
-     * always homed into the root {@code Φ} package. Use a
-     * {@link Canonical} built with a list of objects to make the
-     * pipeline resolve same-package references automatically (see
-     * {@code add-default-package.xsl}).</p>
-     */
-    static final UnaryOperator<XML> CANONICAL = new Canonical();
-
-    /**
      * Text to parse.
      */
     private final Input input;
@@ -70,10 +59,17 @@ public final class EoSyntax implements Syntax {
 
     /**
      * Ctor.
+     *
+     * <p>Applies the canonical XSL pipeline to the raw parser output,
+     * built fresh for this instance. This pipeline is not aware of any
+     * objects, so bare references are always homed into the root
+     * {@code Φ} package. Use a {@link Canonical} built with a list of
+     * objects to make the pipeline resolve same-package references
+     * automatically (see {@code add-default-package.xsl}).</p>
      * @param ipt The EO program to parse
      */
     public EoSyntax(final Input ipt) {
-        this(ipt, EoSyntax.CANONICAL);
+        this(ipt, new Canonical());
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -38,7 +38,7 @@ public final class EoSyntax implements Syntax {
     /**
      * Transform XMIR after parsing.
      */
-    final UnaryOperator<XML> transform;
+    private final UnaryOperator<XML> transform;
 
     /**
      * Ctor.

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -74,17 +74,6 @@ final class EoSyntaxTest {
     }
 
     @Test
-    void buildsFreshTransformPerInstance() {
-        MatcherAssert.assertThat(
-            "two EoSyntax instances share the same canonical transform instance",
-            new EoSyntax(new InputOf("")).transform,
-            Matchers.not(
-                Matchers.sameInstance(new EoSyntax(new InputOf("")).transform)
-            )
-        );
-    }
-
-    @Test
     void parsesSimpleCode() throws Exception {
         MatcherAssert.assertThat(
             "EoSyntax must generate valid XMIR from simple code",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -14,7 +14,6 @@ import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Train;
 import fixtures.LargeProgram;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Set;
@@ -75,15 +74,13 @@ final class EoSyntaxTest {
     }
 
     @Test
-    void buildsFreshTransformPerInstance() throws Exception {
-        final Field field = EoSyntax.class.getDeclaredField("transform");
-        field.setAccessible(true);
-        final EoSyntax first = new EoSyntax(new InputOf(""));
-        final EoSyntax second = new EoSyntax(new InputOf(""));
+    void buildsFreshTransformPerInstance() {
         MatcherAssert.assertThat(
             "two EoSyntax instances share the same canonical transform instance",
-            field.get(first),
-            Matchers.not(Matchers.sameInstance(field.get(second)))
+            new EoSyntax(new InputOf("")).transform,
+            Matchers.not(
+                Matchers.sameInstance(new EoSyntax(new InputOf("")).transform)
+            )
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -14,6 +14,9 @@ import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Train;
 import fixtures.LargeProgram;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Set;
 import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
@@ -57,6 +60,30 @@ final class EoSyntaxTest {
             "class still carries an execution mode restriction",
             EoSyntaxTest.class.isAnnotationPresent(Execution.class),
             Matchers.is(false)
+        );
+    }
+
+    @Test
+    void carriesNoSharedStaticState() {
+        MatcherAssert.assertThat(
+            "EoSyntax declares a shared static field instead of building state per instance",
+            Arrays.stream(EoSyntax.class.getDeclaredFields())
+                .filter(field -> Modifier.isStatic(field.getModifiers()))
+                .count(),
+            Matchers.equalTo(0L)
+        );
+    }
+
+    @Test
+    void buildsFreshTransformPerInstance() throws Exception {
+        final Field field = EoSyntax.class.getDeclaredField("transform");
+        field.setAccessible(true);
+        final EoSyntax first = new EoSyntax(new InputOf(""));
+        final EoSyntax second = new EoSyntax(new InputOf(""));
+        MatcherAssert.assertThat(
+            "two EoSyntax instances share the same canonical transform instance",
+            field.get(first),
+            Matchers.not(Matchers.sameInstance(field.get(second)))
         );
     }
 


### PR DESCRIPTION
EoSyntax held a package-visible static field, CANONICAL, wrapping a single shared Canonical instance reused by every EoSyntax built through the single-argument Input constructor. The project avoids this shape elsewhere in the package: Emit, DrProgram and similar helpers are built fresh per call instead of stashed behind a static holder.

This removes the static field and builds a new Canonical() directly in that constructor, so each EoSyntax gets its own instance. Canonical is stateless today, so behavior is unchanged, but a shared static instance is exactly the shape that invites silent cross-instance coupling if that ever stops being true.

Added two tests: one asserts EoSyntax declares no static fields at all, the other reflects into the private transform field and checks that two instances built from the same constructor don't share the same Canonical object.

Closes #7831