### PR TITLE
#7924: reject stray whitespace where an indent belongs

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -135,7 +135,7 @@ R-2.1.2. Line endings are `\n` or `\r\n`. The parser normalises both to `\n` int
 R-2.2.1. The indent unit is **two spaces**. Odd leading-space counts are an error: `unexpected odd indent`.
 R-2.2.2. Between two consecutive non-blank lines, indent may **increase by at most one level** (i.e., +2 spaces).
 R-2.2.3. Indent may decrease by any amount.
-R-2.2.4. Tabs in leading whitespace are rejected.
+R-2.2.4. Tabs in leading whitespace are rejected. Any other whitespace that is not a space, like a form feed or an em space, is rejected there too: `non-space whitespace in leading indentation`.
 R-2.2.5. A non-blank line whose last character is a space or a tab is rejected: `trailing whitespace at end of line`. This applies to every line, including a text-block body line (§3.11), which bypasses the ordinary line dispatch but is checked the same way. A whitespace-only (blank) line is exempt.
 
 Example:

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -263,6 +263,9 @@ final class Eo implements Iterable<Directive> {
         } else if (span.tab() && !span.blank()) {
             emit.error(span.line(), 0, "tab character in leading whitespace");
             failed = true;
+        } else if (span.stray() && !span.blank()) {
+            emit.error(span.line(), 0, "non-space whitespace in leading indentation");
+            failed = true;
         } else if (!span.blank() && span.indent() % 2 == 1) {
             emit.error(span.line(), 0, "unexpected odd indent");
             failed = true;

--- a/eo-parser/src/main/java/org/eolang/parser/Span.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Span.java
@@ -14,8 +14,8 @@ package org.eolang.parser;
  * {@link Source} that produced this span has already normalised line
  * endings (R-2.1.2).</p>
  *
- * <p>The indent count is computed once, at construction time, and does not
- * mutate. A blank line (entire line is whitespace) yields a span with
+ * <p>The leading whitespace is taken once, at construction time, and does
+ * not mutate. A blank line (entire line is whitespace) yields a span with
  * {@code indent == text.length()}.</p>
  *
  * <p>Per spec R-2.2.1: an odd indent is a {@code unexpected odd indent}
@@ -38,15 +38,10 @@ final class Span {
     private final int number;
 
     /**
-     * Count of leading whitespace characters before the first
-     * non-whitespace one.
+     * Leading whitespace, everything before the first non-whitespace
+     * character.
      */
-    private final int indent;
-
-    /**
-     * Whether any leading whitespace character is a tab.
-     */
-    private final boolean tab;
+    private final String lead;
 
     /**
      * Ctor.
@@ -58,34 +53,22 @@ final class Span {
     }
 
     /**
-     * Ctor.
-     * @param body Line text
-     * @param line Line number
-     * @param leading Count of leading whitespace chars
-     */
-    private Span(final String body, final int line, final int leading) {
-        this(body, line, leading, Span.tabbed(body, leading));
-    }
-
-    /**
      * Primary ctor.
      * @param body Line text
      * @param line Line number
-     * @param leading Count of leading whitespace chars
-     * @param tabbed True if any leading char is a tab
+     * @param leading Leading whitespace of the line
      */
-    private Span(final String body, final int line, final int leading, final boolean tabbed) {
+    private Span(final String body, final int line, final String leading) {
         this.text = body;
         this.number = line;
-        this.indent = leading;
-        this.tab = tabbed;
+        this.lead = leading;
     }
 
     @Override
     public String toString() {
         return String.format(
             "Span(line=%d, indent=%d, text='%s')",
-            this.number, this.indent, this.text
+            this.number, this.indent(), this.text
         );
     }
 
@@ -110,7 +93,7 @@ final class Span {
      * @return Indent
      */
     int indent() {
-        return this.indent;
+        return this.lead.length();
     }
 
     /**
@@ -118,7 +101,26 @@ final class Span {
      * @return Tab flag
      */
     boolean tab() {
-        return this.tab;
+        return this.lead.indexOf('\t') >= 0;
+    }
+
+    /**
+     * True if leading whitespace contains whitespace that is neither a
+     * space nor a tab, like a form feed or an em space. Only ASCII spaces
+     * build an indent (R-2.2.1) and tabs have a rule of their own
+     * (R-2.2.4), so anything else in that position is stray.
+     * @return Stray-whitespace flag
+     */
+    boolean stray() {
+        boolean found = false;
+        for (int idx = 0; idx < this.lead.length(); idx = idx + 1) {
+            final char glyph = this.lead.charAt(idx);
+            if (glyph != ' ' && glyph != '\t') {
+                found = true;
+                break;
+            }
+        }
+        return found;
     }
 
     /**
@@ -126,7 +128,7 @@ final class Span {
      * @return Blank flag
      */
     boolean blank() {
-        return this.indent == this.text.length();
+        return this.indent() == this.text.length();
     }
 
     /**
@@ -151,7 +153,7 @@ final class Span {
      * @return Tail text (empty for blank lines)
      */
     String body() {
-        return this.text.substring(this.indent);
+        return this.text.substring(this.indent());
     }
 
     /**
@@ -167,25 +169,14 @@ final class Span {
                 )
             );
         }
-        return this.text.charAt(this.indent);
+        return this.text.charAt(this.indent());
     }
 
-    private static int leading(final String body) {
+    private static String leading(final String body) {
         int count = 0;
         while (count < body.length() && Character.isWhitespace(body.charAt(count))) {
             count = count + 1;
         }
-        return count;
-    }
-
-    private static boolean tabbed(final String body, final int leading) {
-        boolean found = false;
-        for (int idx = 0; idx < leading; idx = idx + 1) {
-            if (body.charAt(idx) == '\t') {
-                found = true;
-                break;
-            }
-        }
-        return found;
+        return body.substring(0, count);
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -104,6 +104,17 @@ final class EoTest {
     }
 
     @Test
+    void reportsStrayWhitespaceInIndent() {
+        MatcherAssert.assertThat(
+            "a form feed used as an indent must be reported instead of nesting the line",
+            EoTest.render("[] > app", "\f\ffoo > x"),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'non-space whitespace in leading indentation')]"
+            )
+        );
+    }
+
+    @Test
     void reportsTabInLeadingWhitespace() {
         MatcherAssert.assertThat(
             "a tab inside leading whitespace must be reported with the canonical message",

--- a/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SpanTest.java
@@ -248,4 +248,40 @@ final class SpanTest {
             Matchers.equalTo(42)
         );
     }
+
+    @Test
+    void detectsFormFeedInLeadingWhitespace() {
+        MatcherAssert.assertThat(
+            "a form feed standing where an indent belongs must be reported as stray whitespace",
+            new Span("\f\fzaphod > x", 1).stray(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void detectsEmSpaceInLeadingWhitespace() {
+        MatcherAssert.assertThat(
+            "an em space standing where an indent belongs must be reported as stray whitespace",
+            new Span("  \u2003marvin", 13).stray(),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void ignoresPlainSpacesAsStrayWhitespace() {
+        MatcherAssert.assertThat(
+            "an indent of plain spaces cannot carry stray whitespace",
+            new Span("    trillian > y", 7).stray(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void ignoresTabAsStrayWhitespace() {
+        MatcherAssert.assertThat(
+            "a tab has its own rule and must not be reported as stray whitespace",
+            new Span("\tarthur", 4).stray(),
+            Matchers.is(false)
+        );
+    }
 }


### PR DESCRIPTION
Closes #7924.

`Span.leading()` counted every `Character.isWhitespace()` glyph as indent, so a line starting with two form feeds or two em spaces nested as if it started with two spaces. Only spaces build an indent (R-2.2.1) and tabs have their own rule (R-2.2.4); anything else in that position is now reported as `non-space whitespace in leading indentation`.

`Span` keeps the leading whitespace itself instead of a count plus a tab flag, so `indent()`, `tab()` and the new `stray()` all read from one attribute.

@yegor256 Could you please take a look