### PR TITLE
#7987: say what tells `matches` and `match` apart

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -6,6 +6,18 @@
 # ```
 # (`Q.string.regex "/(word)/i").compiled.matches "WORD"
 # ```
+#
+# There are two entry points and one letter between their names.
+# `matches` answers whether the whole text matches: the block it finds has
+# to start at zero and end at the length of the text, so a pattern that
+# covers only part of it answers `false`.
+# `match` searches instead: it hands back the first block found anywhere in
+# the text, and `next` moves to the one after it.
+# ```
+# (`Q.string.regex "/[a-z]+/").compiled.matches "1abc"  # false
+# (`Q.string.regex "/[a-z]+/").compiled.match "1abc"    # the block "abc"
+# ```
+#
 # Supported flags:
 # /d - Enables Unix lines mode.
 # /i - Enables case-insensitive matching.


### PR DESCRIPTION
Closes #7987.

`regex.eo` offers two entry points one letter apart and the header explained neither, while its only example used a pattern that happened to cover the whole text, where the two agree. A reader who wrote `"/[a-z]+/".regex.compiled.matches "1abc"` expecting a search got `false`, and the only place saying so was a test name.

The header now says that `matches` answers for the whole text — the block it finds has to start at zero and end at the length — and that `match` searches for the first block anywhere, with `next` moving on, and it shows one example of each.

Comment only; no behaviour changes. `TestEOstring` is green (418 tests) on a local `mvn clean test -pl :eo-runtime -Deo.deadline=3600`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_