### PR TITLE
#7708: refuse in win32 the numbers posix refuses

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
@@ -8,6 +8,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.SockaddrIn;
@@ -35,6 +36,9 @@ public final class AcceptFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int length = new Int(
+            "the 'length' argument of accept", params[2]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
@@ -48,7 +52,7 @@ public final class AcceptFuncCall implements Syscall {
                             new Dataized(params[1].take("address")).take(Integer.class),
                             new Dataized(params[1].take("padding")).take()
                         ),
-                        new IntByReference(new Dataized(params[2]).asNumber().intValue())
+                        new IntByReference(length)
                     )
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,6 +33,9 @@ public final class AccessFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int mode = new Int(
+            "the 'mode' argument of access", params[1]
+        ).it();
         final String path = new Cstring("the 'path' argument of access", params[0]).it();
         final Phi result = this.win.take("return").copy();
         result.put(
@@ -40,7 +43,7 @@ public final class AccessFuncCall implements Syscall {
             new Data.ToPhi(
                 Msvcrt.INSTANCE._waccess(
                     new WString(path),
-                    new Dataized(params[1]).asNumber().intValue()
+                    mode
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.SockaddrIn;
@@ -34,6 +35,9 @@ public final class BindFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int length = new Int(
+            "the 'length' argument of bind", params[2]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
@@ -46,7 +50,7 @@ public final class BindFuncCall implements Syscall {
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
                     ),
-                    new Dataized(params[2]).asNumber().intValue()
+                    length
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/CloseFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CloseFuncCall.java
@@ -5,7 +5,7 @@
 package org.eolang.win32;
 
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -31,11 +31,14 @@ public final class CloseFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int descriptor = new Int(
+            "the 'descriptor' argument of close", params[0]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
-                Msvcrt.INSTANCE._close(new Dataized(params[0]).asNumber().intValue())
+                Msvcrt.INSTANCE._close(descriptor)
             )
         );
         result.put(1, new PhDefault());

--- a/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.SockaddrIn;
@@ -34,6 +35,9 @@ public final class ConnectFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int length = new Int(
+            "the 'length' argument of connect", params[2]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
@@ -46,7 +50,7 @@ public final class ConnectFuncCall implements Syscall {
                         new Dataized(params[1].take("address")).take(Integer.class),
                         new Dataized(params[1].take("padding")).take()
                     ),
-                    new Dataized(params[2]).asNumber().intValue()
+                    length
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,11 +32,14 @@ public final class CreatFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int mode = new Int(
+            "the 'mode' argument of creat", params[1]
+        ).it();
         final String path = new Cstring("the 'path' argument of creat", params[0]).it();
         final Phi result = this.win.take("return").copy();
         final int code = Msvcrt.INSTANCE._wcreat(
             new WString(path),
-            new Dataized(params[1]).asNumber().intValue()
+            mode
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
@@ -7,6 +7,7 @@ package org.eolang.win32;
 import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,13 +34,16 @@ public final class ListenFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int backlog = new Int(
+            "the 'backlog' argument of listen", params[1]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 Winsock.INSTANCE.listen(
                     new Pointer(new Dataized(params[0]).asNumber().longValue()),
-                    new Dataized(params[1]).asNumber().intValue()
+                    backlog
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
 
@@ -32,12 +32,18 @@ public final class OpenFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int flags = new Int(
+            "the 'flags' argument of open", params[1]
+        ).it();
+        final int mode = new Int(
+            "the 'mode' argument of open", params[2]
+        ).it();
         final String path = new Cstring("the 'path' argument of open", params[0]).it();
         final Phi result = this.win.take("return").copy();
         final int code = Msvcrt.INSTANCE._wopen(
             new WString(path),
-            new Dataized(params[1]).asNumber().intValue(),
-            new Dataized(params[2]).asNumber().intValue()
+            flags,
+            mode
         );
         result.put(0, new Data.ToPhi(code));
         result.put(1, new Errno(code).get());

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -6,8 +6,8 @@ package org.eolang.win32;
 
 import java.util.Arrays;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,12 +33,15 @@ public final class ReadFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int descriptor = new Int(
+            "the 'descriptor' argument of read", params[0]
+        ).it();
         final int size = new Natural(
             new Expect<>("the 'size' argument of read", () -> params[1])
         ).it();
         final byte[] buf = new byte[size];
         final int count = Msvcrt.INSTANCE._read(
-            new Dataized(params[0]).asNumber().intValue(), buf, size
+            descriptor, buf, size
         );
         final Phi result = this.win.take("return").copy();
         result.put(0, new Data.ToPhi(count));

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -35,6 +36,9 @@ public final class RecvFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int flags = new Int(
+            "the 'flags' argument of recv", params[2]
+        ).it();
         final Phi result = this.win.take("return").copy();
         final int size = new Natural(
             new Expect<>("the 'size' argument of recv", () -> params[1])
@@ -44,7 +48,7 @@ public final class RecvFuncCall implements Syscall {
             new Pointer(new Dataized(params[0]).asNumber().longValue()),
             buf,
             size,
-            new Dataized(params[2]).asNumber().intValue()
+            flags
         );
         result.put(0, new Data.ToPhi(received));
         result.put(1, new Data.ToPhi(Arrays.copyOf(buf, Math.max(received, 0))));

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -9,6 +9,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -36,6 +37,9 @@ public final class SendFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int flags = new Int(
+            "the 'flags' argument of send", params[3]
+        ).it();
         final byte[] buf = new Dataized(params[1]).take();
         final int size = new Natural(
             new Expect<>("the 'size' argument of send", () -> params[2])
@@ -54,7 +58,7 @@ public final class SendFuncCall implements Syscall {
                     new Pointer(new Dataized(params[0]).asNumber().longValue()),
                     buf,
                     size,
-                    new Dataized(params[3]).asNumber().intValue()
+                    flags
                 )
             )
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/SocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SocketFuncCall.java
@@ -6,7 +6,7 @@ package org.eolang.win32;
 
 import com.sun.jna.Pointer;
 import org.eolang.Data;
-import org.eolang.Dataized;
+import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -33,15 +33,24 @@ public final class SocketFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int domain = new Int(
+            "the 'domain' argument of socket", params[0]
+        ).it();
+        final int kind = new Int(
+            "the 'type' argument of socket", params[1]
+        ).it();
+        final int protocol = new Int(
+            "the 'protocol' argument of socket", params[2]
+        ).it();
         final Phi result = this.win.take("return").copy();
         result.put(
             0,
             new Data.ToPhi(
                 Pointer.nativeValue(
                     Winsock.INSTANCE.socket(
-                        new Dataized(params[0]).asNumber().intValue(),
-                        new Dataized(params[1]).asNumber().intValue(),
-                        new Dataized(params[2]).asNumber().intValue()
+                        domain,
+                        kind,
+                        protocol
                     )
                 )
             )

--- a/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
@@ -8,6 +8,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExFailure;
 import org.eolang.Expect;
+import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
@@ -34,6 +35,9 @@ public final class WriteFuncCall implements Syscall {
 
     @Override
     public Phi make(final Phi... params) {
+        final int descriptor = new Int(
+            "the 'descriptor' argument of write", params[0]
+        ).it();
         final byte[] buf = new Dataized(params[1]).take();
         final int size = new Natural(
             new Expect<>("the 'size' argument of write", () -> params[2])
@@ -49,7 +53,7 @@ public final class WriteFuncCall implements Syscall {
             0,
             new Data.ToPhi(
                 Msvcrt.INSTANCE._write(
-                    new Dataized(params[0]).asNumber().intValue(),
+                    descriptor,
                     buf,
                     size
                 )

--- a/eo-runtime/src/test/java/org/eolang/win32/AccessFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/AccessFuncCallTest.java
@@ -36,4 +36,23 @@ final class AccessFuncCallTest {
             )
         );
     }
+
+    @Test
+    void refusesFractionalMode() {
+        MatcherAssert.assertThat(
+            "the 'mode' argument of access must be refused by name when it is not an integer, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new AccessFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi("one"),
+                    new Data.ToPhi(3.9)
+                ),
+                "a fractional 'mode' argument of access was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'mode' argument of access"),
+                Matchers.containsString("integer")
+            )
+        );
+    }
 }


### PR DESCRIPTION
`Int` says of itself that the syscall adapters use it to refuse the numbers a C `int` cannot mean, and every adapter of `org.eolang.posix` does. None of `org.eolang.win32` did: all fifteen conversions were a raw `asNumber().intValue()`, which truncates towards zero and saturates, so a fractional descriptor wrote to the truncated one, `nan` became zero and `1e18` became `Integer.MAX_VALUE`, none of it said aloud.

Every one of them now goes through `Int`, with the argument named the way its posix twin names it. The `size` arguments keep the `Natural` they already had, and the socket handles keep `longValue()`, being pointers rather than C `int`s.

The check is made before the native call rather than inside its argument list. `Msvcrt.INSTANCE` is a static field, so touching that class loads the library, and on any machine that is not Windows the loading fails before an argument is ever looked at. Computed first, the argument is refused everywhere, which is what makes it testable at all.

The test in `AccessFuncCallTest` hands a fractional `mode` and expects the same complaint Linux gives.

Closes #7708
