### PR TITLE
#8052: write into the block instead of copying it first

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -208,10 +208,7 @@ final class Heaps {
                     length
                 );
             }
-            final byte[] result = new byte[length];
-            System.arraycopy(source, 0, result, 0, length);
-            System.arraycopy(data, 0, result, offset, data.length);
-            this.blocks.put(identifier, result);
+            System.arraycopy(data, 0, source, offset, data.length);
         } finally {
             this.lock.unlock();
         }

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -209,6 +209,23 @@ final class HeapsTest {
     }
 
     @Test
+    void keepsEveryByteWrittenOneAtATime() {
+        MatcherAssert.assertThat(
+            "a block filled one byte at a time must hold every one of them",
+            Heaps.INSTANCE.malloc(
+                4,
+                idx -> {
+                    for (int offset = 0; offset < 4; offset += 1) {
+                        Heaps.INSTANCE.write(idx, offset, new byte[] {(byte) (offset + 1)});
+                    }
+                    return Heaps.INSTANCE.read(idx, 0, 4);
+                }
+            ),
+            Matchers.equalTo(new byte[] {1, 2, 3, 4})
+        );
+    }
+
+    @Test
     void readsByOffsetAndLength() {
         MatcherAssert.assertThat(
             "Heaps should successfully read correct slice when reading with offset and length, but it didn't",


### PR DESCRIPTION
Nothing outside the map holds the block: `read` returns a `copyOfRange`, `resize` allocates a new array, `size` returns a length. So the copy before every write protected nothing, and filling a block byte by byte, which is what `chunk.write` does, moved `n^2 / 2` bytes to write `n`.

The write now goes into the array the map already holds.

Closes #8052
