### PR TITLE
Require an argument on +alias

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -18,7 +18,14 @@ import java.util.Locale;
  *
  * <p>A leading {@code Q} in any part is promoted to {@code Φ} in the
  * emitted XMIR (R-3.2.3 / R-9.3). This class does the promotion at
- * emission time. *
+ * emission time.</p>
+ *
+ * <p>Two directives name what they act on and are meaningless without
+ * it: {@code +package} takes exactly one argument, and {@code +alias}
+ * at least one — the shorthand {@code +alias Φ.foo} or the full
+ * {@code +alias foo Φ.bar}. A bare one of either is rejected here, so
+ * that {@code expand-aliases} is never handed an alias with nothing to
+ * expand. *
  *
  * @since 0.1
  */
@@ -105,6 +112,12 @@ final class LnMeta implements Line {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "'+package' directive requires exactly one argument"
+            );
+        }
+        if ("alias".equals(head) && parts.isEmpty()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+alias' directive requires at least one argument"
             );
         }
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-without-target.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-without-target.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "'+alias' directive requires at least one argument"
+input: |
+  +alias
+
+  [] > app


### PR DESCRIPTION
Closes #7713

`LnMeta.checkHead()` checked argument presence for `+package` only, so a bare `+alias` line parsed clean and `expand-aliases.xsl` turned its empty tail into a manufactured alias with an empty first part and the target `Φ.` — an invalid alias that later resolution still reads.

`+alias` now needs at least one argument, checked where `+package` already is and reported at the source line, so the author sees what is wrong instead of an alias nobody wrote appearing in the XMIR. Both the shorthand (`+alias Φ.foo`) and the full form (`+alias foo Φ.bar`) are untouched.

One typo pack covers the bare directive; it fails on `master`. All 1445 `eo-parser` tests and `-Pqulice` pass, and every `.eo` source under `eo-runtime` and `eo-integration-tests` still parses clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_