### PR TITLE
fix(#7975): let %f terminate instead of printing why it cannot write

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -42,6 +42,14 @@
 # The `%d` guard names the number it rejects through `as-scientific` and not
 # through `%f`, because every magnitude it rejects is past the range `as-fixed`
 # writes, and a reason rendered with `%f` destroyed itself instead of arriving.
+#
+# The `%f` conversion leaves the `cant-print` fallback of `as-fixed` unbound,
+# so a number it refuses, a non-finite one or a magnitude of 2^63 or larger,
+# terminates with the reason `as-fixed` gives, instead of that reason standing
+# in the text where the number was meant to be. Its tests recover from that
+# termination instead of declaring it with `-->`, because a returned text of
+# more than one byte fails to dataize as a boolean exactly as a termination
+# does, and a `-->` test would pass either way.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -209,7 +217,6 @@
             precise.as-bool.if
               number precision
               6
-            I
           if.
             78-.eq conv
             capped (bytes datum).as-hex
@@ -544,6 +551,20 @@
     "1.000000"
     "%f".printf
       * 0.9999999
+
+  eq. ++> can-stop-formatting-a-huge-number-as-a-fixed-point
+    "stopped"
+    recovered
+      "%f".printf
+        * 1.0e30
+      "stopped"
+
+  eq. ++> can-stop-formatting-a-non-finite-number-as-a-fixed-point
+    "stopped"
+    recovered
+      "value=%f".printf
+        * nan
+      "stopped"
 
   eq. ++> can-truncate-a-negative-float-toward-zero
     "-7"


### PR DESCRIPTION
Closes #7975.

`%f` handed `I` to `as-fixed` as its `cant-print` fallback, so a number `as-fixed` refuses came back as the explanation. Measured on a built `eo-runtime`:

    "value=%f".printf * nan -> "value=Can't write a non-finite number as a fixed-point decimal"
    "%f".printf * 1.0e30 -> "Can't write a fixed-point decimal with a magnitude of 2^63 or larger"

`%d` terminates for both. Dropping the fallback leaves `cant-print` unbound, which `as-fixed` documents as its terminator.

The tests recover instead of using `-->`: a text of over one byte fails `asBool` as a termination does, so a `-->` test passed before the fix.

`mvn clean test -pl :eo-runtime -Dtest=TestEOstring`: 416 run, 0 failures.

@yegor256
