### PR TITLE
#7759: follow a filling through a delegation

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -99,14 +99,35 @@ final class Filled {
         final Map<String, String> found = new HashMap<>(0);
         final Collection<String> seen = new HashSet<>(0);
         String walked = bearer;
-        while (this.pairs.containsKey(walked) && seen.add(walked)) {
+        while (seen.add(walked)) {
+            this.gathered(found, walked);
+            if (!this.pairs.containsKey(walked)) {
+                break;
+            }
+            walked = this.pairs.get(walked);
+        }
+        final Map<String, String> through = new HashMap<>(found.size());
+        for (final Map.Entry<String, String> fill : found.entrySet()) {
+            final Collection<String> passed = new HashSet<>(0);
+            String reached = fill.getValue();
+            while (found.containsKey(reached) && passed.add(reached)) {
+                reached = found.get(reached);
+            }
+            through.put(fill.getKey(), reached);
+        }
+        return through;
+    }
+
+    private void gathered(final Map<String, String> found, final String type) {
+        final Collection<String> seen = new HashSet<>(0);
+        String walked = type;
+        while (!walked.isEmpty() && seen.add(walked)) {
             for (final Map.Entry<String, String> fill
                 : this.fills.getOrDefault(walked, Collections.emptyMap()).entrySet()) {
                 found.putIfAbsent(fill.getKey(), this.end(fill.getValue()));
             }
-            walked = this.pairs.get(walked);
+            walked = this.owned.body(walked);
         }
-        return found;
     }
 
     private String asked(final String start, final String names, final String back) {

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -165,6 +165,21 @@ final class Provided {
         return found;
     }
 
+    /**
+     * What this type hands its answers to.
+     *
+     * <p>Only what the type binds itself, and an empty string when it binds
+     * nothing: unlike {@link #attribute(String, String)}, this invents no
+     * member for a void, since whoever walks a delegation has to arrive
+     * somewhere rather than go on naming names.</p>
+     *
+     * @param type The name the type goes by
+     * @return The locator of the {@code φ} this type binds, or an empty string
+     */
+    String body(final String type) {
+        return this.bound(type, "φ");
+    }
+
     private boolean hollow(final String type) {
         boolean found = false;
         String walked = type;

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-filling-is-followed-through-a-delegation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-filling-is-followed-through-a-delegation.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name is looked for behind a delegation, so what fills a void has to be
+# looked for there too. `two u` fills `y`, the body of `two` puts that `y` into
+# the `x` of `one`, and `one` hands its answers to `x`. So the `next` of what
+# `two u` came back with is the `next` of `u`, not a name rooted at the void of
+# a formation two hops away.
+eo:
+  one.eo: |
+    [x] > one
+      x > @
+  two.eo: |
+    [y] > two
+      one y > @
+  u.eo: |
+    [] > u
+      [] > next
+  app.eo: |
+    [] > app
+      two u > held
+      held.next > @
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.u.next']"


### PR DESCRIPTION
`Provided` looks for a name behind a delegation, `Filled` looked for what fills a void only along the chain of copies. Those are two different walks, so a filling that lives on the delegation side was never seen and the answer stayed rooted at a void that a caller had in fact filled.

`Filled` now gathers along the delegation as well, and resolves a filling that is itself filled, since `two u` fills `y`, `y` fills the `x` of `one`, and the answer wanted is `u`. The delegation is read through the new `Provided.body`, which gives what the type binds and nothing else: `attribute` invents a member for a void, and walking on that never arrives anywhere.

The pack is the program from the report, where the answer used to be `Φ.one.x.next` and is now `Φ.u.next`.

Closes #7759
