### PR TITLE
#7935: report malformed literals by their own messages

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1395,6 +1395,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Two type annotations on one void | `a void attribute may carry at most one type annotation` |
 | Unexpected odd character after a name suffix | `unexpected content after name suffix` |
 | Excessive trailing blank lines | `more than one trailing blank line` |
+| Line head matching no shape of §3 | `line head does not start any known object shape` |
 
 R-9.9.2. The position prefix `[L:P]` (with L = line, P = pos) is prepended to every error message before insertion into the `<error>` element body. Conventions: 1-indexed line, 0-indexed pos.
 

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -472,34 +472,31 @@ final class Eo implements Iterable<Directive> {
         return head == '"' || Eo.bytesHead(head) || Eo.numberHead(span);
     }
 
-    /**
-     * Whether the line's head token reads as a BYTES literal that no
-     * head shape accepts — alphanumerics and dashes with at least one
-     * dash, the way {@code Z9-} does (R-3.13.1). Such a line is a
-     * malformed literal, not an unknown shape.
-     * @param span The line's span
-     * @return True if the head token is a malformed BYTES literal
-     */
     private static boolean bytesAttempt(final Span span) {
         final String body = span.body();
         int end = body.indexOf(' ');
         if (end < 0) {
             end = body.length();
         }
-        final String head = body.substring(0, end);
+        return end > 1 && Eo.dashedAlphanumerics(body.substring(0, end));
+    }
+
+    private static boolean dashedAlphanumerics(final String head) {
         boolean dashed = false;
-        boolean shaped = end > 1;
+        boolean shaped = true;
         for (int idx = 0; idx < head.length() && shaped; idx = idx + 1) {
             final char glyph = head.charAt(idx);
             if (glyph == '-') {
                 dashed = true;
             } else {
-                shaped = glyph >= '0' && glyph <= '9'
-                    || glyph >= 'a' && glyph <= 'z'
-                    || glyph >= 'A' && glyph <= 'Z';
+                shaped = Eo.alphanumeric(glyph);
             }
         }
         return shaped && dashed;
+    }
+
+    private static boolean alphanumeric(final char glyph) {
+        return glyph < 128 && Character.isLetterOrDigit(glyph);
     }
 
     private static boolean bytesHead(final char head) {

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -393,8 +393,10 @@ final class Eo implements Iterable<Directive> {
         final String reason;
         if (span.body().codePoints().findFirst().orElse(0) == 0x1F335) {
             reason = "cactus emoji is reserved for auto-names; not allowed as a line head";
+        } else if (Eo.bytesAttempt(span)) {
+            reason = "invalid bytes literal";
         } else {
-            reason = "line shape not yet implemented in spec parser";
+            reason = "line head does not start any known object shape";
         }
         return (stack, globals, emit) -> {
             throw new ParseError(span.line(), span.indent(), reason);
@@ -468,6 +470,36 @@ final class Eo implements Iterable<Directive> {
     private static boolean literalHead(final Span span) {
         final char head = span.head();
         return head == '"' || Eo.bytesHead(head) || Eo.numberHead(span);
+    }
+
+    /**
+     * Whether the line's head token reads as a BYTES literal that no
+     * head shape accepts — alphanumerics and dashes with at least one
+     * dash, the way {@code Z9-} does (R-3.13.1). Such a line is a
+     * malformed literal, not an unknown shape.
+     * @param span The line's span
+     * @return True if the head token is a malformed BYTES literal
+     */
+    private static boolean bytesAttempt(final Span span) {
+        final String body = span.body();
+        int end = body.indexOf(' ');
+        if (end < 0) {
+            end = body.length();
+        }
+        final String head = body.substring(0, end);
+        boolean dashed = false;
+        boolean shaped = end > 1;
+        for (int idx = 0; idx < head.length() && shaped; idx = idx + 1) {
+            final char glyph = head.charAt(idx);
+            if (glyph == '-') {
+                dashed = true;
+            } else {
+                shaped = glyph >= '0' && glyph <= '9'
+                    || glyph >= 'a' && glyph <= 'z'
+                    || glyph >= 'A' && glyph <= 'Z';
+            }
+        }
+        return shaped && dashed;
     }
 
     private static boolean bytesHead(final char head) {

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -261,6 +261,12 @@ final class Tokens {
         while (Tokens.digitAt(this.body, idx)) {
             idx = idx + 1;
         }
+        if (sign && Tokens.letterAt(this.body, idx)) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + start,
+                "invalid signed-number literal"
+            );
+        }
         if (idx == from) {
             throw new ParseError(
                 this.span.line(), this.span.indent() + start,
@@ -629,6 +635,12 @@ final class Tokens {
         return Tokens.byteDigit(glyph) || glyph >= 'a' && glyph <= 'f';
     }
 
+    private static boolean letterAt(final String body, final int idx) {
+        return idx < body.length()
+            && (body.charAt(idx) >= 'a' && body.charAt(idx) <= 'z'
+                || body.charAt(idx) >= 'A' && body.charAt(idx) <= 'Z');
+    }
+
     private static boolean byteDigit(final char glyph) {
         return Tokens.digit(glyph) || glyph >= 'A' && glyph <= 'F';
     }
@@ -798,6 +810,11 @@ final class Tokens {
             value = this.reserved(Value.Kind.IDENTITY, "I");
         } else if (first >= 'a' && first <= 'z') {
             value = this.readName();
+        } else if (this.oddHexRun()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + this.cursor,
+                "invalid bytes literal"
+            );
         } else {
             throw new ParseError(
                 this.span.line(), this.span.indent() + this.cursor,
@@ -835,6 +852,22 @@ final class Tokens {
             this.cursor = this.cursor + 1;
         }
         return this.body.substring(start, this.cursor);
+    }
+
+    /**
+     * Whether the cursor stands on a run of hex digits that a dash
+     * closes but that pairs do not divide — {@code ABC-}, the odd hex
+     * run of R-3.13.1.
+     * @return True if the run is a malformed BYTES literal
+     */
+    private boolean oddHexRun() {
+        int idx = this.cursor;
+        while (idx < this.body.length() && Tokens.byteDigit(this.body.charAt(idx))) {
+            idx = idx + 1;
+        }
+        return idx > this.cursor
+            && idx < this.body.length()
+            && this.body.charAt(idx) == '-';
     }
 
     private boolean bytePair(final int idx) {

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -637,8 +637,8 @@ final class Tokens {
 
     private static boolean letterAt(final String body, final int idx) {
         return idx < body.length()
-            && (body.charAt(idx) >= 'a' && body.charAt(idx) <= 'z'
-                || body.charAt(idx) >= 'A' && body.charAt(idx) <= 'Z');
+            && body.charAt(idx) < 128
+            && Character.isLetter(body.charAt(idx));
     }
 
     private static boolean byteDigit(final char glyph) {
@@ -801,6 +801,12 @@ final class Tokens {
                 "horizontal formation not allowed as argument"
             );
         }
+        if (this.oddHexRun()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + this.cursor,
+                "invalid bytes literal"
+            );
+        }
         final Value value;
         if (first == '*') {
             value = this.reserved(Value.Kind.STAR, "*");
@@ -810,11 +816,6 @@ final class Tokens {
             value = this.reserved(Value.Kind.IDENTITY, "I");
         } else if (first >= 'a' && first <= 'z') {
             value = this.readName();
-        } else if (this.oddHexRun()) {
-            throw new ParseError(
-                this.span.line(), this.span.indent() + this.cursor,
-                "invalid bytes literal"
-            );
         } else {
             throw new ParseError(
                 this.span.line(), this.span.indent() + this.cursor,
@@ -854,12 +855,6 @@ final class Tokens {
         return this.body.substring(start, this.cursor);
     }
 
-    /**
-     * Whether the cursor stands on a run of hex digits that a dash
-     * closes but that pairs do not divide — {@code ABC-}, the odd hex
-     * run of R-3.13.1.
-     * @return True if the run is a malformed BYTES literal
-     */
     private boolean oddHexRun() {
         int idx = this.cursor;
         while (idx < this.body.length() && Tokens.byteDigit(this.body.charAt(idx))) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/invalid-bytes-literal-head-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/invalid-bytes-literal-head-is-rejected.yaml
@@ -2,12 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 2
-message: |-
-  [2:2] error: 'line head does not start any known object shape'
-    ~0. > disp
-    ^
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'invalid bytes literal')]
 input: |
-  [] > foo
-    ~0. > disp
-      x
+  Z9- > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/non-hex-letter-head-with-digit.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/non-hex-letter-head-with-digit.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets: []
 asserts:
   - /object/errors[count(error)=1]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/non-hex-letter-head-with-digit.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/non-hex-letter-head-with-digit.yaml
@@ -4,7 +4,7 @@
 sheets: []
 asserts:
   - /object/errors[count(error)=1]
-  - /object/errors/error[contains(text(),'line shape not yet implemented')]
+  - /object/errors/error[contains(text(),'line head does not start any known object shape')]
 input: |
   [] > main
     Z9 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/odd-hex-run-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/odd-hex-run-is-rejected.yaml
@@ -2,12 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 2
-message: |-
-  [2:2] error: 'line head does not start any known object shape'
-    ~0. > disp
-    ^
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'invalid bytes literal')]
 input: |
-  [] > foo
-    ~0. > disp
-      x
+  ABC- > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/signed-number-glued-to-a-name-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/signed-number-glued-to-a-name-is-rejected.yaml
@@ -2,12 +2,8 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 2
-message: |-
-  [2:2] error: 'line head does not start any known object shape'
-    ~0. > disp
-    ^
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'invalid signed-number literal') and @pos='0']
 input: |
-  [] > foo
-    ~0. > disp
-      x
+  +1foo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/symbol-head-with-digit.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/symbol-head-with-digit.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets: []
 asserts:
   - /object/errors[count(error)=1]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/symbol-head-with-digit.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/symbol-head-with-digit.yaml
@@ -4,7 +4,7 @@
 sheets: []
 asserts:
   - /object/errors[count(error)=1]
-  - /object/errors/error[contains(text(),'line shape not yet implemented')]
+  - /object/errors/error[contains(text(),'line head does not start any known object shape')]
 input: |
   [] > main
     %1 > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/long-character.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/long-character.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 5
 message: |-
-  [5:6] error: 'line shape not yet implemented in spec parser'
+  [5:6] error: 'line head does not start any known object shape'
         'hello'
         ^
 input: |


### PR DESCRIPTION
Three malformed literals reached messages that named something else.

`Z9-` matched no head shape, so it fell through to `Eo.rejected`, whose
fallback blamed the parser for being unfinished. It now reports `invalid
bytes literal`, and the fallback itself says what is wrong with the line
instead, with a row of its own in the §9.9 table.

`ABC-` is an odd hex run and reached `expected value`; `Tokens` now spots
a hex run closed by a dash that pairs do not divide.

`+1foo` was rejected after the fact by the suffix parser, pointing at `f`.
`readInt` now stops at the digits glued to a name and reports `invalid
signed-number literal` at the literal.

Closes #7935
