### PR TITLE
#8001: key the transpiled Java files by the inference rows

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -41,15 +41,10 @@ final class JavaFiles {
     private final Path generated;
 
     /**
-     * The cache this build shares with every other build on this machine.
-     */
-    private final GlobalCache cache;
-
-    /**
      * Java files generated during the current transpilation.
      *
      * <p>The collection is shared by parallel {@link #total(boolean, Path,
-     * String, boolean)} calls. It is reconciled only after all XMIRs have
+     * String, boolean, GlobalCache)} calls. It is reconciled only after all XMIRs have
      * been processed.</p>
      */
     private final Collection<Path> fresh;
@@ -66,11 +61,9 @@ final class JavaFiles {
     /**
      * Ctor.
      * @param dir Generated sources directory
-     * @param store The cache shared with every build on this machine
      */
-    JavaFiles(final Path dir, final GlobalCache store) {
+    JavaFiles(final Path dir) {
         this.generated = dir;
-        this.cache = store;
         this.fresh = new ConcurrentLinkedQueue<>();
         this.touched = new ConcurrentLinkedQueue<>();
     }
@@ -81,15 +74,17 @@ final class JavaFiles {
      * @param target Full target path to XMIR after transpilation optimizations
      * @param hsh Tojo hash
      * @param tests Whether to generate test sources for this tojo
+     * @param cache The cache of this XMIR, keyed by the objects it holds
      * @return Amount of generated .java files
      * @throws IOException If fails to save files
-     * @checkstyle ParameterNumberCheck (5 lines)
+     * @checkstyle ParameterNumberCheck (6 lines)
      */
     int total(
         final boolean rewrite,
         final Path target,
         final String hsh,
-        final boolean tests
+        final boolean tests,
+        final GlobalCache cache
     ) throws IOException {
         final AtomicInteger saved = new AtomicInteger(0);
         if (Files.exists(target)) {
@@ -109,7 +104,7 @@ final class JavaFiles {
                     new JavaPlaced(
                         new FpIfReleased(
                             hsh,
-                            this.cache.kept(
+                            cache.kept(
                                 this.generated.relativize(tgt),
                                 () -> hsh,
                                 new RewritePolicy(rewrite, tgt),

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -123,9 +123,7 @@ final class Transpiling implements Step {
 
     @Override
     public void exec() throws IOException {
-        final JavaFiles files = new JavaFiles(
-            this.generated, this.cache.with(this.train.version())
-        );
+        final JavaFiles files = new JavaFiles(this.generated);
         final int transpiled = new Threaded<>(
             this.sources,
             tojo -> this.transpiled(tojo, files)
@@ -158,7 +156,10 @@ final class Transpiling implements Step {
         final Supplier<String> hsh = new TojoHash(tojo);
         final AtomicBoolean rewrite = new AtomicBoolean(false);
         final Function<XML, XML> transform = this.train.forSource(name);
-        this.cache.with(this.train.version(xmir.xpath("/object/o/@loc"))).footprint(
+        final GlobalCache store = this.cache.with(
+            this.train.version(xmir.xpath("/object/o/@loc"))
+        );
+        store.footprint(
             base.relativize(dest),
             hsh,
             src -> {
@@ -167,7 +168,8 @@ final class Transpiling implements Step {
             }
         ).apply(source, dest);
         return files.total(
-            rewrite.get(), dest, hsh.get(), this.tests && !tojo.discovered()
+            rewrite.get(), dest, hsh.get(), this.tests && !tojo.discovered(),
+            store
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -41,9 +41,9 @@ final class JavaFilesTest {
                 "the Java files written are not as many as the classes in the XMIR, seed: %d",
                 seed
             ),
-            new JavaFiles(
-                temp.resolve("generated"), new GlobalCache.GcFresh()
-            ).total(true, xmir, "", false),
+            new JavaFiles(temp.resolve("generated")).total(
+                true, xmir, "", false, new GlobalCache.GcFresh()
+            ),
             Matchers.equalTo(1)
         );
     }
@@ -61,12 +61,12 @@ final class JavaFilesTest {
             "<object><class java-name='org.eolang.EOsecond'><java>class EOsecond {}</java></class></object>",
             second
         ).value();
-        final JavaFiles initial = new JavaFiles(generated, new GlobalCache.GcFresh());
-        initial.total(true, first, "", false);
-        initial.total(true, second, "", false);
+        final JavaFiles initial = new JavaFiles(generated);
+        initial.total(true, first, "", false, new GlobalCache.GcFresh());
+        initial.total(true, second, "", false, new GlobalCache.GcFresh());
         initial.removeStale();
-        final JavaFiles current = new JavaFiles(generated, new GlobalCache.GcFresh());
-        current.total(true, second, "", false);
+        final JavaFiles current = new JavaFiles(generated);
+        current.total(true, second, "", false, new GlobalCache.GcFresh());
         current.removeStale();
         MatcherAssert.assertThat(
             "a stale Java file must be deleted while a currently-generated one must remain",
@@ -89,8 +89,8 @@ final class JavaFilesTest {
             "<object><class java-name='org.eolang.EOfirst'><java>class EOfirst {}</java></class></object>",
             xmir
         ).value();
-        final JavaFiles files = new JavaFiles(generated, new GlobalCache.GcFresh());
-        files.total(true, xmir, "", false);
+        final JavaFiles files = new JavaFiles(generated);
+        files.total(true, xmir, "", false, new GlobalCache.GcFresh());
         files.removeStale();
         MatcherAssert.assertThat(
             "a .java file written by another tool outside eo's own output directories must survive, but it didn't",
@@ -136,8 +136,8 @@ final class JavaFilesTest {
             "<object><class java-name='EOmain'><java>class EOmain {}</java></class></object>",
             plain
         ).value();
-        final JavaFiles first = new JavaFiles(generated, new GlobalCache.GcFresh());
-        first.total(true, plain, "", false);
+        final JavaFiles first = new JavaFiles(generated);
+        first.total(true, plain, "", false, new GlobalCache.GcFresh());
         first.removeStale();
         final Path atom = temp.resolve("atom.xmir");
         new Saved(
@@ -149,8 +149,8 @@ final class JavaFilesTest {
             ),
             atom
         ).value();
-        final JavaFiles second = new JavaFiles(generated, new GlobalCache.GcFresh());
-        second.total(true, atom, "", false);
+        final JavaFiles second = new JavaFiles(generated);
+        second.total(true, atom, "", false, new GlobalCache.GcFresh());
         second.removeStale();
         MatcherAssert.assertThat(
             "the class of an object that became an atom must go, but it survived the run",
@@ -173,11 +173,36 @@ final class JavaFilesTest {
             "<object><class java-name='EOmain'><java>class EOmain {}</java></class></object>",
             xmir
         ).value();
-        new JavaFiles(generated, new GcShared(dir, "1.0-key")).total(false, xmir, "abcdef", false);
+        new JavaFiles(generated).total(
+            false, xmir, "abcdef", false, new GcShared(dir, "1.0-key")
+        );
         MatcherAssert.assertThat(
             "the Java file must come from the directory the global cache names",
             Files.readString(generated.resolve("EOmain.java")),
             Matchers.equalTo("class EOcached {}")
+        );
+    }
+
+    @Test
+    void missesTheJavaFileCachedUnderAnotherKey(@Mktmp final Path temp) throws IOException {
+        final Path generated = temp.resolve("generated");
+        final Path dir = temp.resolve("cache");
+        new Saved(
+            "class EOcached {}",
+            dir.resolve("1.0-with-rows").resolve("abcdef").resolve("EOmain.java")
+        ).value();
+        final Path xmir = temp.resolve("main.xmir");
+        new Saved(
+            "<object><class java-name='EOmain'><java>class EOmain {}</java></class></object>",
+            xmir
+        ).value();
+        new JavaFiles(generated).total(
+            false, xmir, "abcdef", false, new GcShared(dir, "1.0-without-rows")
+        );
+        MatcherAssert.assertThat(
+            "a Java file cached under another key must not be taken",
+            Files.readString(generated.resolve("EOmain.java")),
+            Matchers.equalTo("class EOmain {}")
         );
     }
 
@@ -193,8 +218,8 @@ final class JavaFilesTest {
             ),
             xmir
         ).value();
-        return new JavaFiles(
-            temp.resolve("generated"), new GlobalCache.GcFresh()
-        ).total(true, xmir, "", false);
+        return new JavaFiles(temp.resolve("generated")).total(
+            true, xmir, "", false, new GlobalCache.GcFresh()
+        );
     }
 }


### PR DESCRIPTION
The Java files were pooled in one directory made from `Transpilation.version()`, which knows nothing about the tables, while the XMIR beside them was already keyed by the rows the object is named in. So a build that read different rows took Java written from different XMIR.

`total` now takes the cache of the file it is writing, and `Transpiling` hands it the same one it just used for the XMIR, computed once instead of twice.

Built on #8070's branch, since that is what gave `JavaFiles` a `GlobalCache` to be handed at all. Once #8071 is merged the diff here is just this change.

Closes #8001
