### PR TITLE
#7753: hold a meta name to what the schema declares

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -488,7 +488,7 @@ final class MjTranspileTest {
                 String.join(
                     System.lineSeparator(),
                     "+architect yegor256@gmail.com",
-                    "+custom-meta",
+                    "+custommeta",
                     "+package foo.x",
                     "",
                     "[] > main"

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -113,7 +113,7 @@ final class LnMeta implements Line {
                 "meta directive requires a name"
             );
         }
-        if (!head.matches("[a-z]+[a-z0-9]*")) {
+        if (!head.matches("[a-z][a-z0-9]*")) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + 1,
                 "meta name must be lowercase letters and digits, starting with a letter"

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -113,10 +113,10 @@ final class LnMeta implements Line {
                 "meta directive requires a name"
             );
         }
-        if (!head.matches("[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*")) {
+        if (!head.matches("[a-z]+[a-z0-9]*")) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + 1,
-                "meta name must be a NAME starting with a lowercase letter"
+                "meta name must be lowercase letters and digits, starting with a letter"
             );
         }
         if ("package".equals(head) && parts.isEmpty()) {

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -127,10 +127,10 @@ final class EoTest {
     void recoversFromBadLineAndContinues() {
         MatcherAssert.assertThat(
             "after an error the walker must continue and parse subsequent valid lines",
-            EoTest.render("+ok-one", "  +bad-indent", "+ok-two"),
+            EoTest.render("+first", "  +badindent", "+second"),
             XhtmlMatchers.hasXPaths(
-                "/object/metas/meta[head='ok-one']",
-                "/object/metas/meta[head='ok-two']"
+                "/object/metas/meta[head='first']",
+                "/object/metas/meta[head='second']"
             )
         );
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-not-lowercase.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-not-lowercase.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:1] error: 'meta name must be a NAME starting with a lowercase letter'
+  [3:1] error: 'meta name must be lowercase letters and digits, starting with a letter'
   +Package foo
    ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-with-a-hyphen.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/meta-name-with-a-hyphen.yaml
@@ -4,11 +4,10 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:1] error: 'meta name must be lowercase letters and digits, starting with a letter'
-  +foo🌵
-   ^
+  meta name must be lowercase letters and digits, starting with a letter
 input: |
-  +foo🌵
+  +my-meta hello
 
+  # Sample.
   [] > main
-    5 > x
+    QQ.io.stdout "hello" > @


### PR DESCRIPTION
`checkHead` allowed nearly anything after the first letter, hyphens and uppercase included, while `XMIR.xsd` declares the head as `[a-z]+[a-z0-9]*`. The parser writes the schema location into the document it produces, so `+my-meta hello` parsed clean and then failed validation against the schema it points at.

The check now uses the schema's own pattern, so a bad meta name is a parse error with a line and a column.

Two typo packs carried the old wording and were updated. `EoTest.recoversFromBadLineAndContinues` used `+ok-one` and `+ok-two` to show that the walker keeps going after a bad line; the names are now `+first` and `+second`, since the point of that test is the recovery, not the hyphen. Every meta the repo actually uses already fits the pattern.

Closes #7753
