### PR TITLE
#7988: name the missing map key in the error

### DIFF
--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -66,7 +66,10 @@
       [^] > not-found
         false > exists
         cant-get > [^ cant-get] > get
-          recovered
+          if.
+            recovered
+              ^.^.key.length.gte 0
+              false
             "The key '%s' is not in the map".printf
               * ^.^.key
             "The key '%x' is not in the map".printf

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -8,6 +8,8 @@
 # Every key is dataized to bytes exactly once, when the map is built, and the
 # hash code is derived from those bytes rather than from the key itself,
 # so that keys with side effects are never evaluated more than once.
+# A missing key is named in the error as the key itself when it is text, or as
+# its bytes otherwise. The hash code is not printed: the caller never saw it.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -64,8 +66,11 @@
       [^] > not-found
         false > exists
         cant-get > [^ cant-get] > get
-          "Object by hash code %d from given key does not exists".printf
-            * hash
+          recovered
+            "The key '%s' is not in the map".printf
+              * ^.^.key
+            "The key '%x' is not in the map".printf
+              * kbts
     exists. > [^ key] > has
       ^.found key
     entries.mapped > keys
@@ -180,6 +185,24 @@
     map * > mp
       map.entry 1 1
       map.entry 1 2
+
+  eq. ++> can-name-the-missing-key-by-its-bytes-when-it-is-not-text
+    "The key '40-45-00-00-00-00-00-00' is not in the map"
+    get.
+      found.
+        map *
+          map.entry 1 1
+        42
+      I
+
+  eq. ++> can-name-the-missing-key-in-the-error
+    "The key 'absent' is not in the map"
+    get.
+      found.
+        map *
+          map.entry "one" 1
+        "absent"
+      I
 
   ++> can-rebuild-itself
     2.eq mp.size > @


### PR DESCRIPTION
A missing key used to print its hash ("Object by hash code %d from given key does not exists"). I don't have that number, and the grammar was wrong.

The message is now "The key '%s' is not in the map". If the key is not text, it falls back to the key's bytes with %x.

Closes #7988
