### PR TITLE
fix(maven-plugin): renumber the tracked step the cache test expects

### DIFF
--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -122,7 +122,7 @@ final class MjTranspileTest {
                 .execute(MjTranspile.class)
                 .result(),
             Matchers.hasKey(
-                String.format("target/%s/examples/x/00-set-locators.xml", Transpiling.PRE)
+                String.format("target/%s/examples/x/01-set-locators.xml", Transpiling.PRE)
             )
         );
     }


### PR DESCRIPTION
`MjTranspileTest.tracksStepsOfASourceTheCacheAlreadyHolds` fails on `master` ([run 33199804848](https://github.com/objectionary/eo/actions/runs/33199804848/job/98946130318)):

```
Expected: map containing ["target/5-pre-transpile/examples/x/00-set-locators.xml"->ANYTHING]
     but: map was [... 00-recursion-to-cps.xml, 01-set-locators.xml ...]
```

This is a semantic conflict between two branches merged in parallel:

- 9f9f321e (#5783) put `recursion-to-cps.xsl` at the head of `Transpilation.XSLS`, shifting every pre-transpile step by one; it renumbered the two assertions it could see (`01-set-locators.xml`, `10-purify.xml`).
- 81f9597b (#7724) added `tracksStepsOfASourceTheCacheAlreadyHolds` on its own branch, asserting on `00-set-locators.xml`.

Neither diff touched the other, so the merged tree asserts on a file no step writes any more. The fix is the same renumbering the first commit applied to its siblings: `00-set-locators.xml` → `01-set-locators.xml`. What the test checks — that a second build with `trackSteps` writes the steps even when the cache holds the answer — is unchanged.

Verified locally: `mvn -pl eo-maven-plugin -Dtest=MjTranspileTest test` → `Tests run: 95, Failures: 0, Errors: 0, Skipped: 0`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HUgZSyfQNAuMTkGuAnqyzn)_