### PR TITLE
#7918: reject leading zeros in compact tuple count

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -105,11 +105,21 @@ final class LnCompactTuple implements Line {
 
     private static int readCount(final Tokens tokens, final Span span) {
         long count = 0;
+        int digits = 0;
+        boolean zero = false;
         final int start = tokens.cursor();
         while (!tokens.atEnd()) {
             final char glyph = tokens.current();
             if (glyph < '0' || glyph > '9') {
                 break;
+            }
+            zero = zero || digits == 0 && glyph == '0';
+            digits = digits + 1;
+            if (zero && digits > 1) {
+                throw new ParseError(
+                    span.line(), span.indent() + start,
+                    "integer literal must not have leading zeros"
+                );
             }
             count = count * 10 + glyph - '0';
             if (count > Integer.MAX_VALUE) {

--- a/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnCompactTupleTest.java
@@ -79,18 +79,6 @@ final class LnCompactTupleTest {
     }
 
     @Test
-    void recordsNFromLeadingZeroDigits() {
-        final Stack stack = new Stack();
-        new LnCompactTuple(new Span("sprintf *007 > x", 1))
-            .into(stack, new Globals(), new Emit());
-        MatcherAssert.assertThat(
-            "leading zero digits must not change the accumulated count",
-            stack.top().count(),
-            Matchers.equalTo(7)
-        );
-    }
-
-    @Test
     void rejectsCountAboveIntegerMax() {
         Assertions.assertThrows(
             ParseError.class,
@@ -165,6 +153,23 @@ final class LnCompactTupleTest {
             "a `+>` test attribute on a compact-tuple line preceded by one blank line must not emit any error",
             LnCompactTupleTest.render(emit),
             Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
+    @Test
+    void rejectsCountWithLeadingZero() {
+        final LnCompactTuple line = new LnCompactTuple(new Span("sprintf *01 > x", 1));
+        final Stack stack = new Stack();
+        final Globals globals = new Globals();
+        final Emit emit = new Emit();
+        MatcherAssert.assertThat(
+            "a `*N` count with a leading zero must be rejected the same way as an INT literal",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> line.into(stack, globals, emit),
+                "a zero-padded compact tuple count must not parse"
+            ).getMessage(),
+            Matchers.containsString("integer literal must not have leading zeros")
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-count-with-leading-zero.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/compact-tuple-count-with-leading-zero.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #7918: the `*N` count was read straight into an integer, so a zero-padded
+# count slipped through, while the very same spelling is invalid as a plain
+# INT literal under R-9.8.1.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'integer literal must not have leading zeros')]
+input: |
+  [] > root
+    foo *01 > tuple
+      1


### PR DESCRIPTION
Closes #7918.

`LnCompactTuple.readCount()` parsed the digits after `*` straight into an integer, so `foo *01` passed while `01` as a plain INT is rejected by R-9.8.1. Now the count applies the same rule: a multi-digit count starting with `0` fails with `integer literal must not have leading zeros`, and `*0` stays valid.

`recordsNFromLeadingZeroDigits`, added by 715daaa1ef for coverage, asserted `*007` parses as 7 — the very behaviour #7918 reports as a bug — so it is removed. `recordsZeroFromExplicitZeroDigit` keeps `*0` covered.

@yegor256 Could you please take a look