### PR TITLE
#7931: report the top comment block by its last line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Comments.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Comments.java
@@ -60,7 +60,7 @@ final class Comments {
             );
         }
         if (!pending.isEmpty()) {
-            emit.comment(pending, pending.get(0).line());
+            emit.comment(pending, pending.get(pending.size() - 1).line());
             globals.clearComments();
         }
         globals.seal();

--- a/eo-parser/src/main/java/org/eolang/parser/Globals.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Globals.java
@@ -167,7 +167,7 @@ final class Globals {
             );
         }
         if (!this.comments.isEmpty()) {
-            emit.comment(this.comments, this.comments.get(0).line());
+            emit.comment(this.comments, this.comments.get(this.comments.size() - 1).line());
             this.clearComments();
         }
         this.closed = true;

--- a/eo-parser/src/test/java/org/eolang/parser/CommentsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/CommentsTest.java
@@ -33,7 +33,7 @@ final class CommentsTest {
     }
 
     @Test
-    void reportsFirstLineOfMultiLineBlock() {
+    void reportsLastLineOfMultiLineBlock() {
         final Globals globals = new Globals();
         globals.addComment(new Span("# first", 1));
         globals.addComment(new Span("# second", 2));
@@ -41,9 +41,9 @@ final class CommentsTest {
         final Emit emit = new Emit();
         Comments.seal(globals, emit, new Span("+package foo", 4));
         MatcherAssert.assertThat(
-            "a multi-line top comment block must report the line of its first span, not its last",
+            "a multi-line top comment block must report the line of its last span, not its first",
             CommentsTest.render(emit),
-            XhtmlMatchers.hasXPath("/object/comments/comment[@line='1']")
+            XhtmlMatchers.hasXPath("/object/comments/comment[@line='2']")
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
@@ -231,6 +231,15 @@ final class GlobalsTest {
     }
 
     @Test
+    void reportsLastLineOfTheBlockFlushedByAnObject() {
+        MatcherAssert.assertThat(
+            "a block flushed by an object must report its own last line, as the end-of-file flush does",
+            GlobalsTest.render("# first", "# second", "# third", "", "[] > foo"),
+            XhtmlMatchers.hasXPath("/object/comments/comment[@line='3']")
+        );
+    }
+
+    @Test
     void keepsFlushedCommentsWhenTheSealingLineFails() {
         MatcherAssert.assertThat(
             "a top comment block flushed by a line that then fails must survive that line's rollback",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multi-line-top-comment-reports-last-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multi-line-top-comment-reports-last-line.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object/comments/comment[@line='1' and starts-with(text(), 'First.')]
+  - /object/comments/comment[@line='2' and starts-with(text(), 'First.')]
 input: |
   # First.
   # Second.


### PR DESCRIPTION
R-9.5.3 asks for the comment block's own last line, and the end-of-file
flush in `Eo.finish` already reports that. `Globals.seal`, the path every
file with a meta or an object takes, reported the first line instead, so
the same block got two different numbers depending on what followed it.

Both `Globals.seal` and its copy `Comments.seal` now take the last span.

Closes #7931
