### PR TITLE
#7993: say that the four predicates refuse an empty string

### DIFF
--- a/eo-runtime/src/main/eo/string/is-alpha.eo
+++ b/eo-runtime/src/main/eo/string/is-alpha.eo
@@ -1,5 +1,7 @@
 # Check that all signs in the string are letters.
 # Works only for english letters.
+# An empty string is not a letter and is not accepted, since the pattern
+# asks for one sign at least.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/is-alphanumeric.eo
+++ b/eo-runtime/src/main/eo/string/is-alphanumeric.eo
@@ -1,5 +1,7 @@
 # Check that all signs in the string are numbers or letters.
 # Works only for english letters.
+# An empty string is neither and is not accepted, since the pattern asks
+# for one sign at least.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/is-ascii.eo
+++ b/eo-runtime/src/main/eo/string/is-ascii.eo
@@ -1,4 +1,6 @@
 # Check that all signs in the string are ASCII characters.
+# An empty string is not accepted, since the pattern asks for one sign at
+# least, which is what its three siblings answer for the empty text too.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo

--- a/eo-runtime/src/main/eo/string/is-digit.eo
+++ b/eo-runtime/src/main/eo/string/is-digit.eo
@@ -1,5 +1,7 @@
 # Check that all signs in the string are decimal digits.
 # Works only for english digits.
+# An empty string is not a digit and is not accepted, since the pattern
+# asks for one sign at least.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo


### PR DESCRIPTION
Closes #7993.

`is-alpha`, `is-digit`, `is-alphanumeric` and `is-ascii` all answer `false` for an empty text — each pattern is anchored around a `+`, so it asks for one sign at least — and none of their comments said so. A caller who writes `text.is-digit.if` on a text that may be empty got a branch nothing told them to expect.

`false` is kept as the answer rather than the vacuous `true`: it is what the four have always returned, each already has a test pinning it (`can-tell-it-is-not-alphabetic-when-empty` and its three siblings), and turning it round would silently change every caller. So the comments are what moves, one sentence each, and the four now agree on the empty text out loud.

Comments only; no behaviour changes. `TestEOstring` is green (418 tests) on a local `mvn clean test -pl :eo-runtime -Deo.deadline=3600`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NxFBB1HWHS1xgdM6bT9Qvw)_