### PR TITLE
expose group-exists so a non-participating group can be told from an empty match

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -61,6 +61,8 @@
       [] > missing
         T > count
           "Matched block does not exist, can't get count"
+        T > existing
+          "Matched block does not exist, can't get groups"
         start.gte 0 > exists
         T > from
           "Matched block does not exist, can't get 'from' position"
@@ -69,8 +71,6 @@
         T > [index] > group-exists
           "Matched block does not exist, can't get group-exists"
         T > groups
-          "Matched block does not exist, can't get groups"
-        T > existing
           "Matched block does not exist, can't get groups"
         T > next
           "Matched block does not exist, can't get next"

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -31,11 +31,11 @@
   [^ serialized] > pattern
     ^.pattern serialized > compiled
     [^ txt] > match
-      [^ position start from to groups groups-exist] > matched
+      [^ position start from to groups existing] > matched
         groups.length > count
         start.gte 0 > exists
         ^.groups.at index > [^ index] > group
-        ^.groups-exist.at index > [^ index] > group-exists
+        ^.existing.at index > [^ index] > group-exists
         exists.if > next
           if.
             and.
@@ -70,7 +70,7 @@
           "Matched block does not exist, can't get group-exists"
         T > groups
           "Matched block does not exist, can't get groups"
-        T > groups-exist
+        T > existing
           "Matched block does not exist, can't get groups"
         T > next
           "Matched block does not exist, can't get next"

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -31,10 +31,11 @@
   [^ serialized] > pattern
     ^.pattern serialized > compiled
     [^ txt] > match
-      [^ position start from to groups] > matched
+      [^ position start from to groups groups-exist] > matched
         groups.length > count
         start.gte 0 > exists
         ^.groups.at index > [^ index] > group
+        ^.groups-exist.at index > [^ index] > group-exists
         exists.if > next
           if.
             and.
@@ -65,7 +66,11 @@
           "Matched block does not exist, can't get 'from' position"
         T > [index] > group
           "Matched block does not exist, can't get group"
+        T > [index] > group-exists
+          "Matched block does not exist, can't get group-exists"
         T > groups
+          "Matched block does not exist, can't get groups"
+        T > groups-exist
           "Matched block does not exist, can't get groups"
         T > next
           "Matched block does not exist, can't get next"
@@ -113,6 +118,17 @@
     next. > first
       "/./".regex.compiled.match "😀x"
     first.next > second
+
+  ++> can-expose-group-exists-for-a-non-participating-group
+    not. > @
+      first.group-exists 1
+    next. > first
+      "/(x)?y/".regex.compiled.match "y"
+
+  ++> can-expose-group-exists-for-a-participating-group
+    first.group-exists 1 > @
+    next. > first
+      "/(x*)y/".regex.compiled.match "y"
 
   ++> can-expose-groups-on-each-matched-block
     and. > @
@@ -242,6 +258,11 @@
   "(.)+".regex.compiled --> stops-on-a-missing-first-slash
 
   "/[a-z/".regex.compile --> stops-on-compiling-an-invalid-pattern
+
+  group-exists. --> stops-on-taking-a-group-exists-of-an-unmatched-block
+    next.
+      "/[a-z]+/".regex.match "123"
+    1
 
   group. --> stops-on-taking-a-group-of-a-terminal-zero-width-match
     next.

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -114,7 +114,7 @@ public final class EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index exten
             exist = new Phi[]{new Data.ToPhi(true)};
         }
         result.put("groups", new Data.ToPhi(groups));
-        result.put("groups-exist", new Data.ToPhi(exist));
+        result.put("existing", new Data.ToPhi(exist));
     }
 
     private void blank(final Phi result) {
@@ -143,7 +143,7 @@ public final class EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index exten
             new PhTerminator(new Data.ToPhi("Matched block does not exist, can't get groups"))
         );
         result.put(
-            "groups-exist",
+            "existing",
             new PhTerminator(new Data.ToPhi("Matched block does not exist, can't get groups"))
         );
     }

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.java
@@ -100,17 +100,21 @@ public final class EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index exten
         result.put("from", new Data.ToPhi(text.codePointCount(0, matcher.start())));
         result.put("to", new Data.ToPhi(text.codePointCount(0, matcher.end())));
         final Phi[] groups;
+        final Phi[] exist;
         if (matcher.groupCount() > 0) {
             groups = new Phi[matcher.groupCount() + 1];
+            exist = new Phi[matcher.groupCount() + 1];
             for (int idx = 0; idx < groups.length; ++idx) {
-                groups[idx] = new Data.ToPhi(
-                    Optional.ofNullable(matcher.group(idx)).orElse("")
-                );
+                final String captured = matcher.group(idx);
+                groups[idx] = new Data.ToPhi(Optional.ofNullable(captured).orElse(""));
+                exist[idx] = new Data.ToPhi(captured != null);
             }
         } else {
             groups = new Phi[]{new Data.ToPhi(matcher.group())};
+            exist = new Phi[]{new Data.ToPhi(true)};
         }
         result.put("groups", new Data.ToPhi(groups));
+        result.put("groups-exist", new Data.ToPhi(exist));
     }
 
     private void blank(final Phi result) {
@@ -136,6 +140,10 @@ public final class EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index exten
         );
         result.put(
             "groups",
+            new PhTerminator(new Data.ToPhi("Matched block does not exist, can't get groups"))
+        );
+        result.put(
+            "groups-exist",
             new PhTerminator(new Data.ToPhi("Matched block does not exist, can't get groups"))
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/EOstringEOregexEOpatternEOmatchEOmatchedfromindexTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOstringEOregexEOpatternEOmatchEOmatchedfromindexTest.java
@@ -109,6 +109,36 @@ final class EOstringEOregexEOpatternEOmatchEOmatchedfromindexTest {
     }
 
     @Test
+    void readsGroupExistsAsFalseForNonParticipatingOptionalGroup() {
+        MatcherAssert.assertThat(
+            "group-exists must be false for an optional group that did not participate",
+            new Dataized(
+                new PhApplication(
+                    EOstringEOregexEOpatternEOmatchEOmatchedfromindexTest
+                        .optionalGroupMatch().take("group-exists").copy(),
+                    new Bind("index", new Data.ToPhi(2))
+                )
+            ).asBool(),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void readsGroupExistsAsTrueForParticipatingGroup() {
+        MatcherAssert.assertThat(
+            "group-exists must be true for a group that did participate",
+            new Dataized(
+                new PhApplication(
+                    EOstringEOregexEOpatternEOmatchEOmatchedfromindexTest
+                        .optionalGroupMatch().take("group-exists").copy(),
+                    new Bind("index", new Data.ToPhi(1))
+                )
+            ).asBool(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
     void rejectsStartIndexAfterTextEnd() {
         MatcherAssert.assertThat(
             String.format(


### PR DESCRIPTION
A capture group that never took part in a match reports the same empty
string as one that matched an empty string, so `"/(x)?y/".regex.compiled.match
"y"` and `"/(x*)y/".regex.compiled.match "y"` are indistinguishable by
inspecting `group 1`.

This adds a `group-exists` accessor next to `group` on the `matched` object,
backed by a new `groups-exist` array built alongside `groups` in
`EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index`. Where `group idx`
previously turned `matcher.group(idx) == null` into `""`, the fill step now
also records whether the capture was `null` and exposes that per index. The
`missing` branch and the unmatched-block case terminate `group-exists` the
same way the existing `group` and `groups` accessors already do.

Tests cover both directions: a group that does not participate reports
`group-exists` as false, a group that does participate reports it as true,
and asking for `group-exists` on an unmatched block still stops the same way
`group` does.

Closes #7989