### PR TITLE
Mark the scope errors of build-fqns as lossy

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjFormatTest.java
@@ -165,6 +165,36 @@ final class MjFormatTest {
     }
 
     @Test
+    void failsWhenNameOnlyLivesInAnEnclosingScope(@Mktmp final Path temp) {
+        final IllegalStateException exception = Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .withProgram(MjFormatTest.enclosing())
+                .execute(MjFormat.class),
+            "a name reachable only through the parent must not be silently formatted"
+        );
+        final StringWriter writer = new StringWriter();
+        exception.printStackTrace(new PrintWriter(writer));
+        MatcherAssert.assertThat(
+            "the failure must explain that the source does not fully parse",
+            writer.toString(),
+            Matchers.containsString("does not fully parse")
+        );
+    }
+
+    @Test
+    void doesNotOverwriteEnclosingScopeReferenceWhenAutoFixIsOn(@Mktmp final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new FakeMaven(temp)
+                .with("autofix", true)
+                .withProgram(MjFormatTest.enclosing())
+                .execute(MjFormat.class),
+            "a name the printer would home into the root package must not be rewritten"
+        );
+    }
+
+    @Test
     void doesNotOverwriteDroppedBindingRecoveryWhenAutoFixIsOn(@Mktmp final Path temp) {
         Assertions.assertThrows(
             IllegalStateException.class,
@@ -214,6 +244,18 @@ final class MjFormatTest {
             "    true",
             "    1",
             "    2",
+            ""
+        );
+    }
+
+    private static String enclosing() {
+        return String.join(
+            System.lineSeparator(),
+            "+package foo.x",
+            "",
+            "[fallback] > outer",
+            "  [rest] > inner",
+            "    fallback > @",
             ""
         );
     }

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -22,6 +22,15 @@
   after this transformation are not visible in the current scope.
   Maybe they are global or just a mistake.
 
+  Both errors this stage reports are marked "lossy": the reference
+  that caused them survives into the tree, but with the meaning the
+  author wrote stripped off it - the '@hop' marker is gone and
+  "add-default-package.xsl" homes the still dot-less name into the
+  root package, so printing the tree back gives "Q.x" where the
+  source said the parent's "x". A stage that reads the printed form
+  as canonical - "eo:format", above all - therefore has to refuse
+  the file instead of writing that text over it (#7862).
+
   We must skip objects that refer to
   "bytes", "string" or "number" if such objects are inside the
   "Q.bytes", "Q.string" or "Q.bytes".
@@ -257,6 +266,7 @@
             <xsl:attribute name="check" select="'build-fqns'"/>
             <xsl:attribute name="line" select="if (@line) then @line else 0"/>
             <xsl:attribute name="severity" select="'error'"/>
+            <xsl:attribute name="lossy" select="''"/>
             <xsl:text>The φ object is used, but absent in self or parents scope</xsl:text>
           </error>
         </xsl:for-each>
@@ -265,6 +275,7 @@
             <xsl:attribute name="check" select="'build-fqns'"/>
             <xsl:attribute name="line" select="if (@line) then @line else 0"/>
             <xsl:attribute name="severity" select="'error'"/>
+            <xsl:attribute name="lossy" select="''"/>
             <xsl:text>The "</xsl:text>
             <xsl:value-of select="@base"/>
             <xsl:text>" object is declared in an enclosing scope, write it as "</xsl:text>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/build-fqns-outer-scope.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-packs/parse/build-fqns-outer-scope.yaml
@@ -6,6 +6,7 @@ sheets:
   - /org/eolang/parser/parse/build-fqns.xsl
 asserts:
   - /object/errors/error[@check='build-fqns' and @line='3']
+  - /object/errors/error[@check='build-fqns' and @lossy]
   - /object[not(//o[@hop])]
 input: |-
   [x] > holder

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unresolved-phi-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/unresolved-phi-is-rejected.yaml
@@ -6,6 +6,7 @@ sheets: []
 asserts:
   - /object/errors/error[@check='build-fqns']
   - /object/errors/error[@severity='error']
+  - /object/errors/error[@lossy]
   - /object/errors/error[@line='2']
   - /object/errors/error[contains(text(),'φ')]
 input: |


### PR DESCRIPTION
Closes #7862

`MjFormat.parsed()` refuses a source only when its severe parse errors come with a lost fragment: `truncated`, `placeholder` or `@lossy`. The `build-fqns` error for a name found only in an enclosing scope carried none of those marks, so the tree went on to `new Xmir(tree).toEO()` — and by then `build-fqns` had stripped the `@hop` marker and `add-default-package.xsl` had homed the still dot-less name into `Φ`. The printed "canonical" form read `Q.x`, the mojo reported the file as merely not canonical, and `-Deo.autoFix` wrote `Q.x` over a reference to the parent's void while the real diagnostic (write it as `^.x`) never reached the author.

Both errors the stage reports are stamped `lossy` — the enclosing-scope one and the unresolved-`φ` one next to it, which loses its meaning the same way. `MjFormat.lossy()` then refuses with its existing message, and the error surfaces at `eo:parse` as intended. This is the first of the two fixes the issue proposes; the alternative (dropping the second conjunct at `MjFormat.java:161` so any severe parse error blocks formatting) is a wider behaviour change and stays available if that is the preference.

Two new `MjFormatTest` cases cover the refusal and the autofix refusal; both fail on `master` and pass here. The two existing packs for these errors (`build-fqns-outer-scope.yaml`, `unresolved-phi-is-rejected.yaml`) now assert the mark.

`eo-parser` (1443 tests) and `eo-maven-plugin` pass with `-Pqulice`, apart from `OyRemoteTest`, which needs network access this sandbox does not have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_