### PR TITLE
#7983: declare every penalty weight as a Maven parameter

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjPenalties.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjPenalties.java
@@ -13,8 +13,11 @@ import org.eolang.printer.PenaltyKey;
  * A goal that lays EO text out with the printer's penalty weights.
  *
  * <p>{@link MjPrint} and {@link MjFormat} both print XMIR back to EO,
- * and the layout that comes out is decided by the same four numbers, so
- * one declaration serves both and neither can drift from the other.</p>
+ * and the layout that comes out is decided by the same numbers, so one
+ * declaration serves both and neither can drift from the other. Every
+ * {@link PenaltyKey} is declared here, so a build can vary whatever a
+ * printer pack can vary; an absent one keeps its
+ * {@link PenaltyKey#fallback()} value.</p>
  *
  * @since 0.75.0
  */
@@ -33,16 +36,52 @@ abstract class MjPenalties extends MjSafe {
     private Integer bracket;
 
     /**
+     * The factor by which a parenthesis that opens a line is charged more.
+     */
+    @Parameter(alias = "penaltyLeading", property = "eo.penaltyLeading")
+    private Integer leading;
+
+    /**
+     * Points charged for each explicit phi attribute on a line.
+     */
+    @Parameter(alias = "penaltyPhi", property = "eo.penaltyPhi")
+    private Integer phi;
+
+    /**
+     * Points charged for each {@code if} emitted as a suffix attribute.
+     */
+    @Parameter(alias = "penaltyIf", property = "eo.penaltyIf")
+    private Integer conditional;
+
+    /**
      * Points charged for each character past the allowed width.
      */
     @Parameter(alias = "penaltyExcess", property = "eo.penaltyExcess")
     private Integer excess;
 
     /**
+     * Points charged for every symbol in the block.
+     */
+    @Parameter(alias = "penaltySymbol", property = "eo.penaltySymbol")
+    private Integer symbol;
+
+    /**
+     * Points charged for each space beyond the leading indentation.
+     */
+    @Parameter(alias = "penaltySpace", property = "eo.penaltySpace")
+    private Integer space;
+
+    /**
      * The column after which characters start being charged.
      */
-    @Parameter(property = "eo.width")
+    @Parameter(alias = "penaltyWidth", property = "eo.width")
     private Integer width;
+
+    /**
+     * The width of a single indentation level, in spaces.
+     */
+    @Parameter(alias = "penaltyStep", property = "eo.penaltyStep")
+    private Integer step;
 
     /**
      * Assemble the overridden penalty weights from the Maven properties.
@@ -54,18 +93,24 @@ abstract class MjPenalties extends MjSafe {
      */
     final Map<PenaltyKey, Integer> weights() {
         final Map<PenaltyKey, Integer> map = new EnumMap<>(PenaltyKey.class);
-        if (this.indent != null) {
-            map.put(PenaltyKey.INDENT, this.indent);
-        }
-        if (this.bracket != null) {
-            map.put(PenaltyKey.BRACKET, this.bracket);
-        }
-        if (this.excess != null) {
-            map.put(PenaltyKey.EXCESS, this.excess);
-        }
-        if (this.width != null) {
-            map.put(PenaltyKey.WIDTH, this.width);
-        }
+        MjPenalties.set(map, PenaltyKey.INDENT, this.indent);
+        MjPenalties.set(map, PenaltyKey.BRACKET, this.bracket);
+        MjPenalties.set(map, PenaltyKey.LEADING, this.leading);
+        MjPenalties.set(map, PenaltyKey.PHI, this.phi);
+        MjPenalties.set(map, PenaltyKey.IF, this.conditional);
+        MjPenalties.set(map, PenaltyKey.EXCESS, this.excess);
+        MjPenalties.set(map, PenaltyKey.SYMBOL, this.symbol);
+        MjPenalties.set(map, PenaltyKey.SPACE, this.space);
+        MjPenalties.set(map, PenaltyKey.WIDTH, this.width);
+        MjPenalties.set(map, PenaltyKey.STEP, this.step);
         return map;
+    }
+
+    private static void set(
+        final Map<PenaltyKey, Integer> map, final PenaltyKey key, final Integer weight
+    ) {
+        if (weight != null) {
+            map.put(key, weight);
+        }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjPrintTest.java
@@ -12,6 +12,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.cactoos.Text;
 import org.cactoos.io.InputOf;
 import org.cactoos.map.MapEntry;
@@ -19,6 +22,7 @@ import org.cactoos.map.MapOf;
 import org.cactoos.text.TextOf;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.parser.EoSyntax;
+import org.eolang.printer.PenaltyKey;
 import org.eolang.xax.XtSticky;
 import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
@@ -41,6 +45,20 @@ final class MjPrintTest {
      */
     @Mktmp
     private Path dir;
+
+    @Test
+    void declaresAParameterForEveryPenaltyWeight() {
+        final Set<String> declared = new MojoFields().all();
+        Assumptions.assumeFalse(declared.isEmpty());
+        MatcherAssert.assertThat(
+            "a weight a printer pack can vary must be a parameter a build can vary too",
+            Stream.of(PenaltyKey.values())
+                .map(key -> MjPrintTest.param(key.name()))
+                .filter(name -> name.isEmpty() || !declared.contains(name))
+                .collect(Collectors.toList()),
+            Matchers.empty()
+        );
+    }
 
     @Test
     void printsSuccessfully(@Mktmp final Path temp) throws Exception {
@@ -191,8 +209,14 @@ final class MjPrintTest {
         return new MapOf<>(
             new MapEntry<>("INDENT", "indent"),
             new MapEntry<>("BRACKET", "bracket"),
+            new MapEntry<>("LEADING", "leading"),
+            new MapEntry<>("PHI", "phi"),
+            new MapEntry<>("IF", "conditional"),
             new MapEntry<>("EXCESS", "excess"),
-            new MapEntry<>("WIDTH", "width")
+            new MapEntry<>("SYMBOL", "symbol"),
+            new MapEntry<>("SPACE", "space"),
+            new MapEntry<>("WIDTH", "width"),
+            new MapEntry<>("STEP", "step")
         ).getOrDefault(key, "");
     }
 }


### PR DESCRIPTION
Closes #7983.

`PenaltyKey` names ten weights, `MjPenalties` declared four, so `STEP`, `SPACE`, `PHI`, `IF`, `LEADING` and `SYMBOL` could not be set from a build. All ten are declared now, each with the `penalty`-prefixed alias its siblings carry, `width` included. The class comment no longer says the layout is decided by four numbers.

`IF` is exposed as `penaltyIf` over a field named `conditional`, since `if` is not a name a field can take.

The gap was invisible because `MjPrintTest.param` mapped the same four keys and silently dropped the rest: the maven print-packs set `STEP` and `SPACE` next to the four, and the test threw both away before `FakeMaven` saw them. That map now holds every key, and a new test walks `PenaltyKey.values()` through it against the names the mojos declare. Against `master` the two changes fail loudly — 1 failure and 162 errors in `MjPrintTest`, the errors being `FakeMaven` refusing `step` and `space` as parameters no mojo declares. With the mojo fixed, `MjPrintTest` (166) and `MjFormatTest` (12) are green and `qulice:check` passes on the module.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_