### PR TITLE
#7978: report the trailing blank run once, at its own line

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -82,6 +82,10 @@ final class Eo implements Iterable<Directive> {
             parent -> Eo.beforeChild(parent, emit)
         );
         final Recovery recovery = new Recovery(spans);
+        int tail = spans.size();
+        while (tail > 0 && spans.get(tail - 1).blank()) {
+            tail = tail - 1;
+        }
         int idx = 0;
         while (idx < spans.size()) {
             final Span span = spans.get(idx);
@@ -94,14 +98,14 @@ final class Eo implements Iterable<Directive> {
             } else if (!globals.inTextBlock() && !span.trailing()
                 && Eo.isBytesContinuation(span.body())) {
                 idx = Eo.mergeBytesContinuation(spans, idx, stack, globals, emit, recovery);
-            } else if (Eo.process(span, stack, globals, emit)) {
+            } else if (Eo.process(span, idx >= tail, stack, globals, emit)) {
                 idx = recovery.after(idx);
             } else {
                 idx = idx + 1;
             }
         }
         stack.close();
-        Eo.finish(globals, emit);
+        Eo.finish(globals, emit, spans);
         return emit.directives();
     }
 
@@ -221,7 +225,7 @@ final class Eo implements Iterable<Directive> {
             resumption = recovery.skip(idx, head.indent());
         } else if (Eo.process(
             new Span(" ".repeat(head.indent()).concat(body.toString()), head.line()),
-            stack, globals, emit
+            false, stack, globals, emit
         )) {
             resumption = recovery.skip(idx, head.indent());
         } else {
@@ -260,7 +264,8 @@ final class Eo implements Iterable<Directive> {
     }
 
     private static boolean process(
-        final Span span, final Stack stack, final Globals globals, final Emit emit
+        final Span span, final boolean tail, final Stack stack, final Globals globals,
+        final Emit emit
     ) {
         boolean failed = false;
         if (globals.inTextBlock()) {
@@ -283,7 +288,7 @@ final class Eo implements Iterable<Directive> {
             globals.markEmitted();
             globals.clearBlanks();
         } else {
-            failed = Eo.dispatch(span, stack, globals, emit);
+            failed = Eo.dispatch(span, tail, stack, globals, emit);
         }
         return failed;
     }
@@ -320,7 +325,8 @@ final class Eo implements Iterable<Directive> {
     }
 
     private static boolean dispatch(
-        final Span span, final Stack stack, final Globals globals, final Emit emit
+        final Span span, final boolean tail, final Stack stack, final Globals globals,
+        final Emit emit
     ) {
         if (!span.blank() && span.head() != '#') {
             stack.popDeeperThan(span.indent());
@@ -329,7 +335,7 @@ final class Eo implements Iterable<Directive> {
         final Globals saved = globals.savepoint();
         boolean failed = false;
         try {
-            Eo.classify(span).into(stack, globals, emit);
+            Eo.classify(span, tail).into(stack, globals, emit);
         } catch (final ParseError err) {
             point.apply();
             globals.restore(saved);
@@ -361,10 +367,10 @@ final class Eo implements Iterable<Directive> {
             && " .:?".indexOf(body.concat(" ").charAt(3)) >= 0;
     }
 
-    private static Line classify(final Span span) {
+    private static Line classify(final Span span, final boolean tail) {
         final Line line;
         if (span.blank()) {
-            line = new LnBlank(span);
+            line = new LnBlank(span, tail);
         } else if (span.head() == '#') {
             line = new LnComment(span);
         } else if (Eo.metaHead(span)) {
@@ -447,7 +453,9 @@ final class Eo implements Iterable<Directive> {
         return line;
     }
 
-    private static void finish(final Globals globals, final Emit emit) {
+    private static void finish(
+        final Globals globals, final Emit emit, final java.util.List<Span> spans
+    ) {
         if (globals.inTextBlock()) {
             emit.error(
                 globals.textBlockOpenLine(), 0,
@@ -462,8 +470,12 @@ final class Eo implements Iterable<Directive> {
             emit.comment(pending, pending.get(pending.size() - 1).line());
             globals.clearComments();
         }
-        if (globals.trailingBlanks() > 1) {
-            emit.error(0, 0, "more than one trailing blank line");
+        final int blanks = globals.trailingBlanks();
+        if (blanks > 1) {
+            emit.error(
+                spans.get(spans.size() - blanks + 1).line(), 0,
+                "more than one trailing blank line"
+            );
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnBlank.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnBlank.java
@@ -13,11 +13,16 @@ package org.eolang.parser;
  * the blank counters in {@link Globals} so the next line's classifier
  * can read {@code pendingBlanks()} and decide.</p>
  *
- * <p>Per R-6.5.1, blanks inside a comment block are forbidden. Per
- * R-6.5.6 / R-8.4, more than one trailing blank at EOF is an error.
+ * <p>Per R-6.5.1, blanks inside a comment block are forbidden.
  * R-6.5.3 caps the run of consecutive blanks at one; the moment a
  * second blank lands we report it here — its position is unambiguous
  * regardless of what the next non-blank line turns out to be.</p>
+ *
+ * <p>The run of blanks that closes the file is exempt: it separates no
+ * two non-blank lines and precedes no object, so R-6.5.3 has nothing to
+ * say about it. That run is the business of R-6.5.6 / R-8.4, reported
+ * once at end of stream, and a blank of it that reported here too would
+ * say the same thing twice (#7978).</p>
  *
  * @since 0.1
  */
@@ -29,16 +34,23 @@ final class LnBlank implements Line {
     private final Span span;
 
     /**
+     * Whether this blank belongs to the run that closes the file.
+     */
+    private final boolean tail;
+
+    /**
      * Ctor.
      * @param source Source span
+     * @param closing Whether this blank belongs to the run that closes the file
      */
-    LnBlank(final Span source) {
+    LnBlank(final Span source, final boolean closing) {
         this.span = source;
+        this.tail = closing;
     }
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        if (globals.pendingBlanks() >= 1) {
+        if (!this.tail && globals.pendingBlanks() >= 1) {
             emit.error(
                 this.span.line(), 0,
                 "consecutive blank lines forbidden — at most one blank may separate two non-blank lines (R-6.5.3)"

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -208,10 +208,34 @@ final class EoTest {
     @Test
     void reportsExcessiveTrailingBlanks() {
         MatcherAssert.assertThat(
-            "more than one trailing blank line at EOF must be reported per R-6.5.6",
+            "more than one trailing blank line at EOF must be reported per R-6.5.6, at the line of the second one",
             EoTest.render("+foo", "", ""),
             XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'more than one trailing blank line')]"
+                "/object/errors/error[@line='3' and contains(text(),'more than one trailing blank line')]"
+            )
+        );
+    }
+
+    @Test
+    void skipsConsecutiveBlanksRuleAtEndOfFile() {
+        MatcherAssert.assertThat(
+            "the run of blanks that closes the file must be reported once, by R-6.5.6 alone",
+            EoTest.render("+foo", "", "", ""),
+            Matchers.not(
+                XhtmlMatchers.hasXPath(
+                    "/object/errors/error[contains(text(),'consecutive blank lines forbidden')]"
+                )
+            )
+        );
+    }
+
+    @Test
+    void reportsConsecutiveBlanksInTheMiddleOfTheFile() {
+        MatcherAssert.assertThat(
+            "two blanks between two objects are still an R-6.5.3 error",
+            EoTest.render("[] > foo", "", "", "[] > bar"),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[@line='3' and contains(text(),'consecutive blank lines forbidden')]"
             )
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -217,30 +217,6 @@ final class EoTest {
     }
 
     @Test
-    void skipsConsecutiveBlanksRuleAtEndOfFile() {
-        MatcherAssert.assertThat(
-            "the run of blanks that closes the file must be reported once, by R-6.5.6 alone",
-            EoTest.render("+foo", "", "", ""),
-            Matchers.not(
-                XhtmlMatchers.hasXPath(
-                    "/object/errors/error[contains(text(),'consecutive blank lines forbidden')]"
-                )
-            )
-        );
-    }
-
-    @Test
-    void reportsConsecutiveBlanksInTheMiddleOfTheFile() {
-        MatcherAssert.assertThat(
-            "two blanks between two objects are still an R-6.5.3 error",
-            EoTest.render("[] > foo", "", "", "[] > bar"),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[@line='3' and contains(text(),'consecutive blank lines forbidden')]"
-            )
-        );
-    }
-
-    @Test
     void parsesTopLevelFormation() {
         MatcherAssert.assertThat(
             "a single `[] > foo` line must emit one named <o> under the program root",

--- a/eo-parser/src/test/java/org/eolang/parser/LnBlankTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnBlankTest.java
@@ -57,4 +57,30 @@ final class LnBlankTest {
             Matchers.emptyIterable()
         );
     }
+
+    @Test
+    void skipsTheConsecutiveBlanksRuleAtEndOfFile() {
+        final Globals globals = new Globals();
+        globals.blank();
+        final Emit emit = new Emit();
+        new LnBlank(new Span("", 2), true).into(new Stack(), globals, emit);
+        MatcherAssert.assertThat(
+            "a blank of the run that closes the file has no R-6.5.3 error of its own",
+            emit.directives(),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void reportsTheSecondBlankInTheMiddleOfTheFile() {
+        final Globals globals = new Globals();
+        globals.blank();
+        final Emit emit = new Emit();
+        new LnBlank(new Span("", 2), false).into(new Stack(), globals, emit);
+        MatcherAssert.assertThat(
+            "two blanks between two non-blank lines are still an R-6.5.3 error",
+            emit.directives(),
+            Matchers.not(Matchers.emptyIterable())
+        );
+    }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/LnBlankTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnBlankTest.java
@@ -17,7 +17,7 @@ final class LnBlankTest {
     @Test
     void incrementsPendingBlankCounter() {
         final Globals globals = new Globals();
-        new LnBlank(new Span("", 1)).into(new Stack(), globals, new Emit());
+        new LnBlank(new Span("", 1), false).into(new Stack(), globals, new Emit());
         MatcherAssert.assertThat(
             "a blank line must bump pendingBlanks so the next line can read it",
             globals.pendingBlanks(),
@@ -28,7 +28,7 @@ final class LnBlankTest {
     @Test
     void incrementsTrailingBlankCounter() {
         final Globals globals = new Globals();
-        new LnBlank(new Span("", 1)).into(new Stack(), globals, new Emit());
+        new LnBlank(new Span("", 1), false).into(new Stack(), globals, new Emit());
         MatcherAssert.assertThat(
             "a blank line must bump trailingBlanks so EOF can check the tail",
             globals.trailingBlanks(),
@@ -39,7 +39,7 @@ final class LnBlankTest {
     @Test
     void leavesStackUntouched() {
         final Stack stack = new Stack();
-        new LnBlank(new Span("", 1)).into(stack, new Globals(), new Emit());
+        new LnBlank(new Span("", 1), false).into(stack, new Globals(), new Emit());
         MatcherAssert.assertThat(
             "a blank line cannot push, pop, or otherwise change the stack",
             stack.empty(),
@@ -50,7 +50,7 @@ final class LnBlankTest {
     @Test
     void emitsNoDirectives() {
         final Emit emit = new Emit();
-        new LnBlank(new Span("", 1)).into(new Stack(), new Globals(), emit);
+        new LnBlank(new Span("", 1), false).into(new Stack(), new Globals(), emit);
         MatcherAssert.assertThat(
             "a blank line cannot append directives — its only effect is the counter bump",
             emit.directives(),


### PR DESCRIPTION
A file ending with two or more blank lines was reported twice: `LnBlank` raised R-6.5.3 for every extra blank in the run, and `Eo.finish` raised the canonical R-6.5.6 text on top of it, at line 0 pos 0, which points at nothing.

The run of blanks that closes the file separates no two non-blank lines and precedes no object, so R-6.5.3 has nothing to say about it. `LnBlank` now knows when it belongs to that run and stays quiet, and `Eo.finish` reports it at the line of the second trailing blank.

Closes #7978
