### PR TITLE
#7932: close the spec's text block on its own line

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -564,7 +564,8 @@ R-3.11.5. An unclosed block is reported at end-of-stream as a recoverable error.
 ```
 """
 hello
-world""" > text-value                 ← multi-line string named text-value
+world
+""" > text-value                      ← multi-line string named text-value
 ```
 
 ### 3.12 Inline binding — `:label` or `:N`

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-at-the-top-level.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-at-the-top-level.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - //o[@name='text-value' and @base='Φ.string' and o/o[text()='68-65-6C-6C-6F-0A-77-6F-72-6C-64']]
+input: |
+  """
+  hello
+  world
+  """ > text-value


### PR DESCRIPTION
R-3.11.3 closes a text block only with a `"""` standing on its own line,
and `Eo.closesTextBlock` does the same, so the example under §3.11 was a
form neither accepts. Parsing it verbatim gives `unclosed text block
opened at line 1`.

The example now closes on its own line, and a pack test parses that exact
source at the top level.

Closes #7932
