### PR TITLE
#7986: name the offending construct and its offset when a regex fails to compile

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -180,6 +180,14 @@
     "/(.+)/d".regex.compiled
     "A\\r\\nB\\rC\\nD"
 
+  eq. ++> can-name-the-construct-and-the-offset-of-an-invalid-pattern
+    "/a**/".regex.compile I
+    "regex syntax is invalid: Dangling meta character '*' at offset 2 of the pattern"
+
+  eq. ++> can-name-the-offset-inside-a-pattern-that-carries-flags
+    "/a**/i".regex.compile I
+    "regex syntax is invalid: Dangling meta character '*' at offset 2 of the pattern"
+
   eq. ++> can-recover-from-a-pattern-with-a-missing-slash
     "no-slash"
     "(.)+".regex.compile
@@ -221,6 +229,10 @@
 
   not. ++> can-stop-at-a-terminal-zero-width-match
     exists. ("/$/".regex.match "x").next.next
+
+  eq. ++> can-tell-an-unclosed-group-from-a-dangling-repetition
+    "/(/".regex.compile I
+    "regex syntax is invalid: Unclosed group at offset 1 of the pattern"
 
   not. ++> can-tell-it-does-not-match-a-text-against-a-wrong-pattern
     "/[a-z]+/".regex.compiled.matches "123"

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
@@ -67,6 +67,9 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
         if (!expression.endsWith("/")) {
             builder.append("(?").append(expression.substring(last + 1)).append(')');
         }
+        // The flag group is compiled in front of the pattern, so its length is
+        // taken off the index the engine reports, leaving an offset into the
+        // pattern the caller wrote (#7986).
         final int flags = builder.length();
         builder.append(expression, 1, last);
         Phi result;
@@ -78,38 +81,19 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
             result = this.take(Phi.RHO).take("pattern");
             result.put(0, new Data.ToPhi(baos.toByteArray()));
         } catch (final PatternSyntaxException ex) {
-            result = this.fallback(this.explained(ex, flags));
+            final int offset = ex.getIndex() - flags;
+            final String reason;
+            if (ex.getIndex() < 0 || offset < 0) {
+                reason = String.format("regex syntax is invalid: %s", ex.getDescription());
+            } else {
+                reason = String.format(
+                    "regex syntax is invalid: %s at offset %d of the pattern",
+                    ex.getDescription(), offset
+                );
+            }
+            result = this.fallback(reason);
         } catch (final IOException ex) {
             throw new ExFailure("cannot serialize the compiled regex pattern", ex);
-        }
-        return result;
-    }
-
-    /**
-     * The message a failed compilation is reported with.
-     *
-     * <p>The engine walks the pattern with an index and names the construct
-     * it choked on, so both go into the message: one message per mistake
-     * instead of one for all of them (#7986). The index is counted from the
-     * start of what was compiled, which is the flag group first when the
-     * pattern carries flags, so the group is taken off to leave an offset
-     * into the pattern the caller wrote. An error inside the flag group
-     * itself lands before that start and is reported without an offset.</p>
-     *
-     * @param ex The failure the engine raised
-     * @param flags Length of the flag group put in front of the pattern
-     * @return The message
-     */
-    private String explained(final PatternSyntaxException ex, final int flags) {
-        final int offset = ex.getIndex() - flags;
-        final String result;
-        if (ex.getIndex() < 0 || offset < 0) {
-            result = String.format("regex syntax is invalid: %s", ex.getDescription());
-        } else {
-            result = String.format(
-                "regex syntax is invalid: %s at offset %d of the pattern",
-                ex.getDescription(), offset
-            );
         }
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
@@ -67,6 +67,7 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
         if (!expression.endsWith("/")) {
             builder.append("(?").append(expression.substring(last + 1)).append(')');
         }
+        final int flags = builder.length();
         builder.append(expression, 1, last);
         Phi result;
         try {
@@ -77,9 +78,38 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
             result = this.take(Phi.RHO).take("pattern");
             result.put(0, new Data.ToPhi(baos.toByteArray()));
         } catch (final PatternSyntaxException ex) {
-            result = this.fallback("regex syntax is invalid");
+            result = this.fallback(this.explained(ex, flags));
         } catch (final IOException ex) {
             throw new ExFailure("cannot serialize the compiled regex pattern", ex);
+        }
+        return result;
+    }
+
+    /**
+     * The message a failed compilation is reported with.
+     *
+     * <p>The engine walks the pattern with an index and names the construct
+     * it choked on, so both go into the message: one message per mistake
+     * instead of one for all of them (#7986). The index is counted from the
+     * start of what was compiled, which is the flag group first when the
+     * pattern carries flags, so the group is taken off to leave an offset
+     * into the pattern the caller wrote. An error inside the flag group
+     * itself lands before that start and is reported without an offset.</p>
+     *
+     * @param ex The failure the engine raised
+     * @param flags Length of the flag group put in front of the pattern
+     * @return The message
+     */
+    private String explained(final PatternSyntaxException ex, final int flags) {
+        final int offset = ex.getIndex() - flags;
+        final String result;
+        if (ex.getIndex() < 0 || offset < 0) {
+            result = String.format("regex syntax is invalid: %s", ex.getDescription());
+        } else {
+            result = String.format(
+                "regex syntax is invalid: %s at offset %d of the pattern",
+                ex.getDescription(), offset
+            );
         }
         return result;
     }

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
@@ -13,6 +13,15 @@ import java.util.regex.PatternSyntaxException;
 
 /**
  * Regex.compile object.
+ *
+ * <p>A pattern that does not compile is reported with the construct the
+ * engine choked on and the offset it sits at, so that six different
+ * mistakes no longer read the same (#7986). The flag group is compiled in
+ * front of the pattern, so its length is taken off the index the engine
+ * reports, leaving an offset into the pattern the caller wrote; an error
+ * inside the flag group itself lands before that start and is reported
+ * without an offset.</p>
+ *
  * @since 0.39.0
  * @checkstyle IllegalIdentifierNameCheck (6 lines)
  * @checkstyle TypeNameCheck (5 lines)
@@ -67,9 +76,6 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
         if (!expression.endsWith("/")) {
             builder.append("(?").append(expression.substring(last + 1)).append(')');
         }
-        // The flag group is compiled in front of the pattern, so its length is
-        // taken off the index the engine reports, leaving an offset into the
-        // pattern the caller wrote (#7986).
         final int flags = builder.length();
         builder.append(expression, 1, last);
         Phi result;


### PR DESCRIPTION
Every compilation failure was reported as `regex syntax is invalid`, with no position and no reason, so six different mistakes read the same.

The engine already walks the pattern with an index and names the construct it choked on, so both now go into the message: `regex syntax is invalid: Unclosed group at offset 1 of the pattern`. When the pattern carries flags the flag group is compiled in front of it, so its length is taken off the index to leave an offset into the pattern the caller wrote.

Closes #7986
