### PR TITLE
#7755: read a terminator by the name the table uses

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Landed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Landed.java
@@ -64,7 +64,7 @@ final class Landed {
     Map<String, String> all() {
         final Collection<String> made = new HashSet<>(this.given.xpath("/provides/type/@id"));
         final Collection<String> plain = new HashSet<>(
-            this.links.xpath("/links/type[data or bottom]/@id")
+            this.links.xpath("/links/type[data or terminator]/@id")
         );
         final Map<String, String> hops = new Pairs(this.links).all();
         final Walked walked = new Walked(hops, this.comes());

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-termination-that-fills-a-void-is-witnessed.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-termination-that-fills-a-void-is-witnessed.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A termination is an answer like any other, so a void filled with one by a
+# caller and with an object by another is witnessed as the choice between the
+# two. The table spells a termination `terminator`, and that is the word to
+# look for when asking whether a filling can be placed.
+eo:
+  inc.eo: |
+    [x] > inc
+      x > @
+  oak.eo: |
+    [] > oak
+  app.eo: |
+    [] > app
+      inc T > dead
+      inc oak > alive
+provides:
+  - "//type[@id='Φ.inc']/attr[@name='x']/witnessed/union/terminator"
+  - "//type[@id='Φ.inc']/attr[@name='x']/witnessed/union/ref[@loc='Φ.oak']"


### PR DESCRIPTION
`Landed` looked for a `bottom` element. Nothing writes one: #6869 proposed that name and shipped `terminator`, which is what `Terminator`, `Pairs` and `Forms` all use. So a termination was never placed, `Fillings` filed it under the loose fallback, and `chosen.putAll(placed)` then dropped it whenever an ordinary object filled the same void.

One word changed, plus a pack: a void filled with `T` by one caller and with an object by another is now witnessed as the choice between the two, where before only the object was recorded.

Closes #7755
