### PR TITLE
#7924: refuse leading whitespace that is not a space or a tab

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1343,6 +1343,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Odd indent | `unexpected odd indent` |
 | Indent jump > 1 level | `indent increased by more than one level` |
 | Tab in leading whitespace | `tab character in leading whitespace` |
+| Leading whitespace other than a space or a tab (R-2.2.1) | `invalid character in leading whitespace` |
 | Trailing space or tab at end of a non-blank line | `trailing whitespace at end of line` |
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
 | `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application, try vertical application instead` |

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -263,6 +263,9 @@ final class Eo implements Iterable<Directive> {
         } else if (span.tab() && !span.blank()) {
             emit.error(span.line(), 0, "tab character in leading whitespace");
             failed = true;
+        } else if (span.alien() && !span.blank()) {
+            emit.error(span.line(), 0, "invalid character in leading whitespace");
+            failed = true;
         } else if (!span.blank() && span.indent() % 2 == 1) {
             emit.error(span.line(), 0, "unexpected odd indent");
             failed = true;

--- a/eo-parser/src/main/java/org/eolang/parser/Span.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Span.java
@@ -122,6 +122,26 @@ final class Span {
     }
 
     /**
+     * True if the leading whitespace holds a character that is neither a
+     * space nor a tab. An indent is made of spaces (R-2.2.1), and a
+     * character nobody can see in an editor must not decide how deep a
+     * line sits: a pair of form feeds reads as indent 1 to a counter that
+     * takes every whitespace character (#7924).
+     * @return Alien-whitespace flag
+     */
+    boolean alien() {
+        boolean found = false;
+        for (int idx = 0; idx < this.indent; idx = idx + 1) {
+            final char glyph = this.text.charAt(idx);
+            if (glyph != ' ' && glyph != '\t') {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    /**
      * True if the line is entirely whitespace.
      * @return Blank flag
      */

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/form-feed-indent-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/form-feed-indent-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'invalid character in leading whitespace')]
+input: "[] > app\n\f\ffoo > x\n"


### PR DESCRIPTION
`Span` counted every `Character.isWhitespace` character as indentation, so
a pair of form feeds read as indent 1 and nested an object exactly as two
spaces would. An em space and a vertical tab did the same. R-2.2.1 makes
an indent out of spaces, and a character nobody can see in an editor must
not decide how deep a line sits.

Leading whitespace that is neither a space nor a tab is now refused, next
to the tab rule it sits beside, with a row of its own in the §9.9 table.

Closes #7924
