### PR TITLE
#7813: seal the comment header on a text block

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -265,6 +265,7 @@ final class Eo implements Iterable<Directive> {
             emit.error(span.line(), 0, "trailing whitespace at end of line");
             failed = true;
         } else if (Eo.opensTextBlock(span)) {
+            globals.seal(emit, span);
             globals.openTextBlock(span.line(), span.indent());
             globals.markEmitted();
             globals.clearBlanks();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-after-text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/comment-after-text-block.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  [4:0] error: 'comment is allowed only on top of the file, before metas'
+  # wrongly accepted
+  ^
+input: |
+  """
+  text
+  """ > app
+  # wrongly accepted


### PR DESCRIPTION
The TEXT-block opener is handled by its own branch in `Eo.process()`, which marked an object as emitted but never sealed the header zone. A comment after a top-level block was therefore accepted and flushed into `/object/comments` at EOF.

The branch now seals the header the way every other object line does, before it opens the block.

Added a typo pack for the source from the report.

Closes #7813
