### PR TITLE
#7814: seal the comment header on a compact tuple

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -90,6 +90,7 @@ final class LnCompactTuple implements Line {
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }
+        globals.seal(emit, this.span);
         final Level level = this.transition(stack, suffix);
         level.compact(count);
         globals.clearBlanks();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-after-compact-tuple.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-after-compact-tuple.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: |-
+  [2:0] error: 'comment is allowed only on top of the file, before metas'
+  # wrongly accepted
+  ^
+input: |
+  foo *0 > app
+  # wrongly accepted


### PR DESCRIPTION
`LnCompactTuple.into()` marked an object as emitted but never sealed the header zone, so a comment after a top-level compact tuple was accepted and emitted as program documentation. Added the `globals.seal(emit, this.span)` call every other object line makes, in the same place, right after the blank checks.

Added a typo pack for the two-line program from the report. Without the fix it parses clean; with it the comment gets the usual top-comment error.

Closes #7814
