### PR TITLE
#7936: tell a nested atom apart from an ordinary body violation

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Admission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Admission.java
@@ -25,13 +25,29 @@ final class Admission {
     private final boolean permitted;
 
     /**
+     * Whether the line declares an atom of its own.
+     */
+    private final boolean own;
+
+    /**
      * Ctor.
      * @param label The suffix's source name, or {@code null}
      * @param permitted Whether this line shape may sit under an atom parent
      */
     Admission(final String label, final boolean permitted) {
+        this(label, permitted, false);
+    }
+
+    /**
+     * Ctor.
+     * @param label The suffix's source name, or {@code null}
+     * @param permitted Whether this line shape may sit under an atom parent
+     * @param own Whether the line declares an atom of its own
+     */
+    Admission(final String label, final boolean permitted, final boolean own) {
         this.label = label;
         this.permitted = permitted;
+        this.own = own;
     }
 
     /**
@@ -50,5 +66,21 @@ final class Admission {
      */
     boolean permitted() {
         return this.permitted;
+    }
+
+    /**
+     * The message for a line this atom body cannot hold — R-6.3.4 (b)
+     * gives a nested atom its own text, since telling the author that
+     * the child is not a test says nothing about the nesting.
+     * @return Canonical message
+     */
+    String violation() {
+        final String message;
+        if (this.own) {
+            message = "atom may not contain a nested atom";
+        } else {
+            message = "atom may contain only test attributes";
+        }
+        return message;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -125,7 +125,7 @@ final class LnFormation implements Line {
     private void transition(final Stack stack, final Suffix suffix) {
         final Level level = new Transition(stack, this.span).apply(
             Kind.BARE_FORMATION, Openness.OPEN,
-            new Admission(suffix.named(), suffix.test())
+            new Admission(suffix.named(), suffix.test(), suffix.atom())
         );
         if (suffix.atom()) {
             level.mark();

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -59,8 +59,7 @@ final class Transition {
         }
         if (level.patom() && !admission.permitted()) {
             throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "atom may contain only test attributes"
+                this.span.line(), this.span.indent(), admission.violation()
             );
         }
         admission.name(level);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/nested-atom-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/nested-atom-is-rejected.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'atom may not contain a nested atom')]
+input: |
+  [] > foo /number
+    ? > x
+
+    [] > inner /number


### PR DESCRIPTION
An atom declared inside another atom hit the generic R-6.3.1 check and
was told it is not a test attribute, which is true of any child and says
nothing about the nesting. R-6.3.4 (b) treats it as its own condition and
the §9.9 table gives it the text `atom may not contain a nested atom`,
which was nowhere in the code.

`Admission` now carries whether the line declares an atom of its own and
picks the message from that, so `[] > inner` without a signature under
the same atom keeps the message it had.

Closes #7936
