### PR TITLE
#7990: say that a lone carriage return is not a line ending

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Source.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Source.java
@@ -17,8 +17,9 @@ import org.cactoos.scalar.Unchecked;
  * <p>The source is UTF-8 by contract (R-2.1.1) — caller-supplied as a
  * decoded {@link String}, so encoding handling lives in the layer above.
  * Line endings {@code \n} and {@code \r\n} are normalised to {@code \n}
- * (R-2.1.2); a bare {@code \r} also terminates a line. The final line need
- * not carry a terminator.</p>
+ * (R-2.1.2), and those two are the only ones: a {@code \r} that no
+ * {@code \n} follows stays inside the line, where {@link Eo} rejects it.
+ * The final line need not carry a terminator.</p>
  *
  * <p>Spans are produced in source order, numbered from 1. An empty input
  * yields no spans. An input that is a single empty line yields one blank


### PR DESCRIPTION
Closes #7990.

The parser and R-2.1.2 already agree on `master`. `Source.spans` splits on `\n` and `\r\n` and on nothing else, `SourceTest.keepsBareCarriageReturnInsideTheLine` pins that, and a `\r` that no `\n` follows is reported by `Eo`:

```
[1:4] error: 'standalone carriage return is not a line ending'
# D.\r\r[] > foo\r  a > x\r
    ^
```

which is the canonical text of the section 9.9 row for R-2.1.2, covered by `standalone-carriage-return-is-rejected.yaml`. So the file in the report does not parse silently; it is rejected on its first carriage return.

The one place that did disagree is the `Source` class comment, which claimed a bare `\r` also terminates a line. That sentence goes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_