### PR TITLE
#7837: record the dot column in the fragile dispatch spec

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1257,7 +1257,7 @@ R-9.2.4. **Scope resolution adds no hops.** The `build-fqns` reshape that follow
 | Inline binding `:label` | `@as='label'` on the argument `<o>` |
 | Inline binding `:N` | `@as='αN'` |
 | `.method` line | `@method` attribute (empty); `@base` is prefixed with `.`; `@pos` records the dot column (R-9.1.3) |
-| `?.` fragile dispatch (R-3.5.3a) | `@fragile` attribute (empty) added to the dispatch link's `<o>`, alongside its usual emission: a method link keeps `@method=''` and gains `@fragile=''`; a reversed dispatch carries `@fragile=''` without `@method`. `@base` is unchanged (still `.<name>`, not `?.<name>`), so passes matching `starts-with(@base, '.')` are unaffected. `@pos` records the operator's first character (the `?`). |
+| `?.` fragile dispatch (R-3.5.3a) | `@fragile` attribute (empty) added to the dispatch link's `<o>`, alongside its usual emission: a method link keeps `@method=''` and gains `@fragile=''`; a reversed dispatch carries `@fragile=''` without `@method`. `@base` is unchanged (still `.<name>`, not `?.<name>`), so passes matching `starts-with(@base, '.')` are unaffected. `@pos` records the dot column, not the `?` (R-9.1.3, #5359). |
 | Unbound positional arg | `@as` is **not** emitted at parse time. It is added by a later post-parse pass |
 
 R-9.4.1. `@method` and `@as='αN'` are intermediate attributes; they may be transformed or removed by downstream XSL passes (`wrap-method-calls.xsl` and equivalents). The parser emits them; what happens after is out of scope.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-dispatch-pos-is-the-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-dispatch-pos-is-the-dot.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.x.y' and @fragile and @pos='4']
+input: |
+  [] > main
+    x?.y > @


### PR DESCRIPTION
The `?.` row of the §9.4 emission table said `@pos` records the `?` column. The parser records the dot column instead, as R-9.1.3 requires, since #5359 was fixed. The sentence is replaced with the rule the parser actually follows.

Added a pack that asserts it, so the two cannot drift apart again: `x?.y` on a 2-space indent emits `@pos='4'`, the dot column, not `3`.

Closes #7837
