### PR TITLE
compare listing via xnav text instead of interpolated xpath literal

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -163,13 +163,23 @@ final class EoSyntaxTest {
         final String src = "[] > x-н, 1".concat(System.lineSeparator());
         MatcherAssert.assertThat(
             "EO syntax is broken, but listing should be printed",
+            new Xnav(
+                new EoSyntax(new InputOf(src)).parsed().inner()
+            ).element("object").element("listing").text().get(),
+            Matchers.equalTo(src)
+        );
+    }
+
+    @Test
+    void printsErrorsWhenSyntaxIsBroken() throws Exception {
+        MatcherAssert.assertThat(
+            "EO syntax is broken, thus errors should be printed",
             XhtmlMatchers.xhtml(
-                new EoSyntax(new InputOf(src)).parsed().toString()
+                new EoSyntax(
+                    new InputOf("[] > x-н, 1".concat(System.lineSeparator()))
+                ).parsed().toString()
             ),
-            XhtmlMatchers.hasXPaths(
-                "/object/errors/error",
-                String.format("/object[listing='%s']", src)
-            )
+            XhtmlMatchers.hasXPaths("/object/errors/error")
         );
     }
 


### PR DESCRIPTION
printsProperListingEvenWhenSyntaxIsBroken built its listing assertion by interpolating the raw fixture string into a single-quoted XPath literal via String.format. An apostrophe anywhere in that fixture would terminate the literal early and turn the rest of the source into stray XPath syntax, breaking the test with an XPath compile error unrelated to the behavior under test.

The other listing tests in this file, copiesListingCorrectly and keepsListingVerbatimWithXmlSpecialCharacters, already compare the listing text through Xnav's element/text accessor instead of building XPath by hand. This change brings printsProperListingEvenWhenSyntaxIsBroken in line with that pattern: the error check stays an XPath assertion, and the listing content is compared as a plain string via Xnav.

Closes #7829