### PR TITLE
#7238: name a chained inline-phi suffix for what it is

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -95,6 +95,13 @@ final class LnOnlyPhi implements Line {
                     "only-phi parameter list missing closing `]`"
                 );
             }
+            final int chained = Eo.topLevelGreaterBracketIndex(body.substring(close + 1));
+            if (chained >= 0) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent() + close + 1 + chained,
+                    "chained inline-phi suffixes are not allowed"
+                );
+            }
             lhs = body.substring(0, phi).stripTrailing();
             params = LnOnlyPhi.parseParams(
                 body.substring(bracket + 1, close), this.span, bracket + 1

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/chained-inline-phi-suffixes.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/chained-inline-phi-suffixes.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  chained inline-phi suffixes are not allowed
+input: |
+  value > [first] > [second] > result


### PR DESCRIPTION
`value > [first] > [second] > result` was reported as a missing name, because the text after the first parameter list went straight to `Suffix`, which found `[` where a name starts. R-3.10.7 forbids the shape and §9.9 gives it its own message.

The line now looks for a second top-level `> [` after the first list and reports it there.

The typo pack asserts the message from the table.

Closes #7238
