### PR TITLE
#7758: keep a demand on a void after a caller fills it

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Asked.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Asked.java
@@ -42,13 +42,20 @@ final class Asked {
     private final Map<String, String> names;
 
     /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
      * Ctor.
      * @param needs The needs table, as {@link Needs} wrote it
      * @param aliases The name every type goes by, from {@link Ends}
+     * @param provided What the types certainly have
      */
-    Asked(final XML needs, final Map<String, String> aliases) {
+    Asked(final XML needs, final Map<String, String> aliases, final Provided provided) {
         this.wanted = needs;
         this.names = aliases;
+        this.owned = provided;
     }
 
     /**
@@ -61,7 +68,10 @@ final class Asked {
         for (final XML attr : this.wanted.nodes("/needs/type/attr")) {
             final String name = attr.xpath("@name").get(0);
             final String step = ".".concat(name);
-            final String answer = this.names.getOrDefault(attr.xpath("@type").get(0), "");
+            final String bearer = attr.xpath("../@id").get(0);
+            final String answer = this.owned.attribute(
+                this.names.getOrDefault(bearer, bearer), name
+            );
             if (answer.endsWith(step)) {
                 found.computeIfAbsent(
                     answer.substring(0, answer.length() - step.length()),

--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -52,9 +52,13 @@ public final class Demanded implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
+        final Map<String, String> names = new Ends(
+            new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()
+        ).names();
         final Map<String, Map<String, String>> asked = new Asked(
             new XMLDocument(tables.resolve("needs.xml")),
-            new Ends(new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()).names()
+            names,
+            new Provided(given, names, given.xpath("//attr[@void='true']/@type"))
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
             final Demands demands = new Demands(asked, hollow.xpath("@type").get(0));

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caller-does-not-take-away-a-demand.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caller-does-not-take-away-a-demand.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What fills a void does not change what is asked of it. The program asks a
+# `size` of whatever fills `pages`, and it goes on asking it after somebody
+# applies `book` and hands in a `leaf` that has one. The demand is worked out
+# from the formation the receiver is a copy of, not from where the dispatch
+# settled once the argument was put in.
+eo:
+  book.eo: |
+    [pages] > book
+      pages > @
+  leaf.eo: |
+    [] > leaf
+      [] > size
+  app.eo: |
+    [] > app
+      book leaf > mine
+      mine.size > @
+provides:
+  - "/provides/type[@id='Φ.book']/attr[@void='true']/demand[@name='size']"


### PR DESCRIPTION
`Asked` read the locator the dispatch settled on. Once a caller applies the formation, `Filled` has already put the argument in there, so the locator was the argument and not the void, and `Demands` wrote nothing. A demand present in the tables therefore disappeared the moment somebody applied the formation.

It now works the answer out from the receiver instead: the receiver is walked to the formation it is a copy of and `Provided` is asked what that formation keeps under the name, which is the same answer the caller-free program gives. What fills a void does not change what is asked of it.

The pack is the program from the report, with a `leaf` that does have a `size`, since that is the case where the substitution used to hide the demand.

Closes #7758
