### PR TITLE
#7977: name the dotted receiver of a bare reversed dispatch

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -28,6 +28,8 @@ import java.util.List;
  * <ul>
  * <li>R-5.2.3(b) — same-indent {@code .method} after a horizontally
  * completed predecessor.</li>
+ * <li>R-3.8.3 — {@code .method} as the receiver of a bare reversed
+ * dispatch, which may not begin with a dot.</li>
  * <li>R-5.2.5 — {@code .method} as a deeper-indent line.</li>
  * <li>R-5.2.10 — {@code .method} at top level (empty stack).</li>
  * <li>R-6.6.4 — a {@code .method} continuation after a link that
@@ -124,6 +126,14 @@ final class LnMethod implements Line {
     }
 
     private void precheck(final Stack stack) {
+        if (!stack.empty() && stack.top().kind() == Kind.BARE_REVERSED
+            && !stack.top().taken()
+            && stack.top().indent() < this.span.indent()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "reversed dispatch receiver must not begin with dot"
+            );
+        }
         if (stack.empty() || stack.top().indent() < this.span.indent()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/reversed-receiver-starting-with-dot.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/reversed-receiver-starting-with-dot.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+line: 5
+message: |-
+  [5:4] error: 'reversed dispatch receiver must not begin with dot'
+      .other
+      ^
+input: |
+  # D.
+
+  [] > foo
+    name. > @
+      .other


### PR DESCRIPTION
Closes #7977.

R-3.8.3 says the first deeper line under a vertical reversed dispatch is the receiver and must not begin with a dot, and the section 9.9 table gives that condition its own canonical text. `LnMethod.precheck` reached its generic branch first, so the reader was told the line had nothing to attach to:

```
[5:4] error: 'method continuation has no expression to attach to'
```

The precheck now recognises the case ahead of that branch — the top of the stack is a `BARE_REVERSED` that has not taken its receiver, and this line is deeper than it — and raises the canonical message instead:

```
[5:4] error: 'reversed dispatch receiver must not begin with dot'
    .other
    ^
```

The sibling `reversed dispatch missing receiver` still follows at close time, as it did before, since the dispatch indeed never got one.

A new typo pack, `reversed-receiver-starting-with-dot.yaml`, pins the text. The whole `eo-parser` suite is green: 1560 tests, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_