### PR TITLE
Fold a bytes literal, not an application of bytes

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
+++ b/eo-printer/src/main/java/org/eolang/printer/StUnhex.java
@@ -23,9 +23,16 @@ final class StUnhex extends StEnvelope {
 
     /**
      * Xpath for finding bytes.
+     *
+     * <p>The {@code not(o)} is what tells a literal from an application of
+     * {@code bytes} to one. {@link StXnav} evaluates this through
+     * {@link com.github.lombrozo.xnav.Xnav}, where {@code text()} in a
+     * predicate reads every descendant's text, not the direct children's,
+     * so the wrapper of a literal reads as though it carried the hex
+     * itself. A literal's first child holds that text and nothing else.</p>
      */
     private static final String BYTES =
-        "//o[@base='Φ.bytes' and o[1][string-length(normalize-space(text()))>0]]";
+        "//o[@base='Φ.bytes' and o[1][not(o) and string-length(normalize-space(text()))>0]]";
 
     /**
      * Unexing via {@link com.github.lombrozo.xnav.Xnav}.

--- a/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/StUnhexTest.java
@@ -314,6 +314,30 @@ final class StUnhexTest {
         );
     }
 
+    @ParameterizedTest
+    @MethodSource("shifts")
+    void keepsBytesAppliedToALiteral(final Shift shift, final String type) {
+        MatcherAssert.assertThat(
+            String.format(
+                "StUnhex by %s must fold the literal only, leaving the application it sits in",
+                type
+            ),
+            new Xsline(new StUnhex(shift)).pass(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<p><o base='Φ.bytes' name='app'>",
+                        "<o base='Φ.bytes'><o>00-00-00-00</o></o>",
+                        "</o></p>"
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath(
+                "//o[@base='Φ.bytes' and @name='app' and o[@base='Φ.bytes' and text()='00-00-00-00']]"
+            )
+        );
+    }
+
     private static Stream<Arguments> shifts() {
         return Stream.of(
             Arguments.of(StUnhex.XNAV, "xnav")

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bytes-applied-to-a-literal.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/bytes-applied-to-a-literal.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7752: `StUnhex` folded an application of `bytes` to a bytes literal as if it
+# were the literal itself, so one `Φ.bytes` level went missing on the way out
+# and the printed form re-parsed into a different program.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  bytes > app
+    00-00-00-00


### PR DESCRIPTION
Closes #7752

`StUnhex.BYTES` was meant to match a byte literal — a `Φ.bytes` whose first child carries the hex text. It ran through `StXnav`, though, and there `text()` inside a predicate reads the text of every descendant rather than of the direct text children, so an application of `Φ.bytes` to a literal matched as well. `Payload.replace` then set the wrapper's own text to the child's and dropped the child element, losing one `Φ.bytes` level:

```eo
bytes > app
  00-00-00-00
```

printed as `00-00-00-00 > app`, which re-parses into a different program; with two arguments the first was absorbed and only the second survived.

The guard now also asks that `o[1]` hold no elements of its own — a structural condition the wider `text()` cannot paper over, and one only a real literal satisfies. `Φ.number` and `Φ.string` are untouched: their inner `Φ.bytes` does have an element child, so the same clause would break them.

Two tests, both failing on `master`: a `StUnhexTest` case on the shape itself, and a print-pack that round-trips the program from the issue.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_