### PR TITLE
#7763: clean the directory of a class this run skipped

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -62,6 +62,15 @@ final class JavaFiles {
     private final Collection<Path> fresh;
 
     /**
+     * Where a class of the current run would have gone, written or not.
+     *
+     * <p>A class this run decided to skip, such as the implementation of an
+     * atom, names a directory all the same, and a file an earlier run left
+     * there is stale exactly as one beside a file we did write (#7763).</p>
+     */
+    private final Collection<Path> touched;
+
+    /**
      * Ctor.
      * @param dir Generated sources directory
      * @param cached Cache directory for this transpile version
@@ -72,6 +81,7 @@ final class JavaFiles {
         this.cache = cached;
         this.enabled = caching;
         this.fresh = new ConcurrentLinkedQueue<>();
+        this.touched = new ConcurrentLinkedQueue<>();
     }
 
     /**
@@ -98,10 +108,9 @@ final class JavaFiles {
             final boolean atom = object.path("o/o[@name='λ']").findAny().isPresent();
             for (final Xnav clazz : classes) {
                 final String jname = clazz.attribute("java-name").text().get();
+                final Path tgt = new Place(jname).make(this.generated, JavaFiles.JAVA);
+                this.touched.add(tgt);
                 if (!atom || jname.endsWith("Test")) {
-                    final Path tgt = new Place(jname).make(
-                        this.generated, JavaFiles.JAVA
-                    );
                     this.fresh.add(tgt);
                     final Footprint java = new FpJavaGenerated(
                         clazz, new FileGenerationReport(saved, tgt, target)
@@ -148,7 +157,7 @@ final class JavaFiles {
         if (Files.exists(this.generated)) {
             final Set<Path> expected = new HashSet<>(this.fresh);
             final Set<Path> dirs = new HashSet<>();
-            for (final Path file : expected) {
+            for (final Path file : this.touched) {
                 for (Path dir = file.getParent(); dir != null && dir.startsWith(this.generated);
                     dir = dir.getParent()) {
                     dirs.add(dir);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -128,6 +128,37 @@ final class JavaFilesTest {
         );
     }
 
+    @Test
+    void removesTheClassOfAnObjectThatBecameAnAtom(@Mktmp final Path temp) throws IOException {
+        final Path generated = temp.resolve("generated");
+        final Path plain = temp.resolve("plain.xmir");
+        new Saved(
+            "<object><class java-name='EOmain'><java>class EOmain {}</java></class></object>",
+            plain
+        ).value();
+        final JavaFiles first = new JavaFiles(generated, temp.resolve("cache"), false);
+        first.total(true, plain, "", false);
+        first.removeStale();
+        final Path atom = temp.resolve("atom.xmir");
+        new Saved(
+            String.join(
+                "",
+                "<object><o><o name='λ'/></o>",
+                "<class java-name='EOmain'><java>class EOmain {}</java></class>",
+                "</object>"
+            ),
+            atom
+        ).value();
+        final JavaFiles second = new JavaFiles(generated, temp.resolve("cache"), false);
+        second.total(true, atom, "", false);
+        second.removeStale();
+        MatcherAssert.assertThat(
+            "the class of an object that became an atom must go, but it survived the run",
+            Files.exists(generated.resolve("EOmain.java")),
+            Matchers.equalTo(false)
+        );
+    }
+
     private static int generateAtom(final Path temp) throws IOException {
         final Path xmir = temp.resolve("main.xmir");
         new Saved(


### PR DESCRIPTION
`removeStale` built the set of directories to clean out of the files this run wrote. A class it decided not to write, such as the implementation of an atom, named no directory, so nothing there was ever cleaned: rewrite `[] > main` as an atom and the `EOmain.java` of the previous build survives, gets compiled and goes into the jar, and the object resolves at run time to the old formation.

`total` now records where every class it looked at would have gone, skipped ones included, and `removeStale` takes its directories from that. What gets deleted is unchanged: a file this run did not write, in a directory this run did decide about. The guard from #6760 still holds, since a directory eo never considered stays out of the set.

Closes #7763
