### PR TITLE
Closes #7709: `Xmir.toEO()` incorrectly prints `print.:hey` causing parse failure

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -513,12 +513,8 @@ final class Node {
     }
 
     private boolean forced() {
-        return "|".equals(this.base) && this.tail.isEmpty()
-            || this.namedReversed()
+        return ("|".equals(this.base) && this.tail.isEmpty())
+            || (this.reversed && this.tail.startsWith(":"))
             || this.children.stream().anyMatch(Node::constant);
-    }
-
-    private boolean namedReversed() {
-        return this.reversed && this.tail.startsWith(":");
     }
 }

--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -514,6 +514,7 @@ final class Node {
 
     private boolean forced() {
         return "|".equals(this.base) && this.tail.isEmpty()
+            || this.reversed && this.tail.startsWith(":")
             || this.children.stream().anyMatch(Node::constant);
     }
 }

--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -514,7 +514,11 @@ final class Node {
 
     private boolean forced() {
         return "|".equals(this.base) && this.tail.isEmpty()
-            || this.reversed && this.tail.startsWith(":")
+            || this.namedReversed()
             || this.children.stream().anyMatch(Node::constant);
+    }
+
+    private boolean namedReversed() {
+        return this.reversed && this.tail.startsWith(":");
     }
 }

--- a/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
@@ -119,6 +119,25 @@ final class XmirTest {
     }
 
     @Test
+    void printsNamedVerticalApplicationToParseableEo() throws IOException {
+        final String printed = this.asXmir(
+            String.join(
+                "\n",
+                "[] > main",
+                "  f > out",
+                "    ((t r 8.54 \"yes\").print 88 31):hey",
+                ""
+            ),
+            new EnumMap<>(PenaltyKey.class)
+        ).toEO();
+        MatcherAssert.assertThat(
+            String.format("Printed EO should parse back, but was:%n%s", printed),
+            new EoSyntax(new InputOf(printed)).parsed(),
+            Matchers.not(XhtmlMatchers.hasXPath("//errors/error"))
+        );
+    }
+
+    @Test
     void doesNotWarnOnLocalWithoutName() {
         final List<String> warnings = new ArrayList<>(0);
         final Appender appender = new AppenderSkeleton() {

--- a/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
+++ b/eo-printer/src/test/java/org/eolang/printer/XmirTest.java
@@ -131,7 +131,9 @@ final class XmirTest {
             new EnumMap<>(PenaltyKey.class)
         ).toEO();
         MatcherAssert.assertThat(
-            String.format("Printed EO should parse back, but was:%n%s", printed),
+            String.format(
+                "Printed EO should parse back, but was:%n%s", printed
+            ),
             new EoSyntax(new InputOf(printed)).parsed(),
             Matchers.not(XhtmlMatchers.hasXPath("//errors/error"))
         );


### PR DESCRIPTION
Closes #7709.

Verified against the pinned tree: the patch applies cleanly and the issue's post-fix check passes.

Written by an AI coding agent (Sloppy) and opened under my account.

<!-- sloppy-mission-proof:slp_p_IcAiP_ZNk7UfmFokS61DoQ -->