### PR TITLE
#7361: answer the smallest shift count with the largest one

### DIFF
--- a/eo-runtime/src/main/eo/bytes/left.eo
+++ b/eo-runtime/src/main/eo/bytes/left.eo
@@ -1,5 +1,7 @@
 # Left bit shift of the byte chain `b` by `x` bits, expressed as a
-# right shift by the negated amount.
+# right shift by the negated amount. The smallest count has no negation
+# that fits into an `int`, and a shift by that many bits leaves nothing
+# of any chain, so it is answered by the largest right shift instead.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,7 +11,10 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > left
-  ^.right x.neg > @
+  if. > @
+    x.eq -2147483648
+    ^.right 2147483647
+    ^.right x.neg
 
   eq. ++> can-shift-left-an-even-negative
     FF-FF-FF-FF-FF-FF-FF-EE.left 2
@@ -26,6 +31,10 @@
   eq. ++> can-shift-left-an-odd-positive
     5.as-bytes.left 3
     00-A0-00-00-00-00-00-00
+
+  eq. ++> can-shift-left-by-the-smallest-count
+    -1.as-bytes.left -2147483648
+    00-00-00-00-00-00-00-00
 
   eq. ++> can-shift-left-by-zero
     2.as-bytes.left 0


### PR DESCRIPTION
`left x` is `right (x.neg)`, and the one count whose negation does not fit into an `int` broke that: `-1.as-bytes.left -2147483648` terminated with "the 'x' attribute (2.147483648E9) must fit into int range", while the same count on `right` answers eight zero bytes.

A shift by that many bits leaves nothing of any chain, so the smallest count is answered by the largest right shift instead of a negation nothing can represent.

The EO test sits beside the ones already in the file and reproduces the count from the report. With the branch removed it fails with the error above.

Closes #7361
