### PR TITLE
Omit <listing> when the scrubbed source is empty

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -226,7 +226,7 @@ final class Emit {
                 .strict(1)
                 .add("comment")
                 .attr("line", target)
-                .set(body.toString())
+                .set(new Scrubbed(body.toString()))
                 .up().up()
                 .pop()
         );
@@ -278,7 +278,7 @@ final class Emit {
             dirs.attr("lossy", "");
         }
         this.append(
-            dirs.set(this.lines.underlined(line, pos, message))
+            dirs.set(new Scrubbed(this.lines.underlined(line, pos, message)))
                 .up().up()
                 .pop()
         );

--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -23,6 +23,13 @@ import org.xembly.Directives;
  * becomes a sibling of {@code <listing>} even without an absolute
  * {@code xpath()} reset of its own.</p>
  *
+ * <p>When nothing survives the scrub — the source is empty or made
+ * entirely of forbidden characters — no element is appended at all.
+ * {@code XMIR.xsd} types {@code listing} as {@code non-empty}, so an
+ * empty {@code <listing/>} is not a valid instance of it; the schema
+ * allows the element to be omitted instead
+ * ({@code minOccurs="0"}).</p>
+ *
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
@@ -42,12 +49,11 @@ final class Listing implements Iterable<Directive> {
 
     @Override
     public Iterator<Directive> iterator() {
-        return new Directives()
-            .xpath("/object")
-            .strict(1)
-            .add("listing")
-            .set(new Scrubbed(this.source))
-            .up()
-            .iterator();
+        final String text = new Scrubbed(this.source).toString();
+        final Directives dirs = new Directives();
+        if (!text.isEmpty()) {
+            dirs.xpath("/object").strict(1).add("listing").set(text).up();
+        }
+        return dirs.iterator();
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -5,7 +5,6 @@
 package org.eolang.parser;
 
 import java.util.Iterator;
-import java.util.regex.Pattern;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -16,14 +15,8 @@ import org.xembly.Directives;
  *
  * <p>The text is set as is, without any manual escaping: the XML writer
  * escapes it exactly once, so the text value of {@code /object/listing}
- * equals the source. A few characters are dropped first, for two
- * different reasons. The XML 1.1 restricted set — {@code 0x00-0x08},
- * {@code 0x0B-0x0C}, {@code 0x0E-0x1F}, {@code 0x7F-0x84} and
- * {@code 0x86-0x9F} — goes because {@link Directives#set(Object)}
- * refuses those and throws, whatever version the writer emits later.
- * {@code U+FFFE} and {@code U+FFFF} go because they are not XML
- * characters at all and would make the document not well-formed;
- * Xembly says nothing about them.</p>
+ * equals the source. A few characters are dropped first, by
+ * {@link Scrubbed}, because an XML text node cannot hold them.</p>
  *
  * <p>The directives leave the cursor on {@code /object}, not inside the
  * {@code <listing>} they add, so that whatever the caller appends next
@@ -33,15 +26,6 @@ import org.xembly.Directives;
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
-
-    /**
-     * Characters that must not reach an XML text node: the XML 1.1
-     * restricted set, which Xembly refuses, plus {@code U+FFFE} and
-     * {@code U+FFFF}, which are not XML characters.
-     */
-    private static final Pattern FORBIDDEN = Pattern.compile(
-        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
-    );
 
     /**
      * Raw EO source text to embed verbatim under {@code <listing>}.
@@ -62,7 +46,7 @@ final class Listing implements Iterable<Directive> {
             .xpath("/object")
             .strict(1)
             .add("listing")
-            .set(Listing.FORBIDDEN.matcher(this.source).replaceAll(""))
+            .set(new Scrubbed(this.source))
             .up()
             .iterator();
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Scrubbed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Scrubbed.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.regex.Pattern;
+
+/**
+ * Source text an XML text node can hold — the same text without the
+ * characters such a node must not carry.
+ *
+ * <p>The XML 1.1 restricted set goes because
+ * {@link org.xembly.Directives#set(Object)} refuses it and throws,
+ * whatever version the writer emits later; {@code U+FFFE} and
+ * {@code U+FFFF} go because they are not XML characters at all. Every
+ * place that hands raw source text to {@code set()} must wrap it in
+ * this, or a control character in the source breaks the parse instead
+ * of being reported by it (#7825).</p>
+ *
+ * @since 0.62.2
+ */
+final class Scrubbed {
+
+    /**
+     * Characters that must not reach an XML text node.
+     */
+    private static final Pattern FORBIDDEN = Pattern.compile(
+        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
+    );
+
+    /**
+     * The text as it came from the source.
+     */
+    private final String origin;
+
+    /**
+     * Ctor.
+     * @param text The text as it came from the source
+     */
+    Scrubbed(final String text) {
+        this.origin = text;
+    }
+
+    @Override
+    public String toString() {
+        return Scrubbed.FORBIDDEN.matcher(this.origin).replaceAll("");
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -174,6 +174,28 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void reportsErrorOnLineWithCharacterForbiddenInXml() throws Exception {
+        MatcherAssert.assertThat(
+            "a broken line quoting a forbidden character must still produce an <error>",
+            new EoSyntax(
+                new InputOf(String.format("[] > x-%cn, 1%n", 0x07))
+            ).parsed(),
+            XhtmlMatchers.hasXPaths("/object/errors/error")
+        );
+    }
+
+    @Test
+    void keepsCommentWithCharacterForbiddenInXml() throws Exception {
+        MatcherAssert.assertThat(
+            "a comment carrying a forbidden character must still reach <comments>",
+            new EoSyntax(
+                new InputOf(String.format("# note %c here%n%n[] > x%n", 0x07))
+            ).parsed(),
+            XhtmlMatchers.hasXPaths("/object/comments/comment[.='note  here']")
+        );
+    }
+
+    @Test
     void rejectsProgramOfMetasAlone() throws Exception {
         MatcherAssert.assertThat(
             "a file of metas alone declares no object and must be refused",

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -684,6 +684,14 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void parsesEmptySourceIntoSchemaValidXmir() {
+        Assertions.assertDoesNotThrow(
+            () -> new StrictXmir(new EoSyntax("").parsed()).toString(),
+            "XMIR of an empty source must match XMIR.xsd, which has no room for an empty <listing>"
+        );
+    }
+
+    @Test
     void parsesMetaUnderObjectRoot() throws Exception {
         MatcherAssert.assertThat(
             "metas emitted by the walker must appear under /object/metas in the final XMIR",

--- a/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ListingTest.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.parser;
 
-import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.matchers.XhtmlMatchers;
+import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
@@ -35,11 +35,21 @@ final class ListingTest {
     }
 
     @Test
-    void buildsListingForEmptySource() {
+    void omitsListingForEmptySource() {
         MatcherAssert.assertThat(
-            "an empty source leaves a listing that is not empty",
-            ListingTest.listing(""),
-            Matchers.emptyString()
+            "an empty source must produce no <listing>, since the schema forbids an empty one",
+            ListingTest.xmir("").nodes("/object/listing"),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void omitsListingForFullyForbiddenSource() {
+        MatcherAssert.assertThat(
+            "a source made only of forbidden characters must leave no <listing> behind",
+            ListingTest.xmir(String.format("%c%c", (char) 0x01, (char) 0x7F))
+                .nodes("/object/listing"),
+            Matchers.empty()
         );
     }
 
@@ -151,19 +161,14 @@ final class ListingTest {
     }
 
     private static String listing(final String source) {
-        return new Xnav(
-            new XMLDocument(
-                new Xembler(
-                    new Directives().add("object").up().append(new Listing(source))
-                ).xmlQuietly()
-            ).inner()
-        ).element("object").element("listing").text().orElseThrow(
-            () -> new IllegalStateException(
-                String.format(
-                    "no <listing> element for the source \"%s\" of %d characters",
-                    source, source.length()
-                )
-            )
+        return String.join("", ListingTest.xmir(source).xpath("/object/listing/text()"));
+    }
+
+    private static XML xmir(final String source) {
+        return new XMLDocument(
+            new Xembler(
+                new Directives().add("object").up().append(new Listing(source))
+            ).xmlQuietly()
         );
     }
 }


### PR DESCRIPTION
`Listing` always appended a `<listing>` element, whatever was left after the forbidden-character scrub. For an empty `.eo` file, or one made entirely of characters Xembly refuses, that produced `<listing></listing>` — and `XMIR.xsd` types `listing` as `non-empty`, so the empty element is not a valid instance of it. Parsing such a source and wrapping the result in `StrictXmir` failed with `cvc-minLength-valid: Value '' with length = '0' is not facet-valid with respect to minLength '1' for type 'non-empty'`.

The schema's own way of saying "no listing" is to leave the element out — `minOccurs="0"` on the declaration. So `Listing` now emits no directive at all when nothing survives the scrub. Nothing downstream needs the element: the two XSL sheets that mention it (`strip-xmir.xsl` and `remove-noise.xsl`) delete it anyway.

`ListingTest.buildsListingForEmptySource` had locked the old shape in by asserting the listing text was an empty string, so it becomes `omitsListingForEmptySource` and now checks that no element is there; a sibling case covers a source built only from forbidden characters. The driving test is `EoSyntaxTest.parsesEmptySourceIntoSchemaValidXmir`, which runs an empty source through the real `EoSyntax` and validates the result against the schema through `StrictXmir` — the path that was actually broken.

Closes #7826
