### PR TITLE
#7304: decide a Phi's identity by the object, not by its hash

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -71,7 +71,7 @@ public interface Data {
 
         @Override
         public boolean equals(final Object obj) {
-            return this.object.equals(obj);
+            return this == obj || this.object.equals(obj);
         }
 
         @Override

--- a/eo-runtime/src/main/java/org/eolang/PhAgain.java
+++ b/eo-runtime/src/main/java/org/eolang/PhAgain.java
@@ -34,7 +34,7 @@ public final class PhAgain implements Phi {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.next.equals(obj);
+        return this == obj || this.next.equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -78,7 +78,7 @@ public final class PhCoverage implements Phi {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.origin.equals(obj);
+        return this == obj || this.origin.equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -25,13 +25,6 @@ import java.util.stream.Collectors;
  * <p>The class is thread-safe.</p>
  *
  * @since 0.1
- * @todo #7304:60min Stop deciding identity from a hash code in
- *  {@code equals}. The hash of a Phi is its identity hash, which repeats:
- *  two unrelated objects that collide compare equal today, as the run in
- *  #7304 shows: 2135 colliding pairs among three million objects, every one
- *  of them reported equal. Memory blocks no longer depend on it, but this
- *  method still does. Compare identity directly, and check what breaks in
- *  the tests that lean on the current behaviour before changing it.
  * @checkstyle DesignForExtensionCheck (500 lines)
  */
 @SuppressWarnings("PMD.GodClass")
@@ -170,7 +163,7 @@ public class PhDefault implements Phi, Cloneable {
 
     @Override
     public boolean equals(final Object obj) {
-        return obj instanceof Phi && this.hashCode() == obj.hashCode();
+        return this == obj;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -79,7 +79,7 @@ public final class PhLogged implements Phi {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.origin.equals(obj);
+        return this == obj || this.origin.equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhLoop.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLoop.java
@@ -53,7 +53,7 @@ public final class PhLoop implements Phi {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.origin.equals(obj);
+        return this == obj || this.origin.equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -66,7 +66,7 @@ public class PhOnce implements Phi {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.object.get().equals(obj);
+        return this == obj || this.object.get().equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -113,7 +113,7 @@ public final class PhSafe implements Phi, Atom {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.origin.equals(obj);
+        return this == obj || this.origin.equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -127,7 +127,7 @@ public final class PhSticky implements Phi {
 
     @Override
     public boolean equals(final Object obj) {
-        return this.origin.equals(obj);
+        return this == obj || this.origin.equals(obj);
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/Phi.java
+++ b/eo-runtime/src/main/java/org/eolang/Phi.java
@@ -12,8 +12,9 @@ package org.eolang;
  * name would be "Object", but it's already occupied by Java. That's why
  * we call it Phi.</p>
  *
- * <p>The hash code of a Phi is its identity hash, which is not unique:
- * two different objects can share one (see #7304).</p>
+ * <p>Two Phi are equal when they are the same object. The hash code of a
+ * Phi is its identity hash, which is not unique — two different objects
+ * can share one — so equality is never decided from it.</p>
  *
  * @since 0.1
  */

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -52,6 +52,26 @@ final class PhLoggedTest {
     }
 
     @Test
+    void equalsToItself() {
+        final Phi logged = new PhLogged(new PhDefault());
+        MatcherAssert.assertThat(
+            "PhLogged asks its origin about equality, and must still answer for itself first",
+            logged,
+            Matchers.equalTo(logged)
+        );
+    }
+
+    @Test
+    void leavesOriginUnequalToIt() {
+        final Phi phi = new PhDefault();
+        MatcherAssert.assertThat(
+            "Borrowing the origin's hash code cannot make the origin equal to PhLogged, which is another object",
+            phi,
+            Matchers.not(Matchers.equalTo(new PhLogged(phi)))
+        );
+    }
+
+    @Test
     void getsOriginLocator() {
         final Phi phi = Phi.Φ;
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #7304, resolving the `@todo #7304:60min` puzzle in `PhDefault`.

`PhDefault.equals` asked the hash code instead of the object:

```java
return obj instanceof Phi && this.hashCode() == obj.hashCode();
```

The hash of a Phi is `System.identityHashCode(this) + 1`, which repeats — the run recorded in #7304 found 2135 colliding pairs among three million objects, and every one of them compared equal. Equality is now the object itself:

```java
return this == obj;
```

The memory-block half of #7304 is already gone: `Heaps` hands out identifiers from its own counter, so nothing but `equals` was still leaning on the hash. `PhSticky.normalized()` asks `result.equals(this.origin)` to find out whether normalising was a no-op, which is exactly what identity answers.

`Phi`'s javadoc now says a shared hash is harmless because equality is never decided from it, rather than pointing at #7304 as an open defect.

## The decorators had to come along

This is what the puzzle meant by "check what breaks in the tests that lean on the current behaviour". Eight classes answer `equals` by handing the question to the object they wrap — `PhOnce` (and `PhApplication` through it), `PhLogged`, `PhSafe`, `PhSticky`, `PhCoverage`, `PhLoop`, `PhAgain` and `Data.ToPhi`:

```java
return this.origin.equals(obj);
```

While the origin compared by hash, a decorator asked about *itself* still came back `true`, because its own `hashCode` is the origin's. Under identity it comes back `false`: the origin is not the decorator. Five tests caught it, `PhApplicationTest.comparesTwoObjects` and `PhCoverageTest.staysEqualToItsOrigin` among them — an object was no longer equal to itself. Each of the eight now answers for itself before delegating:

```java
return this == obj || this.origin.equals(obj);
```

which restores reflexivity and leaves "a decorator equals what it decorates" exactly as it was. In `PhOnce` it also stops a self-comparison from forcing the wrapped scalar.

## Tests

- `PhLoggedTest.leavesOriginUnequalToIt` compares an object against `new PhLogged(phi)`. A decorator borrows its origin's `hashCode`, so that pair is the runtime's own case of two distinct objects with one hash, and it needs no fake: on `master` the object reports itself equal to the decorator, here it does not.
- `PhLoggedTest.equalsToItself` pins the reflexivity that the delegation above would otherwise have lost.

They sit beside `equalsToOrigin`, which pins the other side of the same pair, rather than in `PhDefaultTest` — that file is 997 lines on `master` against qulice's 1000-line cap, so no test fits in it at all. Filed as #7974.

## One thing left alone

`decorator.equals(origin)` is true while `origin.equals(decorator)` is false. That asymmetry is not introduced here for every Phi — `PhPackage` implements `Phi` directly and has always compared by identity, so `Phi.Φ.equals(new PhLogged(Phi.Φ))` was false before this change too. The half fixed here is the one the defect lived on: an object claiming equality with something that is not it. Whether a decorator should go on claiming equality with what it decorates is a question about what a decorator *is*, so it is left as it stands rather than settled silently in a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWLseJ6wQRBeWvfybvKLko