### PR TITLE
Rebase the folded value's own base when it lands a scope deeper

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Xmir.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Xmir.java
@@ -33,17 +33,6 @@ import org.xml.sax.SAXParseException;
  *
  * @see <a href="https://xml.jcabi.com">xml.jcabi.com</a>
  * @since 0.35.0
- * @todo #7095:60min Re-base every value the print train relocates. A binding
- *  folded onto a reference deeper than itself is read again in a scope that
- *  is not the one it was written in, so its names have to climb the
- *  difference. Only the based-handle fold in {@code inline-cactoos.xsl} does
- *  that today; the four other branches of the template it lives in, and the
- *  three merges in {@code merge-monikers.xsl}, relocate values the same way
- *  and need the same pass. Each wants a pack of its own before it is wired,
- *  since the shapes differ: an applied reference keeps its own children, a
- *  pipe keeps the formation in place. The {@code dropped} mode and its two
- *  functions should move somewhere both sheets can import rather than being
- *  copied into the second one.
  */
 public final class Xmir implements XML {
 

--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -268,13 +268,32 @@
               <xsl:if test="@name and not($keep-name)">
                 <xsl:apply-templates select="@name"/>
               </xsl:if>
-              <xsl:variable name="folded" as="node()*">
-                <xsl:apply-templates select="$value/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
-                <xsl:apply-templates select="$value/node()"/>
+              <!--
+              The folded value is rebased as a whole `o` and then unwrapped
+              into the node being built, rather than as the loose sequence of
+              its attributes and children. The `dropped` mode rewrites an
+              `@base` only as it walks the `o` carrying it, so a bare sequence
+              hands it the value's own `@base` as a stray attribute node that
+              the catch-all copies verbatim: `x.plus 1 &gt;&gt; h` folded into a
+              nested formation kept reading `ξ.x`, which is that formation's own
+              `x` and not the one the handle was written against (#7097). The
+              wrapper also carries whether the value is a formation, so its
+              children are counted one level deeper, the way any nested
+              formation is (see `eo:dropped-base`).
+              -->
+              <xsl:variable name="folded" as="element()">
+                <o>
+                  <xsl:apply-templates select="$value/@*[$keep-name or (name() != 'name' and name() != 'local')]"/>
+                  <xsl:apply-templates select="$value/node()"/>
+                </o>
               </xsl:variable>
-              <xsl:apply-templates select="$folded" mode="dropped">
-                <xsl:with-param name="drop" select="eo:host-drop($target, .)" tunnel="yes"/>
-              </xsl:apply-templates>
+              <xsl:variable name="rebased" as="element()">
+                <xsl:apply-templates select="$folded" mode="dropped">
+                  <xsl:with-param name="drop" select="eo:host-drop($target, .)" tunnel="yes"/>
+                </xsl:apply-templates>
+              </xsl:variable>
+              <xsl:copy-of select="$rebased/@*"/>
+              <xsl:copy-of select="$rebased/node()"/>
               <!--
               The reference is the base of an application (`b 42 &gt; x` over a
               based `a.plus &gt;&gt; b` handle), so it carries its own argument
@@ -622,8 +641,18 @@
   <!--
   Rewrites the bases of a folded value, counting how deep inside it each
   node sits so that a name reaching no further than the value itself is
-  left where it is. Only the based-handle fold uses it so far; see the
-  puzzle on `Xmir` for the branches still to come.
+  left where it is. The based-handle fold is the only site that needs it,
+  and #7097 asked why. Nothing else in the print train moves a value across
+  a formation boundary: the four branches above it either leave the handle
+  standing and copy the reference in place (#5983, #6021, #5834), or
+  relocate the handle onto a reference the guards have already restricted to
+  the handle's own scope, since the nested ones are taken by the branch
+  above (#6021). "merge-monikers" is the same story from the other side —
+  each of its three merges keys its host reference by the reference's
+  nearest formation ancestor and looks the binding up under that same
+  formation, so a host always shares the binding's scope and the drop is
+  zero. Only a handle reached from a nested scope travels, and only the fold
+  below carries it there.
   -->
   <xsl:template match="o" mode="dropped">
     <xsl:param name="drop" as="xs:integer" tunnel="yes"/>

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-handle-folded-into-nested-formation-climbs.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/based-handle-folded-into-nested-formation-climbs.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A based file-local handle ("num.plus 1 >> next", R-3.10.12) whose only
+# reference is a bare one written inside a nested "[] > later" formation. The
+# fold lands the handle's value one formation deeper than the scope it was
+# written in, so every name in it that reaches out of the value has to climb
+# that difference (#7095). Its children already did, but its own "@base" did
+# not: the value was handed to the rebasing pass as the loose sequence of its
+# attributes and children, and an "@base" arriving as a stray attribute node
+# rather than on the "o" carrying it was copied through untouched. So "ξ.num"
+# printed as "$.num" inside "later", which reparses as that formation's own
+# "num" — an attribute it does not declare — instead of the "num" of "foo"
+# the handle was written against (#7097).
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [num] > foo
+    num.plus 1 >> next
+    [] > later
+      next > @
+
+printed: |
+  [num] > foo
+    ^.num.plus 1 > [] > later


### PR DESCRIPTION
Closes #7097.

A based file-local handle whose only use is a reference inside a nested formation gets folded into that reference, which sits one formation deeper than the scope the handle was written in. Every name in the value that reaches out of it has to climb that difference. The `dropped` pass added by #7095 was doing that for the nodes below the value but not for the value itself: it was handed the loose sequence of the value's attributes and children, and the mode only rewrites an `@base` while walking the `o` that carries it, so the value's own base arrived as a stray attribute node and the catch-all copied it through untouched. `num.plus 1 >> next` folded into `[] > later` printed `$.num`, which reparses as that formation's own `num` rather than the `num` of the formation the handle was written against. The value now goes through the pass as a whole `o` and is unwrapped afterwards, which also lets the pass see whether the value is itself a formation and count its children one level deeper.

The puzzle asked for the same pass on four more branches of the inlining template and on the three merges in `merge-monikers.xsl`. None of them needs it, and I put the reasoning on the `dropped` mode rather than leaving it to be rediscovered. The four branches either leave the handle standing and copy the reference in place, or relocate the handle onto a reference their own guards have already restricted to the handle's scope, since every nested reference is taken by the branch above. Each of the three merges keys its host reference by the reference's nearest formation ancestor and then looks the binding up under that same formation, so a host always shares the binding's scope and the drop is zero. That also settles the last line of the puzzle: with only one sheet using them, the `dropped` mode and its two functions have nowhere to move to.

The new print pack fails on `master` (it prints `$.num`) and passes here, and the other 161 packs are unchanged.
