### PR TITLE
#7925: stop reading a lone carriage return as a line ending

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1349,6 +1349,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Indent jump > 1 level | `indent increased by more than one level` |
 | Tab in leading whitespace | `tab character in leading whitespace` |
 | Leading whitespace other than a space or a tab (R-2.2.1) | `invalid character in leading whitespace` |
+| Carriage return that no line feed follows (R-2.1.2) | `standalone carriage return is not a line ending` |
 | Trailing space or tab at end of a non-blank line | `trailing whitespace at end of line` |
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
 | `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application, try vertical application instead` |

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -85,7 +85,13 @@ final class Eo implements Iterable<Directive> {
         int idx = 0;
         while (idx < spans.size()) {
             final Span span = spans.get(idx);
-            if (!globals.inTextBlock() && !span.trailing()
+            final int carriage = span.text().indexOf('\r');
+            if (carriage >= 0) {
+                emit.error(
+                    span.line(), carriage, "standalone carriage return is not a line ending"
+                );
+                idx = recovery.after(idx);
+            } else if (!globals.inTextBlock() && !span.trailing()
                 && Eo.isBytesContinuation(span.body())) {
                 idx = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit, recovery);
             } else if (Eo.process(span, stack, globals, emit)) {

--- a/eo-parser/src/main/java/org/eolang/parser/Source.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Source.java
@@ -60,13 +60,10 @@ final class Source implements Iterable<Span> {
                 number = number + 1;
                 pos = pos + 1;
                 start = pos;
-            } else if (glyph == '\r') {
+            } else if (glyph == '\r' && pos + 1 < len && text.charAt(pos + 1) == '\n') {
                 out.add(new Span(text.substring(start, pos), number));
                 number = number + 1;
-                pos = pos + 1;
-                if (pos < len && text.charAt(pos) == '\n') {
-                    pos = pos + 1;
-                }
+                pos = pos + 2;
                 start = pos;
             } else {
                 pos = pos + 1;

--- a/eo-parser/src/test/java/org/eolang/parser/SourceTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SourceTest.java
@@ -50,11 +50,11 @@ final class SourceTest {
     }
 
     @Test
-    void splitsOnBareCarriageReturn() {
+    void keepsBareCarriageReturnInsideTheLine() {
         MatcherAssert.assertThat(
-            "a bare CR must terminate a line by itself",
+            "R-2.1.2 knows two line endings, and a lone CR is neither of them",
             SourceTest.texts(new Source("alpha".concat(SourceTest.creturn()).concat("beta"))),
-            Matchers.contains("alpha", "beta")
+            Matchers.contains("alpha".concat(SourceTest.creturn()).concat("beta"))
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/standalone-carriage-return-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/standalone-carriage-return-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'standalone carriage return is not a line ending')]
+input: "[] > app\r  foo > x\r"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/windows-line-endings-are-accepted.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/windows-line-endings-are-accepted.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='x']
+input: "[] > app\r\n  foo > x\r\n"


### PR DESCRIPTION
`Source.spans` split on every `\r`, so a file with classic-Mac line
endings parsed as if it held ordinary lines, while R-2.1.2 knows two line
endings and a lone CR is neither.

The splitter now takes `\r\n` as one ending and leaves a lone `\r` in the
line, where the walk reports it by name at its own column. CRLF keeps
splitting the way LF does.

Closes #7925
