### PR TITLE
#7812: close a text block on a fragile dispatch

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -341,7 +341,7 @@ final class Eo implements Iterable<Directive> {
         return !span.blank()
             && span.indent() == globals.textBlockOpenIndent()
             && body.startsWith("\"\"\"")
-            && " .:".indexOf(body.concat(" ").charAt(3)) >= 0;
+            && " .:?".indexOf(body.concat(" ").charAt(3)) >= 0;
     }
 
     private static Line classify(final Span span) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-dispatch-after-text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/fragile-dispatch-after-text-block.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='.length' and @fragile]
+input: |
+  [] > example
+    """
+    hello
+    """?.length > @


### PR DESCRIPTION
The guard that recognises a text-block closer admitted only a space, `.` or `:` after the quotes, so `"""?.length` was taken for another body line and the block was reported unclosed. R-3.5.3a puts `?.` everywhere `.` goes, and `LnTextBlock` already hands the rest of the closer to `readChain()`, which knows the fragile link.

`?` is added to that set. A `?` that is not followed by a dot, such as `"""?x`, now gets a positioned error from the chain reader instead of silently extending the block.

Added a pack for the `?.length` closer from the report.

Closes #7812
