### PR TITLE
#7991: drop the backticks from the `/{…}` separator message

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -226,7 +226,7 @@ final class LnVoid implements Line {
             if (end == idx) {
                 throw new ParseError(
                     span.line(), span.indent() + 1 + offset + idx,
-                    "types in a `/{…}` list must be separated by exactly one space"
+                    "types in a /{…} list must be separated by exactly one space"
                 );
             }
             final String member = inside.substring(idx, end);
@@ -244,7 +244,7 @@ final class LnVoid implements Line {
             if (idx == inside.length()) {
                 throw new ParseError(
                     span.line(), span.indent() + 1 + offset + idx,
-                    "types in a `/{…}` list must be separated by exactly one space"
+                    "types in a /{…} list must be separated by exactly one space"
                 );
             }
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-void-args.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "types in a `/{…}` list must be separated by exactly one space"
+message: "types in a /{…} list must be separated by exactly one space"
 input: |
   [] > fopen /file
     ? > missing /{string  int}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-void-args.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "types in a `/{…}` list must be separated by exactly one space"
+message: "types in a /{…} list must be separated by exactly one space"
 input: |
   [] > fopen /file
     ? > missing /{string }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/args-double-space-position.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void/args-double-space-position.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 2
-message: "[2:17] error: 'types in a `/{…}` list must be separated by exactly one space'"
+message: "[2:17] error: 'types in a /{…} list must be separated by exactly one space'"
 input: |
   [] > atom /A
     ? > x /{string  number}


### PR DESCRIPTION
Closes #7991.

R-9.9.1 assigns one canonical text to every error condition, and the table row for an empty member of a `/{…}` argument list gives it without backticks. `LnVoid` raised it with backticks around the list, so a golden-file comparison between two implementations, which is what section 9.9 exists for, failed on those two characters.

The neighbouring message in the same method, `? is not allowed inside a /{…} argument list`, already matches its row, so the file leans that way and the backticks go rather than the table row gaining them.

Three typo fixtures pinned the old text; they were changed first and failed against `master` (`EoSyntaxTest`, 3 failures out of 752), then passed once `LnVoid` was corrected.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_