### PR TITLE
#7974: give three more PhDefaultTest fixtures classes of their own

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/Counter.java
+++ b/eo-runtime/src/test/java/org/eolang/Counter.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * An object that remembers how many times its φ was dataized.
+ *
+ * @since 0.1.0
+ */
+final class Counter extends PhDefault {
+
+    /**
+     * Count.
+     */
+    private long count;
+
+    /**
+     * Make one, with all its attributes in place.
+     *
+     * <p>The attributes are attached here, and not in a constructor,
+     * because both of them are expressions over the object itself, which
+     * does not exist yet while its constructor runs.</p>
+     *
+     * @return The object
+     */
+    static Counter made() {
+        final Counter made = new Counter();
+        made.add(
+            Phi.PHI,
+            new AtOnce(
+                new AtComposite(
+                    made,
+                    rho -> {
+                        ++made.count;
+                        return new Data.ToPhi(new byte[]{(byte) 0x01});
+                    }
+                )
+            )
+        );
+        made.add("count", new AtComposite(made, rho -> new Data.ToPhi(made.count)));
+        return made;
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -6,7 +6,6 @@ package org.eolang;
 
 import com.yegor256.Together;
 import java.lang.reflect.Field;
-import java.security.SecureRandom;
 import org.cactoos.set.SetOf;
 import org.eolang.EO_org.EO_eolang.EOdummy;
 import org.hamcrest.MatcherAssert;
@@ -427,7 +426,7 @@ final class PhDefaultTest {
 
     @Test
     void doesNotReadMultipleTimes() {
-        final Phi phi = PhDefaultTest.Counter.made();
+        final Phi phi = Counter.made();
         final long total = 2L;
         for (long idx = 0L; idx < total; ++idx) {
             new Dataized(phi).take();
@@ -532,7 +531,7 @@ final class PhDefaultTest {
 
     @Test
     void injectsPhi() {
-        final Phi phi = new PhDefaultTest.WithVoidPhi();
+        final Phi phi = new WithVoidPhi();
         phi.put(0, new Data.ToPhi(5));
         MatcherAssert.assertThat(
             "Object must be injected to phi attribute and dataized",
@@ -547,7 +546,7 @@ final class PhDefaultTest {
             new PhDispatch(
                 new PhApplication(
                     new PhDispatch(
-                        new PhDefaultTest.Rnd(), this.plus()
+                        new Rnd(), this.plus()
                     ),
                     0, new Data.ToPhi(1.2)
                 ),
@@ -717,31 +716,6 @@ final class PhDefaultTest {
     }
 
     /**
-     * Rnd.
-     *
-     * @since 0.1.0
-     */
-    private static final class Rnd extends PhDefault {
-
-        /**
-         * Ctor.
-         */
-        Rnd() {
-            super(
-                new Attrs(
-                    new Attr(
-                        "φ",
-                        new AtComposite(
-                            new PhDefault(),
-                            self -> new Data.ToPhi(new SecureRandom().nextDouble())
-                        )
-                    )
-                )
-            );
-        }
-    }
-
-    /**
      * Int.
      *
      * @since 0.36.0
@@ -818,61 +792,6 @@ final class PhDefaultTest {
                     )
                 )
             );
-        }
-    }
-
-    /**
-     * Dummy.
-     *
-     * @since 0.1.0
-     */
-    static final class WithVoidPhi extends PhDefault {
-
-        /**
-         * Ctor.
-         */
-        WithVoidPhi() {
-            super(new Attrs(new Attr(Phi.PHI, new AtVoid(Phi.PHI))));
-        }
-    }
-
-    /**
-     * Counter.
-     *
-     * @since 0.1.0
-     */
-    static final class Counter extends PhDefault {
-
-        /**
-         * Count.
-         */
-        private long count;
-
-        /**
-         * Make one, with all its attributes in place.
-         *
-         * <p>The attributes are attached here, and not in a constructor,
-         * because both of them are expressions over the object itself, which
-         * does not exist yet while its constructor runs.</p>
-         *
-         * @return The object
-         */
-        static Counter made() {
-            final PhDefaultTest.Counter made = new PhDefaultTest.Counter();
-            made.add(
-                Phi.PHI,
-                new AtOnce(
-                    new AtComposite(
-                        made,
-                        rho -> {
-                            ++made.count;
-                            return new Data.ToPhi(new byte[]{(byte) 0x01});
-                        }
-                    )
-                )
-            );
-            made.add("count", new AtComposite(made, rho -> new Data.ToPhi(made.count)));
-            return made;
         }
     }
 

--- a/eo-runtime/src/test/java/org/eolang/Rnd.java
+++ b/eo-runtime/src/test/java/org/eolang/Rnd.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.security.SecureRandom;
+
+/**
+ * An object whose φ is a fresh random number on every dataization.
+ *
+ * @since 0.1.0
+ */
+final class Rnd extends PhDefault {
+
+    /**
+     * Ctor.
+     */
+    Rnd() {
+        super(
+            new Attrs(
+                new Attr(
+                    "φ",
+                    new AtComposite(
+                        new PhDefault(),
+                        self -> new Data.ToPhi(new SecureRandom().nextDouble())
+                    )
+                )
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/WithVoidPhi.java
+++ b/eo-runtime/src/test/java/org/eolang/WithVoidPhi.java
@@ -1,0 +1,20 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+/**
+ * An object whose φ is void, waiting for one to be put in.
+ *
+ * @since 0.1.0
+ */
+final class WithVoidPhi extends PhDefault {
+
+    /**
+     * Ctor.
+     */
+    WithVoidPhi() {
+        super(new Attrs(new Attr(Phi.PHI, new AtVoid(Phi.PHI))));
+    }
+}


### PR DESCRIPTION
Part of #7974.

The three recursion fixtures this branch used to move are already out,
lifted by dd1f9396f7 in #8550. `Rnd`, `WithVoidPhi` and `Counter` are the
next three that no other test reads, so they move next to
`EndlessRecursion` and friends, and `PhDefaultTest` drops from 901 to 820
lines.

`Foo` and `Kid` have to travel together, since `Foo` makes a `Kid`, and
`Int` cannot keep its name at the top level next to `org.eolang.Int`.
Either would push this past the 200-line `pr-size` limit, so both are
left for a follow-up.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKVckkJjdzaRapxQ3rKJWH
