### PR TITLE
#7984: report a length mismatch under xor's own name

### DIFF
--- a/eo-runtime/src/main/eo/bytes/xor.eo
+++ b/eo-runtime/src/main/eo/bytes/xor.eo
@@ -1,5 +1,9 @@
 # Bitwise exclusive OR of the byte chain with another chain `x`,
 # derived from the `and`, `or`, and `not` atoms.
+#
+# The lengths are compared here first, ahead of the derivation, because
+# `and` requires operands of the same length and would otherwise report a
+# mismatched `xor` under the name of an atom the caller never called.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,9 +13,14 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^ x] > xor
-  or. > @
-    ^.and x.not
-    ^.not.and x
+  if. > @
+    ^.size.eq x.size
+    or.
+      ^.and x.not
+      ^.not.and x
+    T
+      "bytes.xor requires operands of the same length, got %d and %d".printf
+        * ^.size x.size
 
   eq. ++> can-xor-negative-bytes-with-leading-zeroes
     00-00-00-00-8E-EA-4C-B1.xor FF-FF-FF-FF-00-00-00-00


### PR DESCRIPTION
Closes #7984.

`bytes.xor` is derived from `and`, `or` and `not`, and `and` requires operands of the same length, so `0F-F0.xor FF-` failed inside the derivation and the caller was told

```
bytes.and requires operands of the same length, got 2 and 1
```

about an atom they never called. The sizes are compared ahead of the derivation now, and the message names `bytes.xor` in the same shape `and` and `or` use for themselves.

The existing `--> stops-on-xor-with-different-lengths` still covers the termination. The text itself cannot be pinned from EO: `xor` has no fallback attribute, and `recovered` hands back its alternative rather than the reason, so there is nowhere for a test to read the message. Only the name of the atom in it changes.

`TestEObytes` is green (122 tests) on a local `mvn clean test -pl :eo-runtime -Deo.deadline=3600`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_