### PR TITLE
#7756: a name taken off a termination terminates

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Dead.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dead.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Every object of a program that terminates.
+ *
+ * <p>The table says which ones do so outright, and a name taken off one of
+ * them terminates as well: an object that never comes back with a value has
+ * no attribute to hand over, and asking it for one lands where the object
+ * itself does. {@link Provided} keeps no row for a termination and would
+ * answer such a dispatch with nothing, which is a different fact — nothing
+ * known, rather than an answer that fits anywhere.</p>
+ *
+ * <p>A dispatch found this way carries its receiver's fate on to whoever
+ * takes a name off <em>it</em>, so the walk is repeated until it stops
+ * growing rather than made once in the order the dispatches happen to be
+ * written in.</p>
+ *
+ * @since 0.71.0
+ */
+final class Dead {
+
+    /**
+     * The links table.
+     */
+    private final XML table;
+
+    /**
+     * Every dispatch of the program.
+     */
+    private final Collection<XML> all;
+
+    /**
+     * The name every object goes by, once its chain of copies is walked.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param links The links table
+     * @param dispatches Every dispatch of the program
+     * @param ends The name every object goes by
+     */
+    Dead(final XML links, final Collection<XML> dispatches, final Map<String, String> ends) {
+        this.table = links;
+        this.all = dispatches;
+        this.names = ends;
+    }
+
+    /**
+     * The locators of everything that terminates.
+     * @return The locators, the dispatches on a termination among them
+     */
+    Collection<String> all() {
+        final Collection<String> found = new HashSet<>(
+            this.table.xpath("/links/type[terminator]/@id")
+        );
+        boolean grown = true;
+        while (grown) {
+            grown = false;
+            for (final XML dispatch : this.all) {
+                final String made = dispatch.xpath("@loc").get(0);
+                final String bearer = dispatch.xpath("o[not(@as)][1]/@loc").get(0);
+                if (!found.contains(made)
+                    && found.contains(this.names.getOrDefault(bearer, bearer))) {
+                    found.add(made);
+                    grown = true;
+                }
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -74,7 +74,8 @@ public final class Resolved implements Clue {
         final Collection<XML> dispatches = world.dispatches();
         final Map<String, List<String>> args = new Given(world.applications()).arguments();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
-        final Pairs written = new Pairs(new XMLDocument(links));
+        final XML table = new XMLDocument(links);
+        final Pairs written = new Pairs(table);
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, dispatches, args, world.receivers(), voids)
         ).from(
@@ -92,8 +93,16 @@ public final class Resolved implements Clue {
             ).all()
         ).all();
         rows.putAll(written.others());
+        final Collection<String> dead = new Dead(
+            table, dispatches, new Ends(pairs).names()
+        ).all();
         for (final XML dispatch : dispatches) {
-            rows.putIfAbsent(dispatch.xpath("@loc").get(0), new Unknown());
+            final String made = dispatch.xpath("@loc").get(0);
+            if (dead.contains(made)) {
+                rows.put(made, new Terminator());
+            } else {
+                rows.putIfAbsent(made, new Unknown());
+            }
         }
         Files.write(
             links,

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-name-taken-off-a-termination-terminates.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-name-taken-off-a-termination-terminates.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An object that never comes back with a value has no attribute to hand over,
+# so asking it for one lands where the object itself does. The table has no row
+# for a termination, and answering such a dispatch with `unknown` would say we
+# know nothing about it, which is a different fact. A chain says it twice: the
+# `bar` of the `foo` of a termination terminates as well.
+eo:
+  app.eo: |
+    [] > app
+      T > dead
+      dead.foo.bar > @
+links:
+  - "/links/type[@id='Φ.app.φ']/terminator"
+  - "/links/type[@id='Φ.app.φ.ρ']/terminator"


### PR DESCRIPTION
`Provided` keeps no row for a termination, so a name taken off one came back with nothing and the dispatch was written down as `unknown`. That says we know nothing about it, while the row right above says we know exactly what its receiver is.

The new `Dead` collects everything that terminates: what the table says outright, plus every dispatch whose receiver ends there. It repeats the walk until it stops growing, so a chain carries the fate along as well, and `Resolved` writes a `terminator` for those instead of `unknown`.

The pack asserts both hops of `dead.foo.bar`.

Closes #7756
