### PR TITLE
#7941: leave an anonymous formation out of the manifest

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/CoverageManifest.java
@@ -42,6 +42,12 @@ import java.util.LinkedHashSet;
  * a void, the empty-set glyph — no body to dataize, so no {@code located} mode call and no
  * hit ever lands on its declaration line either (#7377).</p>
  *
+ * <p>An anonymous formation is left out too. {@code anonymous-to-nested.xsl}
+ * turns one into a nested class, and {@code to-java.xsl} never runs a
+ * nested class through {@code located} mode, so no hit can ever land on
+ * the line the {@code []} sits on. Its body still gets its own locations
+ * — only the formation's own declaration line is left out (#7941).</p>
+ *
  * <p>An atom attribute is left out along with everything it declares,
  * even though {@code to-java.xsl} does wrap it and its voids and the
  * runtime does record hits for them (#7055). Such an attribute has no
@@ -80,7 +86,7 @@ final class CoverageManifest {
         final XML passed = new Xsline(this.train).pass(xmir);
         final Collection<String> found = new LinkedHashSet<>();
         for (final XML located : passed.nodes(
-            "//*[@line and @pos and @loc and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(@base=codepoints-to-string(8709)) and not(ancestor::void) and not(ancestor-or-self::*[o[@atom]])]"
+            "//*[@line and @pos and @loc and not(contains(@loc,'+')) and not(contains(@loc,'.-')) and not(@atom) and not(@skip-java) and not(self::class) and not(@base=codepoints-to-string(8709)) and not(ancestor::void) and not(ancestor-or-self::*[o[@atom]]) and (@base or @name)]"
         )) {
             found.add(
                 String.format(

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CoverageManifestTest.java
@@ -61,6 +61,30 @@ final class CoverageManifestTest {
     }
 
     @Test
+    void excludesLocationOfAnAnonymousFormation() throws Exception {
+        MatcherAssert.assertThat(
+            "an anonymous formation becomes a nested class the transpiler never instruments, so its line must not be counted",
+            new CoverageManifest().locations(
+                new EoSyntax(
+                    String.join(
+                        System.lineSeparator(),
+                        "+package examples",
+                        "",
+                        "[] > x",
+                        "  bool > @",
+                        "    []",
+                        "      ? >> left",
+                        "      ? >> right",
+                        "      right > @",
+                        ""
+                    )
+                ).parsed()
+            ),
+            Matchers.not(Matchers.hasItem(Matchers.containsString(":5:")))
+        );
+    }
+
+    @Test
     void excludesLocationOfAFilesRootObject() throws Exception {
         MatcherAssert.assertThat(
             "a file's root object is constructed once from Java and never dispatched through PhCoverage, but its own location was still found",


### PR DESCRIPTION
`anonymous-to-nested.xsl` turns an anonymous formation into a nested
class, and `to-java.xsl` never runs one through `located` mode, so no
`PhCoverage` ever wraps it and no hit can land on the line its `[]` sits
on. The manifest counted it anyway, which left about twenty files of
`eo-runtime` with a permanent miss against the `55%` gate.

An anonymous formation carries neither `@base` nor `@name`, in place and
in its nested copy alike, so the XPath now asks for one of the two. Its
body keeps its own locations.

Closes #7941
