### PR TITLE
Fix site build: declare the ctor of MjInferenceReport explicitly

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInferenceReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInferenceReport.java
@@ -64,6 +64,13 @@ public final class MjInferenceReport extends MjSafe {
     )
     private File tables;
 
+    /**
+     * Ctor.
+     */
+    public MjInferenceReport() {
+        // nothing
+    }
+
     @Override
     void exec() throws IOException {
         new Timed(


### PR DESCRIPTION
The `site` build on `master` is red: https://github.com/objectionary/eo/actions/runs/33359137369

```
[WARNING] .../MjInferenceReport.java:32: warning: use of default constructor, which does not provide a comment
[WARNING] public final class MjInferenceReport extends MjSafe {
[ERROR] Failed to execute goal ...maven-site-plugin:3.22.0:site (default-site) on project eo-maven-plugin:
  Error generating maven-javadoc-plugin:3.12.0:javadoc report: Project contains Javadoc Warnings
```

`MjInferenceReport`, added in #7886, relied on the implicit default constructor. Javadoc's doclint reports that as a warning, and `failOnWarnings` turns it into a build failure. Every other mojo in `eo-maven-plugin` (`MjAssemble`, `MjCompile`, `MjInference`, `MjLint`, `MjParse`, `MjPlace`, ...) declares the no-argument constructor explicitly with a `/** Ctor. */` block; this one is the exception.

The fix follows that convention. I also scanned all `src/main/java` in the reactor for other public non-abstract top-level classes that declare no constructor — there are none, so `eo-runtime` and `eo-integration-tests` (skipped after the failure) have nothing of the same kind waiting.

---
_Generated by [Claude Code](https://claude.ai/code/session_012YV3NtZRBKa4EY47wKiKzJ)_