### PR TITLE
#7923: refuse leftover content before a parenthesised inline-phi

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -506,7 +506,9 @@ final class Emissions {
             pcol = pcol + param.length() + 1;
         }
         final Span sub = new Span(" ".repeat(column).concat(lhs), line);
-        Emissions.expression(emit, "φ", new Tokens(sub.body(), sub), line);
+        final Tokens tokens = new Tokens(sub.body(), sub);
+        Emissions.expression(emit, "φ", tokens, line);
+        tokens.checkEnd("unexpected content in the body of an only-phi formation");
         emit.close();
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-inside-a-parenthesised-inline-phi-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/binding-inside-a-parenthesised-inline-phi-is-rejected.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unexpected content in the body of an only-phi formation')]
+input: |
+  foo (bar:slot > [x]) > result

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-inside-a-parenthesised-inline-phi-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/name-suffix-inside-a-parenthesised-inline-phi-is-rejected.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unexpected content in the body of an only-phi formation')]
+input: |
+  foo (bar > named > [x]) > result


### PR DESCRIPTION
`Emissions.inlinePhi` read the expression on the left of `> [params]` and
never asked the reader whether it had reached the end of it, so
`(bar > named > [x])` silently dropped the `> named` and parsed into the
same XMIR as `(bar > [x])`. Two different programs became
indistinguishable, and the same happened to an outer binding.

The reader is now asked, with the message the vertical form of the same
line already gives.

Closes #7923
