### PR TITLE
Reject a reversed-with-hargs inline-phi body

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -52,9 +52,10 @@ import java.util.List;
  *
  * <p>This iteration accepts identifier and root LHS heads with
  * optional chains and identifier / INT / STAR / STRING / FLOAT /
- * ROOT horizontal args. R-3.10.6 LHS restrictions are honoured by
- * scanner exclusion (formations and reversed-with-hargs LHS are not
- * accepted as inputs because their classifiers fire first). *
+ * ROOT horizontal args. Of the R-3.10.6 LHS restrictions, a formation
+ * LHS is honoured by scanner exclusion — its classifier fires first —
+ * while a reversed dispatch carrying horizontal args reaches this line
+ * shape and is rejected here. *
  *
  * <p>The head of a line ends at the first space that sits at paren depth 0
  * and outside any string literal, which is what {@code topLevelSpace} finds,
@@ -152,7 +153,7 @@ final class LnOnlyPhi implements Line {
         final int stars = LnOnlyPhi.compactStar(inner.body(), inner);
         final Tokens tokens = LnOnlyPhi.reader(inner, stars);
         final Level level = this.transition(
-            stack, suffix, stars >= 0 || LnOnlyPhi.bare(tokens)
+            stack, suffix, stars >= 0 || this.bare(tokens)
         );
         tokens.seek(0);
         if (stars >= 0) {
@@ -193,13 +194,21 @@ final class LnOnlyPhi implements Line {
         }
     }
 
-    private static boolean bare(final Tokens tokens) {
-        if (LnOnlyPhi.reversedAhead(tokens, tokens.readValue())) {
+    private boolean bare(final Tokens tokens) {
+        final boolean reversed = LnOnlyPhi.reversedAhead(tokens, tokens.readValue());
+        if (reversed) {
             tokens.consumeDispatch();
         } else {
             tokens.readChain();
         }
-        return tokens.readArgs().isEmpty();
+        final boolean empty = tokens.readArgs().isEmpty();
+        if (reversed && !empty) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "only-phi formation body cannot be a reversed dispatch with horizontal arguments"
+            );
+        }
+        return empty;
     }
 
     private static boolean reversedAhead(final Tokens tokens, final Value head) {

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -219,14 +219,17 @@ final class LnOnlyPhiTest {
     }
 
     @Test
-    void marksReversedDispatchLhsCompletedWithHargs() {
-        final Stack stack = new Stack();
-        new LnOnlyPhi(new Span("if. cond then else > [t] > pair", 1))
-            .into(stack, new Globals(), new Emit());
+    void rejectsReversedDispatchLhsWithHargs() {
         MatcherAssert.assertThat(
-            "a reversed-dispatch φ carrying horizontal args cannot accept a body — must be HCOMPLETED",
-            stack.top().openness(),
-            Matchers.equalTo(Openness.HCOMPLETED)
+            "a reversed-dispatch φ carrying horizontal args is not a legal inline-phi body (R-3.10.6)",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnOnlyPhi(new Span("if. cond then else > [t] > pair", 1))
+                    .into(new Stack(), new Globals(), new Emit())
+            ).getMessage(),
+            Matchers.containsString(
+                "only-phi formation body cannot be a reversed dispatch with horizontal arguments"
+            )
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-reversed-dispatch-as-only-phi-lhs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-reversed-dispatch-as-only-phi-lhs.yaml
@@ -4,8 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object[not(errors)]
-  - //o[@base='.if' and @fragile]
+  - /object/errors/error[contains(text(),'only-phi formation body cannot be a reversed dispatch with horizontal arguments')]
 input: |
   [] > main
     if?. 1 2 > [x] > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/root-reversed-dispatch-as-only-phi-lhs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/root-reversed-dispatch-as-only-phi-lhs.yaml
@@ -4,8 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object[not(errors)]
-  - //o[@base='.ρ']
+  - /object/errors/error[contains(text(),'only-phi formation body cannot be a reversed dispatch with horizontal arguments')]
 input: |
   [] > main
     ^. 1 2 > [x] > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-reversed-with-hargs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-reversed-with-hargs.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "only-phi formation body cannot be a reversed dispatch with horizontal arguments"
+input: |
+  [] > main
+    foo. receiver > [x] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-reversed-with-many-hargs.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-reversed-with-many-hargs.yaml
@@ -2,9 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-sheets: []
-asserts:
-  - /object/errors/error[contains(text(),'reversed-dispatch receiver cannot carry a binding')]
+line: 2
+message: "only-phi formation body cannot be a reversed dispatch with horizontal arguments"
 input: |
   [] > main
-    if. 1:x 2:y > [m] > z
+    if. a b c > [x] > foo


### PR DESCRIPTION
Closes #7842

R-3.10.6 lists the four shapes an inline-phi LHS may take and names `if. a b c > [x] > foo` as one it may not. `LnOnlyPhi` read that shape as an ordinary reversed dispatch and emitted XMIR for it; its own docblock claimed the exclusion was honoured "by scanner exclusion (… reversed-with-hargs LHS are not accepted as inputs because their classifiers fire first)", which is not what happens — the `> [` classifier fires first and the line reaches `LnOnlyPhi`. The check now lives where the body is read, and the docblock says what the code does.

**Worth a reviewer's eye:** three fixtures recorded the accepting behaviour and had to move.

- `root-reversed-dispatch-as-only-phi-lhs.yaml` (`^. 1 2 > [x] > y`) and `fragile-reversed-dispatch-as-only-phi-lhs.yaml` (`if?. 1 2 > [x] > y`) asserted `/object[not(errors)]`; they now assert the rejection, so they still cover that it applies to a root receiver and to a fragile `?.` dispatch.
- `reversed-receiver-binding-rejected-as-only-phi-lhs.yaml` (`if. 1:x 2:y > [m] > z`) is removed: a receiver binding needs a reversed dispatch with arguments, so there is no longer an only-phi LHS that can carry one. The rule itself keeps `reversed-receiver-chain-binding.yaml` and `reversed-receiver-binding-rejected-inside-paren-group.yaml`, and #7198's rollback regression keeps `reversed-receiver-rejection-still-reports-missing-receiver.yaml`.
- `LnOnlyPhiTest.marksReversedDispatchLhsCompletedWithHargs` asserted the openness of the accepted line; it becomes `rejectsReversedDispatchLhsWithHargs`.

If the intent was to widen R-3.10.6 rather than enforce it, this PR is the wrong half of that choice and the spec is what should change instead.

Two typo packs cover the shapes from the issue. All 1446 `eo-parser` tests and `-Pqulice` pass, and every `.eo` source under `eo-runtime` and `eo-integration-tests` still parses clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_