### PR TITLE
Give the dot of a locator a class-name of its own

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -201,10 +201,20 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
-  <!-- Convert location to class name -->
+  <!--
+  Convert location to class name.
+
+  Every glyph the locator can hold maps to a distinct one here, so that two
+  locators cannot name one class - the way "_" maps to "__" and "-" to "_"
+  since #7634. The dot separating the segments used to map to nothing at all,
+  which made "x.a.bc" and "x.ab.c" one name and declared the same nested class
+  twice in one file (#7761); it maps to "$" now, which Java accepts inside an
+  identifier. A "$" the locator itself carries is escaped ahead of the join,
+  so it cannot be read back as a separator.
+  -->
   <xsl:function name="eo:loc-to-class">
     <xsl:param name="loc"/>
-    <xsl:value-of select="concat('EO', eo:identifier(replace(translate(replace(string-join(tokenize($loc, '\.'), ''), '_', '__'), '-', '_'), $eo:cactoos, $eo:alpha)))"/>
+    <xsl:value-of select="concat('EO', eo:identifier(replace(translate(replace(string-join(tokenize(replace($loc, '\$', '\$u0024'), '\.'), '$'), '_', '__'), '-', '_'), $eo:cactoos, $eo:alpha)))"/>
   </xsl:function>
   <!-- Get RHO variable depends on context -->
   <xsl:function name="eo:rho">

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjUnspileTest.java
@@ -72,7 +72,7 @@ final class MjUnspileTest {
             "inner", maven.classesPath().resolve("org/EOnumber$1$2$3.class")
         ).value();
         new Saved(
-            "clss", maven.classesPath().resolve("org/EOnumber$EOΦorgeolanginner.class")
+            "clss", maven.classesPath().resolve("org/EOnumber$EOΦ$org$eolang$inner.class")
         ).value();
         MatcherAssert.assertThat(
             "UnspileMojo must delete inner auto generated classes",
@@ -81,7 +81,7 @@ final class MjUnspileTest {
                 Matchers.not(Matchers.hasKey("target/classes/org/EOnumber.class")),
                 Matchers.not(Matchers.hasKey("target/classes/org/EOnumber$1$2$3.class")),
                 Matchers.not(
-                    Matchers.hasKey("target/classes/org/EOnumber$EOΦorgeolanginner.class")
+                    Matchers.hasKey("target/classes/org/EOnumber$EOΦ$org$eolang$inner.class")
                 )
             )
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/dotted-locators-nested-classes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/dotted-locators-nested-classes.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7761: `eo:loc-to-class` deleted every dot of the locator, so `x.a.bc` and
+# `x.ab.c` named one class and the two anonymous formations were declared twice
+# under the same name in one file.
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - /object/class/java[contains(text(), 'private static class EOΦ$x$a$bc$φ$α0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'private static class EOΦ$x$ab$c$φ$α0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'new EOΦ$x$a$bc$φ$α0();')]
+  - /object/class/java[contains(text(), 'new EOΦ$x$ab$c$φ$α0();')]
+input: |
+  [] > x
+    [] > a
+      [] > bc
+        foo > @
+          []
+            42 > @
+    [] > ab
+      [] > c
+        foo > @
+          []
+            43 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/hyphen-and-underscore-nested-classes.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/hyphen-and-underscore-nested-classes.yaml
@@ -12,10 +12,10 @@ sheets:
   - /org/eolang/maven/transpile/to-java.xsl
 asserts:
   - /object[not(errors)]
-  - /object/class/java[contains(text(), 'private static class EOΦmaina_bφα0 extends PhDefault')]
-  - /object/class/java[contains(text(), 'private static class EOΦmaina__bφα0 extends PhDefault')]
-  - /object/class/java[contains(text(), 'new EOΦmaina_bφα0();')]
-  - /object/class/java[contains(text(), 'new EOΦmaina__bφα0();')]
+  - /object/class/java[contains(text(), 'private static class EOΦ$main$a_b$φ$α0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'private static class EOΦ$main$a__b$φ$α0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'new EOΦ$main$a_b$φ$α0();')]
+  - /object/class/java[contains(text(), 'new EOΦ$main$a__b$φ$α0();')]
 input: |
   [] > main
     [] > a-b

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/removes-pluses-in-test-transpilation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/removes-pluses-in-test-transpilation.yaml
@@ -15,8 +15,8 @@ asserts:
   - /object[not(errors)]
   - //tests[contains(text(), '@Test')]
   - //tests[contains(text(), 'void tests_iterates_with_eachi()')]
-  - //tests[contains(text(), 'tests_iterates_with_eachiφρα1();')]
-  - //tests[contains(text(), 'EOΦlisttests_iterates_with_eachiφρα1')]
+  - //tests[contains(text(), 'tests_iterates_with_eachi$φ$ρ$α1();')]
+  - //tests[contains(text(), 'EOΦ$list$tests_iterates_with_eachi$φ$ρ$α1')]
 input: |
   [] > list
     [x] > bar

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-with-abstracts.yaml
@@ -12,16 +12,16 @@ sheets:
   - /org/eolang/maven/transpile/to-java.xsl
 asserts:
   - /object[not(errors)]
-  - /object/class/java[contains(text(), 'private static class EOΦabcφα0')]
-  - /object/class/java[contains(text(), 'PhDefault r1 = new EOΦabcφα0boundα0();')]
-  - /object/class/java[contains(text(), 'private static class EOΦabcφα0boundα0 extends PhDefault')]
-  - /object/class/java[contains(text(), 'private static class EOΦabcφα1 extends PhDefault')]
+  - /object/class/java[contains(text(), 'private static class EOΦ$a$b$c$φ$α0')]
+  - /object/class/java[contains(text(), 'PhDefault r1 = new EOΦ$a$b$c$φ$α0$bound$α0();')]
+  - /object/class/java[contains(text(), 'private static class EOΦ$a$b$c$φ$α0$bound$α0 extends PhDefault')]
+  - /object/class/java[contains(text(), 'private static class EOΦ$a$b$c$φ$α1 extends PhDefault')]
   - /object/class/tests[contains(text(), '((PhDefault) rr).add("φ",')]
   - /object/class/tests[contains(text(), '((PhDefault) r).add("c",')]
   - /object/class/tests[not(contains(text(), '((PhDefault) r).add("xi🌵",'))]
   - /object/class/tests[contains(text(), 'this.add("b"')]
-  - /object/class/tests[contains(text(), 'PhDefault rrr1 = new EOΦabcφα0();')]
-  - /object/class/tests[contains(text(), 'PhDefault rrr2 = new EOΦabcφα1();')]
+  - /object/class/tests[contains(text(), 'PhDefault rrr1 = new EOΦ$a$b$c$φ$α0();')]
+  - /object/class/tests[contains(text(), 'PhDefault rrr2 = new EOΦ$a$b$c$φ$α1();')]
   - /object/class/tests[contains(text(), 'PhDefault rrr3 = new PhDefault();')]
   - /object/class/tests[contains(text(), 'void b()')]
 input: |


### PR DESCRIPTION
Closes #7761

`eo:loc-to-class` tokenized the locator on `.` and joined with the empty string, so every dot disappeared and nothing took its place. `Φ.examples.x.a.bc.φ.α0` and `Φ.examples.x.ab.c.φ.α0` both came out as `EOΦexamplesxabcφα0`, and since `to-java.xsl` writes one `private static class` per anonymous formation of a top-level object, two such formations in one object gave two declarations of the same class in one file. Handed to javac together that is `already defined`; in a real build the two source roots go through separate passes, so instead the test-scope source shadowed the object class and nothing reported it.

#7634 fixed the same kind of collision between `-` and `_` by doubling the underscore. The dot now maps to `$`, which Java accepts inside an identifier, and a `$` the locator itself carries is escaped to `$u0024` ahead of the join so it cannot be read back as a separator. `EOΦexamplesxabcφα0` becomes `EOΦ$examples$x$a$bc$φ$α0`.

**Names in existing fixtures move with it**, since every nested class of a top-level object is renamed:

- `hyphen-and-underscore-nested-classes.yaml`, `tests-with-abstracts.yaml` and `removes-pluses-in-test-transpilation.yaml` spelled out the old dotless names.
- `MjUnspileTest.deletesInnerGeneratedClasses` writes a fabricated class file; its name is updated so the fixture still looks like something the transpiler would produce.

Beyond the new pack, I transpiled and compiled all of `eo-runtime` with this change: it builds clean, and the longest generated class file name comes to 113 characters, well inside the filesystem limit. `eo-maven-plugin` passes `-Pqulice` apart from `OyRemoteTest`, which needs network access this sandbox does not have.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FcJmdhLc8XcTFrsueNY1Wr)_