### PR TITLE
#7945: key a transpile by the rows it actually reads

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Rows.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Rows.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import org.cactoos.Scalar;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * The rows of the inference tables, indexed by the locator each one is about.
+ *
+ * <p>{@code purify.xsl} reads {@code provides.xml} and {@code links.xml} by
+ * locator only, so a transpile of one file reads that file's rows (#7945).</p>
+ *
+ * @since 0.75.0
+ */
+final class Rows {
+
+    /**
+     * The tables, by the locator of the object each row is about.
+     */
+    private final Scalar<SortedMap<String, String>> index;
+
+    /**
+     * Ctor.
+     * @param tables The directory with the tables of {@link MjInference}
+     */
+    Rows(final Path tables) {
+        this.index = new Sticky<>(
+            () -> {
+                final SortedMap<String, String> rows = new TreeMap<>();
+                for (final String name : new String[] {"provides.xml", "links.xml"}) {
+                    final Path table = tables.resolve(name);
+                    if (Files.exists(table)) {
+                        for (final XML row : new XMLDocument(table).nodes("/*/type[@id]")) {
+                            rows.merge(
+                                row.xpath("@id").get(0),
+                                String.format("%s:%s", name, row),
+                                String::concat
+                            );
+                        }
+                    }
+                }
+                return rows;
+            }
+        );
+    }
+
+    /**
+     * Digest of the rows these objects and what they hold are named in.
+     * Absent tables and empty ones answer alike.
+     * @param locators The locators of the objects a file holds
+     * @return Twelve hex characters
+     */
+    String digest(final Collection<String> locators) {
+        final SortedMap<String, String> rows = new Unchecked<>(this.index).value();
+        try {
+            final MessageDigest sha = MessageDigest.getInstance("SHA-256");
+            for (final String locator : new TreeSet<>(locators)) {
+                for (final Map.Entry<String, String> row : rows.tailMap(locator).entrySet()) {
+                    if (!row.getKey().equals(locator)
+                        && !row.getKey().startsWith(String.format("%s.", locator))) {
+                        break;
+                    }
+                    sha.update(row.getKey().getBytes(StandardCharsets.UTF_8));
+                    sha.update(row.getValue().getBytes(StandardCharsets.UTF_8));
+                }
+            }
+            return String.format("%064x", new BigInteger(1, sha.digest())).substring(0, 12);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -17,13 +17,11 @@ import com.yegor256.xsline.Xsline;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.cactoos.Scalar;
-import org.cactoos.scalar.Sticky;
-import org.cactoos.scalar.Unchecked;
 import org.eolang.parser.TrFull;
 
 /**
@@ -132,11 +130,11 @@ final class Transpilation {
     private final Path inference;
 
     /**
-     * The fingerprint of those tables, worked out once and kept, since
-     * {@link #version()} is asked for every source file of the build and
-     * the tables of {@code eo-runtime} are tens of megabytes.
+     * The rows of those tables, indexed once and kept, since a version is
+     * asked for every source file of the build and the tables of
+     * {@code eo-runtime} are tens of megabytes.
      */
-    private final Scalar<String> fingerprint;
+    private final Rows rows;
 
     /**
      * Ctor.
@@ -164,7 +162,7 @@ final class Transpilation {
         this.measures = measures;
         this.target = dir;
         this.inference = tables;
-        this.fingerprint = new Sticky<>(() -> new Fingerprint(tables).get());
+        this.rows = new Rows(tables);
     }
 
     /**
@@ -185,26 +183,38 @@ final class Transpilation {
      * {@code to-java.xsl} emits (see #6031 and #5955), and
      * {@code trackSteps} decides whether the XMIRs of the train are written
      * at all, which a cache hit would otherwise skip (see #7628).
-     * The content of the inference tables is folded in for the same reason:
-     * {@code purify.xsl} reads them and stamps {@code @pure}, which
-     * {@code to-java.xsl} turns into {@code new PhSticky(...)}, so the same
-     * source with different tables, or with none, is different Java (see
-     * #7627). The content and not the path, since a path differs from one
-     * machine to another and a shared cache would never be hit again.
-     * @return The version segment for {@link CachePath}
+     * The tables belong to {@link #version(Collection)} instead.
+     * @return The version segment shared by every source
      */
     String version() {
         return String.format(
-            "%s-%s-%s-%b-%b-%b-%s",
+            "%s-%s-%b-%b-%b-%s",
             this.version,
             new Fingerprint(
                 Stream.concat(
                     Arrays.stream(Transpilation.XSLS), Arrays.stream(Transpilation.IMPORTS)
                 ).toArray(String[]::new)
             ).get(),
-            new Unchecked<>(this.fingerprint).value(),
             this.tracking.locations(), this.tracking.steps(), this.coverage, this.superclass
         );
+    }
+
+    /**
+     * Cache-key version segment for a file holding these objects.
+     *
+     * <p>{@code purify.xsl} reads the tables and stamps {@code @pure}, which
+     * {@code to-java.xsl} turns into {@code new PhSticky(...)}, so a source
+     * with different rows is different Java (#7627, #7945).</p>
+     *
+     * @param locators The locators of the objects the file holds
+     * @return The version segment for {@link CachePath}
+     * @todo #7945:40min Key the Java files by the rows as well.
+     *  `Transpiling` still pools them in one directory made from
+     *  {@link #version()}, which knows nothing about the tables. Hand
+     *  `JavaFiles.total` the directory of the tojo, made here.
+     */
+    String version(final Collection<String> locators) {
+        return String.format("%s-%s", this.version(), this.rows.digest(locators));
     }
 
     /**

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -183,7 +183,9 @@ final class Transpiling implements Step {
             this.guard.apply(
                 source, dest, tail,
                 new Cache(
-                    new CachePath(cdir, this.version(), hsh.get()),
+                    new CachePath(
+                        cdir, this.train.version(xmir.xpath("/object/o/@loc")), hsh.get()
+                    ),
                     src -> {
                         rewrite.compareAndSet(false, true);
                         final String res = transform.apply(xmir).toString();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RowsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RowsTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Rows}.
+ * @since 0.75.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class RowsTest {
+
+    @Test
+    void takesTheRowsOfWhatTheObjectHolds(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a row of an attribute of the object must change the digest of the object",
+            this.digest(temp.resolve("one"), "<type id=\"Q.foo.phi\"><attr name=\"x\"/></type>"),
+            Matchers.not(
+                Matchers.equalTo(this.digest(temp.resolve("two"), "<type id=\"Q.foo.phi\"/>"))
+            )
+        );
+    }
+
+    @Test
+    void leavesTheRowsOfANeighbourOut(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "an object whose locator merely starts with the same letters is somebody else",
+            this.digest(temp.resolve("with"), "<type id=\"Q.foobar\"><attr name=\"x\"/></type>"),
+            Matchers.equalTo(this.digest(temp.resolve("without"), ""))
+        );
+    }
+
+    private String digest(final Path dir, final String rows) throws IOException {
+        Files.createDirectories(dir);
+        Files.writeString(
+            dir.resolve("provides.xml"), String.format("<provides>%s</provides>", rows)
+        );
+        return new Rows(dir).digest(Collections.singletonList("Q.foo"));
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilationTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -37,13 +38,14 @@ final class TranspilationTest {
     @Test
     void tellsInferenceTablesApartInTheCacheKey(@Mktmp final Path temp) throws IOException {
         final Path tables = Files.createDirectories(temp.resolve("tables"));
-        Files.writeString(tables.resolve("provides.xml"), "<provides/>");
+        Files.writeString(tables.resolve("provides.xml"), "<provides><type id='Q.f'/></provides>");
         MatcherAssert.assertThat(
-            "a build that read the tables must not take the result of one that had none",
-            this.transpilation(tables).version(),
+            "a build that read the rows of this object must not take one that had none",
+            this.transpilation(tables).version(Collections.singletonList("Q.f")),
             Matchers.not(
                 Matchers.equalTo(
-                    this.transpilation(temp.resolve("absent")).version()
+                    this.transpilation(temp.resolve("absent"))
+                        .version(Collections.singletonList("Q.f"))
                 )
             )
         );


### PR DESCRIPTION
The cache key folded a fingerprint of the whole module's inference tables, so one new object changed all three tables, every object of the module missed the cache, and a full copy of the previous tree was left behind under `~/.eo/transpiled`.

`purify.xsl` reads two of those tables, `provides.xml` and `links.xml`, and reads them by locator only: a formation by its own `@loc`, a part of an application by its own, and neither answer sends it to another row. So what a transpile of one file reads is that file's own rows, which is what the key folds in now, through the new `Rows`. An edit to one object leaves the cache entries of the others where they are.

Empty tables and absent ones give the same digest, as they must: with neither can the stylesheet label anything.

The `.java` files are still pooled in one directory keyed by the shared `version()`, which no longer knows about the tables. That is not wrong, since a file whose rows changed misses the cache above and is written again, but it should be keyed by the rows too. Left as a `@todo` in `Transpilation`, since both sides do not fit in 200 lines.

Fixes the key reported in #7945; the Java side is in the added `@todo`.
