### PR TITLE
#7523: drop the comment from Blanks' private ctor

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Blanks.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Blanks.java
@@ -28,7 +28,6 @@ final class Blanks {
      * Utility class.
      */
     private Blanks() {
-        // never called
     }
 
     /**


### PR DESCRIPTION
The private constructor of `Blanks` carried `// never called` as its whole body. The
comment says nothing the `private` keyword above it has not already said, and the
project's guidance is that a method body holds no comments.

The three other utility classes in the same package already leave the body empty:
`Comments`, `Escapes` and `Bindings`. `Blanks` now matches them.

Closes #7523