### PR TITLE
#7811: reject a text that ends with a backslash

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Escapes.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Escapes.java
@@ -49,10 +49,15 @@ final class Escapes {
         int idx = 0;
         while (idx < inner.length()) {
             final char glyph = inner.charAt(idx);
-            if (glyph != '\\' || idx + 1 >= inner.length()) {
+            if (glyph != '\\') {
                 text.append(glyph);
                 idx = idx + 1;
                 continue;
+            }
+            if (idx + 1 >= inner.length()) {
+                throw new NumberFormatException(
+                    "backslash at the end of the text has nothing to escape"
+                );
             }
             final char next = inner.charAt(idx + 1);
             if (next == 'u') {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/text-block-ends-with-a-backslash.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/text-block-ends-with-a-backslash.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  backslash at the end of the text has nothing to escape
+input: |
+  [] > example
+    """
+    x\
+    """ > @


### PR DESCRIPTION
`Escapes.bytes()` treated a backslash with nothing after it as ordinary text, so a text block ending in one was decoded to that backslash instead of being rejected. A quoted string cannot reach that branch, since a final backslash escapes the closing quote and leaves the token unterminated, but a text body ends there normally.

R-9.7.2 does not allow an unescaped backslash in a body and R-9.7.3 makes every other backslash sequence a lexical error, so it now throws and comes back through `Unescaped` as a positioned parser error.

Added a typo pack for the block from the report.

Closes #7811
