### PR TITLE
test(#6638): cover a three-reference boundary for eo:multi-referenced

### DIFF
--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-multi-referenced-three-uses.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/inline-cactoos-multi-referenced-three-uses.yaml
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A plain (non-const) `[] >> name` abstract formation referenced from three
+# sites, one more than the two-reference case of #5876. "eo:multi-referenced"
+# answers this with "exists(eo:references($target, $name)[2])" (#6638) rather
+# than counting the whole sequence, so it must stay true past the boundary of
+# exactly two references, not just at it: the formation and its file-local
+# handle are kept here exactly as they are for two references, and none of
+# the three call sites is folded.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/inline-cactoos.xsl
+asserts:
+  # The three-times-referenced formation is not dropped: it keeps its cactus
+  # name and its file-local handle.
+  - /object/o[@name='foo']/o[starts-with(@name, 'a🌵') and @local='helper' and not(@base)]
+  # None of the three references is inlined into a copy of the formation
+  # body: the bare reference, the `.neg` dispatch and the applied `.plus`
+  # dispatch all stay as cactus-named references.
+  - /object/o[@name='foo']/o[matches(@base, '^ξ\.a🌵[^.]+$') and @name='x']
+  - /object/o[@name='foo']/o[matches(@base, '^ξ\.a🌵[^.]+\.neg$') and @name='y']
+  - /object/o[@name='foo']/o[matches(@base, '^ξ\.a🌵[^.]+\.plus$') and @name='z']
+  # No copy of the formation body was minted at any of the three reference
+  # sites.
+  - /object[count(//o[not(@base)]/o[starts-with(@name, 'a🌵')])=1]
+input: |
+  [a] > foo
+    helper > x
+    helper.neg > y
+    helper.plus 1 > z
+    q.plus 1 > [q] >> helper

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-based-handle-local-name-three-uses.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/restore-based-handle-local-name-three-uses.yaml
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The same based file-local handle as "restore-based-handle-local-name.yaml"
+# (#5944), but reached from three dispatches instead of two. The twin
+# "eo:multi-referenced" in "restore-local-names.xsl" answers this with
+# "exists(eo:references($target, $name)[2])" (#6638) rather than counting the
+# whole sequence, so it must stay true past the boundary of exactly two
+# references: the handle keeps its "@local" marker here exactly as it does
+# for two references, and none of the three dispatches is rewritten.
+sheets:
+  - /org/eolang/parser/parse/wrap-applications.xsl
+  - /org/eolang/parser/parse/resolve-self.xsl
+  - /org/eolang/parser/parse/resolve-local-names.xsl
+  - /org/eolang/parser/parse/validate-before-stars.xsl
+  - /org/eolang/parser/parse/resolve-before-stars.xsl
+  - /org/eolang/parser/parse/fragile-dispatch.xsl
+  - /org/eolang/parser/parse/wrap-method-calls.xsl
+  - /org/eolang/parser/parse/const-to-dataized.xsl
+  - /org/eolang/parser/parse/stars-to-tuples.xsl
+  - /org/eolang/parser/parse/vars-float-up.xsl
+  - /org/eolang/parser/parse/validate-objects-count.xsl
+  - /org/eolang/parser/parse/build-fqns.xsl
+  - /org/eolang/parser/parse/expand-aliases.xsl
+  - /org/eolang/parser/parse/resolve-aliases.xsl
+  - /org/eolang/parser/parse/add-default-package.xsl
+  - /org/eolang/parser/parse/roll-bases.xsl
+  - /org/eolang/printer/print/restore-local-names.xsl
+asserts:
+  # The three-times-referenced based handle keeps its "@local" marker, and its
+  # cactus "@name" is left obfuscated (not promoted to the handle).
+  - /object/o[@name='foo']/o[@local='b' and contains(@name, '🌵') and @base='ξ.a.as-i32']
+  # All three dispatch references stay cactus-based: rewriting them is left to
+  # "merge-monikers", which knows which one hosts the binding.
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and ends-with(@base, '.plus') and @name='x' and o]
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and ends-with(@base, '.neg') and @name='y']
+  - /object/o[@name='foo']/o[contains(@base, '🌵') and ends-with(@base, '.minus') and @name='z' and o]
+input: |
+  [a] > foo
+    b.plus 1 > x
+    b.neg > y
+    b.minus 2 > z
+    a.as-i32 >> b


### PR DESCRIPTION
Issue #6638 reported that \`eo:multi-referenced\` in \`inline-cactoos.xsl\` crashed Saxon by asking \`count(eo:references($target, $name)) > 1\`, since Saxon sometimes backs that sequence with a \`MemoSequence\`, whose iterator refuses \`getLength()\`. The fix landed on master in commit 28e7534480, which swapped the count for \`exists(eo:references($target, $name)[2])\` — that never counts and short-circuits on the second item — and fixed the identical pattern in the twin \`eo:multi-referenced\` inside \`restore-local-names.xsl\` at the same time.

That fix commit shipped with no regression fixture, and the only existing coverage for either function stops at exactly two references.

This PR adds two YAML fixtures under \`eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/\`, each extending an existing two-reference case to three references: one for \`inline-cactoos.xsl\` (a shared abstract formation referenced from three sites) and one for \`restore-local-names.xsl\` (a shared based handle dispatched from three sites). Both assert the formation/handle is still kept in place and none of the three references gets folded, proving \`exists(...[2])\` generalizes past the exactly-two boundary rather than happening to match it by coincidence.

Closes #6638