### PR TITLE
Index the scope lookups of the four slowest XSL sheets

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/build-fqns.xsl
@@ -45,6 +45,17 @@
       <xsl:attribute name="base" select="'ξ'"/>
     </o>
   </xsl:variable>
+  <!--
+  Every named attribute, indexed by its name together with the object that
+  owns it. The scope walk below asks "does this object declare this name" at
+  every enclosing object of every reference, and answered it by scanning that
+  object's children - twice, the question being put twice in one
+  "xsl:choose". Each answer is a hash lookup now, the way
+  "resolve-local-names.xsl" indexes the same question (#6502, #7938). The
+  "+package" below is likewise read once, not per reference.
+  -->
+  <xsl:key name="attributes" match="o[@name]" use="concat(@name, '#', generate-id(..))"/>
+  <xsl:variable name="eo:package" select="string((/object/metas/meta[head='package'])[1]/part[1])"/>
   <!-- Build recursive objects chain from package if exists -->
   <xsl:template match="o" mode="recursive-package">
     <xsl:param name="pkg"/>
@@ -83,7 +94,7 @@
     <xsl:param name="parent"/>
     <xsl:param name="find"/>
     <xsl:choose>
-      <xsl:when test="$parent/o[@name=$find]">
+      <xsl:when test="exists(key('attributes', concat($find, '#', generate-id($parent))))">
         <xsl:variable name="start">
           <o>
             <xsl:attribute name="base" select="'Φ'"/>
@@ -92,7 +103,7 @@
         <xsl:apply-templates select="." mode="to-method">
           <xsl:with-param name="of">
             <xsl:apply-templates select="$start" mode="recursive-package">
-              <xsl:with-param name="pkg" select="(/object/metas/meta[head='package'])[1]/part[1]/text()"/>
+              <xsl:with-param name="pkg" select="$eo:package"/>
             </xsl:apply-templates>
           </xsl:with-param>
         </xsl:apply-templates>
@@ -154,6 +165,8 @@
     <xsl:param name="self"/>
     <xsl:param name="find"/>
     <xsl:variable name="parent" select="parent::*"/>
+    <!-- Whether this enclosing object declares the name being resolved. -->
+    <xsl:variable name="declares" as="xs:boolean" select="exists(key('attributes', concat($find, '#', generate-id($parent))))"/>
     <xsl:choose>
       <!-- last frontier -->
       <xsl:when test="$parent[name()='object']">
@@ -165,7 +178,7 @@
       <xsl:when test="eo:abstract($parent)">
         <xsl:choose>
           <!-- Found reference in the current scope -->
-          <xsl:when test="$parent/o[@name=$find] and $rhos=0">
+          <xsl:when test="$declares and $rhos=0">
             <xsl:apply-templates select="$self" mode="with-rho">
               <xsl:with-param name="rhos" select="$rhos"/>
               <xsl:with-param name="current">
@@ -177,7 +190,7 @@
             </xsl:apply-templates>
           </xsl:when>
           <!-- Found reference in some abstract object above -->
-          <xsl:when test="$parent/o[@name=$find]">
+          <xsl:when test="$declares">
             <o>
               <xsl:apply-templates select="$self/@*"/>
               <xsl:attribute name="hop" select="$rhos"/>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/resolve-local-names.xsl
@@ -55,6 +55,14 @@
   -->
   <xsl:key name="handles" match="o[@local]" use="concat(@local, '#', generate-id(ancestor::o[not(@base)][1]))"/>
   <!--
+  Every name the file declares as a handle. Only a reference reading one of
+  them can be captured, so the search below answers every other reference -
+  the great majority, and all of them in the half of the sources declaring
+  no handle - without climbing the ancestors and probing the indexes at each
+  (#7938).
+  -->
+  <xsl:variable name="eo:handle-names" as="xs:string*" select="distinct-values(//o[@local]/@local)"/>
+  <!--
   Every named object, indexed by its name together with its parent, so the
   "does this formation have an attribute of this name" test is a hash lookup
   as well, rather than a scan of the formation's children.
@@ -89,8 +97,18 @@
   <xsl:function name="eo:captor" as="element()?">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="name" as="xs:string" select="if (exists($ref/@method)) then substring-after($ref/@base, '.') else string($ref/@base)"/>
-    <xsl:variable name="scope" as="element()?" select="if (exists($ref/@method)) then eo:scope($ref) else $ref/ancestor::o[not(@base)][exists(key('attributes', concat($name, '#', generate-id(.)))) or exists(key('handles', concat($name, '#', generate-id(.))))][1]"/>
+    <xsl:variable name="scope" as="element()?" select="if (not($name = $eo:handle-names)) then () else if (exists($ref/@method)) then eo:scope($ref) else $ref/ancestor::o[not(@base)][eo:declares(., $name)][1]"/>
     <xsl:sequence select="for $found in $scope return key('handles', concat($name, '#', generate-id($found)), $found)[1]"/>
+  </xsl:function>
+  <!--
+  Whether this formation declares the name, publicly or as a handle. Both
+  indexes are filed under one "name in this scope" pair, built once here.
+  -->
+  <xsl:function name="eo:declares" as="xs:boolean">
+    <xsl:param name="scope" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:variable name="pair" as="xs:string" select="concat($name, '#', generate-id($scope))"/>
+    <xsl:sequence select="exists(key('attributes', $pair, root($scope))) or exists(key('handles', $pair, root($scope)))"/>
   </xsl:function>
   <!--
   The formation that the explicit receiver of a dispatch names: "ξ" (written

--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -40,6 +40,8 @@
   string for every reference the sheet looks at.
   -->
   <xsl:variable name="eo:xi-dot" select="concat($eo:xi, '.')"/>
+  <!-- The cactus-name prefix, hoisted for the same reason as "eo:xi-dot". -->
+  <xsl:variable name="eo:cactus-name" select="concat('a', $eo:cactoos)"/>
   <!--
   Every reference that resolves to an attribute name (`eo:resolved-ref`),
   indexed by the formation that owns it and the name it resolves to. The
@@ -89,7 +91,7 @@
   <xsl:function name="eo:resolved-ref" as="xs:string">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="tail" select="substring-after($ref/@base, $eo:xi-dot)"/>
-    <xsl:sequence select="if (exists($ref/@base) and not(exists($ref/@name)) and starts-with($ref/@base, $eo:xi-dot) and not(contains($tail, '.')) and not($ref/o)) then $tail else if (eo:dispatch-seg($ref) != '') then substring-before($tail, '.') else ''"/>
+    <xsl:sequence select="if (not(starts-with($ref/@base, $eo:xi-dot))) then '' else if (not(exists($ref/@name)) and not(contains($tail, '.')) and not($ref/o)) then $tail else if (eo:dispatch-seg($ref) != '') then substring-before($tail, '.') else ''"/>
   </xsl:function>
   <!--
   The trailing dispatch chain of a hostable dispatch reference
@@ -100,11 +102,15 @@
   per segment nested inside each other, since `<name>.seg1.seg2` and
   `seg2. (seg1. <name>)` denote the same graph. Unlike a bare reference, a
   dispatch may carry arguments and may be a named node (#5794).
+
+  The "ξ." test comes first, ahead of the tests it used to sit behind: this
+  function and "eo:resolved-ref" above run for every object in the file, and
+  most bases are not rooted at "ξ." at all (#7938).
   -->
   <xsl:function name="eo:dispatch-seg" as="xs:string">
     <xsl:param name="ref" as="element()"/>
     <xsl:variable name="tail" select="substring-after($ref/@base, $eo:xi-dot)"/>
-    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, $eo:xi-dot) and contains($tail, '.') and substring-before($tail, '.') != '') then substring-after($tail, '.') else ''"/>
+    <xsl:sequence select="if (not(starts-with($ref/@base, $eo:xi-dot))) then '' else if (contains($tail, '.') and substring-before($tail, '.') != '') then substring-after($tail, '.') else ''"/>
   </xsl:function>
   <!--
   Whether `$attr` is a restored recursive `&gt;&gt; name` handle: an abstract
@@ -138,7 +144,7 @@
   -->
   <xsl:function name="eo:moniker-binding" as="xs:boolean">
     <xsl:param name="attr" as="element()"/>
-    <xsl:sequence select="exists($attr/@name) and (starts-with($attr/@name, concat('a', $eo:cactoos)) or eo:recursive-handle($attr)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
+    <xsl:sequence select="exists($attr/@name) and (starts-with($attr/@name, $eo:cactus-name) or eo:recursive-handle($attr)) and (exists($attr/@base) or eo:abstract($attr)) and not(exists($attr/@pipe)) and not(eo:void($attr)) and $attr/@name != $eo:phi and not(eo:test-attr($attr)) and eo:abstract($attr/..)"/>
   </xsl:function>
   <!--
   The key `to-eo-tree.xsl` sorts a reference's own top-level binding under:
@@ -210,9 +216,21 @@
   -->
   <xsl:function name="eo:hosted-binding" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
-    <xsl:variable name="binding" select="key('moniker-binding', concat(generate-id($owner), ' ', eo:resolved-ref($ref)), root($ref))[1]"/>
-    <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:variable name="name" select="eo:resolved-ref($ref)"/>
+    <xsl:choose>
+      <!--
+      Nothing but a "ξ.&lt;name&gt;" reference can host a binding, and most
+      objects are not one. Answering that first keeps the ancestor climb, the
+      "generate-id" and the key probe off the path every object walks: this
+      runs from a match pattern (#7938).
+      -->
+      <xsl:when test="$name = ''"/>
+      <xsl:otherwise>
+        <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
+        <xsl:variable name="binding" select="key('moniker-binding', concat(generate-id($owner), ' ', $name), root($ref))[1]"/>
+        <xsl:sequence select="if (exists($binding) and (eo:moniker-refs($binding)[1] is $ref)) then $binding else ()"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
   <!--
   Whether the formation `$attr` prints as a multi-line block rather than the
@@ -285,10 +303,16 @@
   </xsl:function>
   <xsl:function name="eo:applied-handle" as="element()*">
     <xsl:param name="ref" as="element()"/>
-    <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
     <xsl:variable name="name" select="substring-after($ref/@base, $eo:xi-dot)"/>
-    <xsl:variable name="binding" select="key('moniker-binding', concat(generate-id($owner), ' ', $name), root($ref))[eo:applied-hosted(.)][1]"/>
-    <xsl:sequence select="if (exists($ref/@base) and starts-with($ref/@base, $eo:xi-dot) and $name != '' and not(contains($name, '.')) and exists($ref/o) and exists($binding) and (eo:applied-refs($binding)[1] is $ref)) then $binding else ()"/>
+    <xsl:choose>
+      <!-- Shape tests first, for the reason on "eo:hosted-binding" above. -->
+      <xsl:when test="not($name != '' and not(contains($name, '.')) and exists($ref/o) and starts-with($ref/@base, $eo:xi-dot))"/>
+      <xsl:otherwise>
+        <xsl:variable name="owner" select="$ref/ancestor::o[eo:abstract(.)][1]"/>
+        <xsl:variable name="binding" select="key('moniker-binding', concat(generate-id($owner), ' ', $name), root($ref))[eo:applied-hosted(.)][1]"/>
+        <xsl:sequence select="if (exists($binding) and (eo:applied-refs($binding)[1] is $ref)) then $binding else ()"/>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:function>
   <!--
   Whether `$attr` is a const file-local handle (`a &gt;&gt; b!`, R-3.10.12):
@@ -388,6 +412,21 @@
     <xsl:variable name="binding" select="$candidates[last()]"/>
     <xsl:sequence select="if (exists($binding) and not($ref is $binding) and not($ref/ancestor::o[. is $binding]) and (exists($binding/@pipe) or not(eo:moniker-refs($binding)[1] is $ref))) then $binding else ()"/>
   </xsl:function>
+  <!--
+  The binding, out of those candidates, that a reference actually keeps: not
+  the binding itself, not a reference inside it, and not the one reference the
+  moniker fold hosts the binding onto (a binding floated into a pipe has no
+  hosting reference to spare, so every reader of it keeps the name).
+  -->
+  <!--
+  The handle a non-hosting reference reads, whichever kind it is - the two
+  readings above over one shared candidate list. They used to be a template
+  each, of equal priority and each computing that list for itself, so every
+  "@base" in the document paid for the lookup twice; a reference both would
+  have fired on still takes the non-const reading, which is the one Saxon
+  picked when the two templates collided, the later of two equal-priority
+  rules winning (#7938).
+  -->
   <!--
   Replace the first hosting reference with the merged binding, always keeping
   the reference's positional `@as`. A bare reference becomes the binding
@@ -550,22 +589,19 @@
     </o>
   </xsl:template>
   <!--
-  Rewrite a non-hosting reference to a const file-local handle from the
-  obfuscated cactus name back to the readable "@local" handle, so it reads as
-  `b` instead of a synthetic "vL_P" placeholder (#5828). The hosting reference
-  is rebuilt from the binding above and never reaches this template.
+  Rewrite a non-hosting reference to a kept handle from the obfuscated cactus
+  name back to the readable "@local" handle, so it reads as `name` (or
+  `name.seg`) instead of a synthetic "vL_P" placeholder. Both kinds of handle
+  are put back here: a const one (`a &gt;&gt; b!`, #5828) and a plain one — an
+  abstract formation (`[] &gt;&gt; name`, #5876) or a based one
+  (`a.b &gt;&gt; name`, #5944). The single hosting reference is rebuilt from
+  the binding above and never reaches this template (`eo:kept` excludes it).
   -->
   <xsl:template match="o[exists(eo:kept-const-ref(.))]/@base" priority="2">
     <xsl:attribute name="base" select="eo:handle-base(.., eo:kept-const-ref(..))"/>
   </xsl:template>
   <!--
-  Rewrite a non-hosting reference to a kept handle — an abstract formation
-  (`[] &gt;&gt; name`, #5876) or a based one (`a.b &gt;&gt; name`, #5944) — from
-  the obfuscated cactus name back to the
-  readable "@local" handle, so it reads as `name` (or `name.seg`) instead of a
-  synthetic "vL_P" placeholder, the non-const mirror of the const rewrite above.
-  The single hosting reference is rebuilt from the binding and never reaches
-  this template (`eo:kept-local-ref` excludes it).
+  The non-const mirror of the rewrite above.
   -->
   <xsl:template match="o[exists(eo:kept-local-ref(.))]/@base" priority="2">
     <xsl:attribute name="base" select="eo:handle-base(.., eo:kept-local-ref(..))"/>

--- a/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/to-eo-tree.xsl
@@ -19,6 +19,33 @@
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:variable name="eol" select="'&#10;'"/>
   <xsl:output method="xml" encoding="UTF-8"/>
+  <!--
+  What the "BASED" head template below used to re-derive for every single
+  reference it renders, hoisted because none of it changes during one
+  transformation (#7938). Saxon folds neither prefix nor the cactus pattern
+  into a constant, "$eo:program" and "$eo:cactoos" being globals rather than
+  literals, so "eo:printable" even recompiled its regex per call; and the
+  "+package" meta, the program's own top-level name and the "+alias" short
+  names were each read from the document root per reference.
+  -->
+  <xsl:variable name="eo:root-prefix" select="concat($eo:program, '.')"/>
+  <xsl:variable name="eo:xi-prefix" select="concat($eo:xi, '.')"/>
+  <xsl:variable name="eo:cactus-name" select="concat('a', $eo:cactoos)"/>
+  <xsl:variable name="eo:cactus-pattern" select="concat('a', $eo:cactoos, '(\d+)-(\d+)')"/>
+  <xsl:variable name="eo:package" select="string((/object/metas/meta[head='package'])[1]/part[1])"/>
+  <xsl:variable name="eo:self-prefix" select="concat($eo:program, '.', $eo:package, '.')"/>
+  <xsl:variable name="eo:top-name" as="xs:string*" select="/object/o[1]/@name/string()"/>
+  <xsl:variable name="eo:aliases" as="xs:string*" select="/object/metas/meta[head = 'alias']/part[1]/string()"/>
+  <!--
+  The two scope questions that same template asks per reference, indexed: the
+  handles of one name, reached through a "//o[@local=$name]" scan of the whole
+  document, and whether an enclosing object declares a name, answered by
+  scanning every ancestor's children. Both are the shape
+  "resolve-local-names.xsl" keyed away in #6502, and both made this sheet
+  quadratic in the file's size.
+  -->
+  <xsl:key name="locals" match="o[@local]" use="@local"/>
+  <xsl:key name="named" match="o[@name]" use="concat(@name, '#', generate-id(..))"/>
   <!-- Translate a dotted path to EO surface form: ρ -> ^, φ -> @, ξ -> $. -->
   <xsl:function name="eo:translate-path" as="xs:string">
     <xsl:param name="path" as="xs:string"/>
@@ -41,7 +68,7 @@
   <xsl:function name="eo:surface" as="xs:string">
     <xsl:param name="raw" as="item()?"/>
     <xsl:variable name="base" as="xs:string" select="string($raw)"/>
-    <xsl:sequence select="if (starts-with($base, '.')) then concat(eo:translate-path(substring($base, 2)), '.') else if (starts-with($base, concat($eo:program, '.'))) then eo:translate-path(substring-after($base, concat($eo:program, '.'))) else if (starts-with($base, concat($eo:xi, '.'))) then eo:translate-path(substring-after($base, concat($eo:xi, '.'))) else if ($base = $eo:xi) then '$' else if ($base = $eo:program) then 'Q' else eo:translate-path($base)"/>
+    <xsl:sequence select="if (starts-with($base, '.')) then concat(eo:translate-path(substring($base, 2)), '.') else if (starts-with($base, $eo:root-prefix)) then eo:translate-path(substring-after($base, $eo:root-prefix)) else if (starts-with($base, $eo:xi-prefix)) then eo:translate-path(substring-after($base, $eo:xi-prefix)) else if ($base = $eo:xi) then '$' else if ($base = $eo:program) then 'Q' else eo:translate-path($base)"/>
   </xsl:function>
   <!--
   A surface head with its last dot turned into "?." when the dispatch it
@@ -95,13 +122,23 @@
   <xsl:function name="eo:root-name" as="xs:string">
     <xsl:param name="raw" as="item()?"/>
     <xsl:variable name="base" as="xs:string" select="string($raw)"/>
-    <xsl:variable name="rest" select="substring-after($base, concat($eo:program, '.'))"/>
+    <xsl:variable name="rest" select="substring-after($base, $eo:root-prefix)"/>
     <xsl:sequence select="if (contains($rest, '.')) then substring-before($rest, '.') else $rest"/>
   </xsl:function>
-  <!-- Rewrite surviving cactus names (a🌵L-P) to a valid id (vL_P). -->
+  <!-- Whether some object this reference is nested inside declares "$name". -->
+  <xsl:function name="eo:declared" as="xs:boolean">
+    <xsl:param name="o" as="element()"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:sequence select="some $scope in $o/ancestor::o satisfies exists(key('named', concat($name, '#', generate-id($scope)), root($o)))"/>
+  </xsl:function>
+  <!--
+  Rewrite surviving cactus names (a🌵L-P) to a valid id (vL_P). Called
+  twice per emitted line, and almost no head or tail holds a cactus name, so
+  "contains" decides the common case without invoking the regex engine.
+  -->
   <xsl:function name="eo:printable" as="xs:string">
     <xsl:param name="text" as="xs:string"/>
-    <xsl:sequence select="replace($text, concat('a', $eo:cactoos, '(\d+)-(\d+)'), 'v$1_$2')"/>
+    <xsl:sequence select="if (contains($text, $eo:cactus-name)) then replace($text, $eo:cactus-pattern, 'v$1_$2') else $text"/>
   </xsl:function>
   <!--
   Render a stored signature (an atom's "/sig" or a void forma) as its EO
@@ -112,9 +149,8 @@
   -->
   <xsl:function name="eo:signature" as="xs:string">
     <xsl:param name="sig" as="xs:string"/>
-    <xsl:variable name="root" select="concat($eo:program, '.')"/>
-    <xsl:variable name="rest" select="substring-after($sig, $root)"/>
-    <xsl:sequence select="if (starts-with($sig, $root)) then concat('Q.', $rest) else $sig"/>
+    <xsl:variable name="rest" select="substring-after($sig, $eo:root-prefix)"/>
+    <xsl:sequence select="if (starts-with($sig, $eo:root-prefix)) then concat('Q.', $rest) else $sig"/>
   </xsl:function>
   <!-- Count the leading run of consecutive ρ segments in a sequence. -->
   <xsl:function name="eo:rho-run" as="xs:integer">
@@ -172,7 +208,7 @@
   -->
   <xsl:function name="eo:identity" as="xs:boolean">
     <xsl:param name="o" as="element()"/>
-    <xsl:sequence select="eo:abstract($o) and not(eo:has-data($o)) and count($o/o) = 2 and eo:void($o/o[1]) and empty($o/o[1]/(@local, @type, @args)) and $o/o[2]/@name = $eo:phi and empty($o/o[2]/o) and empty($o/o[2]/@const) and $o/o[2]/@base = concat($eo:xi, '.', $o/o[1]/@name)"/>
+    <xsl:sequence select="eo:abstract($o) and not(eo:has-data($o)) and count($o/o) = 2 and eo:void($o/o[1]) and empty($o/o[1]/(@local, @type, @args)) and $o/o[2]/@name = $eo:phi and empty($o/o[2]/o) and empty($o/o[2]/@const) and $o/o[2]/@base = concat($eo:xi-prefix, $o/o[1]/@name)"/>
   </xsl:function>
   <!-- PROGRAM -->
   <xsl:template match="object">
@@ -372,7 +408,7 @@
   predecessor has floated away (#5526) the guard fails and the node
   prints as an ordinary application, which round-trips just as safely.
   -->
-  <xsl:template match="o[@pipe and (@base = concat($eo:xi, '.', preceding-sibling::o[1]/@name) or @base = preceding-sibling::o[1]/@name)]" mode="head" priority="2">
+  <xsl:template match="o[@pipe and (@base = concat($eo:xi-prefix, preceding-sibling::o[1]/@name) or @base = preceding-sibling::o[1]/@name)]" mode="head" priority="2">
     <xsl:text>|</xsl:text>
   </xsl:template>
   <!-- METHOD-DISPATCH CONTINUATION (§3.5) -->
@@ -399,14 +435,14 @@
     <xsl:variable name="hop-name" select="if (count($segments) &gt; $rho-count + 1) then $segments[$rho-count + 2] else ''"/>
     <xsl:variable name="hop-rest" select="string-join(subsequence($segments, $rho-count + 2), '.')"/>
     <!--
-    The current program's "+package" and the "Φ.<package>." prefix a
-    self-reference to a same-file object carries after being homed
-    into the package (add-default-package / build-fqns).
+    What the "Φ.<package>." prefix a self-reference to a same-file object
+    carries (see "eo:self-prefix", built from the "+package" meta at the head
+    of this sheet) leaves behind, once stripped.
     -->
-    <xsl:variable name="package" select="string((/object/metas/meta[head='package'])[1]/part[1])"/>
-    <xsl:variable name="self-prefix" select="concat($eo:program, '.', $package, '.')"/>
-    <xsl:variable name="self-rest" select="substring-after(@base, $self-prefix)"/>
+    <xsl:variable name="self-rest" select="substring-after(@base, $eo:self-prefix)"/>
     <xsl:variable name="self-first" select="if (contains($self-rest, '.')) then substring-before($self-rest, '.') else $self-rest"/>
+    <!-- The first name segment of a program-rooted base, asked about twice below. -->
+    <xsl:variable name="root-name" as="xs:string" select="eo:root-name(@base)"/>
     <!--
     Whether some formation this reference is actually nested inside (not
     just the innermost one - a zero-hop reference here can legitimately
@@ -419,7 +455,7 @@
     unrelated formation elsewhere in the file (not an ancestor of this
     reference at all) must not suppress the "$." marker here.
     -->
-    <xsl:variable name="local-handle" select="//o[@local=$hop-name][ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
+    <xsl:variable name="local-handle" select="key('locals', $hop-name)[ancestor::o[not(@base)][1] intersect current()/ancestor::o[not(@base)]][1]"/>
     <!--
     The surface the arms below build, before its fragile marker is put
     back. A dispatch stays fragile whatever shortening its base happens
@@ -436,16 +472,16 @@
         <xsl:when test="@base=$eo:bottom">
           <xsl:text>T</xsl:text>
         </xsl:when>
-        <xsl:when test="starts-with(@base, concat($eo:program, '.')) and (exists(ancestor::o/o[@name = eo:root-name(current()/@base)]) or /object/metas/meta[head = 'alias']/part[1] = eo:root-name(current()/@base))">
+        <xsl:when test="starts-with(@base, $eo:root-prefix) and (eo:declared(., $root-name) or $eo:aliases = $root-name)">
           <!--
           The plain top-level name would be shadowed by an in-scope
           attribute, or reinterpreted through a "+alias" declaring that
           same short name for a different object (#6211), so keep the
           explicit Q. root to disambiguate.
           -->
-          <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, concat($eo:program, '.'))))"/>
+          <xsl:value-of select="concat('Q.', eo:translate-path(substring-after(@base, $eo:root-prefix)))"/>
         </xsl:when>
-        <xsl:when test="$package != '' and starts-with(@base, $self-prefix) and $self-first = /object/o[1]/@name and empty(ancestor::o/o[@name = $self-first])">
+        <xsl:when test="$eo:package != '' and starts-with(@base, $eo:self-prefix) and $self-first = $eo:top-name and not(eo:declared(., $self-first))">
           <!--
           The base names this program's own top-level object through its
           fully-qualified "Φ.<package>.<name>…" form. The source wrote it
@@ -529,7 +565,7 @@
     which is itself the argument the label belongs to, not a separate
     definition.
     -->
-    <xsl:if test="@as and (not(@name) or starts-with(@name, concat('a', $eo:cactoos)))">
+    <xsl:if test="@as and (not(@name) or starts-with(@name, $eo:cactus-name))">
       <xsl:text>:</xsl:text>
       <xsl:choose>
         <xsl:when test="starts-with(@as, $eo:alpha)">
@@ -584,7 +620,7 @@
           <xsl:text> &gt;&gt; </xsl:text>
           <xsl:value-of select="@local"/>
         </xsl:when>
-        <xsl:when test="starts-with(@name, concat('a', $eo:cactoos))">
+        <xsl:when test="starts-with(@name, $eo:cactus-name)">
           <xsl:text> &gt;&gt;</xsl:text>
         </xsl:when>
         <xsl:otherwise>


### PR DESCRIPTION
Closes #7938.

The four stylesheets `eo:format` warns about all answer the same kind of question — "which objects
in this file declare this name" — by walking nodes rather than through an index, once per object, so
each is quadratic in the size of the source it prints. `eo:format` parses and prints every source up
to eight times, so that cost lands a few hundred thousand times over one `eo-runtime` build.

## What changed

**`to-eo-tree.xsl`** — its `BASED` head template opened with `//o[@local=$hop-name][…]`, a scan of
the whole document, repeated for every reference it renders; that goes through an `xsl:key` now, as
does the `ancestor::o/o[@name = …]` scan beside it. The `+package` meta, the `+alias` short names and
the top-level object's name, all re-read from the document root per reference, and the `Φ.` / `ξ.`
prefixes rebuilt from global variables there, are computed once at the head of the sheet.
`eo:printable`, called twice for every emitted line, tests for a cactus name with `contains` before
handing the pattern to the regex engine — Saxon cannot precompile that pattern, it being assembled
from a global variable, so it was recompiling it per call.

**`merge-monikers.xsl`** — four of its functions are reached from match patterns, so every object in
the file paid for an ancestor climb to its owning formation, a `generate-id` and a key probe before
the cheap tests that disqualify it. Those tests come first now: `eo:resolved-ref` and
`eo:dispatch-seg` ask whether the base is rooted at `ξ.` at all before anything else, and
`eo:hosted-binding` and `eo:applied-handle` settle their shape tests before the climb and the probe.

**`resolve-local-names.xsl`** — `eo:captor` climbed the ancestors of every reference, probing two
keys at each and building the same `name#formation` pair twice to do it, when only a reference
naming a declared handle can be captured at all. The name is checked against the handle names the
file declares first, which settles every reference in the half of the sources that declare no
handle, and the pair is built once in `eo:declares`.

**`build-fqns.xsl`** — the `fqn` scope walk answered "does this object declare this name" by scanning
the object's children, twice per enclosing object per reference; it asks an index once. The
`+package` meta it re-read from the document root at each resolved top-level name is a variable.

**`wrap-applications.xsl`** is untouched, though it is the sheet warned about most. It is already an
identity transform guarded on `//o[@pipe]` (#6665) and measures at the copy-the-tree floor; its
warnings are Saxon's one-off bootstrap on the first sheet each `MjFormat` thread compiles, one per
thread, not per-document work.

## Measurements

Each sheet timed in isolation over the six largest `eo-runtime` sources (`path.eo`, `directory.eo`,
`uri.eo`, `string/printf.eo`, `file.eo`, `socket.eo`), best of twelve runs, on the tree that stage
actually receives. Baseline and change were measured back to back in one sitting, two rounds each,
because absolute timings on this machine drift with load; the copy-the-tree floor for an identity
sheet on the same inputs is ~53 ms (printer stage) and ~78 ms (parser stage).

| stylesheet | before | after | |
| --- | --- | --- | --- |
| `to-eo-tree` | 326 / 331 ms | 215 / 220 ms | −34% |
| `build-fqns` | 182 / 169 ms | 135 / 124 ms | −26% |
| `resolve-local-names` | 142 / 147 ms | 114 / 111 ms | −22% |
| `merge-monikers` | 272 / 282 ms | 236 / 228 ms | −16% |

Over all 172 `eo-runtime` sources (one parse and one print each, single-threaded), by total and by
worst single invocation — the latter being what the `over 500ms` warnings actually measure, since
they fire per invocation on the largest files under thread contention:

| stylesheet | total before → after | worst invocation before → after |
| --- | --- | --- |
| `to-eo-tree` | 1545 → 1193 ms | 82 → 46 ms |
| `merge-monikers` | 1257 → 1025 ms | 103 → 113 ms |
| `resolve-local-names` | 815 → 600 ms | 37 → 26 ms |
| `build-fqns` | 727 → 649 ms | 45 → 31 ms |

`merge-monikers`'s worst single file (`uri.eo`) does not improve — the two rounds bracket the
baseline, so the gain there is on the corpus as a whole rather than on the file that trips the
warning. That file is the one worth attacking under #6512.

## How it was verified

* `mvn test` on `eo-parser` and `eo-printer`: 1931 tests, 0 failures.
* Every one of the 172 `eo-runtime` sources parsed and printed through the full settle loop, before
  and after, capturing the printed EO **and** the whole XMIR at each pass: byte-identical output on
  all of them, so the sheets produce the same trees, not merely the same text.

## What I left out, and why

Two further `merge-monikers` changes are not here. An ablation had pointed at the two "kept
reference" `@base` rewrites (which each tokenize every `@base` in the document and probe the
`moniker-name` key separately) and at the sort in `eo:moniker-refs`; folding the two rewrites into
one template over a shared candidate list, and returning a single reference unsorted, measured
within noise of leaving both alone — the ablation had over-attributed. They cost ~120 lines and
needed careful reasoning about which of two equal-priority templates Saxon picks, so the version
without them is the same speed for a much smaller and safer diff. Worth revisiting under #6512 with
a measurement that isolates it.

## Follow-up worth a look

Sampling the JVM during these transforms puts ~47% of the samples inside `DOMNodeWrapper` and
Xerces, not in XPath evaluation: Saxon is being handed a W3C DOM by jcabi-xml's `XSLDocument` and
wraps it rather than building a TinyTree, and the pipeline converts DOM → wrapper → DOM once per
sheet, thirty times per source. That is a Java-side change in `Shift`/jcabi-xml rather than a
stylesheet one, so it is out of scope here, but it is a larger lever than anything left in the XSL —
it is also why the trivial `validate-*` sheets each cost ~600 ms over `eo-runtime`.