### PR TITLE
#7921: put a bytes continuation to the odd-indent rule

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -198,6 +198,11 @@ final class Eo implements Iterable<Directive> {
                 broken = true;
                 break;
             }
+            if (!next.blank() && next.indent() % 2 == 1) {
+                emit.error(next.line(), 0, "unexpected odd indent");
+                broken = true;
+                break;
+            }
             if (!Eo.isBytesOnly(trimmed)) {
                 emit.error(
                     next.line(), 0, "multi-line bytes interrupted by non-byte content"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/odd-indent-of-a-bytes-continuation-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/odd-indent-of-a-bytes-continuation-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unexpected odd indent')]
+input: |
+  [] > app
+    CA-FE-
+     BE-BE


### PR DESCRIPTION
The continuation path checked only that a chunk does not de-indent from
its opener, so a chunk at three spaces was merged where an ordinary line
at the same column is refused. Indentation is semantic in EO, and validity
was depending on whether the line happened to be a byte chunk.

A continuation at an odd indent now gets the same message every other line
gets.

Closes #7921
