### PR TITLE
#7982: drop the row for a compact tuple on a reversed dispatch

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1381,7 +1381,6 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Bare reversed dispatch missing receiver | `reversed dispatch missing receiver` |
 | Bare reversed dispatch receiver starts with `.` | `reversed dispatch receiver must not begin with dot` |
 | Compact tuple `*N` with N > children | `compact tuple requires at least N children, got K` (N and K substituted) |
-| Compact tuple `*0` on reversed dispatch | `reversed-dispatch compact tuple requires N ≥ 1` |
 | Mixed bindings in arg group | `argument bindings must be all-or-nothing` |
 | Receiver carrying binding | `reversed-dispatch receiver cannot carry a binding` |
 | Inline binding on non-last method in chain | `inline binding allowed only on the last method in a chain` |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/compact-tuple-on-reversed-dispatch.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/compact-tuple-on-reversed-dispatch.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+line: 4
+message: |-
+  [4:7] error: 'unexpected content after name suffix'
+    if. *0 > z
+         ^
+input: |
+  # D.
+
+  [] > foo
+    if. *0 > z
+      true
+      1
+      2


### PR DESCRIPTION
Closes #7982.

R-3.9.1 says a `bare-reversed` head is not a valid compact-tuple head and that `name. *N` is not legal syntax, so the section 9.9 row `Compact tuple *0 on reversed dispatch` promised a canonical text for a shape the grammar cannot build. The string `reversed-dispatch compact tuple requires N ≥ 1` occurs nowhere under `eo-parser/src`, and R-9.9.3 makes the table the contract a second implementation is written against, so the row goes.

What the parser actually reports for such a line is the message for content it cannot place, which nothing pinned:

```
[4:7] error: 'unexpected content after name suffix'
  if. *0 > z
       ^
```

A new typo pack, `compact-tuple-on-reversed-dispatch.yaml`, pins it. `EoSyntaxTest` runs 754 tests green, two more than before.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_