### PR TITLE
#7694: check the trailing whitespace of a text block closer

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -41,6 +41,11 @@ final class Eo implements Iterable<Directive> {
     private static final String ROOT_TOKENS = "*(QTI@^$";
 
     /**
+     * What a line with a space at its end is told, wherever it is written.
+     */
+    private static final String TRAILING = "trailing whitespace at end of line";
+
+    /**
      * Initial capacity of the source line buffer, {@link java.util.ArrayList}'s own default.
      */
     private static final int SPANS_CAPACITY = 10;
@@ -262,7 +267,7 @@ final class Eo implements Iterable<Directive> {
             emit.error(span.line(), 0, "unexpected odd indent");
             failed = true;
         } else if (span.trailing()) {
-            emit.error(span.line(), 0, "trailing whitespace at end of line");
+            emit.error(span.line(), 0, Eo.TRAILING);
             failed = true;
         } else if (Eo.opensTextBlock(span)) {
             globals.seal(emit, span);
@@ -280,7 +285,7 @@ final class Eo implements Iterable<Directive> {
     ) {
         if (Eo.closesTextBlock(span, globals)) {
             if (span.trailing()) {
-                emit.error(span.line(), 0, "trailing whitespace at end of line");
+                emit.error(span.line(), 0, Eo.TRAILING);
             }
             stack.popDeeperThan(span.indent());
             final Rollback point = new Rollback(stack, emit, emit.savepoint(), stack.snapshot());
@@ -294,7 +299,7 @@ final class Eo implements Iterable<Directive> {
         } else {
             final String raw = span.text();
             if (span.trailing()) {
-                emit.error(span.line(), 0, "trailing whitespace at end of line");
+                emit.error(span.line(), 0, Eo.TRAILING);
             }
             if (!span.blank() && span.indent() < globals.textBlockOpenIndent()) {
                 emit.error(

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -279,6 +279,9 @@ final class Eo implements Iterable<Directive> {
         final Span span, final Stack stack, final Globals globals, final Emit emit
     ) {
         if (Eo.closesTextBlock(span, globals)) {
+            if (span.trailing()) {
+                emit.error(span.line(), 0, "trailing whitespace at end of line");
+            }
             stack.popDeeperThan(span.indent());
             final Rollback point = new Rollback(stack, emit, emit.savepoint(), stack.snapshot());
             try {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/text-block-closer-with-trailing-whitespace.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/text-block-closer-with-trailing-whitespace.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: "trailing whitespace at end of line"
+input: "[] > main\n  \"\"\"\n  text\n  \"\"\" > msg  \n"


### PR DESCRIPTION
Every line in flight inside a text block goes to `continueTextBlock` before the ordinary trailing-whitespace gate, and only its body branch checked for it. So `""" > msg` with two spaces after the name parsed clean, while the same spaces on a body line or on any other line are an error.

The closing branch makes the same check now, before the closer is handed to `LnTextBlock`.

The pack writes the source with escapes, the way the body-line pack does, so the spaces survive the yaml.

Closes #7694
