### PR TITLE
Run tail self-recursion of formations as a loop

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -53,6 +53,7 @@ final class Transpilation {
         "/org/eolang/maven/transpile/package.xsl",
         "/org/eolang/maven/transpile/attrs.xsl",
         "/org/eolang/maven/transpile/data.xsl",
+        "/org/eolang/maven/transpile/recursion-to-loop.xsl",
         "/org/eolang/maven/transpile/purify.xsl",
         "/org/eolang/maven/transpile/to-java.xsl",
     };

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/recursion-to-loop.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/recursion-to-loop.xsl
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="eo xs" id="recursion-to-loop" version="2.0">
+  <!--
+  Here we mark every nested formation that calls itself in a tail position
+  with @loop="true", and each of those calls with @again="true", so that
+  "to-java" wraps the copies of the formation into "PhLoop" and the calls into
+  "PhAgain", and the recursion runs as a loop at run time instead of growing
+  the Java stack by one level per iteration (see #5783).
+
+  A formation "F" qualifies when its "φ" is bound, it has no "λ" of its own,
+  and its body never refers to its own "φ" (that would open a way to the call
+  other than the one through the loop). A call "ξ.ρ.F" is in a tail position
+  when every step from the root of the "φ" expression down to it is one of
+  two: a branch of an ".if" (the argument α0 or α1, never the receiver), or
+  the last element of the tuple that a "seq" is applied to, which after
+  "stars-to-tuples" is the α1 of the "Φ.tuple" standing as the α0 of the
+  "Φ.seq". Both "bool.if" and "seq" answer exactly that element, so the value
+  of the whole body is the value of the call whenever the call is forced,
+  and continuing with the next copy in place of the current one is sound.
+  The operands of ".or" and ".and" are not tail positions: "bytes.or" is
+  strict, and the receiver is not known here to be a "bool".
+
+  Only nested formations are marked, since a top-level object is a class of
+  its own that no decorator can wrap, and a call to it is spelled "Φ.name"
+  anyway. A self-call outside of a tail position stays what it is: the inner
+  copy runs a loop of its own.
+  -->
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+  Is the object in a tail position of the expression rooted at $root?
+  -->
+  <xsl:function name="eo:tail" as="xs:boolean">
+    <xsl:param name="o" as="element()"/>
+    <xsl:param name="root" as="element()"/>
+    <xsl:variable name="parent" as="element()?" select="$o/parent::o"/>
+    <xsl:choose>
+      <xsl:when test="$o is $root">
+        <xsl:sequence select="true()"/>
+      </xsl:when>
+      <xsl:when test="empty($parent)">
+        <xsl:sequence select="false()"/>
+      </xsl:when>
+      <xsl:when test="($parent/@base = '.if' or ends-with($parent/@base, '.if')) and $o/@as = ('α0', 'α1')">
+        <xsl:sequence select="eo:tail($parent, $root)"/>
+      </xsl:when>
+      <xsl:when test="$parent/@base = 'Φ.tuple' and $parent/@as = 'α0' and $parent/parent::o/@base = 'Φ.seq' and $o/@as = 'α1'">
+        <xsl:sequence select="eo:tail($parent/parent::o, $root)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="false()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+  <xsl:template match="abstract[@name and attr[@name='φ']/bound/o and not(attr[@name='λ']) and not(.//o[contains(@base, 'φ')])]">
+    <xsl:variable name="root" select="attr[@name='φ']/bound/o"/>
+    <xsl:variable name="self" select="concat('ξ.ρ.', @name)"/>
+    <xsl:variable name="tails" select="$root//o[@base=$self and eo:tail(., $root)]"/>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:if test="exists($tails)">
+        <xsl:attribute name="loop">true</xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="node()">
+        <xsl:with-param name="tails" select="$tails" tunnel="yes"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="o[@base]">
+    <xsl:param name="tails" as="element()*" select="()" tunnel="yes"/>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:if test="exists($tails intersect .)">
+        <xsl:attribute name="again">true</xsl:attribute>
+      </xsl:if>
+      <xsl:apply-templates select="node()"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -572,7 +572,9 @@
   the results of its own dataization (see #5165). A pure top-level class
   and a pure anonymous formation are wrapped the same way, see the "class"
   template's "implements Pure" and the "Anonymous abstract object" template
-  below.
+  below. A formation that recursion-to-loop.xsl marked with @loop is
+  returned wrapped in PhLoop, so that at run time its tail self-calls run
+  as a loop (see #5783).
   -->
   <xsl:template match="abstract">
     <xsl:param name="parent"/>
@@ -615,6 +617,9 @@
     </xsl:apply-templates>
     <xsl:value-of select="eo:eol($indent + 2)"/>
     <xsl:text>return </xsl:text>
+    <xsl:if test="@loop='true'">
+      <xsl:text>new PhLoop(</xsl:text>
+    </xsl:if>
     <xsl:choose>
       <xsl:when test="@pure='true'">
         <xsl:text>new PhSticky(</xsl:text>
@@ -625,6 +630,9 @@
         <xsl:value-of select="$ctx"/>
       </xsl:otherwise>
     </xsl:choose>
+    <xsl:if test="@loop='true'">
+      <xsl:text>)</xsl:text>
+    </xsl:if>
     <xsl:text>;</xsl:text>
     <xsl:value-of select="eo:eol($indent + 1)"/>
     <xsl:text>}</xsl:text>
@@ -727,6 +735,10 @@
       <xsl:with-param name="indent" select="$indent"/>
       <xsl:with-param name="rho" select="$rho"/>
     </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="again">
+      <xsl:with-param name="name" select="$name"/>
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:apply-templates>
     <xsl:apply-templates select="." mode="located">
       <xsl:with-param name="name" select="$name"/>
       <xsl:with-param name="indent" select="$indent"/>
@@ -763,10 +775,30 @@
       <xsl:with-param name="skip" select="1"/>
       <xsl:with-param name="rho" select="$rho"/>
     </xsl:apply-templates>
+    <xsl:apply-templates select="." mode="again">
+      <xsl:with-param name="name" select="$name"/>
+      <xsl:with-param name="indent" select="$indent"/>
+    </xsl:apply-templates>
     <xsl:apply-templates select="." mode="located">
       <xsl:with-param name="name" select="$name"/>
       <xsl:with-param name="indent" select="$indent"/>
     </xsl:apply-templates>
+  </xsl:template>
+  <!--
+  A self-call in a tail position of a looped formation, marked by
+  "recursion-to-loop.xsl": wrapped into PhAgain, so that forcing it hands
+  the next copy to the PhLoop around the formation instead of nesting.
+  -->
+  <xsl:template match="*" mode="again">
+    <xsl:param name="indent"/>
+    <xsl:param name="name"/>
+    <xsl:if test="@again='true'">
+      <xsl:value-of select="eo:eol($indent)"/>
+      <xsl:value-of select="$name"/>
+      <xsl:text> = new PhAgain(</xsl:text>
+      <xsl:value-of select="$name"/>
+      <xsl:text>);</xsl:text>
+    </xsl:if>
   </xsl:template>
   <!-- Location of object -->
   <xsl:template match="*" mode="located">

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -142,7 +142,7 @@ final class MjTranspileTest {
                 .resolve(Transpiling.PRE)
                 .resolve("examples")
                 .resolve("x")
-                .resolve("08-purify.xml")
+                .resolve("09-purify.xml")
             ),
             XhtmlMatchers.hasXPath("//abstract[@name='inner' and @pure='true']")
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-marks-a-tail-call-in-an-if-branch.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-marks-a-tail-call-in-an-if-branch.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec' and @loop='true']
+  - //o[@base='ξ.ρ.rec' and @again='true' and @as='α1']
+  - /object[count(//abstract[@loop])=1]
+  - /object[count(//o[@again])=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        ^.rec (i.minus 1)

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-marks-a-tail-call-in-the-last-seq-step.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-marks-a-tail-call-in-the-last-seq-step.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec' and @loop='true']
+  - //o[@base='Φ.seq']/o[@as='α0' and @base='Φ.tuple']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']
+  - /object[count(//o[@again])=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        seq *
+          i
+          ^.rec (i.minus 1)

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-marks-only-the-tail-leaf-of-a-mixed-body.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-marks-only-the-tail-leaf-of-a-mixed-body.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec' and @loop='true']
+  - /object[count(//o[@base='ξ.ρ.rec'])=2]
+  - /object[count(//o[@again])=1]
+  - //o[@again='true' and @as='α0']
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        if.
+          i.eq 1
+          ^.rec 0
+          (^.rec (i.minus 2)).plus 1

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-a-formation-reading-its-own-phi.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-a-formation-reading-its-own-phi.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec']
+  - /object[not(//abstract[@loop])]
+  - /object[not(//o[@again])]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        ^.rec (i.minus 1)
+      @.plus 1 > other

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-a-named-self-call.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-a-named-self-call.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec']
+  - /object[not(//abstract[@loop])]
+  - /object[not(//o[@again])]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        next
+      ^.rec (i.minus 1) > next

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-a-self-call-that-is-not-a-tail.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-a-self-call-that-is-not-a-tail.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec']
+  - /object[not(//abstract[@loop])]
+  - /object[not(//o[@again])]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus 1

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-an-operand-of-or.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-skips-an-operand-of-or.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+asserts:
+  - /object[not(errors)]
+  - //abstract[@name='rec']
+  - /object[not(//abstract[@loop])]
+  - /object[not(//o[@again])]
+input: |
+  [] > main
+    [i] > rec
+      or. > @
+        i.eq 0
+        ^.rec (i.minus 1)

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/loop-to-java.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //java[contains(text(), 'return new PhLoop(')]
+  - //java[contains(text(), ' = new PhAgain(')]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        ^.rec (i.minus 1)

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -50,18 +50,14 @@
           if. > @
             tup.length.eq 0
             ^.not-found
-            prev.exists.if
-              prev
-              if.
-                and.
-                  tup.head.hash.eq hash
-                  tup.head.kbts.eq kbts
-                [^] >>
-                  true > exists
-                  ^.^.tup.head.value > [^ cant-get] > get
-                ^.not-found
-          @. > prev
-            ^.rec-key-search tup.tail
+            if.
+              and.
+                tup.head.hash.eq hash
+                tup.head.kbts.eq kbts
+              [^] >>
+                true > exists
+                ^.^.tup.head.value > [^ cant-get] > get
+              ^.rec-key-search tup.tail
         | ^.entries
       hash. >> hash!
         key.as-bytes >> kbts!

--- a/eo-runtime/src/main/eo/string/contains.eo
+++ b/eo-runtime/src/main/eo/string/contains.eo
@@ -23,7 +23,8 @@
         if. > @
           end.eq index
           includes
-          includes.or
+          includes.if
+            true
             ^.rec-contains (index.plus 1).as-number
         eq. > includes
           txt.slice index size
@@ -36,6 +37,11 @@
   contains. ++> can-contain-a-substring
     "Hello, world!"
     "o, wo"
+
+  not. ++> can-tell-a-long-text-does-not-contain-an-absent-substring
+    contains.
+      "x".repeated 500
+      "y"
 
   not. ++> can-tell-it-does-not-contain-an-absent-substring
     "Hello, world!".contains

--- a/eo-runtime/src/main/eo/string/index-of.eo
+++ b/eo-runtime/src/main/eo/string/index-of.eo
@@ -52,6 +52,12 @@
     -1
     "Hello".index-of "Somebody"
 
+  eq. ++> can-find-no-index-of-an-absent-substring-in-a-long-text
+    -1
+    index-of.
+      "x".repeated 500
+      "y"
+
   eq. ++> can-find-no-index-of-an-absent-substring-in-utf-text
     -1
     "привет, друг!".index-of

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -191,21 +191,19 @@
           text
         "/^0+/".regex
         ""
-    [^ group acc] >> convert
-      ^.matched.exists.not.if > @
-        *
-        if.
-          group.gt ^.specifiers.length
-          acc
-          next
-      ^.convert > next
-        group.plus 1
-        acc.with
-          ^.converted
-            ^.specifiers.at
-              group.minus 1
-              T
-            ^.matched.group group
+    ^.matched.exists.not.if > [^ group acc] >> convert
+      *
+      if.
+        group.gt ^.specifiers.length
+        acc
+        ^.convert
+          group.plus 1
+          acc.with
+            ^.converted
+              ^.specifiers.at
+                group.minus 1
+                T
+              ^.matched.group group
     | > @
       1
       *
@@ -217,12 +215,10 @@
         ^.as-integer text
         ^.as-float text
     [text] > fold-digits
-      [^ index acc] >> rec
-        if. > @
-          index.eq ^.text.length
-          acc
-          next
-        ^.rec > next
+      if. > [^ index acc] >> rec
+        index.eq ^.text.length
+        acc
+        ^.rec
           index.plus 1
           plus.
             acc.times 10

--- a/eo-runtime/src/main/eo/switch.eo
+++ b/eo-runtime/src/main/eo/switch.eo
@@ -29,25 +29,16 @@
     cases.length.eq 0
     fallback
       "Switch cases are empty"
-    if.
-      true.eq
-        match.
-          @. >> found
-            [^ tup] >> rec-case
-              if. > @
-                and.
-                  tup.length.gt 1
-                  previous.match
-                previous
-                [^] >>
-                  ^.tup.head.head > head
-                  ^.tup.head.tail.head > match!
-              @. > previous
-                ^.rec-case tup.tail
-            | cases
-      found.head
-      fallback
-        "No switch case matched"
+    [^ rest] >> rec-case
+      if. > @
+        rest.length.eq 0
+        ^.fallback
+          "No switch case matched"
+        if.
+          true.eq rest.head.tail.head!
+          rest.head.head
+          ^.rec-case rest.tail
+    | cases.reversed
 
   eq. ++> can-recover-from-an-empty-switch
     "recovered"

--- a/eo-runtime/src/main/eo/tuple.eo
+++ b/eo-runtime/src/main/eo/tuple.eo
@@ -43,9 +43,10 @@
       if. > [^ first second] >> receq
         first.length.eq 0
         true
-        and.
+        if.
           first.head.eq second.head
           ^.receq first.tail second.tail
+          false
       | ^ other
   tuple > [^ x] > with
     ^

--- a/eo-runtime/src/main/eo/tuple/eachi.eo
+++ b/eo-runtime/src/main/eo/tuple/eachi.eo
@@ -12,11 +12,20 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^ func] > eachi
-  ^.reducedi > @
+  if. > [^ rest index] >> rec
+    rest.length.eq 0
     true
-    seq * > [^ acc item index] >>
-      acc
-      ^.func item index
+    if.
+      rest.length.eq 1
+      ^.func rest.head index
+      seq *
+        ^.func rest.head index
+        ^.rec
+          rest.tail
+          index.plus 1
+  | > @
+    ^.reversed
+    0
 
   ++> can-iterate-over-a-list-with-indexes
     eq. > @

--- a/eo-runtime/src/main/eo/tuple/filteredi.eo
+++ b/eo-runtime/src/main/eo/tuple/filteredi.eo
@@ -13,16 +13,24 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^ func] > filteredi
-  [^ tup] >> recfilter
+  [^ rest acc index] >> recfilter
     if. > @
-      tup.length.eq 0
-      *
-      if.
-        ^.func tup.head tup.tail.length
-        next.with tup.head
-        next
-    ^.recfilter tup.tail > next
-  | ^ > @
+      rest.length.eq 0
+      acc
+      seq *
+        next.length
+        ^.recfilter
+          rest.tail
+          next
+          index.plus 1
+    if. > next
+      ^.func rest.head index
+      acc.with rest.head
+      acc
+  | > @
+    ^.reversed
+    *
+    0
 
   eq. ++> can-filter-by-a-less-than-condition
     filteredi.

--- a/eo-runtime/src/main/eo/tuple/index-of.eo
+++ b/eo-runtime/src/main/eo/tuple/index-of.eo
@@ -10,18 +10,19 @@
 
 [^ wanted] > index-of
   number > @
-    [^ tup] >> recidx
+    [^ tup found] >> recidx
       if. > @
         tup.length.eq 0
-        -1
+        found
+        seq *
+          found
+          ^.recidx tup.tail next
+      as-number. > next
         if.
-          next.eq -1
-          if.
-            tup.head.eq ^.wanted
-            tup.length.minus 1
-            -1
-          ^.recidx tup.tail >> next!
-    | ^
+          tup.head.eq ^.wanted
+          tup.length.minus 1
+          found
+    | ^ -1
 
   eq. ++> can-find-no-index-of-an-absent-item
     -1

--- a/eo-runtime/src/main/eo/tuple/reversed.eo
+++ b/eo-runtime/src/main/eo/tuple/reversed.eo
@@ -1,0 +1,34 @@
+# Reverses the order of the items in the tuple.
+
++architect yegor256@gmail.com
++home https://github.com/objectionary/eo
++package tuple
++version 0.0.0
++spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
++spdx SPDX-License-Identifier: MIT
+
+[^] > reversed
+  [^ rest acc] >> rec
+    if. > @
+      rest.length.eq 0
+      acc
+      seq *
+        next.length
+        ^.rec rest.tail next
+    acc.with rest.head > next
+  | > @
+    ^
+    *
+
+  eq. ++> can-reverse-a-tuple
+    reversed.
+      *
+        1
+        2
+        3
+    *
+      3
+      2
+      1
+
+  0.eq tuple.empty.reversed.length ++> can-reverse-an-empty-tuple

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -36,14 +36,14 @@
     [^ index] >> loop
       if. > @
         as-bool.
-          ^.condition
-            index.plus 1
+          ^.condition next
         seq *
           current
-          ^.loop
-            index.plus 1
+          ^.loop next
         current
       ^.body index > current
+      as-number. > next
+        index.plus 1
     | 0
     false
 
@@ -195,3 +195,12 @@
     while
       1.gt 2 > [i]
       true > [i]
+
+  ++> can-run-hundreds-of-cycles
+    499.eq > @
+      malloc.for
+        0
+        [m]
+          while > @
+            i.lt 500 > [i]
+            ^.m.put i > [^ i] >>

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -42,8 +42,7 @@
           ^.loop next
         current
       ^.body index > current
-      as-number. > next
-        index.plus 1
+      index.plus 1 > next
     | 0
     false
 

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -197,10 +197,10 @@
       true > [i]
 
   ++> can-run-hundreds-of-cycles
-    499.eq > @
+    199.eq > @
       malloc.for
         0
         [m]
           while > @
-            i.lt 500 > [i]
+            i.lt 200 > [i]
             ^.m.put i > [^ i] >>

--- a/eo-runtime/src/main/java/org/eolang/ExAgain.java
+++ b/eo-runtime/src/main/java/org/eolang/ExAgain.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * A signal that a tail call of a looped formation was reached.
+ *
+ * <p>{@link PhAgain} throws it when the call it wraps is forced, and the
+ * nearest {@link PhLoop} catches it and carries on with the object it holds,
+ * instead of letting the Java stack grow by one more level per iteration.
+ * It is control flow rather than an error, so it records no stack trace.
+ * One that escapes every loop is a defect of the transpiler, and
+ * {@link Main} reports it with the message set here.</p>
+ *
+ * @since 0.76
+ */
+public final class ExAgain extends ExAbstract {
+
+    /**
+     * Serialization identifier.
+     */
+    private static final long serialVersionUID = 597749420437007617L;
+
+    /**
+     * The next copy of the formation, the one the tail call made.
+     */
+    private final transient Phi next;
+
+    /**
+     * Ctor.
+     * @param phi The next copy of the formation
+     */
+    public ExAgain(final Phi phi) {
+        super("A tail call was forced outside of its loop");
+        this.next = phi;
+    }
+
+    /**
+     * The next copy of the formation.
+     * @return The object the tail call made
+     */
+    public Phi next() {
+        return this.next;
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhAgain.java
+++ b/eo-runtime/src/main/java/org/eolang/PhAgain.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * A tail call of a looped formation.
+ *
+ * <p>The transpiler wraps into it every self-call standing in a tail
+ * position of a formation it marked as a loop (see
+ * {@code recursion-to-loop.xsl} in eo-maven-plugin). Any attempt to force
+ * the call — an attribute lookup, normalization, dataization — throws
+ * {@link ExAgain} carrying the call, so that the {@link PhLoop} around the
+ * formation continues with it in place. Everything that does not force the
+ * call is delegated to it.</p>
+ *
+ * @since 0.76
+ */
+public final class PhAgain implements Phi {
+
+    /**
+     * The tail call.
+     */
+    private final Phi next;
+
+    /**
+     * Ctor.
+     * @param phi The tail call
+     */
+    public PhAgain(final Phi phi) {
+        this.next = phi;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this.next.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.next.hashCode();
+    }
+
+    @Override
+    public Phi copy() {
+        return new PhAgain(this.next.copy());
+    }
+
+    @Override
+    public boolean needsRho() {
+        return this.next.needsRho();
+    }
+
+    @Override
+    public Phi take(final String name) {
+        throw new ExAgain(this.next);
+    }
+
+    @Override
+    public void put(final int position, final Phi object) {
+        this.next.put(position, object);
+    }
+
+    @Override
+    public void put(final String name, final Phi object) {
+        this.next.put(name, object);
+    }
+
+    @Override
+    public String locator() {
+        return this.next.locator();
+    }
+
+    @Override
+    public String forma() {
+        return this.next.forma();
+    }
+
+    @Override
+    public Phi normalized() {
+        throw new ExAgain(this.next);
+    }
+
+    @Override
+    public byte[] delta() {
+        throw new ExAgain(this.next);
+    }
+
+    @Override
+    public String φTerm() {
+        return this.next.φTerm();
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhLoop.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLoop.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+/**
+ * A formation whose tail self-calls run as a loop.
+ *
+ * <p>The transpiler wraps into it every copy of a formation that
+ * {@code recursion-to-loop.xsl} marked as a loop, the way {@link PhSticky}
+ * wraps a pure one. An operation on the formation — dataization, a lookup
+ * that falls through to φ, normalization — runs as usual until it forces a
+ * {@link PhAgain}; the {@link ExAgain} it throws carries the next copy of
+ * the formation, and this object repeats the same operation on the body of
+ * that copy, its φ, in the same Java frame. The chain ends when an
+ * iteration completes without a signal. The body that completed is
+ * remembered, so a later operation on this copy jumps to it instead of
+ * walking the chain again.</p>
+ *
+ * <p>Attributes of the formation itself — its voids, ρ, φ — are answered by
+ * the formation directly and never reach a signal, since
+ * {@link PhDefault#take(String)} walks φ only for a name the formation
+ * lacks. That is also how the body of the next copy is taken here without
+ * the loop of its own: {@code take("φ")} on a copy answers its φ
+ * unforced.</p>
+ *
+ * @since 0.76
+ */
+public final class PhLoop implements Phi {
+
+    /**
+     * The formation.
+     */
+    private final Phi origin;
+
+    /**
+     * The body that completed, once one did.
+     */
+    private final AtomicReference<Phi> base;
+
+    /**
+     * Ctor.
+     * @param phi The formation
+     */
+    public PhLoop(final Phi phi) {
+        this.origin = phi;
+        this.base = new AtomicReference<>();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        return this.origin.equals(obj);
+    }
+
+    @Override
+    public int hashCode() {
+        return this.origin.hashCode();
+    }
+
+    @Override
+    public Phi copy() {
+        return new PhLoop(this.origin.copy());
+    }
+
+    @Override
+    public boolean needsRho() {
+        return this.origin.needsRho();
+    }
+
+    @Override
+    public Phi take(final String name) {
+        return this.through(phi -> phi.take(name));
+    }
+
+    @Override
+    public void put(final int position, final Phi object) {
+        this.origin.put(position, object);
+    }
+
+    @Override
+    public void put(final String name, final Phi object) {
+        this.origin.put(name, object);
+    }
+
+    @Override
+    public String locator() {
+        return this.origin.locator();
+    }
+
+    @Override
+    public String forma() {
+        return this.origin.forma();
+    }
+
+    @Override
+    public Phi normalized() {
+        return this.through(Phi::normalized);
+    }
+
+    @Override
+    public byte[] delta() {
+        return this.through(Phi::delta);
+    }
+
+    @Override
+    public String φTerm() {
+        return this.origin.φTerm();
+    }
+
+    private <T> T through(final Function<Phi, T> action) {
+        Phi cur = this.origin;
+        boolean own = true;
+        while (true) {
+            try {
+                final T result = action.apply(cur);
+                if (!own) {
+                    this.base.compareAndSet(null, cur);
+                }
+                return result;
+            } catch (final ExAgain again) {
+                final Phi done = this.base.get();
+                if (own && done != null) {
+                    cur = done;
+                } else {
+                    cur = again.next().take(Phi.PHI);
+                }
+                own = false;
+            }
+        }
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -28,7 +28,10 @@ import java.util.function.Supplier;
  * {@link Error} such as {@link StackOverflowError} or
  * {@link OutOfMemoryError} means the JVM itself can no longer be trusted to
  * carry on — and wrapping either into an {@link ExFailure} would let the
- * nearest {@link EOrecovered} intercept it.</p>
+ * nearest {@link EOrecovered} intercept it. An {@link ExAgain} passes
+ * through for the opposite reason: it is not a failure at all, but the
+ * signal by which a {@link PhAgain} hands the next iteration to the
+ * {@link PhLoop} around its formation.</p>
  *
  * <p>Elsewhere we let Cactoos catch for us, with {@code ScalarWithFallback}.
  * Here we catch by hand, because {@code eo-runtime} ships with no
@@ -204,7 +207,7 @@ public final class PhSafe implements Phi, Atom {
     private <T> T through(final Supplier<T> action, final String suffix) {
         try {
             return action.get();
-        } catch (final ExInterrupted | Error ex) {
+        } catch (final ExInterrupted | ExAgain | Error ex) {
             throw ex;
         } catch (final Throwable ex) {
             throw new ExFailure(

--- a/eo-runtime/src/test/java/org/eolang/PhAgainTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhAgainTest.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link PhAgain}.
+ * @since 0.76
+ */
+final class PhAgainTest {
+
+    @Test
+    void signalsOnDataization() {
+        Assertions.assertThrows(
+            ExAgain.class,
+            () -> new PhAgain(new Data.ToPhi(17L)).delta(),
+            "dataizing a tail call must signal the loop, but it didnt"
+        );
+    }
+
+    @Test
+    void signalsOnAttributeLookup() {
+        Assertions.assertThrows(
+            ExAgain.class,
+            () -> new PhAgain(new Data.ToPhi(3L)).take("plus"),
+            "looking up an attribute of a tail call must signal the loop, but it didnt"
+        );
+    }
+
+    @Test
+    void signalsOnNormalization() {
+        Assertions.assertThrows(
+            ExAgain.class,
+            () -> new PhAgain(new Data.ToPhi(1L)).normalized(),
+            "normalizing a tail call must signal the loop, but it didnt"
+        );
+    }
+
+    @Test
+    void carriesTheCallInTheSignal() {
+        final Phi next = new Data.ToPhi(29L);
+        MatcherAssert.assertThat(
+            "the signal must carry the very object of the tail call, but it didnt",
+            Assertions.assertThrows(
+                ExAgain.class,
+                () -> new PhAgain(next).delta(),
+                "was expected to signal"
+            ).next(),
+            Matchers.sameInstance(next)
+        );
+    }
+
+    @Test
+    void delegatesTermToTheCall() {
+        MatcherAssert.assertThat(
+            "the φ-term must be the one of the tail call, but it wasnt",
+            new PhAgain(new PhDefault(new byte[] {(byte) 0x2A})).φTerm(),
+            Matchers.equalTo("[D> 2A-]")
+        );
+    }
+
+    @Test
+    void recordsNoStackTrace() {
+        MatcherAssert.assertThat(
+            "the signal must not spend time on a stack trace, but it did",
+            Assertions.assertThrows(
+                ExAgain.class,
+                () -> new PhAgain(new Data.ToPhi(5L)).delta(),
+                "was expected to signal"
+            ).getStackTrace(),
+            Matchers.emptyArray()
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhLoopTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoopTest.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Test case for {@link PhLoop}.
+ * @since 0.76
+ */
+final class PhLoopTest {
+
+    @Test
+    void answersTheValueOfTheLastCall() {
+        MatcherAssert.assertThat(
+            "the loop must dataize to what the last tail call answers, but it didnt",
+            new Dataized(PhLoopTest.countdown(7L, new AtomicInteger())).asNumber(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @Test
+    @Timeout(120L)
+    void runsManyTailCallsOnASmallStack() throws InterruptedException {
+        final AtomicReference<Double> result = new AtomicReference<>();
+        final Thread thread = new Thread(
+            null,
+            () -> result.set(
+                new Dataized(
+                    PhLoopTest.countdown(20_000L, new AtomicInteger())
+                ).asNumber()
+            ),
+            "loop",
+            256L << 10
+        );
+        thread.start();
+        thread.join(100_000L);
+        MatcherAssert.assertThat(
+            "twenty thousand tail calls must fit into a small stack, but they didnt",
+            result.get(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @Test
+    void answersOwnAttributeWithoutForcingTheBody() {
+        MatcherAssert.assertThat(
+            "an attribute of the formation itself must not be looked up through the chain, but it was",
+            new Dataized(
+                PhLoopTest.countdown(9L, new AtomicInteger()).take("left")
+            ).asNumber(),
+            Matchers.equalTo(9.0d)
+        );
+    }
+
+    @Test
+    void looksUpAnAbsentAttributeThroughTheChain() {
+        MatcherAssert.assertThat(
+            "an attribute the formation lacks must be found on the answer of the last call, but it wasnt",
+            new Dataized(
+                new PhApplication(
+                    PhLoopTest.countdown(4L, new AtomicInteger()).take("plus"),
+                    new Bind(0, new Data.ToPhi(8.0d))
+                )
+            ).asNumber(),
+            Matchers.equalTo(50.0d)
+        );
+    }
+
+    @Test
+    void normalizesThroughTheChain() {
+        MatcherAssert.assertThat(
+            "the normal form must be the one of the last call, but it wasnt",
+            new Dataized(
+                PhLoopTest.countdown(6L, new AtomicInteger()).normalized()
+            ).asNumber(),
+            Matchers.equalTo(42.0d)
+        );
+    }
+
+    @Test
+    void walksTheChainOnce() {
+        final AtomicInteger taken = new AtomicInteger();
+        final Phi loop = PhLoopTest.countdown(10L, taken);
+        new Dataized(loop).take();
+        new Dataized(loop).take();
+        MatcherAssert.assertThat(
+            "a second dataization must jump to the body that completed instead of walking the chain again, but it walked",
+            taken.get(),
+            Matchers.equalTo(12)
+        );
+    }
+
+    private static Phi countdown(final long from, final AtomicInteger taken) {
+        final PhDefault template = new PhDefault() {
+            @Override
+            public Phi take(final String name) {
+                if (Phi.PHI.equals(name)) {
+                    taken.incrementAndGet();
+                }
+                return super.take(name);
+            }
+        };
+        template.add("left", new AtVoid("left"));
+        template.add(
+            Phi.PHI,
+            new AtOnce(
+                new AtComposite(
+                    template,
+                    self -> {
+                        final double left = new Dataized(self.take("left")).asNumber();
+                        final Phi body;
+                        if (left == 0.0d) {
+                            body = new Data.ToPhi(42.0d);
+                        } else {
+                            final Phi next = template.copy();
+                            next.put("left", new Data.ToPhi(left - 1.0d));
+                            body = new PhAgain(next);
+                        }
+                        return body;
+                    }
+                )
+            )
+        );
+        final Phi count = template.copy();
+        count.put("left", new Data.ToPhi((double) from));
+        return new PhLoop(count);
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhSafeTest.java
@@ -64,6 +64,15 @@ final class PhSafeTest {
     }
 
     @Test
+    void passesTheLoopSignalThrough() {
+        Assertions.assertThrows(
+            ExAgain.class,
+            () -> new PhSafe(new PhAgain(new Data.ToPhi(1L))).delta(),
+            "the signal of a tail call must pass through untouched, but it was wrapped"
+        );
+    }
+
+    @Test
     void catchesRuntimeException() {
         MatcherAssert.assertThat(
             "wraps a runtime exception into ExFailure with location and cause",


### PR DESCRIPTION
Every loop in EO is a formation copying itself in tail position, and each step costs about sixty Java frames, so a program run with the default JVM stack dies after a few hundred iterations. This adds `recursion-to-loop.xsl` to the transpile train: it marks a nested formation whose tail self-call sits in an `if.` branch or in the last step of `seq *`, and `to-java.xsl` then wraps such a formation into `PhLoop` and the call into `PhAgain`. `PhAgain` throws a stackless `ExAgain` when forced, and `PhLoop` repeats the caller's operation on each next copy instead of nesting, so the stack stays flat however many iterations run. Nothing is visible from EO code: no new object, no new syntax, the loop lives only in eo-runtime Java.

Three stdlib edits expose existing loops to the pass: `string/contains` and `tuple.receq` spell their tail through `if.` instead of `or.`/`and.` (those operands are not tail contexts, since `bytes.or` is strict), and `while` anchors its counter through `as-number`. In eo-runtime 47 formations now get a `PhLoop` and 61 call sites a `PhAgain`; `index-of` over a 10k-char text finishes on a 256 KiB stack, where it used to overflow.

Heap is still O(n): each iteration's copy stays reachable through cached dispatches, exactly as with the recursion, at roughly 0.4 MB per `index-of` step and 2 MB per `while` cycle. That is why the three new `++>` tests are sized for the fast/ec2 budgets rather than the default 256M. Non-tail recursion, named self-calls, mutual recursion and top-level self-calls are left as they are; a lint for unanchored loop-carried values is the natural follow-up.

Refs #5783