### PR TITLE
#7724: write the tracked steps even when the cache has the answer

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -206,6 +206,19 @@ final class Transpilation {
     }
 
     /**
+     * Whether the XMIR of every step is written down.
+     *
+     * <p>A build that asks for them wants to read them, and a cached
+     * transpilation writes none: the dumps are made by the train and the
+     * cache hands back its stored answer without running it (#7724).</p>
+     *
+     * @return True if the steps are tracked
+     */
+    boolean steps() {
+        return this.tracking.steps();
+    }
+
+    /**
      * Build XSL transformation function for a source file.
      * If transformation steps are tracked - creates a new {@link Xsline}
      * for every XMIR in purpose of thread safety.

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -177,7 +177,7 @@ final class Transpiling implements Step {
         final Function<XML, XML> transform = this.train.forSource(name);
         final Path cdir = this.cache.resolve(Transpiling.CACHE);
         final Path tail = base.relativize(dest);
-        if (this.enabled) {
+        if (this.enabled && !this.train.steps()) {
             this.guard.apply(
                 source, dest, tail,
                 new Cache(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -103,6 +103,31 @@ final class MjTranspileTest {
     }
 
     @Test
+    void tracksStepsOfASourceTheCacheAlreadyHolds(@Mktmp final Path temp) throws IOException {
+        final Path cache = temp.resolve("cache");
+        final String src = MjTranspileTest.pair();
+        new FakeMaven(temp.resolve("first"))
+            .withProgram(src)
+            .with("cache", cache.toFile())
+            .with("trackSteps", true)
+            .execute(MjParse.class)
+            .execute(MjTranspile.class);
+        MatcherAssert.assertThat(
+            "a second build with the same flag and source must write the steps again, but the cache took them away",
+            new FakeMaven(temp.resolve("second"))
+                .withProgram(src)
+                .with("cache", cache.toFile())
+                .with("trackSteps", true)
+                .execute(MjParse.class)
+                .execute(MjTranspile.class)
+                .result(),
+            Matchers.hasKey(
+                String.format("target/%s/examples/x/00-set-locators.xml", Transpiling.PRE)
+            )
+        );
+    }
+
+    @Test
     void tracksStepsOfProgramWithTwoObjects(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "the first tracked step of a program holding two objects did not leave its XMIR in the pre-transpile directory",


### PR DESCRIPTION
The per-step XMIRs are written by `TrSpy`, which lives inside the function `Cache` calls only on a miss. #7675 made the flag part of the cache key, so turning it on invalidates what an earlier build stored, but two builds with the flag held at `true` share a key and the second one is a plain hit: the answer is copied out of the cache and nothing lands in `target/5-pre-transpile`, which is the case a developer actually hits while debugging.

A source whose steps are tracked no longer goes through the cache at all. The dumps are the point of the flag, and they only exist while the train is running.

The test builds the same source twice with the flag on, sharing one cache directory, and looks for the first step's XMIR after the second build.

Closes #7724
