### PR TITLE
#7697: reject an empty segment in an alias target

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Dotted.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Dotted.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+/**
+ * A dotted path written in a meta directive.
+ *
+ * <p>Every dot introduces a segment, so a leading dot, a trailing dot and a
+ * doubled dot each name a segment that is not there. Such a path is copied
+ * verbatim into a base by `expand-aliases.xsl`, where it names nothing at
+ * all, which is why it is caught while the line is still being read.</p>
+ *
+ * @since 0.74.0
+ */
+final class Dotted {
+
+    /**
+     * The path.
+     */
+    private final String path;
+
+    /**
+     * Ctor.
+     * @param text The path, as the source wrote it
+     */
+    Dotted(final String text) {
+        this.path = text;
+    }
+
+    /**
+     * Whether the path names a segment that is not there.
+     * @return True if a dot of it introduces nothing
+     */
+    boolean broken() {
+        return this.path.startsWith(".")
+            || this.path.endsWith(".")
+            || this.path.contains("..");
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -125,17 +125,25 @@ final class LnMeta implements Line {
                 "'+package' directive requires exactly one argument"
             );
         }
-        if ("alias".equals(head) && parts.isEmpty()) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "'+alias' directive requires at least one argument"
-            );
-        }
-        if ("alias".equals(head) && LnMeta.ROOT.equals(parts.get(0))) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "'+alias' cannot rename the root token Q"
-            );
+        if ("alias".equals(head)) {
+            if (parts.isEmpty()) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "'+alias' directive requires at least one argument"
+                );
+            }
+            if (LnMeta.ROOT.equals(parts.get(0))) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "'+alias' cannot rename the root token Q"
+                );
+            }
+            if (!parts.get(parts.size() - 1).matches("[^.]+(\\.[^.]+)*")) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "'+alias' target must not have an empty segment"
+                );
+            }
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -138,7 +138,7 @@ final class LnMeta implements Line {
                     "'+alias' cannot rename the root token Q"
                 );
             }
-            if (!parts.get(parts.size() - 1).matches("[^.]+(\\.[^.]+)*")) {
+            if (new Dotted(parts.get(parts.size() - 1)).broken()) {
                 throw new ParseError(
                     this.span.line(), this.span.indent(),
                     "'+alias' target must not have an empty segment"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-target-with-a-doubled-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-target-with-a-doubled-dot.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  '+alias' target must not have an empty segment
+input: |
+  +alias x foo..bar
+
+  [] > main
+    x > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-target-with-a-leading-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-target-with-a-leading-dot.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  '+alias' target must not have an empty segment
+input: |
+  +alias x .foo
+
+  [] > main
+    x > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-target-with-a-trailing-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/alias-target-with-a-trailing-dot.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  '+alias' target must not have an empty segment
+input: |
+  +alias x foo.
+
+  [] > main
+    x > @


### PR DESCRIPTION
`expand-aliases.xsl` puts `Φ.` in front of the target as it stands, so `+alias x .foo` became the base `Φ..foo`, which names nothing. Trailing and doubled dots did the same.

The directive now rejects a target with an empty segment. The two checks it already made are grouped under one `alias` branch, since a third one in a row pushed the method past what qulice allows for NPath.

Three typo packs, one per shape from the report.

Closes #7697
