### PR TITLE
#7182: track the three disabled integration tests with puzzles

### DIFF
--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -27,6 +27,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Integration tests for transpile behavior.
  * @since 0.62
+ * @todo #7182:30min Re-enable the two tests of this class after the next release.
+ *  The sandbox pulls the released .eo sources of the runtime from the remote
+ *  objectionary, and those predate the rule that every object carries a
+ *  comment on top, so the build they take part in ends with [ERROR] lines
+ *  and fails before the assertion is reached. Master already carries the
+ *  comments, so drop this annotation once the remote objectionary serves
+ *  sources that satisfy the rule.
  */
 @Disabled("pulled .eo sources predate the comment-on-top rule and emit [ERROR]")
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")

--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Integration tests for transpile behavior.
  * @since 0.62
- * @todo #7182:30min Re-enable the two tests of this class after the next release.
+ * @todo #7182:30min Re-enable the two transpile tests after the next release.
  *  The sandbox pulls the released .eo sources of the runtime from the remote
  *  objectionary, and those predate the rule that every object carries a
  *  comment on top, so the build they take part in ends with [ERROR] lines

--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
@@ -24,6 +24,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Integration tests for mojas.
  * @since 0.52
+ * @todo #7182:30min Re-enable the disabled test of this class after the next release.
+ *  The sandbox pulls the released .eo sources of the runtime from the remote
+ *  objectionary, and those predate the rule that every object carries a
+ *  comment on top, so the build they take part in ends with [ERROR] lines
+ *  and fails before the assertion is reached. Master already carries the
+ *  comments, so drop this annotation once the remote objectionary serves
+ *  sources that satisfy the rule.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})

--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Integration tests for mojas.
  * @since 0.52
- * @todo #7182:30min Re-enable the disabled test of this class after the next release.
+ * @todo #7182:30min Re-enable the assemble test after the next release.
  *  The sandbox pulls the released .eo sources of the runtime from the remote
  *  objectionary, and those predate the rule that every object carries a
  *  comment on top, so the build they take part in ends with [ERROR] lines

--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -39,7 +39,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
  * @since 0.60
- * @todo #7182:30min Re-enable the disabled test of this class after the next release.
+ * @todo #7182:30min Re-enable the proxy test after the next release.
  *  The sandbox pulls the released .eo sources of the runtime from the remote
  *  objectionary, and those predate the rule that every object carries a
  *  comment on top, so the build they take part in ends with [ERROR] lines

--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -39,6 +39,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
  * @since 0.60
+ * @todo #7182:30min Re-enable the disabled test of this class after the next release.
+ *  The sandbox pulls the released .eo sources of the runtime from the remote
+ *  objectionary, and those predate the rule that every object carries a
+ *  comment on top, so the build they take part in ends with [ERROR] lines
+ *  and fails before the assertion is reached. Master already carries the
+ *  comments, so drop this annotation once the remote objectionary serves
+ *  sources that satisfy the rule.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})


### PR DESCRIPTION
The three `@Disabled` annotations carried a free-text reason and no issue number, so `0pdd` filed nothing and nobody would be told when the reason went away. Each class now carries a `@todo` naming what has to happen before the test comes back, the way `JarIT` next to them already does.

Adds the tracking asked for in #7182. The puzzles themselves are what re-enables the tests later, so no auto-close keyword here.
