### PR TITLE
#6125: move Transpiling to GlobalCache

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -148,41 +148,34 @@ public final class MjTranspile extends MjSafe {
     )
     private File tables;
 
-    /**
-     * Cache guard, see {@link ConcurrentCache} for why it is one per instance.
-     */
-    private final ConcurrentCache guard;
-
-    /**
-     * Ctor.
-     */
-    public MjTranspile() {
-        this.guard = new ConcurrentCache();
-    }
-
     @Override
     public void exec() throws IOException {
         try (TjsForeign tojos = this.tojos()) {
+            final Transpilation train = new Transpilation(
+                this.plugin.getVersion(),
+                new Tracking(this.trackSteps, this.located),
+                this.coverage,
+                this.base(),
+                this.xslMeasures.toPath(),
+                this.targetDir.toPath(),
+                this.tables.toPath()
+            );
             new Timed(
                 new Transpiling(
                     tojos.standalone(),
                     this.targetDir.toPath(),
                     this.generatedDir.toPath(),
-                    this.cache.toPath(),
-                    this.cacheEnabled,
-                    this.plugin.getVersion(),
                     this.tests,
                     this.roots(),
-                    new Transpilation(
-                        this.plugin.getVersion(),
-                        new Tracking(this.trackSteps, this.located),
-                        this.coverage,
-                        this.base(),
-                        this.xslMeasures.toPath(),
-                        this.targetDir.toPath(),
-                        this.tables.toPath()
-                    ),
-                    this.guard
+                    train,
+                    this.stored(),
+                    new JavaFiles(
+                        this.generatedDir.toPath(),
+                        this.cache.toPath()
+                            .resolve(Transpiling.CACHE)
+                            .resolve(train.version()),
+                        this.cacheEnabled
+                    )
                 )
             ).exec();
         }
@@ -224,5 +217,21 @@ public final class MjTranspile extends MjSafe {
             );
         }
         return this.superclass;
+    }
+
+    // The cache is skipped when the XMIR of every step is asked for: those
+    // dumps are made by the train, and a cache hit hands back a stored
+    // answer without running it (#7724). The version segment is not folded
+    // in here, because it differs from one source to the next: the rows of
+    // the inference tables an object is named in go into it (#7945), so
+    // `Transpiling` folds it in per file.
+    private GlobalCache stored() {
+        final GlobalCache store;
+        if (this.trackSteps) {
+            store = new GlobalCache.GcFresh();
+        } else {
+            store = this.caching(Transpiling.CACHE);
+        }
+        return store;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -9,7 +9,6 @@ import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -33,6 +32,16 @@ import org.eolang.parser.OnDetailed;
  * The intermediate optimized XMIRs are stored in the {@link #PRE} directory.</p>
  *
  * @since 0.1
+ * @todo #6125:60min Take the writing of the Java files out of here too.
+ *  {@link JavaFiles} still keeps a cache directory and an enabled flag of
+ *  its own, so this class has to be handed one ready-made, and the key of
+ *  that directory repeats the plugin version {@link GlobalCache} already
+ *  folds in. Give {@link JavaFiles} the same {@link GlobalCache} instead,
+ *  then it goes back to being made here, and {@link #version()}, which is
+ *  read by nothing but the test, goes with it. The three that are left,
+ *  the generated directory, the tests flag and the roots, describe one
+ *  thing, where the output lands, and belong together in an object of
+ *  their own, along with the tail of {@link #exec()} that logs it.
  */
 final class Transpiling implements Step {
 
@@ -49,7 +58,7 @@ final class Transpiling implements Step {
     /**
      * Cache directory for transpiled sources.
      */
-    private static final String CACHE = "transpiled";
+    static final String CACHE = "transpiled";
 
     /**
      * XMIR sources to transpile.
@@ -67,24 +76,9 @@ final class Transpiling implements Step {
     private final Path generated;
 
     /**
-     * Base cache directory.
-     */
-    private final Path cache;
-
-    /**
-     * Whether caching is enabled.
-     */
-    private final boolean enabled;
-
-    /**
      * Whether to transpile tests.
      */
     private final boolean tests;
-
-    /**
-     * The plugin version, for the log.
-     */
-    private final String version;
 
     /**
      * Directories with the Java sources a human wrote.
@@ -97,64 +91,58 @@ final class Transpiling implements Step {
     private final Transpilation train;
 
     /**
-     * Cache guard, see {@link ConcurrentCache} for why it is one per instance.
+     * The cache this build shares with every other build on this machine.
      */
-    private final ConcurrentCache guard;
+    private final GlobalCache cache;
+
+    /**
+     * The Java files this run writes, and the stale ones it removes.
+     */
+    private final JavaFiles files;
 
     /**
      * Constructor.
      * @param srcs XMIR sources to transpile
      * @param target Target directory
      * @param generated Generated sources directory
-     * @param cache Base cache directory
-     * @param enabled Whether caching is enabled
-     * @param ver Plugin version string
      * @param tests Whether to transpile tests
      * @param java Directories with the Java sources a human wrote
      * @param train The XSL train that does the transpiling
-     * @param guard Cache guard, one per instance
+     * @param store The cache shared with every build on this machine
+     * @param written The Java files this run writes
      */
     Transpiling(
         final Collection<TjForeign> srcs,
         final Path target,
         final Path generated,
-        final Path cache,
-        final boolean enabled,
-        final String ver,
         final boolean tests,
         final Collection<Path> java,
         final Transpilation train,
-        final ConcurrentCache guard
+        final GlobalCache store,
+        final JavaFiles written
     ) {
         this.sources = srcs;
         this.target = target;
         this.generated = generated;
-        this.cache = cache;
-        this.enabled = enabled;
         this.tests = tests;
-        this.version = ver;
         this.roots = java;
         this.train = train;
-        this.guard = guard;
+        this.cache = store;
+        this.files = written;
     }
 
     @Override
     public void exec() throws IOException {
-        final JavaFiles files = new JavaFiles(
-            this.generated,
-            this.cache.resolve(Transpiling.CACHE).resolve(this.version()),
-            this.enabled
-        );
         final int transpiled = new Threaded<>(
             this.sources,
-            tojo -> this.transpiled(tojo, files)
+            this::transpiled
         ).total();
-        files.removeStale();
+        this.files.removeStale();
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(),
             transpiled + new PackageInfos(
-                this.generated, this.roots, files.directories()
+                this.generated, this.roots, this.files.directories()
             ).create(),
             this.generated
         );
@@ -168,7 +156,7 @@ final class Transpiling implements Step {
         return this.train.version();
     }
 
-    private int transpiled(final TjForeign tojo, final JavaFiles files) throws IOException {
+    private int transpiled(final TjForeign tojo) throws IOException {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
         final Path base = this.target.resolve(Transpiling.DIR);
@@ -177,51 +165,16 @@ final class Transpiling implements Step {
         final Supplier<String> hsh = new TojoHash(tojo);
         final AtomicBoolean rewrite = new AtomicBoolean(false);
         final Function<XML, XML> transform = this.train.forSource(name);
-        final Path cdir = this.cache.resolve(Transpiling.CACHE);
-        final Path tail = base.relativize(dest);
-        if (this.enabled && !this.train.steps()) {
-            this.guard.apply(
-                source, dest, tail,
-                new Cache(
-                    new CachePath(
-                        cdir, this.train.version(xmir.xpath("/object/o/@loc")), hsh.get()
-                    ),
-                    src -> {
-                        rewrite.compareAndSet(false, true);
-                        final String res = transform.apply(xmir).toString();
-                        Logger.debug(
-                            this,
-                            "Transpiled %[file]s (%s) to %[file]s (%s) (cache miss), version: %s, hash: %s, tail: %s, cache enabled: %b, cache dir: %[file]s",
-                            source,
-                            Transpiling.info(source),
-                            dest,
-                            Transpiling.info(dest),
-                            this.version,
-                            hsh.get(),
-                            tail,
-                            this.enabled,
-                            cdir
-                        );
-                        return res;
-                    }
-                )
-            );
-        } else {
-            rewrite.compareAndSet(false, true);
-            new Saved(transform.apply(xmir).toString(), dest).value();
-        }
-        return files.total(
+        this.cache.with(this.train.version(xmir.xpath("/object/o/@loc"))).footprint(
+            base.relativize(dest),
+            hsh,
+            src -> {
+                rewrite.compareAndSet(false, true);
+                return transform.apply(xmir).toString();
+            }
+        ).apply(source, dest);
+        return this.files.total(
             rewrite.get(), dest, hsh.get(), this.tests && !tojo.discovered()
         );
-    }
-
-    private static String info(final Path info) throws IOException {
-        final String res;
-        if (Files.exists(info)) {
-            res = Files.getLastModifiedTime(info).toString();
-        } else {
-            res = "Not exists yet";
-        }
-        return res;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
@@ -36,9 +36,6 @@ final class TranspilingTest {
             Collections.emptyList(),
             Paths.get("target"),
             Paths.get("target/generated"),
-            Paths.get("target/cache"),
-            true,
-            "1.0-SNAPSHOT",
             false,
             Collections.singleton(Paths.get("src/main/java")),
             new Transpilation(
@@ -50,7 +47,8 @@ final class TranspilingTest {
                 Paths.get("target"),
                 Paths.get("target/eo/6-inference")
             ),
-            new ConcurrentCache()
+            new GlobalCache.GcFresh(),
+            new JavaFiles(Paths.get("target/generated"), Paths.get("target/cache"), false)
         );
     }
 }


### PR DESCRIPTION
The second cut, after #6315. That one took the four cache fields out of `Parsing`; this one takes them out of `Transpiling`.

`Transpiling` held the cache directory, the enabled flag, the plugin version and the `ConcurrentCache` guard, and built `CachePath` and `Cache` by hand, with an `if` over the flag around it. All of that is what `GlobalCache` answers now: one `footprint(tail, hash, compile).apply(source, dest)`, the same call `Parsing` makes. The lambda that turns XMIR into Java text was written once inside the cache and once in the `else`; now it is written once.

Whether the run caches at all is decided in `MjTranspile`, where `trackSteps` is read anyway: with the steps tracked the step gets `GcFresh`, since a cache hit writes no dumps (#7724). `Transpilation.steps()` had no other reader and is gone.

`JavaFiles` still keeps a cache directory and an enabled flag of its own, so it is built at the call site for now and handed in. The constructor goes from 10 parameters to 8, and all four cache parameters leave as a group rather than one at a time.

What is left is a `@todo` in `Transpiling`: give `JavaFiles` the same `GlobalCache`, which puts it back inside the class and takes `version()` with it, and put the generated directory, the tests flag and the roots into an object of their own together with the tail of `exec()`.

Locally: `MjTranspileTest` 95 of 95, `TranspilingTest`, `TranspilationTest` and `JavaFilesTest` green, `qulice:check` and `jtcop` clean.

Not closing the issue with this PR.
