### PR TITLE
Read the listing text back instead of the helper default

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -62,7 +62,7 @@ final class ListingTest {
     @Test
     void buildsListingForEmptySource() {
         MatcherAssert.assertThat(
-            "An empty source must produce an empty listing",
+            "an empty source leaves a listing that is not empty",
             ListingTest.listing(""),
             Matchers.emptyString()
         );
@@ -88,13 +88,38 @@ final class ListingTest {
         }
     )
     void removesForbiddenCharacters(final int codepoint) {
-        final String source = new String(Character.toChars(codepoint));
         MatcherAssert.assertThat(
             String.format(
-                "Character '%s' (%s code) must be removed from EO listing", source, codepoint
+                "the character with code %s is not removed, or its neighbours went with it",
+                codepoint
             ),
-            ListingTest.listing(source),
+            ListingTest.listing(
+                String.format("a%sb", new String(Character.toChars(codepoint)))
+            ),
+            Matchers.equalTo("ab")
+        );
+    }
+
+    @Test
+    void emptiesSourceOfForbiddenCharactersOnly() {
+        MatcherAssert.assertThat(
+            "a source holding nothing but forbidden characters leaves a listing that is not empty",
+            ListingTest.listing(
+                String.format("%c%c%c%c", (char) 0x00, (char) 0x0B, (char) 0x9F, (char) 0xFFFF)
+            ),
             Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void keepsSupplementaryCharacters() {
+        final String source = String.format(
+            "[] > x%s", new String(Character.toChars(0x1F600))
+        );
+        MatcherAssert.assertThat(
+            "a character outside the Basic Multilingual Plane is not kept in the listing",
+            ListingTest.listing(source),
+            Matchers.equalTo(source)
         );
     }
 
@@ -143,6 +168,13 @@ final class ListingTest {
                     new Directives().add("object").up().append(new Listing(source))
                 ).xmlQuietly()
             ).inner()
-        ).element("object").element("listing").text().orElse("");
+        ).element("object").element("listing").text().orElseThrow(
+            () -> new IllegalStateException(
+                String.format(
+                    "no <listing> element for the source \"%s\" of %d characters",
+                    source, source.length()
+                )
+            )
+        );
     }
 }


### PR DESCRIPTION
The `listing()` helper in `ListingTest` ended with `.text().orElse("")`. When the `<listing>` element is absent altogether, `Xnav.text()` gives back an empty `Optional` and the helper quietly returns the default. Every assertion that expected an empty string — `buildsListingForEmptySource` and all fourteen cases of `removesForbiddenCharacters` — was therefore reading the fallback rather than anything `Listing` had written, and passed even when `Listing` emitted no element at all.

The helper now reads the text strictly and throws when the element is missing, naming the source and its length. `removesForbiddenCharacters` no longer feeds a lone forbidden character and asserts emptiness; it wraps the character between two markers and asserts that only the character is gone, so the case proves removal instead of absence. Two more cases join it: a source made of forbidden characters only, which must still leave an empty listing, and a character outside the Basic Multilingual Plane, which must survive the filter intact.

I checked the change by running the class against the real jars: thirty tests pass, and when `Listing` is made to emit a differently named element all thirty fail, including the sixteen that used to pass regardless.

One thing the tests still cannot see: Xembly's `.set("")` leaves `<listing/>`, which is byte-identical to an element built without `.set(...)` at all, so dropping the call for an empty source remains undetectable from the XML.

Closes #7827
