### PR TITLE
#7981: name the inline binding that sits on a non-last method

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -62,7 +62,7 @@ final class LnApplication implements Line {
         final List<MethodChain> chain = tokens.readChain();
         final List<Value> args = tokens.readArgs();
         Bindings.checkAllOrNothing(args, this.span);
-        final String outer = LnApplication.readOuterBinding(tokens);
+        final String outer = LnApplication.readOuterBinding(tokens, this.span);
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );
@@ -97,14 +97,27 @@ final class LnApplication implements Line {
      * attach to the line's whole expression when it occupies an
      * argument position (a deeper-indent child of a vapplication or
      * vertical reversed dispatch).
+     *
+     * <p>A chain that goes on after the binding is rejected here per
+     * R-6.6.4 — the binding would sit on a method the chain does not end
+     * with.</p>
+     *
      * @param tokens Token reader
+     * @param span Source span of the line
      * @return The binding label, or {@code null}
      */
-    static String readOuterBinding(final Tokens tokens) {
+    static String readOuterBinding(final Tokens tokens, final Span span) {
         final String label;
         if (!tokens.atEnd() && tokens.current() == ':') {
-            tokens.seek(tokens.cursor() + 1);
+            final int start = tokens.cursor();
+            tokens.seek(start + 1);
             label = tokens.readBinding();
+            if (!tokens.atEnd() && tokens.current() == '.') {
+                throw new ParseError(
+                    span.line(), span.indent() + start,
+                    "inline binding allowed only on the last method in a chain"
+                );
+            }
         } else {
             label = null;
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -72,7 +72,7 @@ final class LnMethod implements Line {
         final Value method = tokens.readMethodName();
         final List<Value> args = tokens.readArgs();
         Bindings.checkAllOrNothing(args, this.span);
-        final String outer = LnApplication.readOuterBinding(tokens);
+        final String outer = LnApplication.readOuterBinding(tokens, this.span);
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -74,7 +74,7 @@ final class LnReversed implements Line {
                 args.subList(1, args.size()), this.span
             );
         }
-        final String outer = LnApplication.readOuterBinding(tokens);
+        final String outer = LnApplication.readOuterBinding(tokens, this.span);
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -54,7 +54,7 @@ final class LnTextBlock implements Line {
         final Tokens tokens = new Tokens(body, this.span);
         tokens.seek(3);
         final List<MethodChain> chain = tokens.readChain();
-        final String outer = LnApplication.readOuterBinding(tokens);
+        final String outer = LnApplication.readOuterBinding(tokens, this.span);
         final Suffix suffix = new Suffix(
             tokens.tail(), this.span, this.span.indent() + tokens.cursor()
         );

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-on-a-non-last-method.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/binding-on-a-non-last-method.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+line: 4
+message: |-
+  [4:9] error: 'inline binding allowed only on the last method in a chain'
+    bar.baz:1.qux 5 > z
+           ^
+input: |
+  # D.
+
+  [] > foo
+    bar.baz:1.qux 5 > z


### PR DESCRIPTION
Closes #7981.

One correction to the report: the canonical text is not absent from `eo-parser/src`. `LnMethod.precheck` already raises it for a vertical chain, and `bar` / `.baz:1` / `.qux 5 > z` on three lines reports it today. What was missing is the horizontal chain, where the binding is followed by more links on the same line.

There, the binding was read as the line's outer binding, the rest of the chain fell through to the suffix reader, and the line came back as

```
[4:11] error: 'unexpected content after name suffix'
  bar.baz:1.qux 5 > z
           ^
```

with no name suffix anywhere near that position. `readOuterBinding` now rejects a chain that continues after the binding, pointing at the binding itself:

```
[4:9] error: 'inline binding allowed only on the last method in a chain'
  bar.baz:1.qux 5 > z
         ^
```

The reader takes the line's span so it can place the error; its four call sites pass it through. A new typo pack, `binding-on-a-non-last-method.yaml`, pins the text. The whole `eo-parser` suite is green (1558 tests) and `qulice:check` passes on the module.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_