### PR TITLE
Index the void rows of provides.xml, so purify.xsl stops walking the table

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/purify.xsl
@@ -66,6 +66,15 @@
   -->
   <xsl:key name="eo:row" match="type" use="@id"/>
   <!--
+  The void rows of the table, by the type of each one. "eo:data-target" asks
+  what the callers of a program were seen putting into a void named from the
+  outside, and without this index that question walks every element of the
+  table again, for every part of every application of the program. The two
+  walks multiply, and the stylesheet took tens of seconds on the XMIR of
+  eo-runtime because of it.
+  -->
+  <xsl:key name="eo:void" match="attr[@void = 'true']" use="@type"/>
+  <!--
   The directory with the tables of "eo:inference", as a URI. Empty when
   nothing was worked out, and then nothing is labeled.
   -->
@@ -93,6 +102,17 @@
   an object of the root, so the rule about the root has to let them through.
   -->
   <xsl:variable name="eo:literals" as="xs:string+" select="for $n in ('number', 'string', 'bytes', 'true', 'false') return concat($eo:program, '.', $n)"/>
+  <!--
+  The prefix of a copy of an object of the root, the base of a body reading
+  the object it is attached to, and the prefix of a base taking something out
+  of that object. All three are spelled out here rather than where they are
+  asked about, because the questions below put them to every object of a
+  program and a "concat" written inside a predicate is a value the engine is
+  free to work out again for every node that predicate sees.
+  -->
+  <xsl:variable name="eo:root" as="xs:string" select="concat($eo:program, '.')"/>
+  <xsl:variable name="eo:receiver" as="xs:string" select="concat($eo:xi, '.', $eo:rho)"/>
+  <xsl:variable name="eo:from-receiver" as="xs:string" select="concat($eo:receiver, '.')"/>
   <!--
   Whether this object is a formation the label may go on. The questions are
   asked one at a time, cheapest first, and the one that walks the whole body
@@ -124,7 +144,7 @@
   <!-- Whether nothing in the body of this formation copies an object of the root. -->
   <xsl:function name="eo:closed" as="xs:boolean">
     <xsl:param name="f" as="element()"/>
-    <xsl:sequence select="empty($f/descendant-or-self::*[@base = $eo:program or (starts-with(@base, concat($eo:program, '.')) and not(@base = $eo:literals))])"/>
+    <xsl:sequence select="empty($f/descendant-or-self::*[@base = $eo:program or (starts-with(@base, $eo:root) and not(@base = $eo:literals))])"/>
   </xsl:function>
   <!--
   Whether this element is a formation, the same shape the template below
@@ -143,16 +163,20 @@
   before it is put and the label goes on with the receiver never looked at
   (#7613). The cheap half is asked first: a formation that declares "ρ" has
   been judged on it already.
-  Only the reads of this very formation count, which is why the nearest
-  formation around each read has to be this one. A nested formation declaring
-  its own receiver and reading that says nothing about the formation around
-  it - its "ρ" is another attribute of another object - and counting those
-  would withhold the label from most of the formations of a program.
+  Only the reads of this very formation count, which is why no formation may
+  stand between a read and this one. A nested formation declaring its own
+  receiver and reading that says nothing about the formation around it - its
+  "ρ" is another attribute of another object - and counting those would
+  withhold the label from most of the formations of a program. The formations
+  in between are the ancestors of a read that this formation precedes, and
+  asking for them that way leaves the ones above this formation alone: a
+  program nests hundreds of objects deep, and the question is put to every
+  read of every formation the table lets through.
   -->
   <xsl:function name="eo:borrowed" as="xs:boolean">
     <xsl:param name="f" as="element()"/>
     <xsl:param name="row" as="element()"/>
-    <xsl:sequence select="empty($row/attr[@void = 'true'][@name = $eo:rho]) and exists($f/descendant::*[(@base = concat($eo:xi, '.', $eo:rho) or starts-with(@base, concat($eo:xi, '.', $eo:rho, '.'))) and (ancestor::*[eo:formation(.)][1] is $f)])"/>
+    <xsl:sequence select="empty($row/attr[@void = 'true'][@name = $eo:rho]) and exists($f/descendant::*[@base = $eo:receiver or starts-with(@base, $eo:from-receiver)][empty(ancestor::*[$f &lt;&lt; .][eo:formation(.)])])"/>
   </xsl:function>
   <!--
   Whether every void of this row is witnessed as a number or a string, the
@@ -174,7 +198,8 @@
   -->
   <xsl:function name="eo:applied" as="xs:boolean">
     <xsl:param name="a" as="element()"/>
-    <xsl:sequence select="exists($eo:links) and exists($a/o[@loc]) and (every $p in $a/o[@loc] satisfies eo:copies-data(key('eo:row', $p/@loc, $eo:links)))"/>
+    <xsl:variable name="parts" as="element()*" select="$a/o[@loc]"/>
+    <xsl:sequence select="exists($eo:links) and exists($parts) and (every $p in $parts satisfies eo:copies-data(key('eo:row', $p/@loc, $eo:links)))"/>
   </xsl:function>
   <!--
   Whether this row of "links.xml" says its object is data. A row holds one
@@ -207,7 +232,7 @@
   -->
   <xsl:function name="eo:data-target" as="xs:boolean">
     <xsl:param name="loc" as="xs:string"/>
-    <xsl:sequence select="exists($eo:provides) and ((some $t in key('eo:row', $loc, $eo:provides) satisfies $t/@returns = $eo:data) or (some $v in $eo:provides//attr[@void = 'true'][@type = $loc] satisfies (exists($v/witnessed) and (every $e in $v/witnessed//* satisfies (name($e) = 'union' or (name($e) = 'ref' and $e/@loc = $eo:data))))))"/>
+    <xsl:sequence select="exists($eo:provides) and ((some $t in key('eo:row', $loc, $eo:provides) satisfies $t/@returns = $eo:data) or (some $v in key('eo:void', $loc, $eo:provides) satisfies (exists($v/witnessed) and (every $e in $v/witnessed//* satisfies (name($e) = 'union' or (name($e) = 'ref' and $e/@loc = $eo:data))))))"/>
   </xsl:function>
   <!--
   An application whose parts are all data is labeled too, so that the answer


### PR DESCRIPTION
The log is full of this:

```
[WARNING] XSL 'purify' took 47s (over 500ms)
[WARNING] XSL 'purify' took 45s (over 500ms)
[WARNING] XSL 'purify' took 35s (over 500ms)
```

## What was slow

`eo:data-target()` in `purify.xsl` asked

```xpath
$eo:provides//attr[@void = 'true'][@type = $loc]
```

which walks every element of `provides.xml`. That question is put once per
part of every application of a program, through `eo:applied()` →
`eo:copies-data()`, so the two walks multiply: the cost is
_applications × parts × table size_. The tables of `eo-runtime` hold tens of
thousands of rows, which is where the tens of seconds came from.

The fix is one more `xsl:key`, next to the `eo:row` one that is already there
for the same reason:

```xml
<xsl:key name="eo:void" match="attr[@void = 'true']" use="@type"/>
```

## Three smaller things in the same file

- The constants the questions put to every object of a program — the `Φ.` a
  copy from the root starts with, and the `ξ.ρ` / `ξ.ρ.` a body reads its
  receiver through — are worked out once as global variables instead of by a
  `concat()` written inside a predicate, where the engine is free to work them
  out again for every node the predicate sees.
- `eo:borrowed()` asks for the formations *between* a read and the formation
  under judgement (`ancestor::*[$f << .][eo:formation(.)]`) rather than for the
  nearest formation around the read (`ancestor::*[eo:formation(.)][1] is $f`).
  Same answer, since `$f` is always a formation, but the ancestors above `$f`
  are left alone, and a program nests hundreds of objects deep.
- `eo:applied()` binds `$a/o[@loc]` once instead of selecting it twice.

## Nothing about the labels changes

- Output is byte-for-byte identical on every input tried, including the
  no-tables case where the stylesheet is an identity transform.
- The sixteen packs of `purify-packs` pass: `StPureTest`, 17 tests, green.
- `MjTranspileTest`, 95 tests, green.

## Numbers

Saxon-HE 13.0, synthetic `provides.xml` / `links.xml` / XMIR of the shape the
`inference` goal produces, median of five runs:

| program | before | after |
| --- | --- | --- |
| 1500 applications, 6k formations, 30k links | 2028 ms | 399 ms |
| 3000 applications, 6k formations, 30k links | 6538 ms | 493 ms |
| 4000 applications, 20k formations, 60k links, 12 deep | 4770 ms | 1279 ms |

The middle row is the point: doubling the applications of a program used to
more than triple the time, and now barely moves it.

## One thing left, outside this change

With the quadratic term gone, what remains per file is Saxon building its
trees and key indexes over the two tables, which it does once per
transformation — about 430 ms for 11 MB of tables in the measurements above.
`StPure` already caches the parsed DOM, but Saxon still converts it and
rebuilds the indexes for every XMIR. Sharing that across files would be a
Java-side change and is not attempted here.

---
_Generated by [Claude Code](https://claude.ai/code/session_014y9ZDHws5jsmbinqTgUo7t)_