### PR TITLE
#7926: refuse an alias target that names a scope

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Dotted.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Dotted.java
@@ -4,6 +4,10 @@
  */
 package org.eolang.parser;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * A dotted path written in a meta directive.
  *
@@ -15,6 +19,16 @@ package org.eolang.parser;
  * @since 0.74.0
  */
 final class Dotted {
+
+    /**
+     * The tokens that name a scope or the root rather than an object:
+     * the {@code @} decoratee, the {@code ^} parent, the {@code $} self
+     * and the root, in both the spelling the source uses and the one
+     * {@code LnMeta} promotes it to.
+     */
+    private static final Set<String> SCOPES = new HashSet<>(
+        Arrays.asList("@", "^", "$", "Q", "Φ")
+    );
 
     /**
      * The path.
@@ -37,5 +51,29 @@ final class Dotted {
         return this.path.startsWith(".")
             || this.path.endsWith(".")
             || this.path.contains("..");
+    }
+
+    /**
+     * Whether a segment of the path names a scope instead of an object.
+     *
+     * <p>A forma path is made of names, optionally rooted at the global
+     * root. {@code expand-aliases.xsl} copies the path into a base with
+     * the root in front of it, so a scope token there comes out as
+     * {@code Φ.@}, which names nothing (#7926). The root itself is a
+     * scope token too, and stands only at the head of a longer path.</p>
+     *
+     * @return True if a segment of it is a scope token
+     */
+    boolean scoped() {
+        final String[] parts = this.path.split("\\.", -1);
+        boolean found = false;
+        for (int idx = 0; idx < parts.length && !found; idx = idx + 1) {
+            found = Dotted.SCOPES.contains(parts[idx]) && !Dotted.rooted(parts, idx);
+        }
+        return found;
+    }
+
+    private static boolean rooted(final String[] parts, final int idx) {
+        return idx == 0 && parts.length > 1 && "Φ".equals(parts[idx]);
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -120,45 +120,53 @@ final class LnMeta implements Line {
             );
         }
         if ("package".equals(head)) {
-            if (parts.size() != 1) {
-                throw new ParseError(
-                    this.span.line(), this.span.indent(),
-                    "'+package' directive requires exactly one argument"
-                );
-            }
-            if (new Dotted(parts.get(0)).broken()) {
-                throw new ParseError(
-                    this.span.line(), this.span.indent(),
-                    "'+package' path must not have an empty segment"
-                );
-            }
+            this.checkPackage(parts);
         }
         if ("alias".equals(head)) {
-            if (parts.isEmpty()) {
-                throw new ParseError(
-                    this.span.line(), this.span.indent(),
-                    "'+alias' directive requires at least one argument"
-                );
-            }
-            if (LnMeta.ROOT.equals(parts.get(0))) {
-                throw new ParseError(
-                    this.span.line(), this.span.indent(),
-                    "'+alias' cannot rename the root token Q"
-                );
-            }
-            final Dotted target = new Dotted(parts.get(parts.size() - 1));
-            if (target.broken()) {
-                throw new ParseError(
-                    this.span.line(), this.span.indent(),
-                    "'+alias' target must not have an empty segment"
-                );
-            }
-            if (target.scoped()) {
-                throw new ParseError(
-                    this.span.line(), this.span.indent(),
-                    "'+alias' target must be an object name, not a scope token"
-                );
-            }
+            this.checkAlias(parts);
+        }
+    }
+
+    private void checkPackage(final List<String> parts) {
+        if (parts.size() != 1) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+package' directive requires exactly one argument"
+            );
+        }
+        if (new Dotted(parts.get(0)).broken()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+package' path must not have an empty segment"
+            );
+        }
+    }
+
+    private void checkAlias(final List<String> parts) {
+        if (parts.isEmpty()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+alias' directive requires at least one argument"
+            );
+        }
+        if (LnMeta.ROOT.equals(parts.get(0))) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+alias' cannot rename the root token Q"
+            );
+        }
+        final Dotted target = new Dotted(parts.get(parts.size() - 1));
+        if (target.broken()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+alias' target must not have an empty segment"
+            );
+        }
+        if (target.scoped()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "'+alias' target must be an object name, not a scope token"
+            );
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -146,10 +146,17 @@ final class LnMeta implements Line {
                     "'+alias' cannot rename the root token Q"
                 );
             }
-            if (new Dotted(parts.get(parts.size() - 1)).broken()) {
+            final Dotted target = new Dotted(parts.get(parts.size() - 1));
+            if (target.broken()) {
                 throw new ParseError(
                     this.span.line(), this.span.indent(),
                     "'+alias' target must not have an empty segment"
+                );
+            }
+            if (target.scoped()) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent(),
+                    "'+alias' target must be an object name, not a scope token"
                 );
             }
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/alias-to-a-scope-token-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/alias-to-a-scope-token-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),"'+alias' target must be an object name, not a scope token")]
+input: |
+  +alias local @
+
+  local > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/alias-to-the-root-token-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/alias-to-the-root-token-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),"'+alias' target must be an object name, not a scope token")]
+input: |
+  +alias global Q
+
+  global > app


### PR DESCRIPTION
The `+alias` check looked at the alias name and at empty segments and
never at what the target is, so `+alias local @` was accepted and
`expand-aliases.xsl` turned it into the base `Φ.@`, which names nothing.
The same happened to `^`, `$` and a bare `Q`, and a use of the alias
resolved to the malformed base instead of being refused where it was
written.

A target whose segment names a scope, or the root standing on its own, is
now refused at the directive.

Closes #7926
