### PR TITLE
Round the reported parsing time up to a whole millisecond

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
+++ b/eo-parser/src/main/java/org/eolang/parser/EoSyntax.java
@@ -113,7 +113,7 @@ public final class EoSyntax implements Syntax {
                         .xpath("/object")
                         .strict(1)
                         .append(new Eo(text).directives())
-                        .attr("ms", (System.nanoTime() - start) / (1000L * 1000L))
+                        .attr("ms", new Millis(System.nanoTime() - start).asString())
                         .up()
                 ).domQuietly()
             )

--- a/eo-parser/src/main/java/org/eolang/parser/Millis.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Millis.java
@@ -1,0 +1,33 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.cactoos.Text;
+
+/**
+ * Elapsed nanoseconds printed as milliseconds, rounded up, so that
+ * a span shorter than a millisecond reads as one instead of zero.
+ * @since 0.73.4
+ */
+final class Millis implements Text {
+
+    /**
+     * Nanoseconds elapsed.
+     */
+    private final long nanos;
+
+    /**
+     * Ctor.
+     * @param span Nanoseconds elapsed
+     */
+    Millis(final long span) {
+        this.nanos = span;
+    }
+
+    @Override
+    public String asString() {
+        return String.valueOf((this.nanos + 999_999L) / 1_000_000L);
+    }
+}

--- a/eo-parser/src/test/java/fixtures/LargeProgram.java
+++ b/eo-parser/src/test/java/fixtures/LargeProgram.java
@@ -12,8 +12,7 @@ import org.cactoos.Input;
 import org.cactoos.io.InputOf;
 
 /**
- * EO program of many nested objects, long enough for its parsing
- * to last more than a single millisecond.
+ * EO program of as many nested objects as the caller asks for.
  * @since 0.61.0
  */
 public final class LargeProgram implements Input {

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -89,6 +89,17 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void measuresSubMillisecondParsingTime() throws Exception {
+        final EoSyntax syntax = new EoSyntax("# Ünïcödé.\n[] > tiny\n");
+        syntax.parsed();
+        MatcherAssert.assertThat(
+            "ms attribute of a sub-millisecond parse is not rounded up to one",
+            Long.parseLong(syntax.parsed().xpath("/object/@ms").get(0)),
+            Matchers.greaterThan(0L)
+        );
+    }
+
+    @Test
     void reportsMsWithinSaneBound() throws Exception {
         MatcherAssert.assertThat(
             "ms attribute is not within a sane bound for a small program",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -90,7 +90,7 @@ final class EoSyntaxTest {
 
     @Test
     void measuresSubMillisecondParsingTime() throws Exception {
-        final EoSyntax syntax = new EoSyntax("# Ünïcödé.\n[] > tiny\n");
+        final EoSyntax syntax = new EoSyntax(String.format("# Ünïcödé.%n[] > tiny%n"));
         syntax.parsed();
         MatcherAssert.assertThat(
             "ms attribute of a sub-millisecond parse is not rounded up to one",

--- a/eo-parser/src/test/java/org/eolang/parser/MillisTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MillisTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Millis}.
+ * @since 0.73.4
+ */
+final class MillisTest {
+
+    @Test
+    void roundsSubMillisecondSpanUpToOne() {
+        MatcherAssert.assertThat(
+            "a span of a single nanosecond is not printed as one millisecond",
+            new Millis(1L).asString(),
+            Matchers.equalTo("1")
+        );
+    }
+
+    @Test
+    void roundsPartialMillisecondUp() {
+        MatcherAssert.assertThat(
+            "a span of two and a half milliseconds is not printed as three",
+            new Millis(2_500_000L).asString(),
+            Matchers.equalTo("3")
+        );
+    }
+
+    @Test
+    void keepsWholeMillisecondsIntact() {
+        MatcherAssert.assertThat(
+            "a span of exactly seven milliseconds is not printed as seven",
+            new Millis(7_000_000L).asString(),
+            Matchers.equalTo("7")
+        );
+    }
+}


### PR DESCRIPTION
`EoSyntax.parsed()` wrote the `ms` attribute as an integer division of nanoseconds by a million, so any parse that finished in under a millisecond was reported as `0`. That is not a measurement, it is a truncation, and it made `measuresRealParsingTime` and `measuresParsingTimeOnEveryCall` fail on a fast machine against a perfectly working parser.

The elapsed span is now its own object. `Millis` takes a nanosecond span and prints it as milliseconds rounded up, so a span that is real but shorter than a millisecond reads as one, never as zero. `EoSyntax` hands it the span and asks for the text; the arithmetic no longer sits inside the directives.

`EoSyntaxTest` gets a test that parses a tiny program twice and asserts the second, warm parse still reports a positive `ms` — that is the case that used to truncate. `MillisTest` covers the rounding itself. The docblock of `LargeProgram` no longer claims that parsing it lasts more than a millisecond, since nothing enforced that.

Closes #7828
