### PR TITLE
#7920: refuse a chain continuation after a bound link

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -144,6 +144,13 @@ final class Level {
     private boolean argbound;
 
     /**
+     * True when the chain link this entry currently ends with carries an
+     * inline binding, read by {@link LnMethod} to refuse a continuation
+     * that would leave it on a link the chain no longer ends with.
+     */
+    private boolean tied;
+
+    /**
      * Source span recorded with the in-progress arg, used for error
      * positioning when {@link #commitArg()} rejects the arg
      * against the group mode.
@@ -533,6 +540,25 @@ final class Level {
     }
 
     /**
+     * Whether the link this chain currently ends with carries an inline
+     * binding.
+     * @return Tied flag
+     */
+    boolean tied() {
+        return this.tied;
+    }
+
+    /**
+     * Record that the link this chain now ends with carries an inline
+     * binding, so a further {@code .method} continuation can tell that it
+     * would leave that binding on a link that is no longer the last one
+     * (R-6.6.4).
+     */
+    void tie() {
+        this.tied = true;
+    }
+
+    /**
      * A detached twin of this entry, carrying the same mutable state at
      * the moment of copying. Lets {@link Stack} take a savepoint that
      * later mutation of this entry cannot reach (R-7.3).
@@ -560,5 +586,6 @@ final class Level {
         this.argpending = other.argpending;
         this.argbound = other.argbound;
         this.argspan = other.argspan;
+        this.tied = other.tied;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -129,19 +129,13 @@ final class Level {
     private int bindings;
 
     /**
-     * Whether a child arg is currently being tracked but has not yet
-     * been committed into {@link #bindings} — see
-     * {@link #observeBinding(boolean, Span)} / {@link #commitArg()}.
+     * The in-progress child arg, in the same spelling as
+     * {@link #bindings} — 0 none tracked yet, 1 unbound, 2 bound. Held
+     * apart from {@link #bindings} until {@link #commitArg()} joins it,
+     * since {@link #upgradeArgBinding()} may still turn it to bound when
+     * a {@code .method} continuation picks up an outer binding.
      */
-    private boolean argpending;
-
-    /**
-     * Whether the in-progress arg carries a binding (so far). May be
-     * flipped to {@code true} mid-chain by
-     * {@link #upgradeArgBinding()} when a {@code .method} continuation
-     * picks up an outer binding.
-     */
-    private boolean argbound;
+    private int arg;
 
     /**
      * True when the chain link this entry currently ends with carries an
@@ -467,8 +461,7 @@ final class Level {
         this.children = 0;
         this.count = 0;
         this.bindings = 0;
-        this.argpending = false;
-        this.argbound = false;
+        this.arg = 0;
     }
 
     /**
@@ -498,8 +491,11 @@ final class Level {
      */
     void observeBinding(final boolean bound, final Span span) {
         this.commitArg();
-        this.argpending = true;
-        this.argbound = bound;
+        if (bound) {
+            this.arg = 2;
+        } else {
+            this.arg = 1;
+        }
         this.argspan = span;
     }
 
@@ -510,7 +506,7 @@ final class Level {
      * link per the chain-binding rule).
      */
     void upgradeArgBinding() {
-        this.argbound = true;
+        this.arg = 2;
     }
 
     /**
@@ -519,23 +515,17 @@ final class Level {
      * before starting a new arg and at parent close time.
      */
     void commitArg() {
-        if (this.argpending) {
-            final int code;
-            if (this.argbound) {
-                code = 2;
-            } else {
-                code = 1;
-            }
+        if (this.arg != 0) {
+            final int code = this.arg;
+            this.arg = 0;
             if (this.bindings == 0) {
                 this.bindings = code;
             } else if (this.bindings != code) {
-                this.argpending = false;
                 throw new ParseError(
                     this.argspan.line(), this.argspan.indent(),
                     "argument bindings must be all-or-nothing"
                 );
             }
-            this.argpending = false;
         }
     }
 
@@ -583,8 +573,7 @@ final class Level {
         this.tupled = other.tupled;
         this.star = other.star;
         this.bindings = other.bindings;
-        this.argpending = other.argpending;
-        this.argbound = other.argbound;
+        this.arg = other.arg;
         this.argspan = other.argspan;
         this.tied = other.tied;
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -30,6 +30,9 @@ import java.util.List;
  * completed predecessor.</li>
  * <li>R-5.2.5 — {@code .method} as a deeper-indent line.</li>
  * <li>R-5.2.10 — {@code .method} at top level (empty stack).</li>
+ * <li>R-6.6.4 — a {@code .method} continuation after a link that
+ * carries an inline binding, which the continuation would leave on a
+ * link the chain no longer ends with.</li>
  * </ul>
  *
  * <p>Emission follows §9.0.3: each chain link is a separate flat
@@ -110,6 +113,9 @@ final class LnMethod implements Line {
         }
         top.become(kind);
         top.close(openness);
+        if (outer != null) {
+            top.tie();
+        }
         if (suffix.present()) {
             top.name(suffix.label());
         }
@@ -134,6 +140,12 @@ final class LnMethod implements Line {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "method continuation not allowed after only-phi formation"
+            );
+        }
+        if (stack.top().tied()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "inline binding allowed only on the last method in a chain"
             );
         }
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-a-non-last-vertical-method-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-a-non-last-vertical-method-is-rejected.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'inline binding allowed only on the last method in a chain')]
+input: |
+  [] > app
+    source
+    .first:slot
+    .second > result

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-the-last-vertical-method-is-accepted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-on-the-last-vertical-method-is-accepted.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@as='slot']
+input: |
+  [] > app
+    source
+    .first
+    .second:slot > result


### PR DESCRIPTION
R-6.6.4 allows an inline binding on the last method of a chain only, but a
vertical chain never checked it: `.first:slot` followed by `.second` was
accepted and kept `@as="slot"` on a dispatch the chain no longer ends
with, naming a value the next dispatch immediately replaces.

The level now remembers whether the link it ends with is bound, and a
further `.method` is refused with the text the §9.9 table assigns.

Closes #7920
