### PR TITLE
#7976: name the conversion by its letter, not by its byte

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -225,9 +225,9 @@
               capped
                 arg.as-bool.if "true" "false"
               T
-                "The conversion %x in the format is unsupported, only %%s, %%d, %%f, %%x and %%b are".printf
+                "The conversion %s in the format is unsupported, only %%s, %%d, %%f, %%x and %%b are".printf
                   *
-                    bytes conv
+                    string conv
     arg.as-bytes > datum!
     flags-end > digits!
       number flags
@@ -366,9 +366,9 @@
                     64-.eq conv
                     66-.eq conv
               T
-                "The zero flag can't be applied to the %x conversion, only to %%d and %%f".printf
+                "The zero flag can't be applied to the %s conversion, only to %%d and %%f".printf
                   *
-                    bytes conv
+                    string conv
               converted
     digits-value > width!
       number digits


### PR DESCRIPTION
Closes #7976.

Two messages in `string/printf.eo` formatted the conversion with `%x` over its bytes, so the user was shown the hexadecimal value of the byte instead of the letter they wrote:

| call | before | after |
|---|---|---|
| `"%o".printf (* "x")` | `The conversion 6F in the format is unsupported, …` | `The conversion o in the format is unsupported, …` |
| `"%0s".printf (* "x")` | `The zero flag can't be applied to the 73 conversion, …` | `The zero flag can't be applied to the s conversion, …` |

`string conv` is safe at both points: `digits-end` walks the specifier through `code`, which is `as-ascii. string (byte i)`, so a byte that does not decode on its own has already terminated the run before either message can be raised.

The two `--> stops-on-…` tests keep covering the terminations. The texts themselves cannot be pinned from EO — `printf` has no fallback attribute and `recovered` hands back its alternative, not the reason — so nothing in the file can read a message back.

`TestEOstring` is green (418 tests) on a local `mvn clean test -pl :eo-runtime -Deo.deadline=3600`.

Touches the same `if` chain as #7985 (PR #8014), so whichever lands second will want a rebase.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_