### PR TITLE
#8057: index the link rows by id instead of scanning for each

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Relayed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Relayed.java
@@ -74,20 +74,21 @@ public final class Relayed implements Clue {
                 bind.xpath("@void").get(0), key -> new LinkedHashSet<>(0)
             ).add(bind.xpath("ref/@loc").get(0));
         }
+        final Map<String, XML> rows = new LinkedHashMap<>(0);
+        for (final XML type : links.nodes("/links/type[ref]")) {
+            rows.putIfAbsent(type.xpath("@id").get(0), type.nodes("ref").get(0));
+        }
         for (final Map.Entry<String, List<String>> application
             : new Given(new Xmirs(xmirs).applications()).arguments().entrySet()) {
             final String hollow = pairs.getOrDefault(application.getKey(), "");
-            final Collection<XML> rows = links.nodes(
-                String.format("/links/type[@id='%s']/ref", application.getKey())
-            );
-            if (hollows.contains(hollow) && !rows.isEmpty()) {
+            if (hollows.contains(hollow) && rows.containsKey(application.getKey())) {
                 new Xembler(
                     new Passed(
                         owned,
                         fillers.getOrDefault(hollow, Collections.emptyList()),
                         application.getValue()
                     ).directives()
-                ).applyQuietly(rows.iterator().next().inner());
+                ).applyQuietly(rows.get(application.getKey()).inner());
             }
         }
         Files.write(table, links.toString().getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
Every application ran an absolute XPath over the whole `links.xml`. For `eo-runtime` that file is 10.7 Mb with 48,895 `type` elements, and the scan goes through Saxon's DOM wrapper under the document lock, which is where a thread dump taken during a 25 minute `MjInference` run showed the time going.

The rows are now indexed by `@id` in one pass before the loop, the same shape `Pairs` and the `fillers` map above already use, so the lookup is a hash lookup. `putIfAbsent` keeps the first row for an id, which is the one the XPath returned.

Closes #8057
