### PR TITLE
#7700: build a package member once under many threads

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhPackage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhPackage.java
@@ -94,8 +94,7 @@ final class PhPackage implements Phi {
             }
             taken = next;
         } else {
-            this.objects.put(fqn, this.bound(fqn));
-            taken = this.take(name);
+            taken = this.objects.computeIfAbsent(fqn, this::bound).copy();
         }
         return taken;
     }

--- a/eo-runtime/src/test/java/org/eolang/EO_org/EO_eolang/EOprobe.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_org/EO_eolang/EOprobe.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+/*
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_org.EO_eolang; // NOPMD
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.eolang.PhDefault;
+import org.eolang.XmirObject;
+
+/**
+ * Fixture object that counts how often it is built.
+ *
+ * <p>A package builds its member by name, through reflection, so the count
+ * cannot live anywhere but in a static: there is no instance to ask before
+ * the instance exists. It says whether a first take under many threads builds
+ * the member once or once per thread (#7700).</p>
+ *
+ * @since 0.74.0
+ */
+@XmirObject(oname = "probe")
+public final class EOprobe extends PhDefault {
+
+    /**
+     * How many of these were built.
+     */
+    public static final AtomicInteger BUILT = new AtomicInteger(0);
+
+    /**
+     * Ctor.
+     * @checkstyle ConstructorsCodeFreeCheck (12 lines)
+     */
+    @SuppressWarnings("PMD.ConstructorOnlyInitializesOrCallOtherConstructors")
+    public EOprobe() {
+        super();
+        EOprobe.BUILT.incrementAndGet();
+        try {
+            Thread.sleep(100L);
+        } catch (final InterruptedException ex) {
+            Thread.currentThread().interrupt();
+        }
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -6,6 +6,7 @@ package org.eolang;
 
 import com.yegor256.Together;
 import java.util.stream.Stream;
+import org.eolang.EO_org.EO_eolang.EOprobe;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -26,7 +27,7 @@ final class PhPackageTest {
         new Together<>(thread -> pkg.take("probe")).asList();
         MatcherAssert.assertThat(
             "a first take from many threads must build the member once, but every thread built its own",
-            org.eolang.EO_org.EO_eolang.EOprobe.BUILT.get(),
+            EOprobe.BUILT.get(),
             Matchers.equalTo(1)
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhPackageTest.java
@@ -21,6 +21,17 @@ import org.junit.jupiter.params.provider.MethodSource;
 final class PhPackageTest {
 
     @Test
+    void buildsAMemberOnceUnderManyThreads() {
+        final Phi pkg = new PhPackage("org.eolang");
+        new Together<>(thread -> pkg.take("probe")).asList();
+        MatcherAssert.assertThat(
+            "a first take from many threads must build the member once, but every thread built its own",
+            org.eolang.EO_org.EO_eolang.EOprobe.BUILT.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
     void printsGlobalScopeAsTerm() {
         MatcherAssert.assertThat(
             "Global package must render its name as φ-term, but it didnt",


### PR DESCRIPTION
`take()` asked the map whether it holds the member, built it, and put it in, as three steps. A concurrent map guards each step and not the sequence, so every thread that arrived first built its own copy of the same class and overwrote the others.

The three steps are now one `computeIfAbsent`, which is what the map offers for exactly this.

The test releases sixteen threads on a first take of one member and counts how often it was built. The fixture sits in the package a member of `org.eolang` maps to, beside the `EOdummy` already there. Without the change the count is 16, with it 1.

Closes #7700
