### PR TITLE
#8070: give JavaFiles the global cache instead of a directory of its own

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GcShared.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GcShared.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Supplier;
+import org.cactoos.BiFunc;
 import org.cactoos.Func;
 
 /**
@@ -66,6 +67,18 @@ final class GcShared implements GlobalCache {
             );
             return target;
         };
+    }
+
+    @Override
+    public Footprint kept(
+        final Path tail,
+        final Supplier<String> hash,
+        final BiFunc<Path, Path, Boolean> rewrite,
+        final Footprint made
+    ) {
+        return new FpAppliedWithCache(
+            made, new CachePath(this.dir, this.key, hash, tail), rewrite, true
+        );
     }
 
     @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/GlobalCache.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/GlobalCache.java
@@ -6,6 +6,7 @@ package org.eolang.maven;
 
 import java.nio.file.Path;
 import java.util.function.Supplier;
+import org.cactoos.BiFunc;
 import org.cactoos.Func;
 import org.cactoos.io.InputOf;
 
@@ -31,6 +32,25 @@ interface GlobalCache {
     Footprint footprint(Path tail, Supplier<String> hash, Func<Path, String> compile);
 
     /**
+     * How one file, already made by a footprint of its own, is to be kept.
+     *
+     * <p>Unlike {@link #footprint(Path, Supplier, Func)}, the content does not
+     * come from a source file this cache can fingerprint: the caller knows on
+     * its own whether the target is out of date and says so through
+     * {@code rewrite}.</p>
+     *
+     * @param tail Path of that file inside the cache
+     * @param hash Hash segment of the cache path
+     * @param rewrite Whether the target has to be written again
+     * @param made How the file is produced when the cache has nothing
+     * @return The footprint that writes it
+     * @checkstyle ParameterNumberCheck (3 lines)
+     */
+    Footprint kept(
+        Path tail, Supplier<String> hash, BiFunc<Path, Path, Boolean> rewrite, Footprint made
+    );
+
+    /**
      * The same cache, with one more segment folded into its key.
      * @param segment The segment to fold in
      * @return The derived cache
@@ -53,6 +73,18 @@ interface GlobalCache {
             final Path tail, final Supplier<String> hash, final Func<Path, String> compile
         ) {
             return new FpGenerated(src -> new InputOf(compile.apply(src)));
+        }
+
+        @Override
+        public Footprint kept(
+            final Path tail,
+            final Supplier<String> hash,
+            final BiFunc<Path, Path, Boolean> rewrite,
+            final Footprint made
+        ) {
+            return new FpFork(
+                rewrite, made, new FpIfTargetExists(new FpIgnore(), made)
+            );
         }
 
         @Override

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/JavaFiles.java
@@ -15,7 +15,6 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -42,15 +41,9 @@ final class JavaFiles {
     private final Path generated;
 
     /**
-     * Cache directory for transpiled sources, with the cache-key version
-     * segment already resolved into it.
+     * The cache this build shares with every other build on this machine.
      */
-    private final Path cache;
-
-    /**
-     * Whether caching is enabled.
-     */
-    private final boolean enabled;
+    private final GlobalCache cache;
 
     /**
      * Java files generated during the current transpilation.
@@ -73,13 +66,11 @@ final class JavaFiles {
     /**
      * Ctor.
      * @param dir Generated sources directory
-     * @param cached Cache directory for this transpile version
-     * @param caching Whether caching is enabled
+     * @param store The cache shared with every build on this machine
      */
-    JavaFiles(final Path dir, final Path cached, final boolean caching) {
+    JavaFiles(final Path dir, final GlobalCache store) {
         this.generated = dir;
-        this.cache = cached;
-        this.enabled = caching;
+        this.cache = store;
         this.fresh = new ConcurrentLinkedQueue<>();
         this.touched = new ConcurrentLinkedQueue<>();
     }
@@ -118,11 +109,11 @@ final class JavaFiles {
                     new JavaPlaced(
                         new FpIfReleased(
                             hsh,
-                            new FpAppliedWithCache(
-                                java,
-                                this.cached(hsh, jname),
+                            this.cache.kept(
+                                this.generated.relativize(tgt),
+                                () -> hsh,
                                 new RewritePolicy(rewrite, tgt),
-                                this.enabled
+                                java
                             ),
                             java
                         ),
@@ -192,14 +183,5 @@ final class JavaFiles {
             }
         }
         return dirs;
-    }
-
-    private Supplier<Path> cached(final String hsh, final String jname) {
-        final Path tail = this.generated.relativize(
-            new Place(jname).make(
-                this.generated, JavaFiles.JAVA
-            )
-        );
-        return () -> this.cache.resolve(hsh).resolve(tail);
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -151,15 +151,6 @@ public final class MjTranspile extends MjSafe {
     @Override
     public void exec() throws IOException {
         try (TjsForeign tojos = this.tojos()) {
-            final Transpilation train = new Transpilation(
-                this.plugin.getVersion(),
-                new Tracking(this.trackSteps, this.located),
-                this.coverage,
-                this.base(),
-                this.xslMeasures.toPath(),
-                this.targetDir.toPath(),
-                this.tables.toPath()
-            );
             new Timed(
                 new Transpiling(
                     tojos.standalone(),
@@ -167,15 +158,16 @@ public final class MjTranspile extends MjSafe {
                     this.generatedDir.toPath(),
                     this.tests,
                     this.roots(),
-                    train,
-                    this.stored(),
-                    new JavaFiles(
-                        this.generatedDir.toPath(),
-                        this.cache.toPath()
-                            .resolve(Transpiling.CACHE)
-                            .resolve(train.version()),
-                        this.cacheEnabled
-                    )
+                    new Transpilation(
+                        this.plugin.getVersion(),
+                        new Tracking(this.trackSteps, this.located),
+                        this.coverage,
+                        this.base(),
+                        this.xslMeasures.toPath(),
+                        this.targetDir.toPath(),
+                        this.tables.toPath()
+                    ),
+                    this.stored()
                 )
             ).exec();
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -32,16 +32,14 @@ import org.eolang.parser.OnDetailed;
  * The intermediate optimized XMIRs are stored in the {@link #PRE} directory.</p>
  *
  * @since 0.1
- * @todo #6125:60min Take the writing of the Java files out of here too.
- *  {@link JavaFiles} still keeps a cache directory and an enabled flag of
- *  its own, so this class has to be handed one ready-made, and the key of
- *  that directory repeats the plugin version {@link GlobalCache} already
- *  folds in. Give {@link JavaFiles} the same {@link GlobalCache} instead,
- *  then it goes back to being made here, and {@link #version()}, which is
- *  read by nothing but the test, goes with it. The three that are left,
- *  the generated directory, the tests flag and the roots, describe one
- *  thing, where the output lands, and belong together in an object of
- *  their own, along with the tail of {@link #exec()} that logs it.
+ * @todo #6125:30min Take the rest of the writing out of here too.
+ *  The key {@link #version()} makes still repeats the plugin version
+ *  {@link GlobalCache} folds into every step of its own, so drop it there
+ *  and let the cache supply it; {@link #version()} is then read by nothing
+ *  but the test and goes with it. The three that are left, the generated
+ *  directory, the tests flag and the roots, describe one thing, where the
+ *  output lands, and belong together in an object of their own, along with
+ *  the tail of {@link #exec()} that logs it.
  */
 final class Transpiling implements Step {
 
@@ -96,11 +94,6 @@ final class Transpiling implements Step {
     private final GlobalCache cache;
 
     /**
-     * The Java files this run writes, and the stale ones it removes.
-     */
-    private final JavaFiles files;
-
-    /**
      * Constructor.
      * @param srcs XMIR sources to transpile
      * @param target Target directory
@@ -109,7 +102,6 @@ final class Transpiling implements Step {
      * @param java Directories with the Java sources a human wrote
      * @param train The XSL train that does the transpiling
      * @param store The cache shared with every build on this machine
-     * @param written The Java files this run writes
      */
     Transpiling(
         final Collection<TjForeign> srcs,
@@ -118,8 +110,7 @@ final class Transpiling implements Step {
         final boolean tests,
         final Collection<Path> java,
         final Transpilation train,
-        final GlobalCache store,
-        final JavaFiles written
+        final GlobalCache store
     ) {
         this.sources = srcs;
         this.target = target;
@@ -128,21 +119,23 @@ final class Transpiling implements Step {
         this.roots = java;
         this.train = train;
         this.cache = store;
-        this.files = written;
     }
 
     @Override
     public void exec() throws IOException {
+        final JavaFiles files = new JavaFiles(
+            this.generated, this.cache.with(this.train.version())
+        );
         final int transpiled = new Threaded<>(
             this.sources,
-            this::transpiled
+            tojo -> this.transpiled(tojo, files)
         ).total();
-        this.files.removeStale();
+        files.removeStale();
         Logger.info(
             this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
             this.sources.size(),
             transpiled + new PackageInfos(
-                this.generated, this.roots, this.files.directories()
+                this.generated, this.roots, files.directories()
             ).create(),
             this.generated
         );
@@ -156,7 +149,7 @@ final class Transpiling implements Step {
         return this.train.version();
     }
 
-    private int transpiled(final TjForeign tojo) throws IOException {
+    private int transpiled(final TjForeign tojo, final JavaFiles files) throws IOException {
         final Path source = tojo.xmir();
         final XML xmir = new XMLDocument(source);
         final Path base = this.target.resolve(Transpiling.DIR);
@@ -173,7 +166,7 @@ final class Transpiling implements Step {
                 return transform.apply(xmir).toString();
             }
         ).apply(source, dest);
-        return this.files.total(
+        return files.total(
             rewrite.get(), dest, hsh.get(), this.tests && !tojo.discovered()
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/JavaFilesTest.java
@@ -42,7 +42,7 @@ final class JavaFilesTest {
                 seed
             ),
             new JavaFiles(
-                temp.resolve("generated"), temp.resolve("cache").resolve("1.0-SNAPSHOT"), false
+                temp.resolve("generated"), new GlobalCache.GcFresh()
             ).total(true, xmir, "", false),
             Matchers.equalTo(1)
         );
@@ -61,11 +61,11 @@ final class JavaFilesTest {
             "<object><class java-name='org.eolang.EOsecond'><java>class EOsecond {}</java></class></object>",
             second
         ).value();
-        final JavaFiles initial = new JavaFiles(generated, temp.resolve("cache"), false);
+        final JavaFiles initial = new JavaFiles(generated, new GlobalCache.GcFresh());
         initial.total(true, first, "", false);
         initial.total(true, second, "", false);
         initial.removeStale();
-        final JavaFiles current = new JavaFiles(generated, temp.resolve("cache"), false);
+        final JavaFiles current = new JavaFiles(generated, new GlobalCache.GcFresh());
         current.total(true, second, "", false);
         current.removeStale();
         MatcherAssert.assertThat(
@@ -89,7 +89,7 @@ final class JavaFilesTest {
             "<object><class java-name='org.eolang.EOfirst'><java>class EOfirst {}</java></class></object>",
             xmir
         ).value();
-        final JavaFiles files = new JavaFiles(generated, temp.resolve("cache"), false);
+        final JavaFiles files = new JavaFiles(generated, new GlobalCache.GcFresh());
         files.total(true, xmir, "", false);
         files.removeStale();
         MatcherAssert.assertThat(
@@ -136,7 +136,7 @@ final class JavaFilesTest {
             "<object><class java-name='EOmain'><java>class EOmain {}</java></class></object>",
             plain
         ).value();
-        final JavaFiles first = new JavaFiles(generated, temp.resolve("cache"), false);
+        final JavaFiles first = new JavaFiles(generated, new GlobalCache.GcFresh());
         first.total(true, plain, "", false);
         first.removeStale();
         final Path atom = temp.resolve("atom.xmir");
@@ -149,13 +149,35 @@ final class JavaFilesTest {
             ),
             atom
         ).value();
-        final JavaFiles second = new JavaFiles(generated, temp.resolve("cache"), false);
+        final JavaFiles second = new JavaFiles(generated, new GlobalCache.GcFresh());
         second.total(true, atom, "", false);
         second.removeStale();
         MatcherAssert.assertThat(
             "the class of an object that became an atom must go, but it survived the run",
             Files.exists(generated.resolve("EOmain.java")),
             Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void takesTheJavaFileFromTheCacheTheGlobalCacheNames(@Mktmp final Path temp)
+        throws IOException {
+        final Path generated = temp.resolve("generated");
+        final Path dir = temp.resolve("cache");
+        new Saved(
+            "class EOcached {}",
+            dir.resolve("1.0-key").resolve("abcdef").resolve("EOmain.java")
+        ).value();
+        final Path xmir = temp.resolve("main.xmir");
+        new Saved(
+            "<object><class java-name='EOmain'><java>class EOmain {}</java></class></object>",
+            xmir
+        ).value();
+        new JavaFiles(generated, new GcShared(dir, "1.0-key")).total(false, xmir, "abcdef", false);
+        MatcherAssert.assertThat(
+            "the Java file must come from the directory the global cache names",
+            Files.readString(generated.resolve("EOmain.java")),
+            Matchers.equalTo("class EOcached {}")
         );
     }
 
@@ -172,7 +194,7 @@ final class JavaFilesTest {
             xmir
         ).value();
         return new JavaFiles(
-            temp.resolve("generated"), temp.resolve("cache").resolve("1.0-SNAPSHOT"), false
+            temp.resolve("generated"), new GlobalCache.GcFresh()
         ).total(true, xmir, "", false);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TranspilingTest.java
@@ -47,8 +47,7 @@ final class TranspilingTest {
                 Paths.get("target"),
                 Paths.get("target/eo/6-inference")
             ),
-            new GlobalCache.GcFresh(),
-            new JavaFiles(Paths.get("target/generated"), Paths.get("target/cache"), false)
+            new GlobalCache.GcFresh()
         );
     }
 }


### PR DESCRIPTION
First of the puzzle's parts, split because all of it together is 392 lines and the size job caps a pull request at 200.

`JavaFiles` no longer keeps a cache directory and an enabled flag of its own. It takes the `GlobalCache` every other step takes, so `Transpiling` makes it again instead of being handed one ready-made.

That needed a second method on `GlobalCache`: `kept()`, for a file whose content does not come from a source the cache can fingerprint, so the caller says through `rewrite` whether the target is stale. `FpAppliedWithCache` and the cache path now live behind it, where the enabled flag already did.

The puzzle is trimmed to what is left: the key still repeats the plugin version, and the generated directory, the tests flag and the roots still belong together in an object of their own. Both follow.
