### PR TITLE
#8000: draw the inference pages in one place only

### DIFF
--- a/.github/workflows/inference.yml
+++ b/.github/workflows/inference.yml
@@ -31,10 +31,10 @@ jobs:
       - uses: JesseTG/rm@v1.0.3
         with:
           path: ~/.m2/repository/org/eolang
-      # One pass over the whole reactor, with the flag on, so the goal writes
-      # the pages while eo-runtime is being built rather than inferring the
-      # same program twice.
-      - run: mvn install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip '-Deo.inferenceReport'
+      # One pass over the whole reactor, so the `inference-report` goal that
+      # eo-runtime's own pom asks for writes the pages while eo-runtime is
+      # being built, rather than inferring the same program twice.
+      - run: mvn install -ntp --errors --batch-mode -DskipTests -Dinvoker.skip
       # The pages are of eo-runtime, the only program here big enough to have
       # red spots worth hunting. `clean` is true so that the page of an .eo
       # file somebody deleted goes away with it, and it touches nothing

--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -106,12 +106,13 @@ The pages of eo-runtime are published at
 [www.eolang.org/inference](https://www.eolang.org/inference/), rebuilt on every
 tag, so looking at them needs nothing installed.
 
-Building them is off by default, since the tables are what the compiler needs
-and the pages are for a person. The goal runs in whichever module uses the
-plugin, so this is the shortest way to the pages of a working copy:
+Drawing them is a goal of its own, `inference-report`, since the tables are
+what the compiler needs and the pages are for a person: a build that wants
+them asks for the goal, one that does not never runs it. The pom of eo-runtime
+asks for it, so this is the shortest way to the pages of a working copy:
 
 ```bash
-mvn -pl eo-runtime process-sources -Deo.inferenceReport
+mvn -pl eo-runtime process-sources
 open eo-runtime/target/site/inference/index.html
 ```
 
@@ -119,11 +120,6 @@ They land in the `target/site/inference/` of the module they describe, beside
 the coverage report and every other generated page a person opens. They are
 not written into `target/eo/`, which is the compiler's scratch space, however
 much the tables they are made from live there.
-
-A property and not a profile, though coverage next door is turned on with
-`-Pjacoco`. A profile is what you need to add an execution to a build, and
-there is nothing to add here: the goal already runs, and one flag decides
-whether it writes.
 
 ## How it works
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -23,7 +22,6 @@ import org.eolang.inference.Demanded;
 import org.eolang.inference.Depth;
 import org.eolang.inference.Ladder;
 import org.eolang.inference.Relayed;
-import org.eolang.inference.Report;
 import org.eolang.inference.Resolved;
 import org.eolang.inference.Witnessed;
 import org.eolang.parser.TrFull;
@@ -45,12 +43,6 @@ import org.eolang.parser.TrFull;
  * dictionary to be read: a row saying that {@code Φ.app.t.next} has nothing
  * means something to a human as it stands. It also makes the tables of many
  * files one table, since no two files can name the same locator.</p>
- *
- * <p>The pages a reader looks at go nowhere near those three directories.
- * They are written under {@code target/site}, beside the coverage report and
- * every other generated page a person opens, because {@code target/eo} is the
- * compiler's scratch space — a numbered pipeline of intermediate XMIR nobody
- * opens on purpose — and a thing meant to be opened does not belong in it.</p>
  *
  * <p>Two things happen to a file before any rule looks at it. First, every
  * composite base is split into one object per dispatch step: the parser rolls
@@ -83,12 +75,6 @@ final class Inferring implements Step {
     private final Path tables;
 
     /**
-     * The directory for the pages a reader looks at, empty when nobody asked
-     * for them.
-     */
-    private final Path pages;
-
-    /**
      * Ctor.
      * @param parsed The directory with XMIR files, as the parser leaves them
      *  after its canonical pipeline (see {@code org.eolang.parser.Canonical})
@@ -96,23 +82,9 @@ final class Inferring implements Step {
      * @param rows The directory for the tables
      */
     Inferring(final Path parsed, final Path pre, final Path rows) {
-        this(parsed, pre, rows, Paths.get(""));
-    }
-
-    /**
-     * Ctor.
-     * @param parsed The directory with XMIR files, as the parser leaves them
-     *  after its canonical pipeline (see {@code org.eolang.parser.Canonical})
-     * @param pre The directory for the prepared XMIR files
-     * @param rows The directory for the tables
-     * @param site The directory for the pages a reader looks at, empty when
-     *  nobody asked for them
-     */
-    Inferring(final Path parsed, final Path pre, final Path rows, final Path site) {
         this.input = parsed;
         this.prepared = pre;
         this.tables = rows;
-        this.pages = site;
     }
 
     @Override
@@ -132,12 +104,6 @@ final class Inferring implements Step {
                 this.tables, new Tabled(this.tables).asString()
             );
             this.measured();
-            if (!this.pages.toString().isEmpty()) {
-                Logger.info(
-                    this, "Wrote %d page(s) to look at, they are in %[file]s",
-                    new Report(this.prepared, this.tables).written(this.pages), this.pages
-                );
-            }
         } else {
             Logger.info(
                 this, "The directory %[file]s is absent, nothing to infer from it",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
@@ -6,8 +6,6 @@ package org.eolang.maven;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -42,9 +40,8 @@ import org.apache.maven.plugins.annotations.Parameter;
  *
  * <p>The XMIR prepared for the rules is saved in {@link #prepared} and the
  * tables in {@link #tables}, a document each. Not one of them fails the
- * build. The pages a reader opens are not part of that scratch space and go
- * to {@link #pages}, under {@code target/site}, where the coverage report
- * already is.</p>
+ * build. The pages a reader opens are drawn by {@link MjInferenceReport},
+ * a goal of its own, from those same two directories.</p>
  *
  * @since 0.67.0
  */
@@ -78,45 +75,6 @@ public final class MjInference extends MjSafe {
     private File tables;
 
     /**
-     * Whether to write a page per source file, for a reader to look at.
-     *
-     * <p>Off by default. The tables are what the compiler needs and the pages
-     * are for a person, so they are written when somebody asks and not on
-     * every build. A property rather than a profile, though coverage next
-     * door is reached for with {@code -Pjacoco}: a profile is what you need
-     * to add an execution to a build, and there is nothing to add here — the
-     * goal already runs and one flag decides whether it writes.</p>
-     *
-     * @todo #7809:30min Draw the pages in one place only.
-     *  {@link MjInferenceReport} is a goal of its own now and eo-runtime asks
-     *  for it, so this flag, the {@link #pages} parameter and {@code wanted()}
-     *  below have nothing left to do, and neither has the {@code site}
-     *  argument of {@link Inferring} or the branch that reads it in
-     *  {@code Inferring.exec}. They stay for the moment so that a build
-     *  pinned to {@code -Deo.inferenceReport} keeps drawing. Take them out,
-     *  together with the paragraph about the flag in {@code eo-inference}'s
-     *  README and {@code InferringTest.writesThePagesWhereItIsTold}.
-     */
-    @Parameter(
-        alias = "inferenceReport",
-        property = "eo.inferenceReport",
-        required = true,
-        defaultValue = "false"
-    )
-    private boolean report;
-
-    /**
-     * The directory where the pages are written.
-     */
-    @Parameter(
-        alias = "inferenceReportDir",
-        property = "eo.inferenceReportDir",
-        required = true,
-        defaultValue = "${project.build.directory}/site/inference"
-    )
-    private File pages;
-
-    /**
      * Ctor.
      */
     public MjInference() {
@@ -129,19 +87,8 @@ public final class MjInference extends MjSafe {
             new Inferring(
                 this.targetDir.toPath().resolve(Parsing.DIR),
                 this.prepared.toPath(),
-                this.tables.toPath(),
-                this.wanted()
+                this.tables.toPath()
             )
         ).exec();
-    }
-
-    private Path wanted() {
-        final Path found;
-        if (this.report) {
-            found = this.pages.toPath();
-        } else {
-            found = Paths.get("");
-        }
-        return found;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -125,43 +125,6 @@ final class InferringTest {
     }
 
     @Test
-    void writesThePagesWhereItIsTold(@Mktmp final Path temp) throws IOException {
-        Files.writeString(
-            Files.createDirectories(temp.resolve("plot")).resolve("shrub.xmir"),
-            new EoSyntax(
-                String.join(System.lineSeparator(), "[] > shrub", "  [] > twig", "")
-            ).parsed().toString()
-        );
-        new Inferring(
-            temp.resolve("plot"), temp.resolve("pre"), temp.resolve("rows"),
-            temp.resolve("site").resolve("inference")
-        ).exec();
-        MatcherAssert.assertThat(
-            "the pages must land in the directory they were given, but they went elsewhere",
-            Files.exists(
-                temp.resolve("site").resolve("inference").resolve("index.html")
-            ),
-            Matchers.is(true)
-        );
-    }
-
-    @Test
-    void writesNoPagesWhenNobodyAsksForThem(@Mktmp final Path temp) throws IOException {
-        Files.writeString(
-            Files.createDirectories(temp.resolve("plot")).resolve("fern.xmir"),
-            new EoSyntax(
-                String.join(System.lineSeparator(), "[] > fern", "  [] > frond", "")
-            ).parsed().toString()
-        );
-        new Inferring(temp.resolve("plot"), temp.resolve("pre"), temp.resolve("rows")).exec();
-        MatcherAssert.assertThat(
-            "a build nobody asked a report of must write no pages, but it wrote some",
-            Files.exists(temp.resolve("rows").resolve("report")),
-            Matchers.is(false)
-        );
-    }
-
-    @Test
     void keepsFoldersOfProgram(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("tree").resolve("one")).resolve("leaf.xmir"),


### PR DESCRIPTION
Closes #8000, resolving the `7809-1e510e3f` puzzle in `MjInference`.

`MjInferenceReport` is a goal of its own and eo-runtime's own pom lists it, so `-Deo.inferenceReport` had nothing left to add: a build that set it drew the same pages twice, once from `MjInference` and once from the goal.

Gone: the `report` flag, the `pages` parameter it chose a directory with, `MjInference.wanted()`, the `site` argument of `Inferring` with the four-argument constructor and the branch in `exec` that read it, and `InferringTest.writesThePagesWhereItIsTold`. `writesNoPagesWhenNobodyAsksForThem` goes with them, since `Inferring` now draws nothing for anyone to ask for.

`eo-inference`'s README points at the goal instead of the flag, and the `inference` workflow no longer passes it — the pages it publishes come from the goal eo-runtime already runs.

`InferringTest` (67), `MjInferenceTest` and `MjInferenceReportTest` are green, and `qulice:check` passes on the module.