### PR TITLE
Scrub XML-forbidden characters before every set() of raw source text

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emit.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emit.java
@@ -226,7 +226,7 @@ final class Emit {
                 .strict(1)
                 .add("comment")
                 .attr("line", target)
-                .set(body.toString())
+                .set(new Scrubbed(body.toString()))
                 .up().up()
                 .pop()
         );
@@ -278,7 +278,7 @@ final class Emit {
             dirs.attr("lossy", "");
         }
         this.append(
-            dirs.set(this.lines.underlined(line, pos, message))
+            dirs.set(new Scrubbed(this.lines.underlined(line, pos, message)))
                 .up().up()
                 .pop()
         );

--- a/eo-parser/src/main/java/org/eolang/parser/Listing.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Listing.java
@@ -5,7 +5,6 @@
 package org.eolang.parser;
 
 import java.util.Iterator;
-import java.util.regex.Pattern;
 import org.xembly.Directive;
 import org.xembly.Directives;
 
@@ -16,14 +15,8 @@ import org.xembly.Directives;
  *
  * <p>The text is set as is, without any manual escaping: the XML writer
  * escapes it exactly once, so the text value of {@code /object/listing}
- * equals the source. A few characters are dropped first, for two
- * different reasons. The XML 1.1 restricted set — {@code 0x00-0x08},
- * {@code 0x0B-0x0C}, {@code 0x0E-0x1F}, {@code 0x7F-0x84} and
- * {@code 0x86-0x9F} — goes because {@link Directives#set(Object)}
- * refuses those and throws, whatever version the writer emits later.
- * {@code U+FFFE} and {@code U+FFFF} go because they are not XML
- * characters at all and would make the document not well-formed;
- * Xembly says nothing about them.</p>
+ * equals the source. A few characters are dropped first, by
+ * {@link Scrubbed}, because an XML text node cannot hold them.</p>
  *
  * <p>The directives leave the cursor on {@code /object}, not inside the
  * {@code <listing>} they add, so that whatever the caller appends next
@@ -33,15 +26,6 @@ import org.xembly.Directives;
  * @since 0.1
  */
 final class Listing implements Iterable<Directive> {
-
-    /**
-     * Characters that must not reach an XML text node: the XML 1.1
-     * restricted set, which Xembly refuses, plus {@code U+FFFE} and
-     * {@code U+FFFF}, which are not XML characters.
-     */
-    private static final Pattern FORBIDDEN = Pattern.compile(
-        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
-    );
 
     /**
      * Raw EO source text to embed verbatim under {@code <listing>}.
@@ -62,7 +46,7 @@ final class Listing implements Iterable<Directive> {
             .xpath("/object")
             .strict(1)
             .add("listing")
-            .set(Listing.FORBIDDEN.matcher(this.source).replaceAll(""))
+            .set(new Scrubbed(this.source))
             .up()
             .iterator();
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Scrubbed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Scrubbed.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import java.util.regex.Pattern;
+
+/**
+ * Source text an XML text node can hold — the same text without the
+ * characters such a node must not carry.
+ *
+ * <p>The XML 1.1 restricted set goes because
+ * {@link org.xembly.Directives#set(Object)} refuses it and throws,
+ * whatever version the writer emits later; {@code U+FFFE} and
+ * {@code U+FFFF} go because they are not XML characters at all. Every
+ * place that hands raw source text to {@code set()} must wrap it in
+ * this, or a control character in the source breaks the parse instead
+ * of being reported by it (#7825).</p>
+ *
+ * @since 0.62.2
+ */
+final class Scrubbed {
+
+    /**
+     * Characters that must not reach an XML text node.
+     */
+    private static final Pattern FORBIDDEN = Pattern.compile(
+        "[\\x00-\\x08\\x0B\\x0C\\x0E-\\x1F\\x7F-\\x84\\x86-\\x9F\\uFFFE\\uFFFF]"
+    );
+
+    /**
+     * The text as it came from the source.
+     */
+    private final String origin;
+
+    /**
+     * Ctor.
+     * @param text The text as it came from the source
+     */
+    Scrubbed(final String text) {
+        this.origin = text;
+    }
+
+    @Override
+    public String toString() {
+        return Scrubbed.FORBIDDEN.matcher(this.origin).replaceAll("");
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -174,6 +174,28 @@ final class EoSyntaxTest {
     }
 
     @Test
+    void reportsErrorOnLineWithCharacterForbiddenInXml() throws Exception {
+        MatcherAssert.assertThat(
+            "a broken line quoting a forbidden character must still produce an <error>",
+            new EoSyntax(
+                new InputOf(String.format("[] > x-%cn, 1%n", 0x07))
+            ).parsed(),
+            XhtmlMatchers.hasXPaths("/object/errors/error")
+        );
+    }
+
+    @Test
+    void keepsCommentWithCharacterForbiddenInXml() throws Exception {
+        MatcherAssert.assertThat(
+            "a comment carrying a forbidden character must still reach <comments>",
+            new EoSyntax(
+                new InputOf(String.format("# note %c here%n%n[] > x%n", 0x07))
+            ).parsed(),
+            XhtmlMatchers.hasXPaths("/object/comments/comment[.='note  here']")
+        );
+    }
+
+    @Test
     void rejectsProgramOfMetasAlone() throws Exception {
         MatcherAssert.assertThat(
             "a file of metas alone declares no object and must be refused",


### PR DESCRIPTION
Closes #7825.

`Emit.error` handed `Lines.underlined(...)` to `Directives.set()`, and that string quotes the offending source line verbatim. `Emit.comment` did the same with the raw comment body. Xembly's `Arg` refuses the XML 1.1 restricted characters, so a control character anywhere on a line that failed to parse — or inside a comment — made the parse blow up with `IllegalArgumentException: Failed to understand XML content, SET(...)` instead of producing the `<error>` element that was being built at that very moment.

`Listing` already scrubbed exactly that character set before its own `set()` call, and it was the only place that did. This pulls the pattern out into `Scrubbed`, a small decorator over the text whose `toString()` drops the forbidden characters, and routes all three call sites — the listing, the error message and the comment body — through it. `Directives.set` takes an `Object` and calls `toString()`, so the object goes in directly.

Two tests in `EoSyntaxTest` drive it through the real parser: a source line carrying `0x07` that fails to parse must still yield `/object/errors/error`, and a top comment carrying `0x07` must still reach `/object/comments/comment`. Both threw before this change. `ListingTest.dropsCharactersForbiddenInXml` keeps covering the pattern itself, now through `Scrubbed`, so I did not add a third test for the leaf.
