### PR TITLE
#8061: say access mode, not access mod

### DIFF
--- a/eo-runtime/src/main/eo/file.eo
+++ b/eo-runtime/src/main/eo/file.eo
@@ -67,11 +67,11 @@
   [^ mode scope cant-open] > open
     known.not.if > @
       T
-        "Wrong access mod. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
+        "Wrong access mode. Only next modes are available: 'r', 'w', 'a', 'r+', 'w+', 'a+'"
       if.
         existing.and ^.exists.not
         cant-open
-          "File must exist for given access mod: '%s'".printf
+          "File must exist for given access mode: '%s'".printf
             *
               mode >> access!
         seq *


### PR DESCRIPTION
Both messages in `file.eo` said "access mod" where they meant "access mode". The two messages further down the same file already spell it in full, and `mod` in this repository is the remainder of `number.mod`.

Closes #8061
