### PR TITLE
#7927: refuse a control character inside an identifier

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Scrubbed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Scrubbed.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.parser;
 
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -45,5 +46,27 @@ final class Scrubbed {
     @Override
     public String toString() {
         return Scrubbed.FORBIDDEN.matcher(this.origin).replaceAll("");
+    }
+
+    /**
+     * Where the first character an XML node cannot hold sits.
+     *
+     * <p>Text is scrubbed of them, but a name is not: it becomes an
+     * attribute of a generated object, and a name with a hole in it is
+     * not the name the source wrote. A reader of an identifier asks this
+     * instead, and reports the character at the column it sits in
+     * (#7927).</p>
+     *
+     * @return Index of the first such character, or -1 when there is none
+     */
+    int found() {
+        final Matcher matcher = Scrubbed.FORBIDDEN.matcher(this.origin);
+        final int index;
+        if (matcher.find()) {
+            index = matcher.start();
+        } else {
+            index = -1;
+        }
+        return index;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -310,7 +310,7 @@ final class Suffix {
      * @return Emitted token — variable verbatim, forma promoted
      */
     static String typeAtom(final String raw, final Span span, final int pos) {
-        Suffix.checkCactus(raw, span, pos);
+        Suffix.checkGlyphs(raw, span, pos);
         final char first = raw.charAt(0);
         if (first >= 'A' && first <= 'Z'
             && !Suffix.VARIABLE.matcher(raw).matches() && !raw.startsWith("Q.")) {
@@ -399,7 +399,7 @@ final class Suffix {
             );
         }
         final String name = tail.substring(start, idx);
-        Suffix.checkCactus(name, span, home + start);
+        Suffix.checkGlyphs(name, span, home + start);
         Suffix.checkLowercaseStart(name, span, home, start);
         Suffix.endsClean(tail, idx, span, home);
         return new Suffix(form, name, "", false);
@@ -425,11 +425,18 @@ final class Suffix {
         }
     }
 
-    private static void checkCactus(final String name, final Span span, final int pos) {
+    private static void checkGlyphs(final String name, final Span span, final int pos) {
         if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
             throw new ParseError(
                 span.line(), pos,
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
+        final int control = new Scrubbed(name).found();
+        if (control >= 0) {
+            throw new ParseError(
+                span.line(), pos + control,
+                "control character is not allowed in an identifier"
             );
         }
     }
@@ -477,7 +484,7 @@ final class Suffix {
                 )
             );
         }
-        Suffix.checkCactus(handle, span, home + begin);
+        Suffix.checkGlyphs(handle, span, home + begin);
         Suffix.checkLowercaseStart(handle, span, home, begin);
         if (!cnst && tail.startsWith("!", rest)) {
             cnst = true;
@@ -507,7 +514,7 @@ final class Suffix {
         int idx = Suffix.skipName(tail, begin);
         Suffix.checkNamePresent(tail, begin, idx, span, home);
         final String name = tail.substring(begin, idx);
-        Suffix.checkCactus(name, span, home + begin);
+        Suffix.checkGlyphs(name, span, home + begin);
         Suffix.checkLowercaseStart(name, span, home, begin);
         boolean cnst = false;
         if (idx < tail.length() && tail.charAt(idx) == '!') {

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -209,6 +209,13 @@ final class Tokens {
                 "cactus emoji is reserved for auto-names; not allowed in identifiers"
             );
         }
+        final int control = new Scrubbed(raw).found();
+        if (control >= 0) {
+            throw new ParseError(
+                this.span.line(), this.span.indent() + start + control,
+                "control character is not allowed in an identifier"
+            );
+        }
         this.cursor = idx;
         return new Value(Value.Kind.IDENTIFIER, raw, this.span.indent() + start);
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-name-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-name-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'control character is not allowed in an identifier')]
+input: "[] > app\n  foo\fbar > x\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-name-suffix-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-name-suffix-is-rejected.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets: []
 asserts:
   - /object/errors/error[contains(text(),'control character is not allowed in an identifier')]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-name-suffix-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-name-suffix-is-rejected.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'control character is not allowed in an identifier')]
+input: "[] > app\n  foo > x\fy\n"


### PR DESCRIPTION
A control character inside a NAME travelled into an Xembly attribute and
aborted the parse with `IllegalArgumentException`, so `EoSyntax` returned
neither XMIR nor an error document. Text nodes are already scrubbed of
those characters, but a name is not: it becomes an attribute of a
generated object, and a name with a hole in it is not the name the source
wrote.

The reader of an identifier now asks where the first such character sits
and reports it there, both for a base and for a name suffix.

Closes #7927
