### PR TITLE
#7944: remove the test sources a transpile without tests leaves

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaPlaced.java
@@ -51,12 +51,10 @@ final class JavaPlaced implements BiProc<Xnav, Boolean> {
         if (clazz.element("java").text().isPresent()) {
             this.footprint.apply(Paths.get(""), this.target);
         }
-        if (tests) {
-            if (JavaPlaced.testsPresent(clazz)) {
-                this.placeJavaTests(clazz);
-            } else {
-                this.removeJavaTests(clazz);
-            }
+        if (tests && JavaPlaced.testsPresent(clazz)) {
+            this.placeJavaTests(clazz);
+        } else {
+            this.removeJavaTests(clazz);
         }
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -127,7 +127,7 @@ final class JavaPlacedTest {
     }
 
     @Test
-    void removesJavaCompanionsWhenTestsAreNotTranspiled(@Mktmp final Path temp) throws Exception {
+    void removesCompanionsWhenNoneAreTranspiled(@Mktmp final Path temp) throws Exception {
         final Path target = temp.resolve("target");
         final Path generated = target.resolve("generated-sources");
         final Path utest = target.resolve("FooTest.java");

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaPlacedTest.java
@@ -30,7 +30,11 @@ final class JavaPlacedTest {
         final Path target = temp.resolve("target").resolve("Foo.java");
         final String expected = "public final class Main {}";
         final Path generated = temp.resolve("generated-sources");
-        final Xnav java = new Xnav(new Xembler(new Directives().add("java").set(expected)).xml());
+        final Xnav java = new Xnav(
+            new Xembler(
+                new Directives().add("class").attr("java-name", "Foo").add("java").set(expected)
+            ).xml()
+        ).element("class");
         new JavaPlaced(
             new FpJavaGenerated(
                 java,
@@ -119,6 +123,24 @@ final class JavaPlacedTest {
         placed.exec(this.clazz(""), true);
         MatcherAssert.assertThat(
             "Obsolete Java test was not removed", created && Files.notExists(test)
+        );
+    }
+
+    @Test
+    void removesJavaCompanionsWhenTestsAreNotTranspiled(@Mktmp final Path temp) throws Exception {
+        final Path target = temp.resolve("target");
+        final Path generated = target.resolve("generated-sources");
+        final Path utest = target.resolve("FooTest.java");
+        final JavaPlaced placed = new JavaPlaced(
+            new FpJavaGenerated(this.clazz("@Test"), generated, utest), utest, generated
+        );
+        placed.exec(this.clazz("@Test"), true);
+        final Path test = target.resolve("generated-test-sources").resolve("TestFoo.java");
+        final boolean created = Files.exists(test);
+        placed.exec(this.clazz("@Test"), false);
+        MatcherAssert.assertThat(
+            "A test of a previous build survived a transpile that asked for no tests",
+            created && Files.notExists(test)
         );
     }
 


### PR DESCRIPTION
`JavaPlaced.exec` removed an obsolete test only inside the branch that
transpiles tests, so with `-Deo.transpileTests=false` nothing ran at all
and the previous build's test class stayed. `MjTranspile.exec` adds
`generated-test-sources` to the test compile source root either way, so
the tests the build asked not to transpile were compiled and run, and
`JavaFiles.removeStale` never looks into that directory.

The removal now runs whenever the class is not getting a test written for
it, whether it lost its tests or the build asked for none.

Closes #7944
