### PR TITLE
#7306: answer the authentication challenge of a proxy

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MvnCredentials.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MvnCredentials.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+
+/**
+ * What a proxy of Maven settings answers its authentication challenge with.
+ *
+ * <p>Only the challenge of a proxy is answered, never the one of the server
+ * behind it: the credentials of {@code settings.xml} are the proxy's own, and
+ * handing them to whoever asks would send them to a host that never asked for
+ * them.</p>
+ *
+ * @since 0.74.0
+ */
+public final class MvnCredentials extends Authenticator {
+
+    /**
+     * The user name.
+     */
+    private final String user;
+
+    /**
+     * The password.
+     */
+    private final String secret;
+
+    /**
+     * Ctor.
+     * @param name The user name
+     * @param password The password
+     */
+    public MvnCredentials(final String name, final String password) {
+        super();
+        this.user = name;
+        this.secret = password;
+    }
+
+    @Override
+    public PasswordAuthentication getPasswordAuthentication() {
+        final PasswordAuthentication found;
+        if (this.getRequestorType() == RequestorType.PROXY) {
+            final String password;
+            if (this.secret == null) {
+                password = "";
+            } else {
+                password = this.secret;
+            }
+            found = new PasswordAuthentication(this.user, password.toCharArray());
+        } else {
+            found = null;
+        }
+        return found;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MvnProxy.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MvnProxy.java
@@ -4,22 +4,16 @@
  */
 package org.eolang.maven;
 
+import java.net.Authenticator;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 import java.util.Arrays;
+import java.util.Optional;
 
 /**
  * One active proxy of Maven settings, carrying the excluded hosts that a
  * plain {@link Proxy} drops.
  * @since 0.73.4
- * @todo #7257:40min Honour the proxy credentials too. A proxy with a
- *  {@code username} and {@code password} in {@code settings.xml} still gets
- *  407 on every request, because nothing answers its authentication
- *  challenge. Add a {@code java.net.Authenticator} built from these two
- *  fields and hand it to the {@code HttpClient} in {@code OyRemote}. The
- *  {@code protocol} field is a separate matter: {@code java.net.http} only
- *  speaks to HTTP proxies, so a {@code socks5} one has to either fail loudly
- *  or go through the {@code socksProxyHost} system properties.
  */
 final class MvnProxy {
 
@@ -45,6 +39,27 @@ final class MvnProxy {
             Proxy.Type.HTTP,
             new InetSocketAddress(this.origin.getHost(), this.origin.getPort())
         );
+    }
+
+    /**
+     * What answers this proxy's authentication challenge.
+     *
+     * <p>A proxy that wants a user name and a password gets a 407 on every
+     * request while nothing answers it, and the two fields sit unread in
+     * {@code settings.xml}. A proxy that wants neither is left alone, since
+     * an authenticator with nothing to say only makes the client ask.</p>
+     *
+     * @return The credentials, empty when the settings carry none
+     */
+    Optional<Authenticator> credentials() {
+        final String name = this.origin.getUsername();
+        final Optional<Authenticator> found;
+        if (name == null || name.isEmpty()) {
+            found = Optional.empty();
+        } else {
+            found = Optional.of(new MvnCredentials(name, this.origin.getPassword()));
+        }
+        return found;
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/OyRemote.java
@@ -176,6 +176,7 @@ final class OyRemote implements Objectionary {
             .followRedirects(HttpClient.Redirect.NORMAL);
         if (proxies.length > 0) {
             builder.proxy(new NonProxyHostsSelector(proxies[0]));
+            proxies[0].credentials().ifPresent(builder::authenticator);
         }
         return builder.build();
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Proxies.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Proxies.java
@@ -4,11 +4,19 @@
  */
 package org.eolang.maven;
 
+import java.util.Collection;
+import java.util.stream.Collectors;
 import org.apache.maven.settings.Settings;
 import org.cactoos.Scalar;
 
 /**
  * Active proxies of Maven settings, translated to the ones of Java.
+ *
+ * <p>Only an HTTP proxy is translated. {@code java.net.http} speaks to no
+ * other kind, so a {@code socks5} one would be taken from the settings and
+ * then quietly stepped around, which is worse than saying it cannot be
+ * used.</p>
+ *
  * @since 0.62.0
  */
 final class Proxies implements Scalar<MvnProxy[]> {
@@ -28,10 +36,23 @@ final class Proxies implements Scalar<MvnProxy[]> {
 
     @Override
     public MvnProxy[] value() {
-        return this.settings.getProxies()
-            .stream()
-            .filter(org.apache.maven.settings.Proxy::isActive)
-            .map(MvnProxy::new)
-            .toArray(MvnProxy[]::new);
+        final Collection<org.apache.maven.settings.Proxy> active =
+            this.settings.getProxies()
+                .stream()
+                .filter(org.apache.maven.settings.Proxy::isActive)
+                .collect(Collectors.toList());
+        for (final org.apache.maven.settings.Proxy proxy : active) {
+            final String protocol = proxy.getProtocol();
+            if (protocol != null && !protocol.isEmpty()
+                && !"http".equalsIgnoreCase(protocol) && !"https".equalsIgnoreCase(protocol)) {
+                throw new IllegalStateException(
+                    String.format(
+                        "The proxy %s:%d speaks %s, and only an HTTP proxy can be used here",
+                        proxy.getHost(), proxy.getPort(), protocol
+                    )
+                );
+            }
+        }
+        return active.stream().map(MvnProxy::new).toArray(MvnProxy[]::new);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MvnProxyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MvnProxyTest.java
@@ -39,4 +39,30 @@ final class MvnProxyTest {
             Matchers.is(false)
         );
     }
+
+    @Test
+    void answersTheChallengeWithTheCredentialsOfTheSettings() {
+        final org.apache.maven.settings.Proxy origin = new org.apache.maven.settings.Proxy();
+        origin.setHost("prox.eolang.org");
+        origin.setPort(3128);
+        origin.setUsername("jeff");
+        origin.setPassword("secret");
+        MatcherAssert.assertThat(
+            "a proxy that wants a name and a password must have something to answer with",
+            new MvnProxy(origin).credentials().isPresent(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void saysNothingWhenTheSettingsCarryNoCredentials() {
+        final org.apache.maven.settings.Proxy origin = new org.apache.maven.settings.Proxy();
+        origin.setHost("prox.eolang.org");
+        origin.setPort(3128);
+        MatcherAssert.assertThat(
+            "a proxy that wants nothing must be left alone, but it was given an authenticator",
+            new MvnProxy(origin).credentials().isPresent(),
+            Matchers.is(false)
+        );
+    }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ProxiesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ProxiesTest.java
@@ -9,6 +9,7 @@ import java.net.Proxy;
 import org.apache.maven.settings.Settings;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -46,6 +47,21 @@ final class ProxiesTest {
             "Settings without proxies must give no proxies at all",
             new Proxies(new Settings()).value(),
             Matchers.emptyArray()
+        );
+    }
+
+    @Test
+    void refusesAProxyThatSpeaksSomethingElse() {
+        final Settings settings = ProxiesTest.settings("socks.eolang.org", 1080, true);
+        settings.getProxies().get(0).setProtocol("socks5");
+        MatcherAssert.assertThat(
+            "the protocol must be named, since only an HTTP proxy can be used here",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new Proxies(settings).value(),
+                "a proxy nothing can talk to must not be taken for one that works"
+            ).getMessage(),
+            Matchers.containsString("socks5")
         );
     }
 


### PR DESCRIPTION
The puzzle from #7257. A proxy with a user name and a password in `settings.xml` got a 407 on every request, since nothing answered its challenge, and the two fields sat unread.

`MvnProxy.credentials()` gives an authenticator when the settings carry a name, and `OyRemote` hands it to the client beside the selector. `MvnCredentials` answers the challenge of the proxy only, never the one of the server behind it: those credentials belong to the proxy and to nobody else.

The protocol half of the puzzle is the other change. `java.net.http` speaks to no proxy but an HTTP one, so `Proxies` refuses an active proxy that says anything else instead of taking it and then quietly stepping around it.

Three tests: the credentials present, the credentials absent, and the refusal naming the protocol.

Closes #7306
