### PR TITLE
bug(#7781): make the wrong-bytes regex test depend on the bytes

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -150,6 +150,12 @@
 
   "/[0-9]/\\d+/".regex.compiled.matches "2/75" ++> can-match-an-entire-pattern
 
+  exists. ++> can-match-with-serialized-bytes-of-the-right-type
+    next.
+      match.
+        regex.pattern "/h.llo/".regex.compiled.serialized
+        "hello"
+
   matches. ++> can-match-with-the-case-insensitive-option
     "/(string)/i".regex.compiled
     "StRiNg"
@@ -225,10 +231,11 @@
   not. ++> can-tell-it-does-not-match-with-unmatched-leading-characters
     "/[a-z]+/".regex.compiled.matches "1abc"
 
-  next. --> rejects-serialized-bytes-of-the-wrong-type
-    match.
-      ^.pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
-      "hello"
+  exists. --> rejects-serialized-bytes-of-the-wrong-type
+    next.
+      match.
+        regex.pattern AC-ED-00-05-74-00-0D-6E-6F-74-20-61-20-70-61-74-74-65-72-6E
+        "hello"
 
   "/pattern".regex.compiled --> stops-on-a-missing-closing-slash
 


### PR DESCRIPTION
Closes #7781.

`rejects-serialized-bytes-of-the-wrong-type` read `^` inside the bare `[]` that `-->` wraps the body in, so it panicked on a receiver that was never declared, before the bytes were ever examined. Naming the object is not enough on its own: `next` answers with the `matched` formation, which carries no data, so the dataization panics whatever the bytes are. The test now names the object and dataizes `exists`, and a sibling `++>` feeds the same shape the bytes of a real compiled pattern.

Verified by mutating `matched-from-index` to swallow the wrong-type bytes and match `h.llo` instead of panicking:

| test shape | healthy atom | mutant |
| --- | --- | --- |
| `next.` + `^.pattern` (before) | panics, "declares no receiver" | panics, still green |
| `next.` + `regex.pattern` | panics, "cannot deserialize" | panics, "no Δ in matched", still green |
| `exists.` + `regex.pattern` (this PR) | panics, "cannot deserialize" | nothing thrown, test red |

@maxonfjvipon Could you please take a look
