### PR TITLE
Refuse an attribute a package cannot hand back

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -11,6 +11,16 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * A package object, coming from {@link Phi}.
+ *
+ * <p>A package is a namespace, so its attributes are the objects the
+ * package holds and nothing else: the only attribute a caller may bind
+ * into one is {@link Phi#RHO}, the receiver a dispatch sets. Everything
+ * else a package answers it loads by name, caching it under the fully
+ * qualified name {@link #take(String)} looks it up by, which is not the
+ * name the caller writes — so an object bound under a plain attribute
+ * name could never be handed back, and {@link #put(String, Phi)} says so
+ * rather than storing it out of reach.</p>
+ *
  * @since 0.22
  */
 final class PhPackage implements Phi {
@@ -84,7 +94,7 @@ final class PhPackage implements Phi {
             }
             taken = next;
         } else {
-            this.put(fqn, this.bound(fqn));
+            this.objects.put(fqn, this.bound(fqn));
             taken = this.take(name);
         }
         return taken;
@@ -99,6 +109,12 @@ final class PhPackage implements Phi {
 
     @Override
     public void put(final String name, final Phi object) {
+        if (!name.equals(Phi.RHO)) {
+            throw new ExFailure(
+                "Can't #put(\"%s\", %s) to package object \"%s\", only %s is accepted",
+                name, object, this.pkg, Phi.RHO
+            );
+        }
         this.objects.put(name, object);
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -75,6 +75,19 @@ final class PhPackageTest {
     }
 
     @Test
+    void refusesOrdinaryAttribute() {
+        MatcherAssert.assertThat(
+            "Exception message must name the attribute a package cannot hold",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new PhPackage("test-put").put("injected", Phi.Φ),
+                "A package must refuse an attribute its take() could never hand back"
+            ).getMessage(),
+            Matchers.containsString("injected")
+        );
+    }
+
+    @Test
     void setsRhoToObject() {
         final Phi pckg = Phi.Φ;
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #7699

`PhPackage` keys `objects` by the fully qualified name `take()` looks up (`pkg + "." + name`), but `put(String, Phi)` stored under the raw name. So `Phi.Φ.put("injected", …)` returned normally, put the value where nothing could reach it, and the matching `take("injected")` went on to hunt for `org.eolang.EOinjected` and threw.

The issue offers two ways out; this takes the second. A package is a namespace — its attributes are the objects it holds, loaded and cached by FQN — so the only attribute a caller can meaningfully bind into one is `ρ`, the receiver a dispatch sets. `put()` now refuses anything else with the same shape of message `put(int, Phi)` already uses, and the internal cache in `take()` writes to the map directly rather than going through the public method. The class docblock now states the contract.

Making the raw name retrievable instead would mean either double-keying every entry or prefixing on write, and `take(Phi.RHO)` reads the raw key, so the two conventions would have to coexist in one map. Failing at the call that creates the bad state seemed the smaller change.

`PhPackageTest` gains `refusesOrdinaryAttribute`, which fails on `master`. The rest of `eo-runtime`'s Java suite passes, apart from `SyscallTest`, which cannot bind an ephemeral port in this sandbox.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_