### PR TITLE
#8053: name the real reason a read is refused

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -155,6 +155,18 @@ final class Heaps {
     byte[] read(final int identifier, final int offset, final int length) {
         this.lock.lock();
         try {
+            if (offset < 0) {
+                throw new ExFailure(
+                    "Block '%d': can't read at negative offset '%d'",
+                    identifier, offset
+                );
+            }
+            if (length < 0) {
+                throw new ExFailure(
+                    "Block '%d': can't read a negative number of bytes '%d'",
+                    identifier, length
+                );
+            }
             if (!this.fits(identifier, offset, length)) {
                 throw new ExFailure(
                     "Can't read '%d' bytes from offset '%d', because only '%d' are allocated",

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -226,6 +226,38 @@ final class HeapsTest {
     }
 
     @Test
+    void blamesTheOffsetWhenItIsNegative() {
+        MatcherAssert.assertThat(
+            "a negative read offset must be named as the reason, not the allocated size",
+            Heaps.INSTANCE.malloc(
+                8,
+                idx -> Assertions.assertThrows(
+                    ExFailure.class,
+                    () -> Heaps.INSTANCE.read(idx, -1, 4),
+                    "a negative read offset must be refused"
+                ).getMessage()
+            ),
+            Matchers.containsString("negative offset '-1'")
+        );
+    }
+
+    @Test
+    void blamesTheLengthWhenItIsNegative() {
+        MatcherAssert.assertThat(
+            "a negative read length must be named as the reason, not the allocated size",
+            Heaps.INSTANCE.malloc(
+                8,
+                idx -> Assertions.assertThrows(
+                    ExFailure.class,
+                    () -> Heaps.INSTANCE.read(idx, 2, -3),
+                    "a negative read length must be refused"
+                ).getMessage()
+            ),
+            Matchers.containsString("negative number of bytes '-3'")
+        );
+    }
+
+    @Test
     void readsByOffsetAndLength() {
         MatcherAssert.assertThat(
             "Heaps should successfully read correct slice when reading with offset and length, but it didn't",


### PR DESCRIPTION
`read` asked `fits` and, whatever it answered no for, reported the allocated size. `fits` says no for three reasons and only one of them is the size, so a negative offset came back as "because only '8' are allocated", which points at something that has nothing to do with it.

The two cases `write` already checks for itself are now checked here too, in the same shape, and the message about the allocated size is left for the range that really does run past the end.

Closes #8053
