### PR TITLE
#7895: label an application whose parts are data by any evidence

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
@@ -176,23 +176,42 @@
     <xsl:param name="a" as="element()"/>
     <xsl:sequence select="exists($eo:links) and exists($a/o[@loc]) and (every $p in $a/o[@loc] satisfies eo:copies-data(key('eo:row', $p/@loc, $eo:links)))"/>
   </xsl:function>
-  <!-- Whether this row of "links.xml" says its object is a copy of data. -->
+  <!--
+  Whether this row of "links.xml" says its object is data. A row holds one
+  answer, and three of the kinds it may hold are data: a copy of a data
+  object outright, a copy of something the tables say is data anyway
+  ("eo:data-target"), and a choice all of whose members are one of those.
+  A row with no answer, or one holding anything else, leaves the application
+  unlabeled.
+  -->
   <xsl:function name="eo:copies-data" as="xs:boolean">
     <xsl:param name="row" as="element()?"/>
-    <xsl:sequence select="exists($row) and count($row/*) = 1 and exists($row/ref[@loc = $eo:data])"/>
+    <xsl:sequence select="exists($row) and count($row/*) = 1 and (exists($row/ref[@loc = $eo:data]) or (exists($row/ref) and eo:data-target($row/ref/@loc)) or (exists($row/union) and eo:chosen($row/union)))"/>
+  </xsl:function>
+  <!--
+  Whether every member of this choice is data. A member is written the same
+  way the answer of a row is, so the same two questions are put to it: the
+  bytes of a literal, which the table writes as "data", and a copy of
+  something known to be data.
+  -->
+  <xsl:function name="eo:chosen" as="xs:boolean">
+    <xsl:param name="union" as="element()"/>
+    <xsl:sequence select="exists($union/*) and (every $m in $union/* satisfies (exists($m/self::data) or (exists($m/self::ref) and ($m/@loc = $eo:data or eo:data-target($m/@loc)))))"/>
+  </xsl:function>
+  <!--
+  Whether the object this locator names is data, judged by what the tables
+  say about it rather than by its own row of "links.xml": a formation that
+  comes back with a data object, and a void the program is only ever seen
+  filling with data. The second question is the one "eo:filled" puts to the
+  voids of a formation, asked here of one void named from the outside.
+  -->
+  <xsl:function name="eo:data-target" as="xs:boolean">
+    <xsl:param name="loc" as="xs:string"/>
+    <xsl:sequence select="exists($eo:provides) and ((some $t in key('eo:row', $loc, $eo:provides) satisfies $t/@returns = $eo:data) or (some $v in $eo:provides//attr[@void = 'true'][@type = $loc] satisfies (exists($v/witnessed) and empty($v/witnessed/descendant::*[not(self::union or (self::ref and @loc = $eo:data))]))))"/>
   </xsl:function>
   <!--
   An application whose parts are all data is labeled too, so that the answer
   it works out is remembered instead of being worked out on every read.
-  @todo #7656:90min Label an application whose parts are data by the other
-  kinds of evidence "links.xml" holds. Today only a part that is a copy of
-  data - a literal, or a local that holds one - counts, and the three other
-  cases the table already carries are ignored: a "var" of a void whose row
-  in "provides.xml" is witnessed as data (the same question "eo:filled"
-  asks), a "ref" to a formation whose row says "returns" a data object, and
-  a "union" all of whose members are one of those. Each of them widens the
-  set of applications that stop being recomputed, and none of them needs a
-  new table.
   -->
   <xsl:template match="*[@loc][@base][not(@base = $eo:literals)][o[@loc]]">
     <xsl:copy>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
@@ -196,7 +196,7 @@
   -->
   <xsl:function name="eo:chosen" as="xs:boolean">
     <xsl:param name="union" as="element()"/>
-    <xsl:sequence select="exists($union/*) and (every $m in $union/* satisfies (exists($m/self::data) or (exists($m/self::ref) and ($m/@loc = $eo:data or eo:data-target($m/@loc)))))"/>
+    <xsl:sequence select="exists($union/*) and (every $m in $union/* satisfies (name($m) = 'data' or (name($m) = 'ref' and ($m/@loc = $eo:data or eo:data-target($m/@loc)))))"/>
   </xsl:function>
   <!--
   Whether the object this locator names is data, judged by what the tables
@@ -207,7 +207,7 @@
   -->
   <xsl:function name="eo:data-target" as="xs:boolean">
     <xsl:param name="loc" as="xs:string"/>
-    <xsl:sequence select="exists($eo:provides) and ((some $t in key('eo:row', $loc, $eo:provides) satisfies $t/@returns = $eo:data) or (some $v in $eo:provides//attr[@void = 'true'][@type = $loc] satisfies (exists($v/witnessed) and empty($v/witnessed/descendant::*[not(self::union or (self::ref and @loc = $eo:data))]))))"/>
+    <xsl:sequence select="exists($eo:provides) and ((some $t in key('eo:row', $loc, $eo:provides) satisfies $t/@returns = $eo:data) or (some $v in $eo:provides//attr[@void = 'true'][@type = $loc] satisfies (exists($v/witnessed) and (every $e in $v/witnessed//* satisfies (name($e) = 'union' or (name($e) = 'ref' and $e/@loc = $eo:data))))))"/>
   </xsl:function>
   <!--
   An application whose parts are all data is labeled too, so that the answer

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/purify-packs/application-of-a-data-void-is-pure.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/purify-packs/application-of-a-data-void-is-pure.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A part of an application does not have to be a literal to be data. Every
+# caller of `inc` hands it a number, so the tables say the `x` it passes on is
+# only ever a number, and the application it writes answers the same bytes
+# every time.
+eo:
+  app.eo: |
+    [] > app
+      inc 42 > y
+      y > @
+  inc.eo: |
+    [x] > inc
+      foo x 1 > @
+  foo.eo: |
+    [a b] > foo
+      a > @
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+      [x] > plus
+        x > @
+pure:
+  - "//o[@base='Φ.foo' and @pure='true']"


### PR DESCRIPTION
The puzzle from #7656. Only a part that is a copy of data counted, so an application whose parts are data by any of the other evidence in the tables kept being worked out on every read.

`eo:copies-data` now takes a row that holds a copy of something the tables call data, and a choice all of whose members are one of those. What counts as data by evidence is `eo:data-target`: a formation whose row says it comes back with a data object, and a void the program is only ever seen filling with data, which is the question `eo:filled` already puts to the voids of a formation.

The pack passes a number into `inc` at every call site, so the `x` it hands on is data and the application it writes is labeled. Without the change nothing labels it.

Closes #7895
