### PR TITLE
#7863: keep the readers of a handle floated into a pipe

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -69,8 +69,12 @@
   declares a segment of the reference's base. Cactus names are auto-generated
   and effectively unique, so this bucket holds one node and the climb becomes a
   parentage check on it rather than a scan of every ancestor's attributes.
+  A handle floated into a pipe is indexed here too, even though it is not a
+  merge candidate itself: "inline-cactoos" mints a pipe for a handle whose
+  value applies a formation it relocates (#7863), and the readers of such a
+  handle are left on the cactus name, which only these lookups put back.
   -->
-  <xsl:key name="moniker-name" match="o[eo:moniker-binding(.)]" use="@name"/>
+  <xsl:key name="moniker-name" match="o[eo:moniker-binding(.) or (exists(@pipe) and exists(@local))]" use="@name"/>
   <!--
   The single attribute name a hostable `ξ.<name>` reference resolves to, or
   the empty string for anything that is not hostable. Two shapes host a
@@ -320,7 +324,7 @@
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[eo:const-handle(.)][some $scope in $ref/ancestor::o satisfies $scope is ..]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
-    <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and (exists($binding/@pipe) or not(eo:moniker-refs($binding)[1] is $ref))) then $binding else ()"/>
   </xsl:function>
   <!--
   Whether the bare name of `$binding` would read as something else at `$ref`:
@@ -382,7 +386,7 @@
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="candidates" select="key('moniker-name', tokenize($ref/@base, '\.'), root($ref))[not(eo:const-handle(.)) and exists(@local)][some $scope in $ref/ancestor::o satisfies $scope is ..]"/>
     <xsl:variable name="binding" select="$candidates[last()]"/>
-    <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and not(eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and (exists($binding/@pipe) or not(eo:moniker-refs($binding)[1] is $ref))) then $binding else ()"/>
   </xsl:function>
   <!--
   Replace the first hosting reference with the merged binding, always keeping

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-minted-handle-multi-referenced.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/pipe-minted-handle-multi-referenced.yaml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A `>> name` handle whose value applies a formation declared later in the
+# same scope, read twice through method dispatch (#7863). "inline-cactoos"
+# relocates the single-use formation above the handle and re-emits the handle
+# as a pipe, so the pipe here is minted by the relocation and not stamped by
+# the parser, as in "pipe-named-handle-multi-referenced". Both readers must
+# still read `found`, the handle's own name, and not the cactus name the
+# relocation leaves them on.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [cases fallback] > switch
+    if. > @
+      true.eq found.match
+      found.head
+      fallback "no case"
+    rec-case cases.reversed >> found
+    [^ rest] >> rec-case
+      if. > @
+        rest.is-empty
+        false
+        rec-case rest.tail
+printed: |
+  [cases fallback] > switch
+    if. > @
+      true.eq found.match
+      found.head
+      fallback
+        "no case"
+    rest.is-empty.if > [^ rest] >> rec-case
+      false
+      ^.rec-case rest.tail
+    | cases.reversed >> found


### PR DESCRIPTION
When a `>> name` handle applies a formation declared later in the same scope, "inline-cactoos" relocates that formation and re-emits the handle as a pipe. `merge-monikers` skipped it, because `eo:moniker-binding` excludes every `@pipe` binding, so both readers kept the cactus name and printed as `v6_2.match` and `v6_2.head`.

Two changes:

- the `moniker-name` key also indexes `o[@pipe and @local]`, so `eo:kept-local-ref` can find such a handle;
- `eo:kept-local-ref` no longer holds back the first reader of a pipe binding. That carve-out exists because the first reader is the site the binding merges onto, and nothing merges onto a pipe, so for a pipe it only left one reader on the cactus name.

Added a print pack with the case from the report. The existing `pipe-named-handle-multi-referenced` pack keeps the parser-stamped pipe covered.

Closes #7863
