### PR TITLE
Rewrite non-tail self-recursion into continuation-passing style

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -45,6 +45,7 @@ final class Transpilation {
      * fingerprint in {@link #version()} are derived from the same source.
      */
     static final String[] XSLS = {
+        "/org/eolang/maven/transpile/recursion-to-cps.xsl",
         "/org/eolang/parser/parse/set-locators.xsl",
         "/org/eolang/maven/transpile/set-original-names.xsl",
         "/org/eolang/maven/transpile/classes.xsl",
@@ -73,6 +74,7 @@ final class Transpilation {
     static final String[] IMPORTS = {
         "/org/eolang/parser/_funcs.xsl",
         "/org/eolang/parser/_specials.xsl",
+        "/org/eolang/maven/transpile/_recursion.xsl",
     };
 
     /**

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/_recursion.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/_recursion.xsl
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="eo xs" id="_recursion" version="2.0">
+  <!--
+  Functions shared by "recursion-to-cps.xsl" and "recursion-to-loop.xsl",
+  the two stages that turn the self-recursion of a formation into a loop
+  (see #5783). Both need the same notion of a tail position, so it lives
+  here and is imported by each of them.
+  -->
+  <!--
+  Is the object in a tail position of the expression rooted at $root? It is
+  when every step from $root down to it is one of two: a branch of an ".if"
+  (the argument α0 or α1, never the receiver), or the last element of the
+  tuple that a "seq" is applied to, which after "stars-to-tuples" is the α1
+  of the "Φ.tuple" standing as the α0 of the "Φ.seq". Both "bool.if" and
+  "seq" answer exactly that element, so the value of the whole expression is
+  the value of the object whenever the object is forced. The operands of
+  ".or" and ".and" are not tail positions: "bytes.or" is strict, and the
+  receiver is not known here to be a "bool".
+  -->
+  <xsl:function name="eo:tail" as="xs:boolean">
+    <xsl:param name="o" as="element()"/>
+    <xsl:param name="root" as="element()"/>
+    <xsl:variable name="parent" as="element()?" select="$o/parent::o"/>
+    <xsl:choose>
+      <xsl:when test="$o is $root">
+        <xsl:sequence select="true()"/>
+      </xsl:when>
+      <xsl:when test="empty($parent)">
+        <xsl:sequence select="false()"/>
+      </xsl:when>
+      <xsl:when test="($parent/@base = '.if' or ends-with($parent/@base, '.if')) and $o/@as = ('α0', 'α1')">
+        <xsl:sequence select="eo:tail($parent, $root)"/>
+      </xsl:when>
+      <xsl:when test="$parent/@base = 'Φ.tuple' and $parent/@as = 'α0' and $parent/parent::o/@base = 'Φ.seq' and $o/@as = 'α1'">
+        <xsl:sequence select="eo:tail($parent/parent::o, $root)"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:sequence select="false()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+</xsl:stylesheet>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/recursion-to-cps.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/recursion-to-cps.xsl
@@ -1,0 +1,533 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:eo="https://www.eolang.org" xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="eo xs" id="recursion-to-cps" version="2.0">
+  <!--
+  Here we rewrite every nested formation that calls itself outside of a tail
+  position into continuation-passing style, so that afterwards
+  "recursion-to-loop.xsl" finds nothing but tail calls in it and the
+  recursion runs as a loop at run time (see #5783). Nothing of this is
+  visible to an EO programmer: the rewrite happens on the way to Java only.
+
+  A formation "F" gets one more void, "k🌵", the continuation. Every tail
+  leaf of its "φ" (in the sense of "eo:tail" from "_recursion.xsl") that is
+  not a self-call is handed to the continuation, "ξ.k🌵 (leaf)"; a tail
+  self-call passes the continuation on as its last argument; and a leaf that
+  leads to a self-call "S" outside of a tail position becomes the tail call
+  "ξ.ρ.F (args of S) ξ.c🌵1", where "c🌵1" is a fresh attribute "[^ r🌵]" of
+  the formation the leaf sits in, whose "φ" is the leaf with "S" replaced by
+  "ξ.r🌵", handed to the continuation of "F" in turn. The continuation is an
+  attribute and not an argument written in place, since the "ρ" of an object
+  passed as an argument is the object it is passed to, while the "ρ" of an
+  attribute is the object it is taken from, and "c🌵1" has to see the copy of
+  "F" that made it. A leaf leads to "S" when "S" is inside of it, or inside of an
+  attribute of "F" the leaf refers to, directly or through other attributes:
+  such an attribute, "^.F (n.minus 1) > prev", moves into "C" as well, and
+  the leaf keeps referring to it by name. The leaf moves one formation
+  deeper, so every reference in it that escapes the scope of the leaf (a
+  "ξ..." with at least as many "ρ" hops as the anonymous formations between
+  the leaf and the reference) gets one more "ρ", unless it names an
+  attribute that moved along. A leaf leading to two self-calls is rewritten
+  twice, the second continuation nesting inside the first, and an attribute
+  leading to both lands in the inner one. Every application of "F" outside
+  of "F" itself gets the identity "[r🌵] r🌵 > @" as the continuation.
+
+  A reference "ξ.ρ.ρ.F" is resolved the way the runtime resolves it: as the
+  attribute "F" of the formation two hops above the formation the reference
+  sits in. Names are not unique in a file, since the package objects merge
+  many files, each with its own "a🌵16-4"-like names for the ">>" handles.
+
+  The calls to the continuation and the tail self-calls inside a
+  continuation are marked @again here, since "recursion-to-loop.xsl" only
+  recognises "ξ.ρ.F" at the level of "φ" itself; the markers are consumed
+  by "to-java.xsl". At run time the whole chain unwinds inside the "PhLoop"
+  of the first copy of "F": each marker throws, the loop takes the "φ" of
+  the next copy or continuation, and the Java stack stays flat while the
+  result is being built.
+
+  The rewrite takes two passes: the first writes every continuation in
+  place, as an argument marked @cont, and the second lifts each of them
+  into an attribute of the nearest formation around it, numbered in the
+  order of the document, leaving a reference to the attribute behind.
+
+  The price is an eager spine: "F" used to return the leaf at once and walk
+  the recursion only as far as the consumer of the leaf forced it, while now
+  the loop runs down to the base case before anything is returned. That is
+  unobservable when the step condition is pure and the recursion is finite,
+  which holds for the standard library; a formation that recurses over an
+  infinite lazy structure and never reads the result of the self-call would
+  stop terminating.
+
+  Skipped, and left to recurse as they are: a formation whose "φ" leads to
+  no self-call outside of a tail position, or does not lead to every
+  attribute that holds one (a lazy structure like "range", whose next step
+  is read from outside), that has a "λ", that reads a "φ", that is referred
+  to other than by an application "ξ(.ρ)*.F", whose "φ" holds a named
+  binding, that calls itself from inside a nested formation or from inside
+  the arguments of another self-call, or whose application from outside is
+  the receiver of a dispatch while one of its attributes moves away.
+  -->
+  <xsl:import href="/org/eolang/maven/transpile/_recursion.xsl"/>
+  <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:variable name="eo:k" select="'k🌵'"/>
+  <xsl:variable name="eo:r" select="'r🌵'"/>
+  <!--
+  The spelling of a reference to the attribute $name of the formation $hops
+  levels above the current one: "ξ.ρ.ρ.name" for two hops.
+  -->
+  <xsl:function name="eo:up" as="xs:string">
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:param name="hops" as="xs:integer"/>
+    <xsl:sequence select="concat('ξ', string-join(for $i in 1 to $hops return '.ρ', ''), '.', $name)"/>
+  </xsl:function>
+  <!-- How many "ρ" the reference $base climbs before it names anything: 2 for "ξ.ρ.ρ.x" -->
+  <xsl:function name="eo:hops" as="xs:integer">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:sequence select="if (starts-with($base, 'ξ')) then string-length(replace($base, '^ξ((\.ρ)*)(\..*)?$', '$1')) idiv 2 else 0"/>
+  </xsl:function>
+  <!--
+  The formation named at the head of the reference $ref, "F" in "ξ.ρ.ρ.F"
+  or in "ξ.ρ.ρ.F.x": the attribute "F" of the formation as many hops above
+  the formation holding $ref as there are "ρ" in it; nothing, when the
+  reference is spelled otherwise or no such formation exists.
+  -->
+  <xsl:function name="eo:formation" as="element()?">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="base" select="string($ref/@base)"/>
+    <xsl:variable name="hops" select="eo:hops($base)"/>
+    <xsl:sequence select="if (matches($base, '^ξ(\.ρ)*\.[^.]')) then ($ref/ancestor::o[not(@base)][$hops + 1]/o[not(@base) and @name = tokenize($base, '\.')[$hops + 2]])[1] else ()"/>
+  </xsl:function>
+  <!--
+  The attribute of the formation $f the reference $ref names at its head,
+  "A" in "ξ.A" from the scope of $f or in "ξ.ρ.A" from one formation below
+  it; nothing, when the reference stops elsewhere.
+  -->
+  <xsl:function name="eo:attribute" as="element()?">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:param name="f" as="element()"/>
+    <xsl:variable name="base" select="string($ref/@base)"/>
+    <xsl:variable name="hops" select="eo:hops($base)"/>
+    <xsl:sequence select="if (matches($base, '^ξ(\.ρ)*\.[^.]') and $ref/ancestor::o[not(@base)][$hops + 1] is $f) then ($f/o[@name = tokenize($base, '\.')[$hops + 2]])[1] else ()"/>
+  </xsl:function>
+  <!--
+  Every reference to the formation $f, however it is spelled: all of them
+  sit inside the parent of $f, since that is where "ξ(.ρ)*.F" climbs to.
+  -->
+  <xsl:function name="eo:refs" as="element()*">
+    <xsl:param name="f" as="element()"/>
+    <xsl:sequence select="$f/parent::o//o[@base][matches(@base, concat('^ξ(\.ρ)*\.', $f/@name, '(\.|$)'))][eo:formation(.) is $f]"/>
+  </xsl:function>
+  <!--
+  The attributes of $f the nodes $nodes refer to, directly or through other
+  attributes, with $seen guarding against a cycle of attributes.
+  -->
+  <xsl:function name="eo:used" as="element()*">
+    <xsl:param name="nodes" as="element()*"/>
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="seen" as="element()*"/>
+    <xsl:variable name="attrs" select="(for $ref in $nodes/descendant-or-self::o[starts-with(@base, 'ξ')] return eo:attribute($ref, $f)) except ($seen, $nodes)"/>
+    <xsl:sequence select="$attrs, if (exists($attrs)) then eo:used($attrs, $f, ($seen, $attrs)) else ()"/>
+  </xsl:function>
+  <!--
+  The self-calls among $calls the nodes $nodes lead to: the ones among and
+  below them, and the ones inside the attributes of $f they use.
+  -->
+  <xsl:function name="eo:reach" as="element()*">
+    <xsl:param name="nodes" as="element()*"/>
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="calls" as="element()*"/>
+    <xsl:param name="seen" as="element()*"/>
+    <xsl:sequence select="($nodes, eo:used($nodes, $f, $seen))/descendant-or-self::o intersect $calls"/>
+  </xsl:function>
+  <!-- The attributes of $f that lead to a self-call among $calls, and so move into the continuations -->
+  <xsl:function name="eo:tainted" as="element()*">
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="calls" as="element()*"/>
+    <xsl:sequence select="$f/o[not(@name='φ') and not(@base='∅')][exists(eo:reach(., $f, $calls, ()))]"/>
+  </xsl:function>
+  <!--
+  How deep the attribute $a of $f lands: in the continuation of the last
+  self-call among $done it leads to.
+  -->
+  <xsl:function name="eo:place" as="xs:integer">
+    <xsl:param name="a" as="element()"/>
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="calls" as="element()*"/>
+    <xsl:param name="done" as="element()*"/>
+    <xsl:sequence select="(max(for $c in eo:reach($a, $f, $calls, ()) return index-of(for $d in $done return generate-id($d), generate-id($c))), 0)[1]"/>
+  </xsl:function>
+  <!--
+  The base $base as it reads $depth continuations deep inside of $f, for a
+  reference found $nesting anonymous formations below the moved leaf: a
+  "ξ..." reference climbing at least $nesting hops escapes the leaf and
+  gets $depth more "ρ", less the depth of the attribute among $tainted it
+  names, if any; anything else is left alone.
+  -->
+  <xsl:function name="eo:hopped" as="xs:string">
+    <xsl:param name="base" as="xs:string"/>
+    <xsl:param name="nesting" as="xs:integer"/>
+    <xsl:param name="depth" as="xs:integer"/>
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="calls" as="element()*"/>
+    <xsl:param name="done" as="element()*"/>
+    <xsl:param name="tainted" as="element()*"/>
+    <xsl:variable name="climb" select="eo:hops($base)"/>
+    <xsl:variable name="moved" select="if ($climb = $nesting) then $tainted[@name = tokenize($base, '\.')[$climb + 2]] else ()"/>
+    <xsl:variable name="hops" select="if (not(starts-with($base, 'ξ')) or $climb &lt; $nesting) then 0 else if (exists($moved)) then $depth - eo:place($moved[1], $f, $calls, $done) else $depth"/>
+    <xsl:sequence select="concat(substring($base, 1, 1), string-join(for $i in 1 to $hops return '.ρ', ''), substring($base, 2))"/>
+  </xsl:function>
+  <!-- Is the formation $f to be rewritten? See the list of the skipped shapes above -->
+  <xsl:function name="eo:cps" as="xs:boolean">
+    <xsl:param name="f" as="element()"/>
+    <xsl:variable name="phi" select="$f/o[@name='φ' and @base]"/>
+    <xsl:variable name="calls" select="$f//o[@base = concat('ξ.ρ.', $f/@name)]"/>
+    <xsl:sequence select="exists($f/parent::o) and exists($phi) and exists(eo:reach($phi, $f, $calls, ())[not(eo:tail(., $phi))]) and (every $a in eo:tainted($f, $calls) satisfies exists($a intersect eo:used($phi, $f, ()))) and empty($f/o[@name='λ']) and empty($f//o[contains(@base, 'φ')]) and empty($phi//o[@name][not(ancestor::o[not(@base)][. &gt;&gt; $phi])]) and (every $call in $calls satisfies (eo:formation($call) is $f and empty(eo:reach($call/o, $f, $calls, ())))) and (every $ref in eo:refs($f) satisfies (matches($ref/@base, '^ξ(\.ρ)*\.[^.]+$') and (empty($ref/ancestor::o[. is $f]) or exists($ref intersect $calls)) and (empty(eo:tainted($f, $calls)) or empty($ref[not(@as)]/parent::o[starts-with(@base, '.')]))))"/>
+  </xsl:function>
+  <!--
+  The rewritten formation that the reference $ref applies from outside of
+  it, or nothing.
+  -->
+  <xsl:function name="eo:target" as="element()?">
+    <xsl:param name="ref" as="element()"/>
+    <xsl:variable name="f" select="eo:formation($ref)"/>
+    <xsl:sequence select="if (matches($ref/@base, '^ξ(\.ρ)*\.[^.]+$') and exists($f) and empty($ref/ancestor::o[. is $f]) and eo:cps($f)) then $f else ()"/>
+  </xsl:function>
+  <!-- The name of the continuation $c among the continuations of the formation it sits in -->
+  <xsl:function name="eo:cont" as="xs:string">
+    <xsl:param name="c" as="element()"/>
+    <xsl:variable name="home" select="$c/ancestor::o[not(@base)][1]"/>
+    <xsl:sequence select="concat('c🌵', count($c/preceding::o[@cont='true'][ancestor::o[not(@base)][1] is $home]) + 1)"/>
+  </xsl:function>
+  <!-- Two passes: the rewrite, then the lifting of the continuations -->
+  <xsl:template match="/">
+    <xsl:variable name="rewritten">
+      <xsl:apply-templates select="node()"/>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="exists($rewritten//o[@cont='true'])">
+        <xsl:apply-templates select="$rewritten/node()" mode="hoist"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="$rewritten/node()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <!-- The formation: one more void, the continuation, and a rewritten φ -->
+  <xsl:template match="o[not(@base) and @name][eo:cps(.)]">
+    <xsl:variable name="f" select="."/>
+    <xsl:variable name="calls" select="$f//o[@base = concat('ξ.ρ.', $f/@name)]"/>
+    <xsl:variable name="tainted" select="eo:tainted($f, $calls)"/>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates select="o[@base='∅']"/>
+      <o base="∅" name="{$eo:k}">
+        <xsl:copy-of select="@line|@pos"/>
+      </o>
+      <xsl:apply-templates select="o[not(@base='∅') and not(@name='φ')] except $tainted"/>
+      <xsl:apply-templates select="o[@name='φ']" mode="body">
+        <xsl:with-param name="f" select="$f"/>
+        <xsl:with-param name="depth" select="0"/>
+        <xsl:with-param name="slot" select="concat('α', count(o[@base='∅' and not(@name='ρ')]))"/>
+        <xsl:with-param name="calls" select="$calls"/>
+        <xsl:with-param name="done" select="()"/>
+        <xsl:with-param name="tainted" select="$tainted"/>
+      </xsl:apply-templates>
+    </xsl:copy>
+  </xsl:template>
+  <!-- An application of a rewritten formation from outside: the identity continuation -->
+  <xsl:template match="o[@base]">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+      <xsl:call-template name="eo:identity">
+        <xsl:with-param name="f" select="eo:target(.)"/>
+      </xsl:call-template>
+    </xsl:copy>
+  </xsl:template>
+  <!-- The identity "[r🌵] r🌵 > @" as the continuation of the application of $f, if any -->
+  <xsl:template name="eo:identity">
+    <xsl:param name="f" as="element()?"/>
+    <xsl:if test="exists($f)">
+      <o as="α{count($f/o[@base='∅' and not(@name='ρ')])}">
+        <xsl:copy-of select="@line|@pos"/>
+        <o base="∅" name="{$eo:r}">
+          <xsl:copy-of select="@line|@pos"/>
+        </o>
+        <o base="ξ.{$eo:r}" name="φ">
+          <xsl:copy-of select="@line|@pos"/>
+        </o>
+      </o>
+    </xsl:if>
+  </xsl:template>
+  <!--
+  An expression in a tail position of the φ of the formation $f, seen from
+  $depth continuations deep, with the self-calls $done already turned into
+  continuations: walked down through the branches of an ".if" and the last
+  step of a "seq", and rewritten at its leaves.
+  -->
+  <xsl:template match="o" mode="body">
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="depth" as="xs:integer"/>
+    <xsl:param name="slot" as="xs:string"/>
+    <xsl:param name="calls" as="element()*"/>
+    <xsl:param name="done" as="element()*"/>
+    <xsl:param name="tainted" as="element()*"/>
+    <xsl:param name="root" as="xs:boolean" select="false()"/>
+    <xsl:variable name="left" select="eo:reach(., $f, $calls, ()) except $done"/>
+    <xsl:variable name="k" select="eo:up($eo:k, $depth)"/>
+    <xsl:variable name="head" as="attribute()*">
+      <xsl:choose>
+        <xsl:when test="$root">
+          <xsl:attribute name="name">φ</xsl:attribute>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="@as|@name"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:choose>
+      <xsl:when test="ends-with(@base, '.if') and o[@as=('α0', 'α1')] and empty(eo:reach(o[not(@as=('α0', 'α1'))], $f, $calls, ()) intersect $left)">
+        <xsl:copy>
+          <xsl:apply-templates select="@* except (@as, @name)"/>
+          <xsl:copy-of select="$head"/>
+          <xsl:attribute name="base" select="eo:hopped(@base, 0, $depth, $f, $calls, $done, $tainted)"/>
+          <xsl:for-each select="node()">
+            <xsl:choose>
+              <xsl:when test="self::o[@as=('α0', 'α1')]">
+                <xsl:apply-templates select="." mode="body">
+                  <xsl:with-param name="f" select="$f"/>
+                  <xsl:with-param name="depth" select="$depth"/>
+                  <xsl:with-param name="slot" select="$slot"/>
+                  <xsl:with-param name="calls" select="$calls"/>
+                  <xsl:with-param name="done" select="$done"/>
+                  <xsl:with-param name="tainted" select="$tainted"/>
+                </xsl:apply-templates>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:apply-templates select="." mode="hop">
+                  <xsl:with-param name="f" select="$f"/>
+                  <xsl:with-param name="depth" select="$depth"/>
+                  <xsl:with-param name="calls" select="$calls"/>
+                  <xsl:with-param name="done" select="$done"/>
+                  <xsl:with-param name="tainted" select="$tainted"/>
+                </xsl:apply-templates>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:when test="@base='Φ.seq' and o[@as='α0' and @base='Φ.tuple']/o[@as='α1'] and empty(eo:reach((o[not(@as='α0')], o[@as='α0']/o[not(@as='α1')]), $f, $calls, ()) intersect $left)">
+        <xsl:copy>
+          <xsl:apply-templates select="@* except (@as, @name)"/>
+          <xsl:copy-of select="$head"/>
+          <xsl:for-each select="node()">
+            <xsl:choose>
+              <xsl:when test="self::o[@as='α0']">
+                <xsl:copy>
+                  <xsl:apply-templates select="@*"/>
+                  <xsl:for-each select="node()">
+                    <xsl:choose>
+                      <xsl:when test="self::o[@as='α1']">
+                        <xsl:apply-templates select="." mode="body">
+                          <xsl:with-param name="f" select="$f"/>
+                          <xsl:with-param name="depth" select="$depth"/>
+                          <xsl:with-param name="slot" select="$slot"/>
+                          <xsl:with-param name="calls" select="$calls"/>
+                          <xsl:with-param name="done" select="$done"/>
+                          <xsl:with-param name="tainted" select="$tainted"/>
+                        </xsl:apply-templates>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:apply-templates select="." mode="hop">
+                          <xsl:with-param name="f" select="$f"/>
+                          <xsl:with-param name="depth" select="$depth"/>
+                          <xsl:with-param name="calls" select="$calls"/>
+                          <xsl:with-param name="done" select="$done"/>
+                          <xsl:with-param name="tainted" select="$tainted"/>
+                        </xsl:apply-templates>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </xsl:for-each>
+                </xsl:copy>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:apply-templates select="." mode="hop">
+                  <xsl:with-param name="f" select="$f"/>
+                  <xsl:with-param name="depth" select="$depth"/>
+                  <xsl:with-param name="calls" select="$calls"/>
+                  <xsl:with-param name="done" select="$done"/>
+                  <xsl:with-param name="tainted" select="$tainted"/>
+                </xsl:apply-templates>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:for-each>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:when test="exists(. intersect $left)">
+        <xsl:copy>
+          <xsl:apply-templates select="@* except (@as, @name)"/>
+          <xsl:copy-of select="$head"/>
+          <xsl:attribute name="base" select="eo:up($f/@name, $depth + 1)"/>
+          <xsl:attribute name="again">true</xsl:attribute>
+          <xsl:apply-templates select="node()" mode="hop">
+            <xsl:with-param name="f" select="$f"/>
+            <xsl:with-param name="depth" select="$depth"/>
+            <xsl:with-param name="calls" select="$calls"/>
+            <xsl:with-param name="done" select="$done"/>
+            <xsl:with-param name="tainted" select="$tainted"/>
+          </xsl:apply-templates>
+          <o as="{$slot}" base="{$k}">
+            <xsl:copy-of select="@line|@pos"/>
+          </o>
+        </xsl:copy>
+      </xsl:when>
+      <xsl:when test="exists($left)">
+        <xsl:variable name="call" select="$left[1]"/>
+        <xsl:variable name="opened" select="($done, $call)"/>
+        <o base="{eo:up($f/@name, $depth + 1)}" again="true">
+          <xsl:copy-of select="$head"/>
+          <xsl:copy-of select="$call/@line|$call/@pos"/>
+          <xsl:apply-templates select="$call/node()" mode="hop">
+            <xsl:with-param name="f" select="$f"/>
+            <xsl:with-param name="depth" select="$depth"/>
+            <xsl:with-param name="calls" select="$calls"/>
+            <xsl:with-param name="done" select="$done"/>
+            <xsl:with-param name="tainted" select="$tainted"/>
+          </xsl:apply-templates>
+          <o as="{$slot}" cont="true">
+            <xsl:copy-of select="$call/@line|$call/@pos"/>
+            <o base="∅" name="ρ">
+              <xsl:copy-of select="$call/@line|$call/@pos"/>
+            </o>
+            <o base="∅" name="{$eo:r}">
+              <xsl:copy-of select="$call/@line|$call/@pos"/>
+            </o>
+            <xsl:apply-templates select="$tainted[empty(eo:reach(., $f, $calls, ()) except $opened) and eo:place(., $f, $calls, $opened) = $depth + 1]" mode="hop">
+              <xsl:with-param name="f" select="$f"/>
+              <xsl:with-param name="depth" select="$depth + 1"/>
+              <xsl:with-param name="calls" select="$calls"/>
+              <xsl:with-param name="done" select="$opened"/>
+              <xsl:with-param name="tainted" select="$tainted"/>
+            </xsl:apply-templates>
+            <xsl:apply-templates select="." mode="body">
+              <xsl:with-param name="f" select="$f"/>
+              <xsl:with-param name="depth" select="$depth + 1"/>
+              <xsl:with-param name="slot" select="$slot"/>
+              <xsl:with-param name="calls" select="$calls"/>
+              <xsl:with-param name="done" select="$opened"/>
+              <xsl:with-param name="tainted" select="$tainted"/>
+              <xsl:with-param name="root" select="true()"/>
+            </xsl:apply-templates>
+          </o>
+        </o>
+      </xsl:when>
+      <xsl:otherwise>
+        <o base="{$k}" again="true">
+          <xsl:copy-of select="$head"/>
+          <xsl:copy-of select="@line|@pos"/>
+          <xsl:copy>
+            <xsl:apply-templates select="@* except (@as, @name)"/>
+            <xsl:if test="@base">
+              <xsl:attribute name="base" select="eo:hopped(@base, 0, $depth, $f, $calls, $done, $tainted)"/>
+            </xsl:if>
+            <xsl:attribute name="as">α0</xsl:attribute>
+            <xsl:apply-templates select="node()" mode="hop">
+              <xsl:with-param name="f" select="$f"/>
+              <xsl:with-param name="depth" select="$depth"/>
+              <xsl:with-param name="calls" select="$calls"/>
+              <xsl:with-param name="done" select="$done"/>
+              <xsl:with-param name="tainted" select="$tainted"/>
+              <xsl:with-param name="nesting" select="if (not(@base) and o) then 1 else 0"/>
+            </xsl:apply-templates>
+            <xsl:call-template name="eo:identity">
+              <xsl:with-param name="f" select="eo:target(.)"/>
+            </xsl:call-template>
+          </xsl:copy>
+        </o>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <!--
+  A part of a leaf or of a moved attribute of $f on its way $depth
+  continuations deep: a self-call among $done becomes the reference to the
+  result void of the continuation it opened, every escaping reference climbs
+  the hops "eo:hopped" says, and an application of another rewritten
+  formation gets the identity.
+  -->
+  <xsl:template match="o" mode="hop">
+    <xsl:param name="f" as="element()"/>
+    <xsl:param name="depth" as="xs:integer"/>
+    <xsl:param name="calls" as="element()*"/>
+    <xsl:param name="done" as="element()*"/>
+    <xsl:param name="tainted" as="element()*"/>
+    <xsl:param name="nesting" as="xs:integer" select="0"/>
+    <xsl:variable name="opened" select="index-of(for $d in $done return generate-id($d), generate-id(.))"/>
+    <xsl:choose>
+      <xsl:when test="exists($opened)">
+        <o base="{eo:up($eo:r, $depth - $opened[1])}">
+          <xsl:copy-of select="@as|@name|@line|@pos"/>
+        </o>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*"/>
+          <xsl:if test="@base">
+            <xsl:attribute name="base" select="eo:hopped(@base, $nesting, $depth, $f, $calls, $done, $tainted)"/>
+          </xsl:if>
+          <xsl:apply-templates select="node()" mode="hop">
+            <xsl:with-param name="f" select="$f"/>
+            <xsl:with-param name="depth" select="$depth"/>
+            <xsl:with-param name="calls" select="$calls"/>
+            <xsl:with-param name="done" select="$done"/>
+            <xsl:with-param name="tainted" select="$tainted"/>
+            <xsl:with-param name="nesting" select="if (not(@base) and o) then $nesting + 1 else $nesting"/>
+          </xsl:apply-templates>
+          <xsl:if test="@base">
+            <xsl:call-template name="eo:identity">
+              <xsl:with-param name="f" select="eo:target(.)"/>
+            </xsl:call-template>
+          </xsl:if>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+  <xsl:template match="text()" mode="hop">
+    <xsl:copy/>
+  </xsl:template>
+  <!-- The second pass: a continuation written in place becomes a reference to a lifted one -->
+  <xsl:template match="o[@cont='true']" mode="hoist" priority="1">
+    <o as="{@as}" base="ξ.{eo:cont(.)}">
+      <xsl:copy-of select="@line|@pos"/>
+    </o>
+  </xsl:template>
+  <xsl:template match="o[not(@base)]" mode="hoist">
+    <xsl:copy>
+      <xsl:apply-templates select="@*" mode="hoist"/>
+      <xsl:call-template name="eo:inside"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- The continuation lifted: an attribute of the formation it was written in -->
+  <xsl:template match="o" mode="lift">
+    <xsl:copy>
+      <xsl:apply-templates select="@* except (@as, @cont)" mode="hoist"/>
+      <xsl:attribute name="name" select="eo:cont(.)"/>
+      <xsl:call-template name="eo:inside"/>
+    </xsl:copy>
+  </xsl:template>
+  <!-- The children of a formation, followed by the continuations written inside of it -->
+  <xsl:template name="eo:inside">
+    <xsl:apply-templates select="node()" mode="hoist"/>
+    <xsl:apply-templates select=".//o[@cont='true'][ancestor::o[not(@base)][1] is current()]" mode="lift"/>
+  </xsl:template>
+  <xsl:template match="node()|@*" mode="hoist">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*" mode="hoist"/>
+    </xsl:copy>
+  </xsl:template>
+  <xsl:template match="node()|@*">
+    <xsl:copy>
+      <xsl:apply-templates select="node()|@*"/>
+    </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/recursion-to-loop.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/recursion-to-loop.xsl
@@ -29,32 +29,8 @@
   anyway. A self-call outside of a tail position stays what it is: the inner
   copy runs a loop of its own.
   -->
+  <xsl:import href="/org/eolang/maven/transpile/_recursion.xsl"/>
   <xsl:output encoding="UTF-8" method="xml"/>
-  <!--
-  Is the object in a tail position of the expression rooted at $root?
-  -->
-  <xsl:function name="eo:tail" as="xs:boolean">
-    <xsl:param name="o" as="element()"/>
-    <xsl:param name="root" as="element()"/>
-    <xsl:variable name="parent" as="element()?" select="$o/parent::o"/>
-    <xsl:choose>
-      <xsl:when test="$o is $root">
-        <xsl:sequence select="true()"/>
-      </xsl:when>
-      <xsl:when test="empty($parent)">
-        <xsl:sequence select="false()"/>
-      </xsl:when>
-      <xsl:when test="($parent/@base = '.if' or ends-with($parent/@base, '.if')) and $o/@as = ('α0', 'α1')">
-        <xsl:sequence select="eo:tail($parent, $root)"/>
-      </xsl:when>
-      <xsl:when test="$parent/@base = 'Φ.tuple' and $parent/@as = 'α0' and $parent/parent::o/@base = 'Φ.seq' and $o/@as = 'α1'">
-        <xsl:sequence select="eo:tail($parent/parent::o, $root)"/>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:sequence select="false()"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:function>
   <xsl:template match="abstract[@name and attr[@name='φ']/bound/o and not(attr[@name='λ']) and not(.//o[contains(@base, 'φ')])]">
     <xsl:variable name="root" select="attr[@name='φ']/bound/o"/>
     <xsl:variable name="self" select="concat('ξ.ρ.', @name)"/>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -110,7 +110,7 @@ final class MjTranspileTest {
                 .execute(MjTranspile.class)
                 .result(),
             Matchers.hasKey(
-                String.format("target/%s/examples/x/00-set-locators.xml", Transpiling.PRE)
+                String.format("target/%s/examples/x/01-set-locators.xml", Transpiling.PRE)
             )
         );
     }
@@ -142,7 +142,7 @@ final class MjTranspileTest {
                 .resolve(Transpiling.PRE)
                 .resolve("examples")
                 .resolve("x")
-                .resolve("09-purify.xml")
+                .resolve("10-purify.xml")
             ),
             XhtmlMatchers.hasXPath("//abstract[@name='inner' and @pure='true']")
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-appends-the-identity-inside-a-continuation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-appends-the-identity-inside-a-continuation.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[@name='k🌵'])=2]
+  - //o[@name='rec']//o[starts-with(@name,'c🌵')]/o[@name='φ' and @base='ξ.ρ.k🌵']/o[@base='.plus']/o[@as='α0' and @base='ξ.ρ.ρ.other' and count(o)=2]/o[@as='α1']/o[@name='φ' and @base='ξ.r🌵']
+  - //o[@name='main']/o[@name='φ' and @base='ξ.rec']/o[@as='α1']/o[@name='φ' and @base='ξ.r🌵']
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus (^.other 2)
+    [j] > other
+      if. > @
+        j.eq 0
+        0
+        (^.other (j.minus 1)).plus 1
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-a-non-tail-self-call.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-a-non-tail-self-call.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='rec']/o[@base='∅' and @name='k🌵' and preceding-sibling::o[@name='i']]
+  - //o[@name='rec']/o[@name='φ' and @base='.if']/o[@as='α0' and @base='ξ.k🌵' and @again='true']/o[@as='α0' and @base='Φ.number']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α0' and ends-with(@base, '.minus')]
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1' and o[@base='∅' and @name='ρ'] and o[@base='∅' and @name='r🌵']]
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ' and not(@as) and @base='ξ.ρ.k🌵' and @again='true']/o[@as='α0' and @base='.plus' and not(@name)]/o[not(@as) and @base='ξ.r🌵']
+  - //o[@name='main']/o[@name='φ' and @base='ξ.rec']/o[@as='α1' and o[@base='∅' and @name='r🌵'] and o[@name='φ' and @base='ξ.r🌵']]
+  - /object[count(//o[@base='∅' and @name='k🌵'])=1]
+  - /object[count(//o[starts-with(@name,'c🌵')])=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus 1
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-a-self-call-in-the-condition-of-an-if.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-a-self-call-in-the-condition-of-an-if.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='rec']/o[@name='φ' and @base='ξ.ρ.rec' and @again='true']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1']/o[@name='φ' and @base='.if' and not(@again)]/o[not(@as) and @base='ξ.r🌵']
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ' and @base='.if']/o[@as='α0' and @base='ξ.ρ.k🌵' and @again='true']/o[@as='α0' and @base='Φ.number']
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ' and @base='.if']/o[@as='α1' and @base='ξ.ρ.k🌵' and @again='true']/o[@as='α0' and @base='ξ.ρ.i']
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        ^.rec (i.minus 1)
+        1
+        i
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-the-last-step-of-a-seq.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-the-last-step-of-a-seq.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='rec']/o[@name='φ' and @base='Φ.seq']/o[@as='α0' and @base='Φ.tuple']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α1' and @base='ξ.c🌵1']
+  - //o[@name='rec']/o[@name='φ' and @base='Φ.seq']/o[@as='α0' and @base='Φ.tuple']/o[@as='α0' and @base='Φ.tuple']/o[@as='α1' and @base='ξ.i' and not(@again)]
+input: |
+  [] > main
+    [i] > rec
+      seq * > @
+        i
+        (^.rec (i.minus 1)).plus 1
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-two-formations-sharing-a-name.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-two-formations-sharing-a-name.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[@base='∅' and @name='k🌵']) = 2]
+  - //o[@name='first']/o[@name='rec']/o[@base='∅' and @name='k🌵']
+  - //o[@name='second']/o[@name='rec']/o[@base='∅' and @name='k🌵']
+  - //o[@name='first']/o[@name='φ' and @base='ξ.rec']/o[@as='α1']/o[@name='r🌵']
+  - //o[@name='second']/o[@name='φ' and @base='ξ.rec']/o[@as='α1']/o[@name='r🌵']
+input: |
+  [] > main
+    [] > first
+      [i] > rec
+        if. > @
+          i.eq 0
+          0
+          (^.rec (i.minus 1)).plus 1
+      rec 5 > @
+    [] > second
+      [i] > rec
+        if. > @
+          i.eq 0
+          0
+          (^.rec (i.minus 1)).times 2
+      rec 7 > @
+    first.plus second > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-two-self-calls-in-one-leaf.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-converts-two-self-calls-in-one-leaf.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[starts-with(@name,'c🌵')])=2]
+  - //o[@name='fibo']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.fibo' and @again='true']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1']/o[@name='φ' and @base='ξ.ρ.ρ.fibo' and @again='true']/o[@as='α0' and @base='ξ.ρ.n.minus']
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ' and @base='ξ.ρ.ρ.fibo']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1']/o[@name='φ' and @base='ξ.ρ.ρ.k🌵' and @again='true']/o[@as='α0' and @base='.plus' and o[not(@as) and @base='ξ.ρ.r🌵'] and o[@as='α0' and @base='ξ.r🌵']]
+  - //o[@name='fibo']/o[@name='c🌵1']/o[@name='c🌵1']/o[@name='φ' and @base='ξ.ρ.ρ.k🌵']
+input: |
+  [] > main
+    [n] > fibo
+      if. > @
+        n.lt 2
+        n
+        (^.fibo (n.minus 1)).plus (^.fibo (n.minus 2))
+    fibo 10 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-hops-references-moved-into-a-continuation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-hops-references-moved-into-a-continuation.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ' and @base='ξ.ρ.k🌵']/o[@base='.plus']/o[@as='α0' and @base='ξ.ρ.i.plus']/o[@as='α0' and @base='ξ.ρ.ρ.step']
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ']/o[@base='.plus']/o[@as='α0']/o[@as='α1' and not(@base) and o[@name='x'] and o[@name='φ' and @base='ξ.x.plus']/o[@as='α0' and @base='ξ.ρ.ρ.i']]
+  - //o[@name='other']/o[@name='φ' and @base='ξ.ρ.rec']/o[@as='α1']/o[@name='φ' and @base='ξ.r🌵']
+input: |
+  [] > main
+    1 > step
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus
+          i.plus
+            ^.step
+            [x]
+              x.plus ^.i > @
+    [] > other
+      ^.rec 3 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-lifts-a-continuation-into-an-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-lifts-a-continuation-into-an-attribute.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@cont])]
+  - /object[not(//o[@as and not(@base) and o[@name='ρ']])]
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α1' and @base='ξ.c🌵1' and not(o)]
+  - //o[@name='rec']/o[@name='c🌵1' and not(@as) and not(@base)]/o[@base='∅' and @name='ρ']
+  - //o[@name='rec']/o[@name='c🌵1']/o[@name='φ' and @base='ξ.ρ.k🌵']/o[@as='α0' and @base='.plus']/o[@base='ξ.r🌵']
+  - /object[count(//o[@name='c🌵1'])=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus 1
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-moves-a-dataized-attribute-and-its-dependants.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-moves-a-dataized-attribute-and-its-dependants.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='rec']/o[@base='∅' and @name='k🌵']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α0' and @base='ξ.i.minus']
+  - //o[starts-with(@name,'c🌵')]/o[@base='.as-bytes' and @name='half']/o[@base='Φ.dataized']/o[@as='α0' and @base='ξ.r🌵']
+  - //o[starts-with(@name,'c🌵')]/o[@base='ξ.half.plus' and @name='twice']/o[@as='α0' and @base='ξ.half']
+  - //o[starts-with(@name,'c🌵')]/o[@name='φ' and @base='ξ.ρ.k🌵']/o[@as='α0' and @base='ξ.twice.plus']/o[@as='α0' and @base='ξ.ρ.i']
+  - /object[not(//o[@name='rec']/o[@name=('half', 'twice')])]
+  - /object[count(//o[starts-with(@name,'c🌵')])=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        twice.plus i
+      half.plus half > twice
+      ^.rec (i.minus 1) > half!
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-moves-an-attribute-holding-a-self-call-into-the-continuation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-moves-an-attribute-holding-a-self-call-into-the-continuation.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='rec']/o[@base='∅' and @name='k🌵']
+  - /object[not(//o[@name='rec']/o[@name='prev'])]
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α0' and @base='ξ.i.minus']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1']/o[@base='ξ.r🌵' and @name='prev']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='ξ.ρ.rec']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1']/o[@name='φ' and @base='ξ.ρ.k🌵' and @again='true']/o[@as='α0' and @base='ξ.prev.times']/o[@as='α0' and @base='ξ.prev']
+  - /object[count(//o[starts-with(@name,'c🌵')])=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        1
+        prev.times prev
+      ^.rec (i.minus 1) > prev
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-moves-an-attribute-into-each-branch-that-reads-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-moves-an-attribute-into-each-branch-that-reads-it.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[count(//o[starts-with(@name,'c🌵')])=2]
+  - /object[count(//o[starts-with(@name,'c🌵')]/o[@base='ξ.r🌵' and @name='rest'])=2]
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='.if']/o[@as='α0' and @base='ξ.ρ.rec' and @again='true']/o[@as='α1' and @base='ξ.c🌵1']/ancestor::o[not(@base)][1]/o[@name='c🌵1']/o[@name='φ' and @base='ξ.ρ.k🌵']/o[@base='ξ.rest.plus']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='.if']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α1' and @base='ξ.c🌵2']/ancestor::o[not(@base)][1]/o[@name='c🌵2']/o[@name='φ' and @base='ξ.ρ.k🌵']/o[@base='ξ.rest.minus']
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        if.
+          i.gt 10
+          rest.plus 1
+          rest.minus 1
+      ^.rec (i.minus 1) > rest
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-passes-the-continuation-through-a-tail-call.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-passes-the-continuation-through-a-tail-call.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='.if']/o[@as='α0' and @base='ξ.ρ.rec' and @again='true' and count(o)=2]/o[@as='α1' and @base='ξ.k🌵']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α1' and @base='.if']/o[@as='α1' and @base='ξ.ρ.rec' and @again='true']/o[@as='α1' and @base='ξ.c🌵1']
+  - //o[@name='rec']/o[@name='φ']/o[@as='α0' and @base='ξ.k🌵' and @again='true']
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        if.
+          i.eq 1
+          ^.rec 0
+          (^.rec (i.minus 1)).plus 1
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-formation-passed-as-a-value.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-formation-passed-as-a-value.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@name='k🌵'])]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus 1
+    rec.i > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-formation-whose-moved-attribute-is-read-from-outside.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-formation-whose-moved-attribute-is-read-from-outside.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@name='k🌵'])]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        1
+        prev.times prev
+      ^.rec (i.minus 1) > prev
+    (rec 5).prev > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-formation-with-only-tail-calls.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-formation-with-only-tail-calls.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@name='k🌵'])]
+  - /object[not(//o[@again])]
+  - //o[@name='main']/o[@name='φ' and @base='ξ.rec' and count(o)=1]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        ^.rec (i.minus 1)
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-self-call-inside-a-nested-formation.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-self-call-inside-a-nested-formation.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@name='k🌵'])]
+  - /object[not(//o[starts-with(@name,'c🌵')])]
+input: |
+  [] > main
+    [i] > rec
+      [] > @
+        (^.^.rec (^.i.minus 1)).plus 1 > @
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-self-call-whose-argument-reads-a-moved-attribute.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-skips-a-self-call-whose-argument-reads-a-moved-attribute.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+asserts:
+  - /object[not(errors)]
+  - /object[not(//o[@name='k🌵'])]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        1
+        cur.plus prev
+      ^.rec (i.minus 1) > prev
+      ^.rec (prev.minus 1) > cur
+    rec 5 > @

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-to-java.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/cps-to-java.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets:
+  - /org/eolang/maven/transpile/recursion-to-cps.xsl
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/anonymous-to-nested.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/recursion-to-loop.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //java[contains(text(), 'return new PhLoop(')]
+  - //java[contains(text(), 'new AtRho()')]
+  - //java[contains(text(), '"c🌵1"')]
+  - //java[contains(text(), 'new AtVoid("k🌵")')]
+  - //java[contains(text(), 'new AtVoid("r🌵")')]
+  - //java[contains(text(), ' = new PhAgain(')]
+input: |
+  [] > main
+    [i] > rec
+      if. > @
+        i.eq 0
+        0
+        (^.rec (i.minus 1)).plus 1
+    rec 5 > @


### PR DESCRIPTION
A new transpile sheet, `recursion-to-cps.xsl`, runs first in the train and turns a non-tail self-recursive formation into continuation-passing style: the formation gets a `k🌵` void, every tail leaf hands its value to `k🌵`, and a leaf that consumes a self-call recurs with a continuation instead, so the existing `recursion-to-loop.xsl` then flattens the whole descent into one `PhLoop` trampoline. Because the ρ of a formation passed as an argument is bound to its holder, each continuation is lifted into a named `c🌵N` attribute of its home formation and passed by reference; the shared tail-detection logic moved into `_recursion.xsl`.

This is the third round of #5783: after tail recursion was flattened, 21 stdlib formations still grew the Java stack one block per step because their result consumes the self-call. The sheet now converts 16 of them (`tuple.reducedi`, `ln`, `power`, `as-decimal`, `as-fixed`, `sine`, `arc-sine`, `string.repeated`, `directory.stepped`, …) and deliberately skips lazy structures, attributes read by Java atoms, and formations whose moved attributes are read from outside — 20 packs pin both sides. Control depth is now constant; the remaining data-depth of the nested result is a separate follow-up, as is a lint for what the compiler skips (objectionary/lints#1321).

The full `eo-runtime` suite is green with the sheet enabled, and the memory footprint of the converted formations matches master. Mutual recursion and top-level `Φ.name` self-calls stay unconverted for now.