### PR TITLE
#7984: report xor length mismatches as bytes.xor

### DIFF
--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -8,10 +8,21 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[^ x] > xor
-  or. > @
-    ^.and x.not
-    ^.not.and x
+[^ x cant-xor] > xor
+  if. > @
+    ^.size.eq x.size
+    or.
+      ^.and x.not
+      ^.not.and x
+    cant-xor
+      "bytes.xor requires operands of the same length, got %d and %d".printf
+        * ^.size x.size
+
+  eq. ++> can-explain-why-xor-stops-on-different-lengths
+    "bytes.xor requires operands of the same length, got 2 and 3"
+    20-1F.xor
+      CA-FE-BE
+      I
 
   eq. ++> can-xor-negative-bytes-with-leading-zeroes
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00


### PR DESCRIPTION
Closes #7984.

`bytes.xor` was derived directly from `and`, `or`, and `not`, so operands of different lengths failed in the first `and` and exposed `bytes.and` in the diagnostic.

This change checks the operand sizes before entering that derivation. A mismatch now goes through a `cant-xor` fallback with the message:

```
bytes.xor requires operands of the same length, got 2 and 3
```

The fallback keeps the operation recoverable in the same way as other guarded EO operations. The EO tests now verify both the exact diagnostic text and termination when no fallback is supplied.

Tested with:

```
mvn -pl eo-runtime test -DskipITs
```

All 2,658 runtime tests passed (635 skipped by their existing conditions).
