### PR TITLE
bug(#7111): keep ms timing tests off the canonical XSL chain

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -95,7 +95,9 @@ final class EoSyntaxTest {
         MatcherAssert.assertThat(
             "ms attribute is not a measured elapsed time",
             Long.parseLong(
-                new EoSyntax(new LargeProgram(30)).parsed().xpath("/object/@ms").get(0)
+                new EoSyntax(
+                    new LargeProgram(30), UnaryOperator.<XML>identity()
+                ).parsed().xpath("/object/@ms").get(0)
             ),
             Matchers.greaterThan(0L)
         );
@@ -127,7 +129,9 @@ final class EoSyntaxTest {
 
     @Test
     void measuresParsingTimeOnEveryCall() throws Exception {
-        final EoSyntax syntax = new EoSyntax(new LargeProgram(30));
+        final EoSyntax syntax = new EoSyntax(
+            new LargeProgram(30), UnaryOperator.<XML>identity()
+        );
         syntax.parsed();
         MatcherAssert.assertThat(
             "second parse of the same syntax does not measure its own elapsed time",


### PR DESCRIPTION
Fixes the master build failure in [run 33244486724](https://github.com/objectionary/eo/actions/runs/33244486724/job/99079499503):

```
[ERROR] EoSyntaxTest.measuresParsingTimeOnEveryCall » Timeout
        measuresParsingTimeOnEveryCall() timed out after 20 seconds
```

### Why it timed out

The program size was never the cost. Measured locally, per `parsed()` call:

| what | cost |
|---|---|
| parsing `LargeProgram(30)` (the `ms` value itself) | ~15 ms |
| the `Canonical` XSL train applied afterwards | ~300 ms |

`EoSyntax` builds a fresh `Canonical` train per instance (it holds no static state, by design — see `carriesNoSharedStaticState`), so every `parsed()` call recompiles the whole chain. That fixed cost dwarfs the parse: a parse of an *empty* program costs ~290 ms against ~356 ms for 30 objects. This is why the two earlier attempts to fit the budget by shrinking the fixture (`LargeProgram` 2000 → 30 objects, ca060ae2 → de16a3ca) did not help — they trimmed the 5% and left the 95%.

`measuresParsingTimeOnEveryCall` parses twice, so it paid that overhead twice, and on the macOS runner with `parallel.config.strategy = dynamic` the wall clock crossed 20s. `measuresRealParsingTime` parses the same fixture once and was next in line.

### The change

`ms` is stamped inside the Xembly directives, *before* `transform.apply(...)` runs, so the XSL chain is not part of what either test asserts — it is pure overhead. Both tests now pass `UnaryOperator.<XML>identity()` as the transform. What they assert is unchanged; only the untimed work around it is gone.

Coverage of the canonical pipeline is unaffected: `parsesSimpleCode`, `reportsMsWithinSaneBound` and the yaml packs (including `replaced-only-phi-rollback-keeps-ms`) still exercise it.

### Verification

`mvn -pl eo-parser test -Dtest=EoSyntaxTest` — 728 run, 0 failures, 0 errors. Per-method times from the surefire report, under the same concurrent execution:

| test | before | after |
|---|---|---|
| `measuresParsingTimeOnEveryCall` | timed out at 20s (25.34s on CI) | 0.080s |
| `measuresRealParsingTime` | ~12s on CI | 0.018s |

Even at the ~40x slowdown the loaded runner showed, that leaves ~3s against the 20s budget.

Qulice and jtcop pass on `eo-parser` (121 files, 1017 rules).

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xp6ezqF5sYw6gxjZFcKU1A)_