### PR TITLE
test(#7854): hold the errno-before-lstat order in file.touched

### DIFF
--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -8,6 +8,16 @@
 # whether or not its target exists; the exclusivity that guards the
 # plain-file race stays for every other path, and win32 keeps its exclusive
 # open unconditionally, since its reparse points do not share that rule.
+#
+# The file may be made by somebody else between the question and the answer,
+# so an `open` coming back with `EEXIST` is taken for the file it names rather
+# than for a failure, and the file is handed back with whatever that somebody
+# put in it, since nothing here opens with `O_TRUNC`. That arm asks for `errno`
+# before it asks about `linked`: `errno` belongs to the last native call this
+# thread made, and `linked` is not a `const`, so reading it first would run
+# another `lstat` and leave the `EEXIST` of the `open` overwritten by whatever
+# that one ended with. `EOfileEOtouchedRaceTest` holds the interleaving that
+# reaches the arm.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedRaceTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.yegor256.Together;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@code file.touched} under concurrency.
+ *
+ * <p>{@code touched} asks whether the path can be reached and creates it when
+ * it cannot, and the two questions are not one step: another thread can create
+ * the very same file in between, so the exclusive {@code open} of this one
+ * comes back with {@code EEXIST} having done nothing wrong. Answering that
+ * with the file rather than with a failure is the branch this exercises, and a
+ * single-threaded {@code ++>} test cannot reach it, since nothing there ever
+ * loses the race (#7077).</p>
+ *
+ * <p>The interleaving is left to the threads instead of being forced between
+ * the two steps: every thread is given the same missing path, so whichever one
+ * wins the {@code open} leaves the rest to take the {@code EEXIST} branch. A
+ * thread that is refused comes back through {@code Together} as the failure it
+ * threw, and one that is answered reads {@code exists} off what it was given,
+ * which is the file on disk and not a claim about it.</p>
+ *
+ * <p>Four threads are enough to leave somebody holding the {@code EEXIST}, and
+ * every thread of them builds a graph of objects of its own: a dozen at once is
+ * gigabytes of heap and minutes of collecting it, for no more of the race than
+ * four reach.</p>
+ *
+ * @since 0.75.0
+ */
+final class EOfileEOtouchedRaceTest {
+
+    /**
+     * What the writing thread puts in the raced file.
+     */
+    private static final String CONTENT = "written by somebody else";
+
+    @RepeatedTest(10)
+    void touchesOneFileFromManyThreadsAtOnce(@TempDir final Path temp) {
+        final String path = temp.resolve("touched.txt").toString();
+        MatcherAssert.assertThat(
+            "every thread racing for the same missing file must be told it is there, since the one that loses the exclusive open is the one the EEXIST branch rescues",
+            new Together<>(
+                4,
+                thread -> new Dataized(
+                    this.touched(path).take("exists")
+                ).asBool()
+            ).asList(),
+            Matchers.everyItem(Matchers.is(true))
+        );
+    }
+
+    @RepeatedTest(10)
+    void keepsWhatAnotherThreadWroteInBetween(@TempDir final Path temp) throws Exception {
+        final Path file = temp.resolve("shared.txt");
+        new Together<>(
+            4,
+            thread -> {
+                final boolean done;
+                if (thread == 0) {
+                    Files.write(
+                        file, EOfileEOtouchedRaceTest.CONTENT.getBytes(StandardCharsets.UTF_8)
+                    );
+                    done = true;
+                } else {
+                    done = new Dataized(
+                        this.touched(file.toString()).take("exists")
+                    ).asBool();
+                }
+                return done;
+            }
+        ).asList();
+        MatcherAssert.assertThat(
+            "touching a file another thread has just written must hand it back unchanged, since nothing here opens it with O_TRUNC",
+            new String(Files.readAllBytes(file), StandardCharsets.UTF_8),
+            Matchers.equalTo(EOfileEOtouchedRaceTest.CONTENT)
+        );
+    }
+
+    private Phi touched(final String path) {
+        final Phi file = Phi.Φ.take("file").copy();
+        file.put(0, new Data.ToPhi(path));
+        return file.take("touched");
+    }
+}


### PR DESCRIPTION
Fixes #7854, and the half of #7077 that yegor256 [found still open](https://github.com/objectionary/eo/issues/7077#issuecomment-5409090979).

The `@todo #7077:60min` asked for a regression test that reaches the `EEXIST` arm of `touched`. Writing it showed the arm does not work, so this does both.

### The arm

```eo
or.
  descriptor.gte 0
  linked.not.and
    errno.eq eexist
```

`and` is `^.if (01-.eq x) false`, so its receiver goes first, and the receiver here is `linked`, that is `^.is-symlink false`. It is not a `const`, so asking for it runs another `lstat`, and `errno` belongs to the last native call the thread made: by the time `errno.eq eexist` is asked, the `EEXIST` of the `open` is gone and the arm answers `false`. `touched` then terminates on a file that another thread has legitimately created in between.

The arm now asks in the other order, which is how the same branch is written in `directory/made.eo` and why that one works:

```eo
or.
  descriptor.gte 0
  and.
    errno.eq eexist
    linked.not
```

Nothing runs between the `open` and the `errno` read any more. `linked.not` still gates the arm, only after the number has been taken.

### The test

`EOfileEOtouchedRaceTest` follows `EOdirectoryEOmadeRaceTest`, which holds the same interleaving for `directory.made`. Four threads are given the same missing path: whoever wins the exclusive `open` leaves the others to take the `EEXIST` arm, and a thread that is refused comes back through `Together` as the failure it threw. The second test has one thread write content while the others touch, and checks the content survives, since nothing here opens with `O_TRUNC`.

### On the evidence

Locally I only have Windows, and the two runs there are green both with and without the fix: win32 goes through `_open`/`_errno` and does not put an `lstat` in between, so the platform never shows it. The failing evidence is yegor256's own run of an equivalent test on POSIX, which died on round 12 of 20 with `Cant touch the file: File exists`, and CI covers Linux and macOS here.
