### PR TITLE
#8054: refuse a byte that is neither true nor false

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -117,6 +117,12 @@ public final class Dataized {
                 weak.length, Arrays.toString(weak)
             );
         }
+        if (weak[0] != 0 && weak[0] != 1) {
+            throw new ExFailure(
+                "Can't dataize the byte %s to boolean, only 00- and 01- are booleans",
+                Arrays.toString(weak)
+            );
+        }
         return weak[0] == 1;
     }
 

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -67,6 +67,19 @@ final class DataizedTest {
     }
 
     @Test
+    void refusesAByteThatIsNeitherTrueNorFalse() {
+        MatcherAssert.assertThat(
+            "a one byte datum that is not 00- or 01- must be refused, not read as false",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(new PhDefault(new byte[] {(byte) 0xFF})).asBool(),
+                "dataizing FF- as boolean was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.containsString("only 00- and 01- are booleans")
+        );
+    }
+
+    @Test
     void reportsActualLengthWhenBoolIsEmpty() {
         MatcherAssert.assertThat(
             "the message must report the true (zero) length, not claim it's over one",


### PR DESCRIPTION
`asBool` guarded the length of the datum and then read anything other than `01-` as `false`, so `02-` and `FF-` came back as a valid answer. A byte that is neither `00-` nor `01-` is the same kind of mistake as a datum of the wrong length, made by the same caller, and it was the only one not reported.

Closes #8054
