### PR TITLE
#7762: mark a generated JUnit class in front, not behind

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
@@ -70,7 +70,7 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
             Path::resolve,
             Path::resolve
             );
-        final String origin = String.format("%sTest.java", jparts[jparts.length - 1]);
+        final String origin = String.format("Test%s.java", jparts[jparts.length - 1]);
         final Path resolved = base.resolve(origin);
         final Path resulted;
         final String content;
@@ -82,7 +82,7 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
             )
         ) {
             final String atomized = String.format(
-                "%sEOAtomTest.java", jparts[jparts.length - 1]
+                "TestAtom%s.java", jparts[jparts.length - 1]
             );
             resulted = base.resolve(atomized);
             content = clazz.element("tests").text().get().replace(
@@ -108,8 +108,8 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
             Path::resolve
         );
         final String name = parts[parts.length - 1];
-        for (final String suffix : new String[]{"Test.java", "EOAtomTest.java"}) {
-            final Path test = base.resolve(String.format("%s%s", name, suffix));
+        for (final String mark : new String[]{"Test", "TestAtom"}) {
+            final Path test = base.resolve(String.format("%s%s.java", mark, name));
             if (!test.equals(retained)) {
                 Files.deleteIfExists(test);
             }

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -144,6 +144,20 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
+  <!--
+  Get the name of the JUnit class generated for the tests of an object. The
+  mark goes in front of the class and not after it, because every name
+  "eo:class-name" makes starts with "EO", so a name starting with "Test" is
+  one it can never make. A suffix could be made: an object called "xTest"
+  gives the same "EOxTest" the tests of an object called "x" used to give, and
+  the two files then declare one class in one package (#7762).
+  -->
+  <xsl:function name="eo:test-class-name" as="xs:string">
+    <xsl:param name="n" as="xs:string"/>
+    <xsl:variable name="full" select="eo:class-name($n)"/>
+    <xsl:variable name="last" select="tokenize($full, '\.')[last()]"/>
+    <xsl:value-of select="concat(substring($full, 1, string-length($full) - string-length($last)), 'Test', $last)"/>
+  </xsl:function>
   <!-- Get clean escaped package segment, prefixed to never clash with an object class -->
   <xsl:function name="eo:clean-package" as="xs:string">
     <xsl:param name="n" as="xs:string"/>
@@ -942,7 +956,7 @@
     <xsl:text>")</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
     <xsl:text>public final class </xsl:text>
-    <xsl:value-of select="concat(eo:class-name(@name), 'Test')"/>
+    <xsl:value-of select="eo:test-class-name(@name)"/>
     <xsl:choose>
       <xsl:when test="@base">
         <xsl:text> extends PhOnce {</xsl:text>
@@ -960,7 +974,7 @@
   </xsl:template>
   <!-- Testing ctors. -->
   <xsl:template match="class" mode="testing-ctors">
-    <xsl:variable name="class" select="concat(eo:class-name(@name), 'Test')"/>
+    <xsl:variable name="class" select="eo:test-class-name(@name)"/>
     <xsl:text>/**</xsl:text>
     <xsl:value-of select="eo:eol(1)"/>
     <xsl:text> * Ctor.</xsl:text>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -69,7 +69,7 @@ final class JavaPlacedTest {
         MatcherAssert.assertThat(
             "Generated tests does not match with expected",
             new TextOf(
-                target.resolve("generated-test-sources").resolve("FooTest.java")
+                target.resolve("generated-test-sources").resolve("TestFoo.java")
             ).asString(),
             Matchers.equalTo(expected)
         );
@@ -99,7 +99,7 @@ final class JavaPlacedTest {
         MatcherAssert.assertThat(
             "A generated class marked only with @ParameterizedTest was silently skipped",
             new TextOf(
-                target.resolve("generated-test-sources").resolve("FooTest.java")
+                target.resolve("generated-test-sources").resolve("TestFoo.java")
             ).asString(),
             Matchers.equalTo(expected)
         );
@@ -114,7 +114,7 @@ final class JavaPlacedTest {
             new FpJavaGenerated(this.clazz("@Test"), generated, utest), utest, generated
         );
         placed.exec(this.clazz("@Test"), true);
-        final Path test = target.resolve("generated-test-sources").resolve("FooTest.java");
+        final Path test = target.resolve("generated-test-sources").resolve("TestFoo.java");
         final boolean created = Files.exists(test);
         placed.exec(this.clazz(""), true);
         MatcherAssert.assertThat(
@@ -131,9 +131,9 @@ final class JavaPlacedTest {
             new FpJavaGenerated(this.clazz("@Test"), generated, utest), utest, generated
         );
         Files.createDirectories(temp.resolve("src/test/java"));
-        new Saved("", temp.resolve("src/test/java/FooTest.java")).value();
+        new Saved("", temp.resolve("src/test/java/TestFoo.java")).value();
         placed.exec(this.clazz("@Test"), true);
-        final Path atom = target.resolve("generated-test-sources").resolve("FooEOAtomTest.java");
+        final Path atom = target.resolve("generated-test-sources").resolve("TestAtomFoo.java");
         final boolean created = Files.exists(atom);
         placed.exec(this.clazz(""), true);
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
@@ -225,17 +225,17 @@ final class MjMergeTest {
     private static Path generated(final FakeMaven maven, final String name, final String kind)
         throws IOException {
         final Path base;
-        final String suffix;
+        final String mark;
         if ("tests".equals(kind)) {
             base = maven.generatedPath().getParent().resolve("generated-test-sources");
-            suffix = "Test";
+            mark = "Test";
         } else {
             base = maven.generatedPath();
-            suffix = "";
+            mark = "";
         }
         return base.resolve("org").resolve("eolang").resolve(
             String.format(
-                "EO%s%s.java", name.replace(".eo", "").replace("/", "$EO"), suffix
+                "%sEO%s.java", mark, name.replace(".eo", "").replace("/", "$EO")
             )
         );
     }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/tests-of-a-member-keep-running.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/merge-packs/tests-of-a-member-keep-running.yaml
@@ -29,7 +29,7 @@ xmir:
     - "/object/o[@name='number']/o[@name='lt'][not(o[@name='+can-tell-two-is-above-one'])]"
 tests:
   number.eo:
-    - 'class EOnumberTest'
+    - 'class TestEOnumber'
     - 'void can_be_what_a_number_is()'
     - 'void can_tell_two_is_above_one()'
     - 'void _stops_on_one_below_two()'

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/live-object-with-test-suite.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/live-object-with-test-suite.yaml
@@ -13,7 +13,7 @@ asserts:
   - /object[not(errors)]
   - //java[contains(text(), 'EOfoo')]
   - //java[not(contains(text(), 'void formats_name() throws java.lang.Exception {'))]
-  - //tests[contains(text(), 'EOfooTest')]
+  - //tests[contains(text(), 'TestEOfoo')]
   - //tests[contains(text(), '  @Test')]
   - //tests[contains(text(), '  void formats_name() throws java.lang.Exception {')]
   - //tests[contains(text(), '    new Dataized(')]

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-class-does-not-take-an-objects-name.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/tests-class-does-not-take-an-objects-name.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The JUnit class of an object must not be named the way an object of the same
+# package could be. The tests of `x` used to give `EOxTest`, and so does an
+# object called `xTest`, so the two declared one class in one package and the
+# test source quietly shadowed the object (#7762). Every class name the
+# transpiler makes for an object starts with `EO`, so the mark goes in front.
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //class[@java-name='org.eolang.EOx']
+  - //tests[contains(text(), 'public final class TestEOx')]
+  - //tests[not(contains(text(), 'class EOxTest'))]
+input: |
+  [] > x
+    42 > @
+
+    [] +> checks-something
+      eq. > @
+        1
+        1


### PR DESCRIPTION
The JUnit class of an object was named by appending `Test` to the object's own class name, and an object called `xTest` gives that same name. Both files then declared `EOxTest` in one package, and since the two source roots are compiled apart nothing failed: the test-scope class quietly shadowed the object.

Every class name `eo:class-name` makes starts with `EO`, so a name that starts with `Test` is one it can never make. The tests of `x` are now `TestEOx`, and the file `JavaPlaced` writes follows: `TestFoo.java`, with `TestAtomFoo.java` for the fallback when a hand-written test of that name already exists. Surefire picks both up through its default `Test*.java` include.

A pack asserts the tests of `x` declare `TestEOx` and not `EOxTest`.

Closes #7762
