### PR TITLE
#7943: write a package annotation only where we transpiled

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -156,13 +156,7 @@ final class JavaFiles {
     void removeStale() throws IOException {
         if (Files.exists(this.generated)) {
             final Set<Path> expected = new HashSet<>(this.fresh);
-            final Set<Path> dirs = new HashSet<>();
-            for (final Path file : this.touched) {
-                for (Path dir = file.getParent(); dir != null && dir.startsWith(this.generated);
-                    dir = dir.getParent()) {
-                    dirs.add(dir);
-                }
-            }
+            final Collection<Path> dirs = this.directories();
             try (Stream<Path> walk = Files.walk(this.generated)) {
                 for (final Path file : walk.filter(Files::isRegularFile)
                     .filter(path -> path.toString().endsWith(JavaFiles.JAVA)).collect(
@@ -177,6 +171,27 @@ final class JavaFiles {
                 }
             }
         }
+    }
+
+    /**
+     * The directories this run's own output landed in, every parent up
+     * to and including the generated sources root.
+     *
+     * <p>A class this run decided to skip names a directory all the
+     * same, so the set covers what a transpile owns, and nothing another
+     * generator wrote into the same convention directory.</p>
+     *
+     * @return The directories
+     */
+    Collection<Path> directories() {
+        final Set<Path> dirs = new HashSet<>();
+        for (final Path file : this.touched) {
+            for (Path dir = file.getParent(); dir != null && dir.startsWith(this.generated);
+                dir = dir.getParent()) {
+                dirs.add(dir);
+            }
+        }
+        return dirs;
     }
 
     private Supplier<Path> cached(final String hsh, final String jname) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/PackageInfos.java
@@ -13,7 +13,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 /**
  * Package info classes.
@@ -57,55 +56,57 @@ final class PackageInfos {
     private final Collection<Path> sources;
 
     /**
+     * The directories a transpile of this run wrote a class into.
+     */
+    private final Collection<Path> dirs;
+
+    /**
      * Constructor.
      * @param root In which directory create files
      * @param sources Where the hand-written Java sources are
+     * @param dirs Where this run's own transpiled classes landed
      */
-    PackageInfos(final Path root, final Collection<Path> sources) {
+    PackageInfos(final Path root, final Collection<Path> sources, final Collection<Path> dirs) {
         this.root = root;
         this.sources = sources;
+        this.dirs = dirs;
     }
 
     /**
-     * Create {@code package-info.java} files in all the directories under the {@link #root}.
+     * Create {@code package-info.java} files in the directories this run
+     * wrote a transpiled class into.
+     *
+     * <p>Never in every directory under the {@link #root}:
+     * {@code generated-sources} is the standard Maven convention
+     * directory, and other generators write their own output there, which
+     * a package annotation of ours has no business claiming. This is the
+     * same rule {@link JavaFiles#removeStale()} follows on the way
+     * out.</p>
+     *
      * @return Amount of created files
      * @throws IOException If fails to create a file
      */
     int create() throws IOException {
-        final int size;
-        if (Files.exists(this.root)) {
-            final List<Path> dirs;
-            try (Stream<Path> walk = Files.walk(this.root)) {
-                dirs = walk.filter(
-                    file -> Files.isDirectory(file)
-                        && !file.equals(this.root)
-                        && !file.equals(this.root.resolve("org"))
-                        && !this.taken(file)
-                    )
-                    .collect(Collectors.toList());
-            }
-            for (final Path dir : dirs) {
-                Logger.debug(
-                    this,
-                    "Created %s",
-                    new Saved(
-                        PackageInfos.content(
-                            this.root.relativize(dir)
-                                .toString()
-                                .replace(File.separator, ".")
-                        ), dir.resolve("package-info.java")
-                    ).value()
-                );
-            }
-            size = dirs.size();
-        } else {
-            Logger.info(
+        final List<Path> made = this.dirs.stream()
+            .filter(dir -> !dir.equals(this.root))
+            .filter(dir -> !dir.equals(this.root.resolve("org")))
+            .filter(dir -> !this.taken(dir))
+            .sorted()
+            .collect(Collectors.toList());
+        for (final Path dir : made) {
+            Logger.debug(
                 this,
-                "No generated sources found, skipping package-info.java creation"
+                "Created %s",
+                new Saved(
+                    PackageInfos.content(
+                        this.root.relativize(dir)
+                            .toString()
+                            .replace(File.separator, ".")
+                    ), dir.resolve("package-info.java")
+                ).value()
             );
-            size = 0;
         }
-        return size;
+        return made.size();
     }
 
     private boolean taken(final Path dir) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -153,7 +153,9 @@ final class Transpiling implements Step {
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(),
-            transpiled + new PackageInfos(this.generated, this.roots).create(),
+            transpiled + new PackageInfos(
+                this.generated, this.roots, files.directories()
+            ).create(),
             this.generated
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PackageInfosTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PackageInfosTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -33,15 +34,18 @@ final class PackageInfosTest {
         Files.createDirectories(subdir.resolve("subsubdir"));
         MatcherAssert.assertThat(
             "We should create exactly two package-info.java files for two subdirectories",
-            new PackageInfos(tmp, Collections.emptyList()).create(),
+            new PackageInfos(
+                tmp, Collections.emptyList(), Arrays.asList(subdir, subdir.resolve("subsubdir"))
+            ).create(),
             Matchers.equalTo(2)
         );
     }
 
     @Test
     void namesTheRootPackageWithAnEmptyValue(@Mktmp final Path tmp) throws IOException {
-        Files.createDirectories(tmp.resolve("org").resolve("eolang"));
-        new PackageInfos(tmp, Collections.emptyList()).create();
+        final Path eolang = tmp.resolve("org").resolve("eolang");
+        Files.createDirectories(eolang);
+        new PackageInfos(tmp, Collections.emptyList(), Collections.singleton(eolang)).create();
         MatcherAssert.assertThat(
             "The root EO package is not the empty name the annotation must carry",
             Files.readString(tmp.resolve("org").resolve("eolang").resolve("package-info.java")),
@@ -59,7 +63,11 @@ final class PackageInfosTest {
             handwritten.resolve("EO_привет").resolve("package-info.java"),
             "package EO_привет;".getBytes(StandardCharsets.UTF_8)
         );
-        new PackageInfos(generated, Collections.singleton(handwritten)).create();
+        new PackageInfos(
+            generated,
+            Collections.singleton(handwritten),
+            Collections.singleton(generated.resolve("EO_привет"))
+        ).create();
         MatcherAssert.assertThat(
             "package-info.java is generated for a package that already has a hand-written one",
             Files.exists(generated.resolve("EO_привет").resolve("package-info.java")),
@@ -73,7 +81,9 @@ final class PackageInfosTest {
         final Path subsubdir = subdir.resolve("subsubdir");
         Files.createDirectory(subdir);
         Files.createDirectories(subsubdir);
-        new PackageInfos(tmp, Collections.emptyList()).create();
+        new PackageInfos(
+            tmp, Collections.emptyList(), Arrays.asList(subdir, subsubdir)
+        ).create();
         MatcherAssert.assertThat(
             "package-info.java should be created in the both subdirectories",
             Files.exists(subdir.resolve("package-info.java"))
@@ -83,17 +93,31 @@ final class PackageInfosTest {
     }
 
     @Test
+    void skipsADirectoryThisRunWroteNothingInto(@Mktmp final Path tmp) throws IOException {
+        final Path foreign = tmp.resolve("annotations").resolve("com").resolve("acme");
+        Files.createDirectories(foreign);
+        new PackageInfos(tmp, Collections.emptyList(), Collections.emptyList()).create();
+        MatcherAssert.assertThat(
+            "a directory another generator owns must not get a package annotation of ours",
+            Files.exists(foreign.resolve("package-info.java")),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void ignoresTheRootDirectoryItself(@Mktmp final Path tmp) throws IOException {
         MatcherAssert.assertThat(
             "No package-info.java files should be created in the root directory",
-            new PackageInfos(tmp, Collections.emptyList()).create(),
+            new PackageInfos(
+                tmp, Collections.emptyList(), Collections.singleton(tmp)
+            ).create(),
             Matchers.equalTo(0)
         );
     }
 
     @Test
     void ignoresTheRootDirectoryAndDoesNotCreateFiles(@Mktmp final Path tmp) throws IOException {
-        new PackageInfos(tmp, Collections.emptyList()).create();
+        new PackageInfos(tmp, Collections.emptyList(), Collections.singleton(tmp)).create();
         MatcherAssert.assertThat(
             "package-info.java should not be created in the root directory",
             Files.exists(tmp.resolve("package-info.java")),
@@ -103,8 +127,9 @@ final class PackageInfosTest {
 
     @Test
     void keepsEoInsideAnObjectsOwnName(@Mktmp final Path tmp) throws IOException {
-        Files.createDirectories(tmp.resolve("org").resolve("eolang").resolve("EO_xEOy"));
-        new PackageInfos(tmp, Collections.emptyList()).create();
+        final Path own = tmp.resolve("org").resolve("eolang").resolve("EO_xEOy");
+        Files.createDirectories(own);
+        new PackageInfos(tmp, Collections.emptyList(), Collections.singleton(own)).create();
         MatcherAssert.assertThat(
             "only the leading EO_ transpiler prefix should be stripped, not the EO inside xEOy",
             Files.readString(
@@ -130,7 +155,7 @@ final class PackageInfosTest {
     ) throws IOException {
         final Path subdir = tmp.resolve(dir);
         Files.createDirectory(subdir);
-        new PackageInfos(tmp, Collections.emptyList()).create();
+        new PackageInfos(tmp, Collections.emptyList(), Collections.singleton(subdir)).create();
         MatcherAssert.assertThat(
             "package-info.java should contain correct package name",
             Files.readString(subdir.resolve("package-info.java")),


### PR DESCRIPTION
`PackageInfos.create()` walked the whole of `target/generated-sources` and
dropped a `package-info.java` into every directory it found. That
directory is shared: `maven-compiler-plugin` writes annotation-processor
output there and `eo:print` writes there by default, so on a build without
`clean` the goal annotated somebody else's packages and shipped the files
in the artifact.

The directories a run wrote a class into are the set `JavaFiles` already
keeps for `removeStale`. It hands them over now, so the creating half
follows the rule the removing half does.

Closes #7943
