### PR TITLE
Consume a paren group whole

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -386,6 +386,8 @@ foo ([x] body)               ← rejected: horizontal formation as argument
 foo [x] 5                    ← rejected: `[x]` in the horizontal arg list of foo
 ```
 
+R-3.6.6. **A paren group is consumed whole.** The expression between `(` and `)` must account for every character inside it; a group is an expression, not a recovery boundary. Anything the inner expression leaves behind — an optional marker, a name suffix, a test attribute, any token that has no place at that position — is rejected (`unexpected content inside a parenthesised expression`) rather than dropped, so `foo (bar baz?)`, `foo (bar baz >)` and `foo (bar baz +> test)` fail the same way `bar baz?` does without the parens.
+
 Outer kinds produced:
 - Head only, no args, no chained `.method` → **`head`**. A `*` token alone in head position is also `head` kind, emitted with `@base='Φ.tuple'` and `@star=''` (see §9.4.2 "Star tuple as head"). Openness and wrappability are the same as any other `head`.
 - Head with chained `.method.method…` but 0 horizontal args → **`hmethod`**. The head of the chain may itself be a paren group, a literal, `*`, or an identifier; the chain wraps it.

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -410,7 +410,9 @@ final class Emissions {
             final Span sub = new Span(
                 " ".repeat(value.pos() + 1).concat(inner), line
             );
-            Emissions.expression(emit, name, new Tokens(sub.body(), sub), line);
+            final Tokens tokens = new Tokens(sub.body(), sub);
+            Emissions.expression(emit, name, tokens, line);
+            tokens.checkEnd("unexpected content inside a parenthesised expression");
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -546,6 +546,24 @@ final class Tokens {
     }
 
     /**
+     * Reject whatever the cursor has left ahead of it. A construct that
+     * owns the whole body it was handed — a parenthesised expression, for
+     * one — says so once its reader is done, and the content the reader
+     * could not place is reported rather than dropped.
+     * @param message What to say about the leftovers
+     */
+    void checkEnd(final String message) {
+        final String rest = this.tail().stripLeading();
+        if (!rest.isEmpty()) {
+            throw new ParseError(
+                this.span.line(),
+                this.span.indent() + this.body.length() - rest.length(),
+                message
+            );
+        }
+    }
+
+    /**
      * The full source body the token stream operates on.
      * @return Body string
      */

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/group-trailing-arrow.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/group-trailing-arrow.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "unexpected content inside a parenthesised expression"
+input: |
+  [] > app
+    foo (bar baz >) > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/group-trailing-question.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/group-trailing-question.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "unexpected content inside a parenthesised expression"
+input: |
+  [] > app
+    foo (bar baz?) > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/group-trailing-test-suffix.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/group-trailing-test-suffix.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "unexpected content inside a parenthesised expression"
+input: |
+  [] > app
+    foo (bar baz +> test) > y


### PR DESCRIPTION
Closes #7843

`Emissions.group()` called `Emissions.expression()` on the text between `(` and `)` and never asked whether the nested `Tokens` cursor had reached the end. Whatever the inner expression could not place was silently dropped, so `foo (bar baz?) > app` parsed as `foo (bar baz) > app` — the `?` disappeared from the XMIR — and `foo (bar baz >)` and `foo (bar baz +> test)` were accepted the same way. Without the parens each of those is rejected for unexpected content after the expression.

A paren group is an expression, not a recovery boundary, so its inner expression has to account for every character inside it. `Tokens.checkEnd()` answers for the reader's own leftovers (it already owns the `span.indent() + cursor` position convention every other parse error in that class uses), and `group()` calls it once the inner expression is read.

Three typo packs cover the three shapes from the issue. All 1449 `eo-parser` tests and `-Pqulice` pass, and every `.eo` source under `eo-runtime`, `eo-integration-tests` and `eo-maven-plugin` still parses exactly as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_