### PR TITLE
bug(#7762): expect the JUnit class under its new name

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -43,7 +43,7 @@ jobs:
           # change made by this branch.
           head=$(git rev-parse HEAD)
           base=$(git rev-parse "${head}^1")
-          # The tests of `foo.eo` are transpiled into `EOfooTest`, and so are
+          # The tests of `foo.eo` are transpiled into `TestEOfoo`, and so are
           # the tests of `foo/bar.eo`, because a package member is tested
           # through the package that owns it. A file holding no `++>` and no
           # `-->` test gets no class at all, and naming a class that does not
@@ -63,7 +63,7 @@ jobs:
                   if grep -qrE -- ' (\+\+>|-->) ' \
                     "eo-runtime/src/main/eo/${name}.eo" \
                     "eo-runtime/src/main/eo/${name}" 2>/dev/null; then
-                    echo "EO${name}Test"
+                    echo "TestEO${name}"
                   fi
                 done \
               | paste -sd, -

--- a/eo-runtime/src/test/groovy/check-target-files.groovy
+++ b/eo-runtime/src/test/groovy/check-target-files.groovy
@@ -9,7 +9,7 @@ List<String> expected = [
   'eo/5-transpile/malloc.xmir',
   'generated-sources/org/eolang/EOseq.java',
   'generated-sources/org/eolang/EOsocket.java',
-  'generated-test-sources/org/eolang/EObytesTest.java',
+  'generated-test-sources/org/eolang/TestEObytes.java',
   'classes/org/eolang/package-info.class',
 ]
 


### PR DESCRIPTION
The daily build [failed](https://github.com/objectionary/eo/actions/runs/33241953886/job/99072695637) in `eo-runtime` at `groovy-maven-plugin:execute (project-validate)`:

```
The file '.../eo-runtime/target/generated-test-sources/org/eolang/EObytesTest.java' is not present
```

`cffddae0` ("mark a generated JUnit class in front, not behind", #7762) renamed the classes generated for `++>` attributes from `<name>Test` to `Test<name>`, in `JavaPlaced` and in `to-java.xsl`. Two places still spell the old name:

  * `eo-runtime/src/test/groovy/check-target-files.groovy` asserts `generated-test-sources/org/eolang/EObytesTest.java`, which is now `TestEObytes.java`. This is what broke the daily build; the check runs under `-Pqulice`, past `verify`, which is what `.github/daily.sh` and `src/test/scripts/test-repetition.sh` use.
  * `.github/workflows/fast.yml` builds the `-Dtest` list as `EO${name}Test`. Surefire fails when it is told to run a class that does not exist, so the `fast` job would go red on any pull request touching an `.eo` file that owns tests. This one has not fired yet only because no such pull request has run since the rename.

`bytes.eo` still carries `++>` attributes, so `TestEObytes` is generated; there is no handwritten `src/test/java/org/eolang/TestEObytes.java`, so the `TestAtom...` fallback in `JavaPlaced` does not apply here.