### PR TITLE
#7696: reject an empty segment in a package path

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -119,11 +119,19 @@ final class LnMeta implements Line {
                 "meta name must be lowercase letters and digits, starting with a letter"
             );
         }
-        if ("package".equals(head) && parts.size() != 1) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "'+package' directive requires exactly one argument"
-            );
+        if ("package".equals(head)) {
+            if (parts.size() != 1) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "'+package' directive requires exactly one argument"
+                );
+            }
+            if (new Dotted(parts.get(0)).broken()) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "'+package' path must not have an empty segment"
+                );
+            }
         }
         if ("alias".equals(head)) {
             if (parts.isEmpty()) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/package-path-with-a-doubled-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/package-path-with-a-doubled-dot.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  '+package' path must not have an empty segment
+input: |
+  +package foo..bar
+
+  [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/package-path-with-a-leading-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/package-path-with-a-leading-dot.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  '+package' path must not have an empty segment
+input: |
+  +package .foo
+
+  [] > main

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/package-path-with-a-trailing-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/package-path-with-a-trailing-dot.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  '+package' path must not have an empty segment
+input: |
+  +package foo.
+
+  [] > main


### PR DESCRIPTION
`set-locators.xsl` writes the package part into a locator as it stands, and nothing checked its shape, so `+package .foo` gave `Φ..foo.main`, which is not a locator R-9.1.6 allows. Trailing and doubled dots did the same.

The directive now rejects a path with an empty segment, before any of it reaches a locator.

Three typo packs, one per shape from the report.

Closes #7696
