### PR TITLE
Keep Q out of +alias

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -18,11 +18,22 @@ import java.util.Locale;
  *
  * <p>A leading {@code Q} in any part is promoted to {@code Φ} in the
  * emitted XMIR (R-3.2.3 / R-9.3). This class does the promotion at
- * emission time. *
+ * emission time.</p>
+ *
+ * <p>{@code Q} names the global root and nothing else, so a
+ * {@code +alias} that would give the token another meaning
+ * ({@code +alias Q Q.foo}, or the shorthand {@code +alias Q}) is
+ * rejected here — {@code expand-aliases} reads that first part as the
+ * alias name and would otherwise let one file rewrite the root. *
  *
  * @since 0.1
  */
 final class LnMeta implements Line {
+
+    /**
+     * The global root, what a {@code Q} part is promoted to (R-9.3).
+     */
+    private static final String ROOT = "Φ";
 
     /**
      * The meta line's span.
@@ -107,6 +118,12 @@ final class LnMeta implements Line {
                 "'+package' directive requires exactly one argument"
             );
         }
+        if ("alias".equals(head) && !parts.isEmpty() && LnMeta.ROOT.equals(parts.get(0))) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+alias' cannot rename the root token Q"
+            );
+        }
     }
 
     private static List<String> split(
@@ -143,9 +160,9 @@ final class LnMeta implements Line {
     private static String promoteQ(final String part) {
         final String promoted;
         if ("Q".equals(part)) {
-            promoted = "Φ";
+            promoted = LnMeta.ROOT;
         } else if (part.startsWith("Q.")) {
-            promoted = "Φ".concat(part.substring(1));
+            promoted = LnMeta.ROOT.concat(part.substring(1));
         } else {
             promoted = part;
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-over-root-token.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-over-root-token.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "'+alias' cannot rename the root token Q"
+input: |
+  +alias Q Q.foo
+
+  [] > main
+    Q > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-shorthand-over-root-token.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-shorthand-over-root-token.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "'+alias' cannot rename the root token Q"
+input: |
+  +alias Q
+
+  [] > main
+    Q > @


### PR DESCRIPTION
Closes #7698

`Q` is a root token, not an ordinary name: `Tokens.readRoot()` and R-9.3 map it to `Φ`. `LnMeta` left the first `+alias` part unrestricted, though, and `expand-aliases.xsl` reads that part as the alias name, so `+alias Q Q.foo` redefined the root for the whole file. Parsing

```eo
+alias Q Q.foo

[] > main
  Q > @
```

reported no error and gave the `φ` child `base="Φ.Φ.foo"` — a base that names nothing.

`+alias` now refuses a first part that is the root. That covers the composite form (`+alias Q Q.foo`, where the first part *is* the alias name) and the shorthand (`+alias Q`, where `expand-aliases` derives the same name from the dot-less target); `+alias Q.foo` and every other target keep working, since only the alias name is checked.

Two typo packs cover the two forms; both fail on `master`. All 1447 `eo-parser` tests and `-Pqulice` pass, and every `.eo` source in the repo parses exactly as before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_