### PR TITLE
#7942: take only the elements that carry a locator

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -69,12 +69,10 @@ final class CoverageManifest {
     /**
      * The locations a transpile of this XMIR would instrument, each as
      * {@code loc:line:pos}, the same string {@code PhCoverage} records a
-     * hit under.
-     * <p>An element with no {@code @loc} is not a location at all: a
-     * parser {@code <error>} carries a line and a position and nothing
-     * else, and every other element of a parsed XMIR that carries both
-     * carries a locator too.</p>
-     *
+     * hit under. An element with no {@code @loc} is not a location at
+     * all: a parser error element carries a line and a position and
+     * nothing else, and every other element of a parsed XMIR that
+     * carries both carries a locator too.
      * @param xmir The XMIR a source was parsed and optimized into
      * @return The locations, in document order
      */

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -70,6 +70,11 @@ final class CoverageManifest {
      * The locations a transpile of this XMIR would instrument, each as
      * {@code loc:line:pos}, the same string {@code PhCoverage} records a
      * hit under.
+     * <p>An element with no {@code @loc} is not a location at all: a
+     * parser {@code <error>} carries a line and a position and nothing
+     * else, and every other element of a parsed XMIR that carries both
+     * carries a locator too.</p>
+     *
      * @param xmir The XMIR a source was parsed and optimized into
      * @return The locations, in document order
      */
@@ -77,7 +82,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(@base=codepoints-to-string(8709)) and not(ancestor::void) and not(ancestor-or-self::*[o[@atom]])]"
+            "//*[@line and @pos and @loc and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(@base=codepoints-to-string(8709)) and not(ancestor::void) and not(ancestor-or-self::*[o[@atom]])]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -127,6 +127,13 @@ public final class MjCoverageReport extends MjSafe {
                     source, key -> new LinkedHashMap<>(0)
                 );
                 final XML xmir = new EoSyntax(Files.readString(tojo.source())).parsed();
+                if (!xmir.nodes("/object/errors/error").isEmpty()) {
+                    throw new IOException(
+                        String.format(
+                            "Can't build a coverage report, %s doesn't parse", source
+                        )
+                    );
+                }
                 for (final String location : manifest.locations(xmir)) {
                     final int last = location.lastIndexOf(':');
                     final int line = Integer.parseInt(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -48,6 +48,19 @@ final class CoverageManifestTest {
     }
 
     @Test
+    void findsNoLocationsInASourceThatDoesNotParse() throws Exception {
+        MatcherAssert.assertThat(
+            "a parser error carries a line and a position and no locator, so it cannot be a location",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(System.lineSeparator(), "[] > x", "  TRUE > t", "")
+                ).parsed()
+            ),
+            Matchers.iterableWithSize(0)
+        );
+    }
+
+    @Test
     void excludesLocationOfAFilesRootObject() throws Exception {
         MatcherAssert.assertThat(
             "a file's root object is constructed once from Java and never dispatched through PhCoverage, but its own location was still found",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCoverageReportTest.java
@@ -103,6 +103,26 @@ final class MjCoverageReportTest {
     }
 
     @Test
+    void namesTheSourceThatDoesNotParse(@Mktmp final Path temp) throws Exception {
+        final FakeMaven maven = new FakeMaven(temp).withProgram(
+            String.join(System.lineSeparator(), "[] > x", "  TRUE > t")
+        ).execute(MjParse.class);
+        final Path hits = temp.resolve("coverage.txt");
+        Files.writeString(hits, "");
+        MatcherAssert.assertThat(
+            "a source that does not parse must be named by the failure it causes, but it wasnt",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> maven.with("hits", hits.toFile())
+                    .with("lcov", temp.resolve("coverage.info").toFile())
+                    .execute(MjCoverageReport.class),
+                "coverage-report must fail on a source that does not parse, but it didnt"
+            ).getCause().getCause().getMessage(),
+            Matchers.containsString("doesn't parse")
+        );
+    }
+
+    @Test
     void reportsAFileThatHasNothingToInstrument(@Mktmp final Path temp) throws Exception {
         final FakeMaven maven = new FakeMaven(temp).withProgram(
             String.join(


### PR DESCRIPTION
The XPath took every element carrying `@line` and `@pos` and then read
`./@loc` from it. A parser `<error>` carries a line and a position and no
locator, so a source that does not parse died inside `coverage-report`
with an index-out-of-bounds message naming neither the file nor the real
problem.

The XPath now asks for `@loc` as well, and the report names the source
that does not parse before it gets that far.

Closes #7942
