### PR TITLE
#7809: split the report out of the inference goal

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
@@ -86,6 +86,16 @@ public final class MjInference extends MjSafe {
      * door is reached for with {@code -Pjacoco}: a profile is what you need
      * to add an execution to a build, and there is nothing to add here — the
      * goal already runs and one flag decides whether it writes.</p>
+     *
+     * @todo #7809:30min Draw the pages in one place only.
+     *  {@link MjInferenceReport} is a goal of its own now and eo-runtime asks
+     *  for it, so this flag, the {@link #pages} parameter and {@code wanted()}
+     *  below have nothing left to do, and neither has the {@code site}
+     *  argument of {@link Inferring} or the branch that reads it in
+     *  {@code Inferring.exec}. They stay for the moment so that a build
+     *  pinned to {@code -Deo.inferenceReport} keeps drawing. Take them out,
+     *  together with the paragraph about the flag in {@code eo-inference}'s
+     *  README and {@code InferringTest.writesThePagesWhereItIsTold}.
      */
     @Parameter(
         alias = "inferenceReport",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInferenceReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInferenceReport.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+
+/**
+ * Draw a page per source file from the tables {@link MjInference} wrote.
+ *
+ * <p>The three numbers the tables come with say how much of a program we
+ * understand without saying which part. A page says both, with the author's
+ * own source on it and a mark on every object: green where the formation can
+ * be named, amber where the answer is somebody else's void, red where there
+ * is nothing.</p>
+ *
+ * <p>A goal of its own rather than a flag on {@link MjInference}: a build
+ * that wants the pages asks for this goal, one that does not never runs it.</p>
+ *
+ * @since 0.71.0
+ */
+@Mojo(
+    name = "inference-report",
+    defaultPhase = LifecyclePhase.PROCESS_SOURCES,
+    threadSafe = true
+)
+public final class MjInferenceReport extends MjSafe {
+
+    /**
+     * The directory where the pages are written.
+     */
+    @Parameter(
+        alias = "inferenceReportDir",
+        property = "eo.inferenceReportDir",
+        required = true,
+        defaultValue = "${project.build.directory}/site/inference"
+    )
+    private File pages;
+
+    /**
+     * The directory where the XMIR prepared for the rules was saved.
+     */
+    @Parameter(
+        alias = "preInferenceDir",
+        property = "eo.preInferenceDir",
+        required = true,
+        defaultValue = "${project.build.directory}/eo/6-pre-inference"
+    )
+    private File prepared;
+
+    /**
+     * The directory where the tables were saved.
+     */
+    @Parameter(
+        alias = "inferenceDir",
+        property = "eo.inferenceDir",
+        required = true,
+        defaultValue = "${project.build.directory}/eo/6-inference"
+    )
+    private File tables;
+
+    @Override
+    void exec() throws IOException {
+        new Timed(
+            new Reporting(this.prepared.toPath(), this.tables.toPath(), this.pages.toPath())
+        ).exec();
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.eolang.inference.Report;
+
+/**
+ * The pages a reader opens, one per source file of the program.
+ *
+ * <p>This one takes the tables as it finds them and draws the author's own
+ * source with a mark on every object. The pages land under
+ * {@code target/site}, beside the coverage report, and not in
+ * {@code target/eo/}, which is the compiler's scratch space.</p>
+ *
+ * @since 0.71.0
+ */
+final class Reporting implements Step {
+
+    /**
+     * The directory with the prepared XMIR files.
+     */
+    private final Path prepared;
+
+    /**
+     * The directory with the tables.
+     */
+    private final Path tables;
+
+    /**
+     * The directory for the pages.
+     */
+    private final Path pages;
+
+    /**
+     * Ctor.
+     * @param pre The directory with the prepared XMIR files
+     * @param rows The directory with the tables
+     * @param site The directory for the pages
+     */
+    Reporting(final Path pre, final Path rows, final Path site) {
+        this.prepared = pre;
+        this.tables = rows;
+        this.pages = site;
+    }
+
+    @Override
+    public void exec() throws IOException {
+        if (Files.exists(this.tables)) {
+            Logger.info(
+                this, "Wrote %d page(s) to look at, they are in %[file]s",
+                new Report(this.prepared, this.tables).written(this.pages), this.pages
+            );
+        } else {
+            Logger.info(
+                this, "The directory %[file]s is absent, nothing to draw from it",
+                this.tables
+            );
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FakeMaven.java
@@ -197,6 +197,9 @@ final class FakeMaven {
             this.params.putIfAbsent(
                 "tables", this.targetPath().resolve("6-inference").toFile()
             );
+            this.params.putIfAbsent(
+                "pages", this.targetPath().getParent().resolve("site/inference").toFile()
+            );
             this.params.putIfAbsent("placedFormat", "csv");
             this.params.putIfAbsent("plugin", FakeMaven.pluginDescriptor());
             this.params.putIfAbsent(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjInferenceReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjInferenceReportTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test cases for {@link MjInferenceReport}.
+ * @since 0.71.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class MjInferenceReportTest {
+
+    @Test
+    void drawsPagesOfProgram(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a page for the reader must be drawn from the tables, but it wasnt",
+            Files.exists(
+                new FakeMaven(temp).withProgram(
+                    String.join(System.lineSeparator(), "[] > app", "  [] > t", "")
+                )
+                .execute(MjParse.class)
+                .execute(MjInference.class)
+                .execute(MjInferenceReport.class)
+                .targetPath()
+                .getParent()
+                .resolve("site")
+                .resolve("inference")
+                .resolve("index.html")
+            ),
+            Matchers.is(true)
+        );
+    }
+}

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -256,7 +256,6 @@
           <foreignFormat>csv</foreignFormat>
           <!-- Every lint warning is an error here; nothing may be tolerated. -->
           <failOnWarning>true</failOnWarning>
-          <inferenceReport>true</inferenceReport>
           <skipExperimentalLints>true</skipExperimentalLints>
           <offline>true</offline>
           <ignoreRuntime>true</ignoreRuntime>
@@ -277,6 +276,7 @@
               <goal>format</goal>
               <goal>compile</goal>
               <goal>inference</goal>
+              <goal>inference-report</goal>
               <goal>merge</goal>
               <goal>transpile</goal>
               <goal>atoms-table</goal>


### PR DESCRIPTION
`MjInference` did two jobs: it wrote the tables the compiler needs and, behind a flag, drew the pages a person reads.

This adds the second job as a goal of its own. `inference-report` draws the pages from tables somebody already wrote, through the new `Reporting` step. `eo-runtime` asks for the goal instead of setting `eo.inferenceReport`, so its pages come out as before.

The old flag on `MjInference` stays for now, so that a build pinned to `-Deo.inferenceReport` keeps drawing. Taking it out, along with the `site` argument of `Inferring`, is a `@todo` on the flag itself, since the two together do not fit in 200 lines.

Splits the goal reported in #7809; the removal side is left in the added `@todo`.
