### PR TITLE
#7933: keep the spec's pipe examples inside a body

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -661,14 +661,18 @@ R-3.14.8. **Predecessor placement — body vs argument block.** Where the predec
 Outer kind: **`pipe-application`** (openness `open` for the vertical form's body, `vertical-completed` for the horizontal form).
 
 ```
-[x] > foo                             ← named formation
-  x.plus x > @
-| 5 > foo5                            ← foo5 = foo applied to 5 (i.e. (5).plus 5)
+[] > app
+  [x] > foo                           ← named formation
+    x.plus x > @
+  | 5 > foo5                          ← foo5 = foo applied to 5 (i.e. (5).plus 5)
 
-[a b] >>                              ← auto-named (anonymous) formation
-  a.plus b > @
-| 2 3 > pair                          ← one application, two args, referring to the auto-name
+  [a b] >>                            ← auto-named (anonymous) formation
+    a.plus b > @
+  | 2 3 > pair                        ← one application, two args, referring to the auto-name
 ```
+
+A pipe belongs inside a body or an argument block, never at file level: the
+predecessor and the pipe are two objects (R-3.14.8), and a file holds one.
 
 Illegal:
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/two-pipes-in-one-body.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/two-pipes-in-one-body.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo5' and @base='ξ.foo' and count(o)=1]
+  - //o[@name='pair' and count(o)=2]
+input: |
+  [] > app
+    [x] > foo
+      x.plus x > @
+    | 5 > foo5
+
+    [a b] >>
+      a.plus b > @
+    | 2 3 > pair


### PR DESCRIPTION
Both examples of §3.14 were written at indent 0, so the predecessor and
the pipe landed under `<object>` as siblings and the pipeline answered
`Only one object per source file is allowed and required`.

R-3.14.8 already says the predecessor stays in place beside the pipe, so
the shape needs a body around it. The examples now sit inside a formation,
the way the pack tests for the same two shapes already do, and a note says
why file level is not an option.

Closes #7933
