### PR TITLE
#7692: render a literal only for a binding of the first slot

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Bind.java
+++ b/eo-runtime/src/main/java/org/eolang/Bind.java
@@ -32,12 +32,18 @@ public final class Bind {
     private final Supplier<String> term;
 
     /**
+     * Whether this binding fills the first slot of what it is applied to.
+     */
+    private final boolean zero;
+
+    /**
      * Ctor.
      * @param pos The position
      * @param obj The object to bind
      */
     public Bind(final int pos, final Phi obj) {
         this(
+            pos == 0,
             target -> target.put(pos, obj),
             () -> String.format("%d->%s", pos, obj.φTerm())
         );
@@ -50,6 +56,7 @@ public final class Bind {
      */
     public Bind(final String name, final Phi obj) {
         this(
+            false,
             target -> target.put(name, obj),
             () -> String.format("%s->%s", name, obj.φTerm())
         );
@@ -57,12 +64,30 @@ public final class Bind {
 
     /**
      * Ctor.
+     * @param first Whether the binding fills the first slot
      * @param command Attaches the bound object to a target
      * @param term Renders the φ-term fragment
      */
-    private Bind(final Consumer<Phi> command, final Supplier<String> term) {
+    private Bind(
+        final boolean first, final Consumer<Phi> command, final Supplier<String> term
+    ) {
+        this.zero = first;
         this.command = command;
         this.term = term;
+    }
+
+    /**
+     * Whether this binding fills the first slot.
+     *
+     * <p>A literal is an object applied to its bytes in that slot and
+     * nothing else, so whoever renders one has to tell that application
+     * from a named binding of the same object, which is no literal and
+     * cannot even be dataized (#7692).</p>
+     *
+     * @return True if the binding is positional and fills slot zero
+     */
+    boolean first() {
+        return this.zero;
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -76,7 +76,7 @@ public final class PhApplication extends PhOnce {
         final String head = phi.φTerm();
         final String body = PhApplication.body(binds);
         final Matcher data = PhApplication.DATA.matcher(body);
-        final boolean literal = binds.length == 1 && data.find();
+        final boolean literal = binds.length == 1 && binds[0].first() && data.find();
         final String string;
         if (literal && "Φ.string".equals(head)) {
             string = PhApplication.string(PhApplication.bytes(data.group(1)));

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -31,6 +31,28 @@ final class PhApplicationTest {
     }
 
     @Test
+    void keepsANamedBindingOfANumberStructural() {
+        MatcherAssert.assertThat(
+            "a named binding is no literal and must render as the application it is, but it read as a number",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "number"),
+                "wrong",
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "bytes"),
+                    0,
+                    new PhDefault(
+                        new byte[] {
+                            (byte) 0x40, (byte) 0x45, (byte) 0x00, (byte) 0x00,
+                            (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                        }
+                    )
+                )
+            ).φTerm(),
+            Matchers.startsWith("Φ.number(wrong->")
+        );
+    }
+
+    @Test
     void appliesSeveralBindingsToObject() {
         MatcherAssert.assertThat(
             "PhApplication must bind every pair to the object, but it didnt",


### PR DESCRIPTION
The literal shorthand fired on the rendered text of any single binding, so `Φ.number` bound by a name it does not have printed as `42` and then failed to dataize. `Term` promises that two different constructions read differently, and this made one lie.

`Bind` now says whether it fills the first slot, and `PhApplication` asks it instead of reading the kind back out of the rendered body. A literal is an object applied to its bytes in slot zero and nothing else; everything else keeps its structural form.

The test builds the application from the report and checks it renders as `Φ.number(wrong->...)`.

Closes #7692
