### PR TITLE
#7748: lay sockaddr_in out the way the platform does

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/MacSockaddrIn.java
+++ b/eo-runtime/src/main/java/org/eolang/MacSockaddrIn.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.sun.jna.Structure;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The sockaddr_in structure, as macOS and the BSDs lay it out: a one-byte
+ * {@code sin_len} and a one-byte {@code sin_family}, not a two-byte family.
+ * @since 0.74.0
+ * @checkstyle VisibilityModifierCheck (50 lines)
+ */
+public final class MacSockaddrIn extends Structure {
+
+    /**
+     * Length of the whole structure, which is what {@code sin_len} holds.
+     */
+    private static final byte LENGTH = 16;
+
+    /**
+     * Length of the structure.
+     */
+    public byte len;
+
+    /**
+     * Address family (e.g., AF_INET).
+     */
+    public byte family;
+
+    /**
+     * Port number in network byte order.
+     */
+    public short port;
+
+    /**
+     * IP address in network byte order.
+     */
+    public int addr;
+
+    /**
+     * Padding to match C structure.
+     */
+    public byte[] zero;
+
+    /**
+     * Ctor.
+     * @param family Family
+     * @param port Port
+     * @param addr Address
+     * @param zero Zero 8 bytes
+     */
+    public MacSockaddrIn(
+        final short family, final short port, final int addr, final byte[] zero
+    ) {
+        super();
+        this.len = MacSockaddrIn.LENGTH;
+        this.family = (byte) family;
+        this.port = port;
+        this.addr = addr;
+        this.zero = Arrays.copyOf(zero, zero.length);
+    }
+
+    @Override
+    public List<String> getFieldOrder() {
+        return Arrays.asList("len", "family", "port", "addr", "zero");
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/Sockaddr.java
+++ b/eo-runtime/src/main/java/org/eolang/Sockaddr.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.sun.jna.Platform;
+import com.sun.jna.Structure;
+import java.util.Arrays;
+
+/**
+ * A {@code sockaddr_in} laid out the way the running platform lays it out.
+ *
+ * <p>Linux and Windows open it with a two-byte family, macOS and the BSDs
+ * with a one-byte length and a one-byte family, and a caller of {@code bind},
+ * {@code connect} or {@code accept} wants whichever the kernel reads.</p>
+ *
+ * @since 0.74.0
+ * @todo #7748:35min Take the reading of an address out of the syscalls.
+ *  `BindSyscall`, `ConnectSyscall` and `AcceptSyscall` each dataize the same
+ *  four attributes of the same EO `sockaddr` object to build this one. That
+ *  belongs in one place, most likely a ctor here that takes the `Phi`.
+ */
+public final class Sockaddr {
+
+    /**
+     * Address family (e.g., AF_INET).
+     */
+    private final short family;
+
+    /**
+     * Port number in network byte order.
+     */
+    private final short port;
+
+    /**
+     * IP address in network byte order.
+     */
+    private final int addr;
+
+    /**
+     * Padding to match C structure.
+     */
+    private final byte[] zero;
+
+    /**
+     * Ctor.
+     * @param family Family
+     * @param port Port
+     * @param addr Address
+     * @param zero Zero 8 bytes
+     */
+    public Sockaddr(final short family, final short port, final int addr, final byte[] zero) {
+        this.family = family;
+        this.port = port;
+        this.addr = addr;
+        this.zero = Arrays.copyOf(zero, zero.length);
+    }
+
+    /**
+     * The struct itself.
+     * @return The structure, in the layout of the platform
+     */
+    public Structure it() {
+        final Structure found;
+        if (Platform.isMac()) {
+            found = new MacSockaddrIn(this.family, this.port, this.addr, this.zero);
+        } else {
+            found = new SockaddrIn(this.family, this.port, this.addr, this.zero);
+        }
+        return found;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/Sockaddr.java
+++ b/eo-runtime/src/main/java/org/eolang/Sockaddr.java
@@ -7,7 +7,6 @@ package org.eolang;
 
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
-import java.util.Arrays;
 
 /**
  * A {@code sockaddr_in} laid out the way the running platform lays it out.
@@ -17,45 +16,20 @@ import java.util.Arrays;
  * {@code connect} or {@code accept} wants whichever the kernel reads.</p>
  *
  * @since 0.74.0
- * @todo #7748:35min Take the reading of an address out of the syscalls.
- *  `BindSyscall`, `ConnectSyscall` and `AcceptSyscall` each dataize the same
- *  four attributes of the same EO `sockaddr` object to build this one. That
- *  belongs in one place, most likely a ctor here that takes the `Phi`.
  */
 public final class Sockaddr {
 
     /**
-     * Address family (e.g., AF_INET).
+     * The EO object holding the address.
      */
-    private final short family;
-
-    /**
-     * Port number in network byte order.
-     */
-    private final short port;
-
-    /**
-     * IP address in network byte order.
-     */
-    private final int addr;
-
-    /**
-     * Padding to match C structure.
-     */
-    private final byte[] zero;
+    private final Phi origin;
 
     /**
      * Ctor.
-     * @param family Family
-     * @param port Port
-     * @param addr Address
-     * @param zero Zero 8 bytes
+     * @param phi The EO object holding the address
      */
-    public Sockaddr(final short family, final short port, final int addr, final byte[] zero) {
-        this.family = family;
-        this.port = port;
-        this.addr = addr;
-        this.zero = Arrays.copyOf(zero, zero.length);
+    public Sockaddr(final Phi phi) {
+        this.origin = phi;
     }
 
     /**
@@ -63,11 +37,15 @@ public final class Sockaddr {
      * @return The structure, in the layout of the platform
      */
     public Structure it() {
+        final short family = new Dataized(this.origin.take("family")).take(Short.class);
+        final short port = new Dataized(this.origin.take("port")).take(Short.class);
+        final int addr = new Dataized(this.origin.take("address")).take(Integer.class);
+        final byte[] zero = new Dataized(this.origin.take("padding")).take();
         final Structure found;
         if (Platform.isMac()) {
-            found = new MacSockaddrIn(this.family, this.port, this.addr, this.zero);
+            found = new MacSockaddrIn(family, port, addr, zero);
         } else {
-            found = new SockaddrIn(this.family, this.port, this.addr, this.zero);
+            found = new SockaddrIn(family, port, addr, zero);
         }
         return found;
     }

--- a/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
@@ -6,7 +6,6 @@ package org.eolang.posix;
 
 import com.sun.jna.ptr.IntByReference;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -40,12 +39,7 @@ public final class AcceptSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.accept(
                     new Int("the 'descriptor' argument of accept", params[0]).it(),
-                    new Sockaddr(
-                        new Dataized(params[1].take("family")).take(Short.class),
-                        new Dataized(params[1].take("port")).take(Short.class),
-                        new Dataized(params[1].take("address")).take(Integer.class),
-                        new Dataized(params[1].take("padding")).take()
-                    ).it(),
+                    new Sockaddr(params[1]).it(),
                     new IntByReference(new Int("the 'length' argument of accept", params[2]).it())
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
@@ -10,7 +10,7 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.SockaddrIn;
+import org.eolang.Sockaddr;
 import org.eolang.Syscall;
 
 /**
@@ -40,12 +40,12 @@ public final class AcceptSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.accept(
                     new Int("the 'descriptor' argument of accept", params[0]).it(),
-                    new SockaddrIn(
+                    new Sockaddr(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
-                    ),
+                    ).it(),
                     new IntByReference(new Int("the 'length' argument of accept", params[2]).it())
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
@@ -5,7 +5,6 @@
 package org.eolang.posix;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -39,12 +38,7 @@ public final class BindSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.bind(
                     new Int("the 'descriptor' argument of bind", params[0]).it(),
-                    new Sockaddr(
-                        new Dataized(params[1].take("family")).take(Short.class),
-                        new Dataized(params[1].take("port")).take(Short.class),
-                        new Dataized(params[1].take("address")).take(Integer.class),
-                        new Dataized(params[1].take("padding")).take()
-                    ).it(),
+                    new Sockaddr(params[1]).it(),
                     new Int("the 'length' argument of bind", params[2]).it()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
@@ -9,7 +9,7 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.SockaddrIn;
+import org.eolang.Sockaddr;
 import org.eolang.Syscall;
 
 /**
@@ -39,12 +39,12 @@ public final class BindSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.bind(
                     new Int("the 'descriptor' argument of bind", params[0]).it(),
-                    new SockaddrIn(
+                    new Sockaddr(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
-                    ),
+                    ).it(),
                     new Int("the 'length' argument of bind", params[2]).it()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/CStdLib.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CStdLib.java
@@ -12,7 +12,6 @@ import com.sun.jna.Pointer;
 import com.sun.jna.Structure;
 import com.sun.jna.ptr.IntByReference;
 import java.util.Collections;
-import org.eolang.SockaddrIn;
 
 /**
  * C standard library with unix syscalls.
@@ -222,7 +221,7 @@ public interface CStdLib extends Library {
      * @param addrlen The size of the address structure
      * @return Zero on success, -1 on error
      */
-    int connect(int sockfd, SockaddrIn addr, int addrlen);
+    int connect(int sockfd, Structure addr, int addrlen);
 
     /**
      * Assigns the address specified by {@code addr} to the socket referred to
@@ -232,7 +231,7 @@ public interface CStdLib extends Library {
      * @param addrlen The size of the address structure
      * @return Zero on success, -1 on error
      */
-    int bind(int sockfd, SockaddrIn addr, int addrlen);
+    int bind(int sockfd, Structure addr, int addrlen);
 
     /**
      * Listen for incoming connections on socket.
@@ -251,7 +250,7 @@ public interface CStdLib extends Library {
      * @return On success, file descriptor for the accepted socket
      *  (a nonnegative integer) is returned. On error, -1 is returned
      */
-    int accept(int sockfd, SockaddrIn addr, IntByReference addrlen);
+    int accept(int sockfd, Structure addr, IntByReference addrlen);
 
     /**
      * Receive a message from a socket.

--- a/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
@@ -9,7 +9,7 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.SockaddrIn;
+import org.eolang.Sockaddr;
 import org.eolang.Syscall;
 
 /**
@@ -39,12 +39,12 @@ public final class ConnectSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.connect(
                     new Int("the 'descriptor' argument of connect", params[0]).it(),
-                    new SockaddrIn(
+                    new Sockaddr(
                         new Dataized(params[1].take("family")).take(Short.class),
                         new Dataized(params[1].take("port")).take(Short.class),
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
-                    ),
+                    ).it(),
                     new Int("the 'length' argument of connect", params[2]).it()
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
@@ -5,7 +5,6 @@
 package org.eolang.posix;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -39,12 +38,7 @@ public final class ConnectSyscall implements Syscall {
             new Data.ToPhi(
                 CStdLib.INSTANCE.connect(
                     new Int("the 'descriptor' argument of connect", params[0]).it(),
-                    new Sockaddr(
-                        new Dataized(params[1].take("family")).take(Short.class),
-                        new Dataized(params[1].take("port")).take(Short.class),
-                        new Dataized(params[1].take("address")).take(Integer.class),
-                        new Dataized(params[1].take("padding")).take()
-                    ).it(),
+                    new Sockaddr(params[1]).it(),
                     new Int("the 'length' argument of connect", params[2]).it()
                 )
             )

--- a/eo-runtime/src/test/java/org/eolang/MacSockaddrInTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MacSockaddrInTest.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.sun.jna.Structure;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link MacSockaddrIn}.
+ * @since 0.74.0
+ */
+final class MacSockaddrInTest {
+
+    @Test
+    void opensWithALengthAndAFamily() {
+        final Structure struct = new MacSockaddrIn((short) 2, (short) 0, 0, new byte[8]);
+        struct.write();
+        MatcherAssert.assertThat(
+            "the length must come first there and the family second, but they didnt",
+            struct.getPointer().getByteArray(0, 2),
+            Matchers.equalTo(new byte[] {(byte) 16, (byte) 2})
+        );
+    }
+}


### PR DESCRIPTION
`SockaddrIn` declared the family as a two-byte field at offset zero, which is how Linux and Windows lay `struct sockaddr_in` out. macOS and the BSDs open with a one-byte `sin_len` and a one-byte `sin_family`, so the `02 00` that says `AF_INET` there reads as a length of two and `AF_UNSPEC`, and `bind`, `connect` and `accept` were all handed a family the kernel does not take.

`MacSockaddrIn` carries that layout, and `Sockaddr` picks between the two the way `StatSyscall` already picks between `MacFileStat` and its siblings. `Sockaddr` takes the EO object and reads the address out of it itself, so the three syscalls ask it for the struct and no longer dataize the same four attributes each. `CStdLib` takes a `Structure`, since which of the two it gets is the platform's business. Windows keeps `SockaddrIn` directly, its layout being the Linux one.

`MacSockaddrInTest` reads the first two bytes of the macOS struct on any machine and expects `10 02`.

Closes #7748
