### PR TITLE
#7919: put an inline-phi argument group to the all-or-nothing rule

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -28,10 +28,14 @@ final class Bindings {
     /**
      * The parent kinds whose deeper children are application arguments,
      * so the all-or-nothing rule of R-6.6.2 governs the group they form.
+     * An inline-phi formation is one of them: the block under a bare
+     * {@code φ} is the argument group of the expression the line binds to
+     * {@code φ}, and an application is no less one for being written with
+     * an inline-phi suffix instead of a head (#7919).
      */
     private static final Set<Kind> TRACKED = EnumSet.of(
         Kind.HEAD, Kind.HMETHOD, Kind.VAPPLICATION, Kind.IDENTITY_OBJECT,
-        Kind.PIPE_APPLICATION, Kind.COMPACT_TUPLE, Kind.VMETHOD
+        Kind.PIPE_APPLICATION, Kind.COMPACT_TUPLE, Kind.VMETHOD, Kind.ONLY_PHI
     );
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-inline-phi-group-reversed.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-inline-phi-group-reversed.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'argument bindings must be all-or-nothing')]
+input: |
+  [] > app
+    foo > [x] > result
+      first
+      second:second

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-inline-phi-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/mixed-bindings-in-inline-phi-group.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'argument bindings must be all-or-nothing')]
+input: |
+  [] > app
+    foo > [x] > result
+      first:first
+      second


### PR DESCRIPTION
`Bindings.observeChild` tracked every parent whose deeper children are
application arguments except the inline-phi formation, so the block under
a bare `φ` could mix a bound argument with an unbound one and nothing said
so. The same group written with an explicit head is refused.

`Kind.ONLY_PHI` joins the tracked kinds. An application is no less one for
being written with an inline-phi suffix.

Closes #7919
