### PR TITLE
#7810: log how long the inference took and how big the tables are

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -119,11 +119,16 @@ final class Inferring implements Step {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
             final int ready = this.ready();
+            final long start = System.currentTimeMillis();
             new Witnessed(new Demanded(new Resolved(new Clues())))
                 .follow(this.prepared, this.tables);
             Logger.info(
-                this, "Inferred the types of %d XMIR(s), tables are in %[file]s",
-                ready, this.tables
+                this, "Inferred the types of %d XMIR(s) in %[ms]s",
+                ready, System.currentTimeMillis() - start
+            );
+            Logger.info(
+                this, "Inference tables are in %[file]s (%s)",
+                this.tables, new Tabled(this.tables).asString()
             );
             this.measured();
             if (!this.pages.toString().isEmpty()) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Tabled.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Tabled.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * How much a directory of tables holds, in words a log line can carry.
+ *
+ * <p>A path on its own says where to look and nothing about what is there.
+ * Whoever reads the log wants to know whether the tables were written at all
+ * and how big they came out, since a table that shrank by half between two
+ * builds is the first sign that a rule stopped seeing something.</p>
+ *
+ * @since 0.71.0
+ */
+final class Tabled {
+
+    /**
+     * The directory the tables are in.
+     */
+    private final Path dir;
+
+    /**
+     * Ctor.
+     * @param tables The directory the tables are in
+     */
+    Tabled(final Path tables) {
+        this.dir = tables;
+    }
+
+    /**
+     * How many tables there are and how much they weigh together.
+     * @return The description, for a log line
+     * @throws IOException If the directory cannot be read
+     */
+    String asString() throws IOException {
+        final Collection<Path> files = new ArrayList<>(0);
+        if (Files.exists(this.dir)) {
+            try (Stream<Path> all = Files.list(this.dir)) {
+                files.addAll(all.filter(Files::isRegularFile).collect(Collectors.toList()));
+            }
+        }
+        long bytes = 0L;
+        for (final Path file : files) {
+            bytes = bytes + Files.size(file);
+        }
+        return Logger.format("%d table(s), %[size]s total", files.size(), bytes);
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TabledTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TabledTest.java
@@ -1,0 +1,43 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Tabled}.
+ * @since 0.71.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class TabledTest {
+
+    @Test
+    void countsTheTablesAndTheirWeight(@Mktmp final Path temp) throws IOException {
+        Files.writeString(temp.resolve("provides.xml"), "<provides/>");
+        Files.writeString(temp.resolve("links.xml"), "<links/>");
+        MatcherAssert.assertThat(
+            "both tables must be counted, with their bytes together",
+            new Tabled(temp).asString(),
+            Matchers.equalTo("2 table(s), 19b total")
+        );
+    }
+
+    @Test
+    void saysNothingIsThereWhenTheDirectoryIsAbsent(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a directory nobody wrote must be counted as empty, not blow up",
+            new Tabled(temp.resolve("absent")).asString(),
+            Matchers.startsWith("0 table(s)")
+        );
+    }
+}


### PR DESCRIPTION
The mojo said only how many XMIRs it read and where the tables went. Now it says how long the pass took and what came out of it:

```
[INFO] Inferred the types of 171 XMIR(s) in 540ms
[INFO] Inference tables are in eo-runtime/target/eo/6-inference (6 table(s), 5674Kb total)
```

The counting and weighing sits in `Tabled`, with its own test, including the case where nobody wrote the directory at all.

Closes #7810
