### PR TITLE
#7918: refuse a compact tuple count spelled with leading zeros

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -120,6 +120,12 @@ final class LnCompactTuple implements Line {
             }
             tokens.seek(tokens.cursor() + 1);
         }
+        if (tokens.cursor() - start > 1 && tokens.body().charAt(start) == '0') {
+            throw new ParseError(
+                span.line(), span.indent() + start,
+                "integer literal must not have leading zeros"
+            );
+        }
         return (int) count;
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
@@ -79,14 +79,12 @@ final class LnCompactTupleTest {
     }
 
     @Test
-    void recordsNFromLeadingZeroDigits() {
-        final Stack stack = new Stack();
-        new LnCompactTuple(new Span("sprintf *007 > x", 1))
-            .into(stack, new Globals(), new Emit());
-        MatcherAssert.assertThat(
-            "leading zero digits must not change the accumulated count",
-            stack.top().count(),
-            Matchers.equalTo(7)
+    void rejectsCountWithLeadingZeros() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnCompactTuple(new Span("sprintf *007 > x", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "a count spelled with leading zeros is no more an integer than 007 is"
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-count-with-leading-zero-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-count-with-leading-zero-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'integer literal must not have leading zeros')]
+input: |
+  [] > root
+    foo *01 > tuple
+      1


### PR DESCRIPTION
`readCount` parsed the digits after `*` straight into an integer and never
put them to the rule R-9.8.1 gives every other `INT`, so `*01` was read as
one and `*00` as nothing, while `01` written anywhere else in the same file
is refused.

The count now carries the same message the table assigns that condition.
A single `*0` stays what it was.

Closes #7918
