### PR TITLE
Guard the win32 calls against a NUL too

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
@@ -5,6 +5,7 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
@@ -32,12 +33,13 @@ public final class AccessFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of access", params[0]).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 Msvcrt.INSTANCE._waccess(
-                    new WString(new Dataized(params[0]).asString()),
+                    new WString(path),
                     new Dataized(params[1]).asNumber().intValue()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
@@ -5,6 +5,7 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,9 +32,10 @@ public final class CreatFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of creat", params[0]).it();
         final Phi result = this.win.take("return").copy();
         final int code = Msvcrt.INSTANCE._wcreat(
-            new WString(new Dataized(params[0]).asString()),
+            new WString(path),
             new Dataized(params[1]).asNumber().intValue()
         );
         result.put(0, new Data.ToPhi(code));

--- a/eo-runtime/src/main/java/org/eolang/win32/GetFileAttributesFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetFileAttributesFuncCall.java
@@ -5,8 +5,8 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -32,14 +32,13 @@ public final class GetFileAttributesFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring(
+            "the 'path' argument of GetFileAttributes", params[0]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
-            new Data.ToPhi(
-                Kernel32.INSTANCE.GetFileAttributesW(
-                    new WString(new Dataized(params[0]).asString())
-                )
-            )
+            new Data.ToPhi(Kernel32.INSTANCE.GetFileAttributesW(new WString(path)))
         );
         result.put(1, new PhDefault());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/win32/GetenvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetenvFuncCall.java
@@ -4,8 +4,8 @@
  */
 package org.eolang.win32;
 
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -30,8 +30,9 @@ public final class GetenvFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String name = new Cstring("the 'name' argument of getenv", params[0]).it();
         final Phi result = this.win.take("return").copy();
-        final String env = Msvcrt.INSTANCE.getenv(new Dataized(params[0]).asString());
+        final String env = Msvcrt.INSTANCE.getenv(name);
         final boolean present = env != null;
         result.put(0, new Data.ToPhi(present));
         if (present) {

--- a/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
@@ -5,8 +5,8 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -31,8 +31,9 @@ public final class MkdirFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of mkdir", params[0]).it();
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._wmkdir(new WString(new Dataized(params[0]).asString()));
+        final int code = Msvcrt.INSTANCE._wmkdir(new WString(path));
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
@@ -5,6 +5,7 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Phi;
@@ -31,9 +32,10 @@ public final class OpenFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of open", params[0]).it();
         final Phi result = this.win.take("return").copy();
         final int code = Msvcrt.INSTANCE._wopen(
-            new WString(new Dataized(params[0]).asString()),
+            new WString(path),
             new Dataized(params[1]).asNumber().intValue(),
             new Dataized(params[2]).asNumber().intValue()
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
@@ -5,8 +5,8 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -31,10 +31,12 @@ public final class RenameFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String from = new Cstring("the 'from' argument of rename", params[0]).it();
+        final String target = new Cstring("the 'to' argument of rename", params[1]).it();
         final Phi result = this.win.take("return").copy();
         final int code = Msvcrt.INSTANCE._wrename(
-            new WString(new Dataized(params[0]).asString()),
-            new WString(new Dataized(params[1]).asString())
+            new WString(from),
+            new WString(target)
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
@@ -5,8 +5,8 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -31,8 +31,9 @@ public final class RmdirFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of rmdir", params[0]).it();
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._wrmdir(new WString(new Dataized(params[0]).asString()));
+        final int code = Msvcrt.INSTANCE._wrmdir(new WString(path));
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
@@ -5,8 +5,8 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -36,13 +36,12 @@ public final class Stat64FuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of stat64", params[0]).it();
         final Phi result = this.win.take("return").copy();
         final WinStat info = new WinStat();
         result.put(
             0,
-            new Data.ToPhi(
-                Msvcrt.INSTANCE._wstat64(new WString(new Dataized(params[0]).asString()), info)
-            )
+            new Data.ToPhi(Msvcrt.INSTANCE._wstat64(new WString(path), info))
         );
         final Phi struct = this.win.take("stat64");
         struct.put(0, new Data.ToPhi((long) (info.mode & 0xFFFF)));

--- a/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
@@ -5,8 +5,8 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -31,8 +31,9 @@ public final class UnlinkFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final String path = new Cstring("the 'path' argument of unlink", params[0]).it();
         final Phi result = this.win.take("return").copy();
-        final int code = Msvcrt.INSTANCE._wunlink(new WString(new Dataized(params[0]).asString()));
+        final int code = Msvcrt.INSTANCE._wunlink(new WString(path));
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());
         return result;

--- a/eo-runtime/src/test/java/org/eolang/win32/AccessFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/AccessFuncCallTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link AccessFuncCall}.
+ * @since 0.57.0
+ */
+final class AccessFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of access carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new AccessFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two")),
+                    new Data.ToPhi(0L)
+                ),
+                "a 'path' argument of access with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of access"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/CreatFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/CreatFuncCallTest.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link CreatFuncCall}.
+ * @since 0.57.0
+ */
+final class CreatFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of creat carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new CreatFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two")),
+                    new Data.ToPhi(0L)
+                ),
+                "a 'path' argument of creat with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of creat"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/GetFileAttributesFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/GetFileAttributesFuncCallTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link GetFileAttributesFuncCall}.
+ * @since 0.57.0
+ */
+final class GetFileAttributesFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of GetFileAttributes carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new GetFileAttributesFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'path' argument of GetFileAttributes with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of GetFileAttributes"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/GetenvFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/GetenvFuncCallTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link GetenvFuncCall}.
+ * @since 0.57.0
+ */
+final class GetenvFuncCallTest {
+
+    @Test
+    void refusesNameWithNul() {
+        MatcherAssert.assertThat(
+            "the 'name' argument of getenv carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new GetenvFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'name' argument of getenv with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'name' argument of getenv"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/MkdirFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/MkdirFuncCallTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link MkdirFuncCall}.
+ * @since 0.57.0
+ */
+final class MkdirFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of mkdir carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new MkdirFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'path' argument of mkdir with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of mkdir"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/OpenFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/OpenFuncCallTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link OpenFuncCall}.
+ * @since 0.57.0
+ */
+final class OpenFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of open carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new OpenFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two")),
+                    new Data.ToPhi(0L),
+                    new Data.ToPhi(0L)
+                ),
+                "a 'path' argument of open with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of open"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/RenameFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/RenameFuncCallTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RenameFuncCall}.
+ * @since 0.57.0
+ */
+final class RenameFuncCallTest {
+
+    @Test
+    void refusesSourceWithNul() {
+        MatcherAssert.assertThat(
+            "the 'from' argument carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new RenameFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two")),
+                    new Data.ToPhi("plain")
+                ),
+                "a 'from' argument with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'from' argument of rename"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+
+    @Test
+    void refusesTargetWithNul() {
+        MatcherAssert.assertThat(
+            "the 'to' argument carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new RenameFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi("plain"),
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'to' argument with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'to' argument of rename"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/RmdirFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/RmdirFuncCallTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link RmdirFuncCall}.
+ * @since 0.57.0
+ */
+final class RmdirFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of rmdir carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new RmdirFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'path' argument of rmdir with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of rmdir"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/Stat64FuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/Stat64FuncCallTest.java
@@ -12,9 +12,11 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -44,6 +46,24 @@ final class Stat64FuncCallTest {
                     .take("size")
             ).asNumber().longValue(),
             Matchers.equalTo((long) content.length)
+        );
+    }
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Stat64FuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'path' argument with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of stat64"),
+                Matchers.containsString("NUL")
+            )
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/win32/UnlinkFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/UnlinkFuncCallTest.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link UnlinkFuncCall}.
+ * @since 0.57.0
+ */
+final class UnlinkFuncCallTest {
+
+    @Test
+    void refusesPathWithNul() {
+        MatcherAssert.assertThat(
+            "the 'path' argument of unlink carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new UnlinkFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "one", "two"))
+                ),
+                "a 'path' argument of unlink with a NUL was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'path' argument of unlink"),
+                Matchers.containsString("NUL")
+            )
+        );
+    }
+}


### PR DESCRIPTION
Closes #7749

`Cstring` was added in #7570 and wired into the POSIX adapters, but the win32 half kept taking its text straight from `Dataized`. So on Windows the case #7570 closed was still open: a path with a NUL in the middle reached `_wunlink` and the rest of them cut short at that point.

All eleven call sites now go through `Cstring`, so the same string fails the same way on both platforms:

- `_wunlink`, `_wmkdir`, `_wrmdir`, `_wstat64`, `_wopen`, `_wcreat`, `_waccess`, `_wrename` (both arguments), `GetFileAttributesW`, and `getenv`.

Each reads its argument into a local before the native call, the way its POSIX counterpart does, and names the argument in the failure message (`the 'path' argument of unlink`, and so on).

The guard runs before anything touches JNA, so the new tests exercise it on any OS — nine test classes, one per adapter, plus a second case for `rename`'s two arguments; all eleven fail on `master`. `eo-runtime` passes `-Pqulice`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_