### PR TITLE
#7841: reject leftover punctuation in an only-phi body

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -188,6 +188,12 @@ final class LnOnlyPhi implements Line {
 
     private void emitPhi(final Emit emit, final Tokens tokens, final boolean open) {
         Emissions.expression(emit, "φ", tokens, this.span.line());
+        if (!tokens.atEnd()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + tokens.cursor(),
+                "unexpected content in the body of an only-phi formation"
+            );
+        }
         if (!open) {
             emit.close();
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-tag-on-inline-phi-body.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-tag-on-inline-phi-body.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  unexpected content in the body of an only-phi formation
+input: |
+  foo:bar > [x] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/const-marker-on-inline-phi-body.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/const-marker-on-inline-phi-body.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  unexpected content in the body of an only-phi formation
+input: |
+  foo! > [x] > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/optional-marker-on-inline-phi-body.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/optional-marker-on-inline-phi-body.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  unexpected content in the body of an only-phi formation
+input: |
+  foo? > [x] > app


### PR DESCRIPTION
The only-phi line cut the text before `> [` and handed it to `Emissions.expression()` without checking that the reader reached the end of it. Whatever was left over was dropped, so `foo! > [x] > app` parsed into the same XMIR as `foo > [x] > app` and the `!` disappeared. Same for `foo?` and `foo:bar`, while the ordinary application forms of all three are rejected.

`emitPhi` now requires the reader to be at the end of the body and reports the leftover otherwise.

Three typo packs, one per form from the report.

Closes #7841
