### PR TITLE
#7709: keep the suffix shape when a dispatch carries a binding

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -135,6 +135,14 @@ final class Node {
      * indentation and repeated base characters outweigh that one bracket
      * (#5650).</p>
      *
+     * <p>When the dispatch carries an inline binding ({@code :hey}), the
+     * suffix shape is taken whatever the penalties say. The vertical head of
+     * a reversed dispatch ends with the dot, and a binding glued onto it
+     * ({@code print.:hey}) is text the grammar does not accept, so the
+     * printer would write a file the next build cannot read (#7709). The
+     * suffix shape puts the receiver in front of the dot and leaves the
+     * binding after a name, where it parses.</p>
+     *
      * @param style The style to lay out in
      * @param indent The indentation level
      * @return The rendered block
@@ -144,7 +152,7 @@ final class Node {
         final Optional<Node> suffix = this.suffixed();
         if (suffix.isPresent()) {
             final String alt = suffix.get().shaped(style, indent);
-            if (style.points(alt) <= style.points(best)) {
+            if (this.labelled() || style.points(alt) <= style.points(best)) {
                 best = alt;
             }
         }
@@ -386,7 +394,8 @@ final class Node {
             String best = this.vertical(style, indent);
             final Optional<String> flat = this.horizontal(style, indent);
             if (flat.isPresent()
-                && (this.forced() || style.points(flat.get()) <= style.points(best))) {
+                && (this.forced() || this.labelled()
+                || style.points(flat.get()) <= style.points(best))) {
                 best = flat.get();
             }
             if (star.isPresent() && style.points(star.get()) < style.points(best)) {
@@ -510,6 +519,10 @@ final class Node {
 
     private boolean constant() {
         return "!".equals(this.tail);
+    }
+
+    private boolean labelled() {
+        return this.reversed && this.tail.startsWith(":");
     }
 
     private boolean forced() {

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/binding-on-reversed-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/binding-on-reversed-dispatch.yaml
@@ -1,0 +1,26 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An application bound to a void by name, whose receiver needs a vertical
+# layout of its own. The head of a vertical reversed dispatch ends with the
+# dot, so a binding glued onto it reads `print.:hey` and the grammar rejects
+# it. The suffix shape puts the receiver in front of the dot and the binding
+# lands after a name, where it parses.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  [] > main
+    f > out
+      ((t r 8.54 "yes").print 88 31):hey
+
+printed: |
+  [] > main
+    f > out
+      (t r 8.54 "yes").print:hey
+        88
+        31


### PR DESCRIPTION
The head of a vertical reversed dispatch ends with the dot, so an inline binding glued onto it came out as `print.:hey`, which the grammar rejects. `MjFormat` writes the printer output over the source, so a valid file became one the next build cannot read.

`Node` now takes the suffix shape whenever the dispatch carries a binding, whatever the penalties say: the receiver moves in front of the dot and the binding lands after a name. The horizontal shape is preferred over the vertical one for the same reason when no suffix shape exists.

New print-pack `binding-on-reversed-dispatch.yaml` holds the case from the issue. `printsToParseableEo` reparses it, so the round trip is checked too.

Closes #7709
