### PR TITLE
#7757: count the filled voids the way the free ones are counted

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answered.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answered.java
@@ -8,6 +8,7 @@ import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -61,10 +62,12 @@ final class Answered {
             new HashSet<>(pairs.certain()),
             new Ends(pairs.all()).names()
         );
-        final Map<String, Integer> filled = pairs.binds();
+        final Map<String, Collection<String>> filled = pairs.filled();
         final Map<String, Answer> found = new LinkedHashMap<>(0);
         for (final String locator : new Xmirs(this.world).locators()) {
-            found.put(locator, answers.of(locator, filled.getOrDefault(locator, 0)));
+            found.put(
+                locator, answers.of(locator, filled.getOrDefault(locator, Collections.emptyList()))
+            );
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -90,17 +90,18 @@ final class Answers {
     /**
      * What this object turns out to be.
      * @param locator The locator of the object
-     * @param filled How many voids this object has filled itself
+     * @param filled The locators of the voids this object has filled, its own
+     *  and the ones filled earlier in its chain of copies
      * @return The answer, saying what it settled on and how deep that is
      */
-    Answer of(final String locator, final int filled) {
+    Answer of(final String locator, final Collection<String> filled) {
         final String end = this.ends.getOrDefault(locator, locator);
         final String root = this.root(end);
         final Answer found;
         if (this.ground.contains(end)) {
             found = new Answer(end, 4);
         } else if (this.table.containsKey(end)) {
-            found = new Answer(end, this.depth(end, this.voids(end) - filled));
+            found = new Answer(end, this.depth(end, this.free(end, filled)));
         } else if (root.isEmpty()) {
             found = new Answer(end, 0);
         } else {
@@ -121,10 +122,11 @@ final class Answers {
         return found;
     }
 
-    private int voids(final String type) {
+    private int free(final String type, final Collection<String> filled) {
         int found = 0;
         for (final Map<String, String> row : this.own(type)) {
-            if ("true".equals(row.get("void")) && !"ρ".equals(row.get("name"))) {
+            if ("true".equals(row.get("void")) && !"ρ".equals(row.get("name"))
+                && !filled.contains(row.getOrDefault("type", ""))) {
                 found = found + 1;
             }
         }

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -6,7 +6,10 @@ package org.eolang.inference;
 
 import com.jcabi.xml.XML;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 /**
@@ -86,14 +89,38 @@ final class Pairs {
     }
 
     /**
-     * How many voids every object of the table has filled.
-     * @return The counts, by the locator of the object, without the ones that
-     *  filled none
+     * Every void an object of the table has filled.
+     *
+     * <p>The binds of one row are not the whole of it. A copy of a copy keeps
+     * what the earlier copy put in: {@code pair u > half} fills one void and
+     * {@code half v > full} the other, and {@code full} holds both, though its
+     * own row names only the second. So the chain is walked and the binds
+     * found along it are gathered together.</p>
+     *
+     * @return The locators of the voids filled, by the locator of the object
+     *  that filled them, without the objects that filled none
      */
-    Map<String, Integer> binds() {
-        final Map<String, Integer> found = new LinkedHashMap<>(0);
+    Map<String, Collection<String>> filled() {
+        final Map<String, Collection<String>> own = new LinkedHashMap<>(0);
         for (final XML link : this.table.nodes("/links/type[ref/bind]")) {
-            found.put(link.xpath("@id").get(0), link.nodes("ref/bind").size());
+            own.put(link.xpath("@id").get(0), link.xpath("ref/bind/@void"));
+        }
+        final Map<String, String> hops = this.all();
+        final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
+        for (final String object : hops.keySet()) {
+            final Collection<String> voids = new LinkedHashSet<>(0);
+            final Collection<String> seen = new HashSet<>(0);
+            String walked = object;
+            while (seen.add(walked)) {
+                voids.addAll(own.getOrDefault(walked, Collections.emptyList()));
+                if (!hops.containsKey(walked)) {
+                    break;
+                }
+                walked = hops.get(walked);
+            }
+            if (!voids.isEmpty()) {
+                found.put(object, voids);
+            }
         }
         return found;
     }

--- a/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
@@ -32,7 +32,7 @@ final class AnswersTest {
             "a copy of an oak must answer that it is an oak, but it named something else",
             new Answers(
                 rows, Collections.emptyMap(), Collections.emptyList(), chain
-            ).of("Φ.grove.α0", 0).where(),
+            ).of("Φ.grove.α0", Collections.emptyList()).where(),
             Matchers.equalTo("Φ.oak")
         );
     }
@@ -53,7 +53,7 @@ final class AnswersTest {
             new Answers(
                 rows, Collections.emptyMap(), Collections.emptyList(),
                 Collections.emptyMap()
-            ).of("Φ.inc", 0).rung(),
+            ).of("Φ.inc", Collections.emptyList()).rung(),
             Matchers.equalTo(2)
         );
     }
@@ -65,8 +65,58 @@ final class AnswersTest {
             new Answers(
                 Collections.emptyMap(), Collections.emptyMap(),
                 Collections.emptyList(), Collections.emptyMap()
-            ).of("Φ.nowhere", 0).where(),
+            ).of("Φ.nowhere", Collections.emptyList()).where(),
             Matchers.equalTo("Φ.nowhere")
+        );
+    }
+
+    @Test
+    void countsTheVoidsFilledEarlierInTheChain() {
+        final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
+        final Map<String, String> whole = new LinkedHashMap<>(0);
+        whole.put("id", "Φ.pair");
+        whole.put("complete", "true");
+        final Map<String, String> left = new LinkedHashMap<>(0);
+        left.put("name", "x");
+        left.put("void", "true");
+        left.put("type", "Φ.pair.x");
+        final Map<String, String> right = new LinkedHashMap<>(0);
+        right.put("name", "y");
+        right.put("void", "true");
+        right.put("type", "Φ.pair.y");
+        rows.put("Φ.pair", Arrays.asList(whole, left, right));
+        MatcherAssert.assertThat(
+            "a copy whose voids were filled one at a time has none left free, but it had",
+            new Answers(
+                rows, Collections.emptyMap(), Collections.emptyList(),
+                Collections.singletonMap("Φ.app.full", "Φ.pair")
+            ).of("Φ.app.full", Arrays.asList("Φ.pair.x", "Φ.pair.y")).rung(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
+    void doesNotCountTheReceiverAmongTheVoidsFilled() {
+        final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
+        final Map<String, String> whole = new LinkedHashMap<>(0);
+        whole.put("id", "Φ.grow");
+        whole.put("complete", "true");
+        final Map<String, String> bearer = new LinkedHashMap<>(0);
+        bearer.put("name", "ρ");
+        bearer.put("void", "true");
+        bearer.put("type", "Φ.grow.ρ");
+        final Map<String, String> hollow = new LinkedHashMap<>(0);
+        hollow.put("name", "x");
+        hollow.put("void", "true");
+        hollow.put("type", "Φ.grow.x");
+        rows.put("Φ.grow", Arrays.asList(whole, bearer, hollow));
+        MatcherAssert.assertThat(
+            "a dispatch fills the receiver and nothing else, so x must stay free, but it didnt",
+            new Answers(
+                rows, Collections.emptyMap(), Collections.emptyList(),
+                Collections.singletonMap("Φ.app.half", "Φ.grow")
+            ).of("Φ.app.half", Collections.singletonList("Φ.grow.ρ")).rung(),
+            Matchers.equalTo(2)
         );
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/PairsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PairsTest.java
@@ -7,6 +7,7 @@ package org.eolang.inference;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -31,6 +32,25 @@ final class PairsTest {
                 ).others()
             ).asXml(),
             XhtmlMatchers.hasXPath("/links/type[@id='a']/terminator")
+        );
+    }
+
+    @Test
+    void gathersTheVoidsFilledAlongTheWholeChain() {
+        MatcherAssert.assertThat(
+            "a copy of a copy keeps what the earlier one filled, but it forgot it",
+            new Pairs(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<links><type id='half'><ref loc='pair'>",
+                        "<bind void='pair.x'><ref loc='u'/></bind></ref></type>",
+                        "<type id='full'><ref loc='half'>",
+                        "<bind void='pair.y'><ref loc='v'/></bind></ref></type></links>"
+                    )
+                )
+            ).filled().get("full"),
+            Matchers.containsInAnyOrder("pair.y", "pair.x")
         );
     }
 }


### PR DESCRIPTION
The rung came from subtracting a count of binds from a count of voids, and the two counted different populations. The voids left `ρ` out; the binds put it in, and left out everything filled earlier in the chain of copies. So a formation that takes a receiver looked whole while a void of it was free, and a copy of a copy looked unfinished while both its voids were filled.

`Pairs.filled()` replaces `binds()`: it walks the chain and gives back the locators of the voids an object filled, its own and the earlier ones. `Answers` no longer subtracts, it counts the non-`ρ` voids of the formation that are not among those locators.

Two tests for the rungs, one for the gathering along a chain.

Closes #7757
