### PR TITLE
fix(#7992): scanf matches a run of spaces for a space in the format

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -439,12 +439,19 @@
       "%s!".scanf "hello!"
 
   eq. ++> can-scan-two-fields-separated-by-extra-spaces
-    "%s %s".scanf "a  b"
-    * "a" "b"
+    "%s %s".scanf
+      "a  b"
+    *
+      "a"
+      "b"
 
   eq. ++> can-scan-three-fields-separated-by-extra-spaces
-    "%s %s %s".scanf "a  b c"
-    * "a" "b" "c"
+    "%s %s %s".scanf
+      "a  b c"
+    *
+      "a"
+      "b"
+      "c"
 
   eq. ++> can-scan-while-ignoring-trailing-text
     42

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -6,6 +6,8 @@
 # - %d - parse as integer and convert to `number`
 # - %f - parse as float and convert to `number`
 # - %s - parse as string and convert to `string`.
+# A space in the format matches a run of one or more spaces in the input, so
+# extra spaces between fields never shift or drop the values that follow.
 #
 # The `%f` conversion never materializes the whole power of ten at once,
 # because `10.power 309` is already infinity: a single multiplication by it
@@ -311,13 +313,21 @@
             accumulated
             found
             true
-          ^.tokenize
-            position.plus 1
-            accumulated.chained
-              *
-                escaped ch
-            found
-            false
+          if.
+            ch.eq " "
+            ^.tokenize
+              position.plus 1
+              accumulated.chained
+                * "\\s+"
+              found
+              false
+            ^.tokenize
+              position.plus 1
+              accumulated.chained
+                *
+                  escaped ch
+              found
+              false
     ^.^.slice > ch
       position
       1
@@ -427,6 +437,14 @@
     "hello"
     head.
       "%s!".scanf "hello!"
+
+  eq. ++> can-scan-two-fields-separated-by-extra-spaces
+    "%s %s".scanf "a  b"
+    * "a" "b"
+
+  eq. ++> can-scan-three-fields-separated-by-extra-spaces
+    "%s %s %s".scanf "a  b c"
+    * "a" "b" "c"
 
   eq. ++> can-scan-while-ignoring-trailing-text
     42


### PR DESCRIPTION
`scanf` turns each character of its format string into a piece of a regex.
Every character that is not a `%d`/`%f`/`%s` specifier fell into the same
branch, so a literal space in the format became a literal single space in
the regex — it could only match exactly one space in the input. Any extra
blank between two `%s` fields then landed as an empty string, and every
value after it shifted one slot to the left:

```
"%s %s".scanf "a b"       -> * "a" "b"
"%s %s".scanf "a  b"      -> * "a" ""      (b lost)
"%s %s %s".scanf "a  b c" -> * "a" "" "b"  (c lost)
```

A space in the format now compiles to `\s+` instead of a literal space, so
it matches a run of one or more blanks. Added `can-scan-two-fields-separated-by-extra-spaces`
and `can-scan-three-fields-separated-by-extra-spaces`, reproducing the two
broken cases from the issue, and a docblock line documenting the behavior.

Closes #7992