### PR TITLE
#7922: put a bytes continuation to the one-level indent rule

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/BytesIndent.java
+++ b/eo-parser/src/main/java/org/eolang/parser/BytesIndent.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+/**
+ * What is wrong with the indent of one line of a multi-line bytes literal.
+ *
+ * <p>A continuation must not de-indent below the line that opened the
+ * literal, must not sit on an odd indent (R-2.2.1), and must not jump more
+ * than one level deeper than the line above it, which is the same rule
+ * every other block line obeys.</p>
+ *
+ * @since 0.1
+ */
+final class BytesIndent {
+
+    /**
+     * The continuation line.
+     */
+    private final Span line;
+
+    /**
+     * Indent of the line that opened the literal.
+     */
+    private final int head;
+
+    /**
+     * Indent of the line right above this one.
+     */
+    private final int above;
+
+    /**
+     * Ctor.
+     * @param span The continuation line
+     * @param opener Indent of the line that opened the literal
+     * @param previous Indent of the line right above this one
+     */
+    BytesIndent(final Span span, final int opener, final int previous) {
+        this.line = span;
+        this.head = opener;
+        this.above = previous;
+    }
+
+    /**
+     * Report what is wrong with this line, if anything is.
+     * @param emit Where the complaint goes
+     * @return True when the line was reported
+     */
+    boolean reported(final Emit emit) {
+        final String complaint = this.complaint();
+        final boolean wrong = !complaint.isEmpty();
+        if (wrong) {
+            emit.error(this.line.line(), 0, complaint);
+        }
+        return wrong;
+    }
+
+    private String complaint() {
+        final String found;
+        if (this.line.blank()) {
+            found = "";
+        } else if (this.line.indent() < this.head) {
+            found = "multi-line bytes continuation must not de-indent";
+        } else if (this.line.indent() % 2 == 1) {
+            found = "unexpected odd indent";
+        } else if (this.line.indent() > this.above + 2) {
+            found = "indent increased by more than one level";
+        } else {
+            found = "";
+        }
+        return found;
+    }
+}

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -187,22 +187,16 @@ final class Eo implements Iterable<Directive> {
         final Span head = spans.get(start);
         final StringBuilder body = new StringBuilder(head.body().stripTrailing());
         int idx = start + 1;
+        int above = head.indent();
         boolean broken = false;
         while (idx < spans.size()) {
             final Span next = spans.get(idx);
             final String trimmed = next.body().stripTrailing();
-            if (!next.blank() && next.indent() < head.indent()) {
-                emit.error(
-                    next.line(), 0, "multi-line bytes continuation must not de-indent"
-                );
+            if (new BytesIndent(next, head.indent(), above).reported(emit)) {
                 broken = true;
                 break;
             }
-            if (!next.blank() && next.indent() % 2 == 1) {
-                emit.error(next.line(), 0, "unexpected odd indent");
-                broken = true;
-                break;
-            }
+            above = next.indent();
             if (!Eo.isBytesOnly(trimmed)) {
                 emit.error(
                     next.line(), 0, "multi-line bytes interrupted by non-byte content"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/indent-jump-of-a-bytes-continuation-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/indent-jump-of-a-bytes-continuation-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'indent increased by more than one level')]
+input: |
+  foo > main
+    CA-FE-
+        BE-BE

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/one-level-deeper-bytes-continuation-is-accepted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/one-level-deeper-bytes-continuation-is-accepted.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.bytes']/o[text()='CA-FE-BE-BE']
+input: |
+  foo > main
+    CA-FE-
+      BE-BE


### PR DESCRIPTION
The merger took any chunk at least as deep as its opener, so a jump from
two spaces to six was accepted where the same jump on an ordinary line is
refused. Significant whitespace decides EO structure, and the special
bytes path was letting malformed source through on the strength of being
a byte chunk.

A chunk deeper than one level below the line above it now gets the message
every other line gets. A chunk at the opener's indent, or one level below
it, is merged as before.

Closes #7922
