### PR TITLE
#7985: refuse an argument that is not a boolean in `%b`

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -39,6 +39,12 @@
 # is printed as that control character instead of being rejected, and `%b`
 # remains the conversion to reach for a boolean.
 #
+# The `%b` conversion refuses an argument whose bytes are neither `00-` nor
+# `01-`, so a text or a number reaching it terminates instead of being
+# printed as `false`. The coin lands the other way up as well: the
+# one-character texts of U+0000 and U+0001 are accepted as booleans, since
+# their bytes are the bytes of `false` and `true`.
+#
 # The `%d` guard names the number it rejects through `as-scientific` and not
 # through `%f`, because every magnitude it rejects is past the range `as-fixed`
 # writes, and a reason rendered with `%f` destroyed itself instead of arriving.
@@ -222,8 +228,15 @@
             capped (bytes datum).as-hex
             if.
               62-.eq conv
-              capped
-                arg.as-bool.if "true" "false"
+              if.
+                or.
+                  01-.eq datum
+                  00-.eq datum
+                capped
+                  arg.as-bool.if "true" "false"
+                T
+                  "The argument %x is not a boolean, the %%b conversion takes true or false".printf
+                    * datum
               T
                 "The conversion %x in the format is unsupported, only %%s, %%d, %%f, %%x and %%b are".printf
                   *
@@ -564,6 +577,20 @@
     recovered
       "value=%f".printf
         * nan
+      "stopped"
+
+  eq. ++> can-stop-formatting-a-number-as-a-boolean
+    "stopped"
+    recovered
+      "%b".printf
+        * 0
+      "stopped"
+
+  eq. ++> can-stop-formatting-a-string-as-a-boolean
+    "stopped"
+    recovered
+      "%b".printf
+        * "x"
       "stopped"
 
   eq. ++> can-truncate-a-negative-float-toward-zero


### PR DESCRIPTION
Closes #7985.

`%b` read the bytes of its argument and printed `true` only for `01-`, so everything else came out as `false`:

```
"%b".printf (* "x")   -> false
"%b".printf (* 0)     -> false
```

which states something about a string and a number that is not so. It accepts the bytes of `true` and `false` now and terminates on anything else, naming the argument, the way `%s` and `%d` refuse what they cannot convert.

Two tests cover it. They recover from the termination rather than declaring it with `-->`, for the reason the file's own header already gives about `%f`: a returned text of more than one byte fails to dataize as a boolean exactly as a termination does, so a `-->` test would have passed against `master` too. `recovered` gives the assertion something to compare, and against `master` it would come back `"false"` rather than `"stopped"`.

The header gains a paragraph on what `%b` now refuses, and on the other face of the same coin the file already documents: a one-character text of U+0000 or U+0001 has the bytes of a boolean and is still accepted.

`TestEOstring` is green (418 tests) on a local `mvn clean test -pl :eo-runtime -Deo.deadline=3600`, with both new tests among them.

Touches the same `if` chain as #7976 (PR #8015), so whichever lands second will want a rebase.