### PR TITLE
#8049: refuse the smallest i64 divided by minus one

### DIFF
--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -24,19 +24,6 @@
       cant-divide
         "the smallest i64 divided by minus one is past the largest i64"
       quotiented
-  if. > quotiented
-    eq.
-      and.
-        ^.as-bytes.xor x.as-bytes
-        80-00-00-00-00-00-00-00
-      80-00-00-00-00-00-00-00
-    as-bytes.
-      plus.
-        i64
-          not.
-            looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
-        i64 00-00-00-00-00-00-00-01
-    i64 quotient
   00-00-00-00-00-00-00-01.left i > [i] >> bit
   [^ index remainder quot] >> looped
     if. > @
@@ -70,6 +57,19 @@
                 index
               00-00-00-00-00-00-00-01
           quot
+  if. > quotiented
+    eq.
+      and.
+        ^.as-bytes.xor x.as-bytes
+        80-00-00-00-00-00-00-00
+      80-00-00-00-00-00-00-00
+    as-bytes.
+      plus.
+        i64
+          not.
+            looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
+        i64 00-00-00-00-00-00-00-01
+    i64 quotient
   as-bytes. >> subtrahend
     plus.
       i64

--- a/eo-runtime/src/main/eo/i64/div.eo
+++ b/eo-runtime/src/main/eo/i64/div.eo
@@ -1,7 +1,9 @@
 # Integer division of an `i64` number by the `i64` number `x`, truncated
 # toward zero. The quotient is built by restoring long division over the
 # magnitudes of both operands, with the sign applied afterwards. When `x` is
-# zero, the caller-supplied `cant-divide` fallback is returned.
+# zero, the caller-supplied `cant-divide` fallback is returned, and so it is
+# when the smallest `i64` is divided by minus one, since that quotient is one
+# past the largest `i64` and has no answer here.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -16,18 +18,25 @@
     cant-divide
       "i64 cannot be divided by zero"
     if.
-      eq.
-        and.
-          ^.as-bytes.xor x.as-bytes
-          80-00-00-00-00-00-00-00
+      and.
+        ^.as-bytes.eq 80-00-00-00-00-00-00-00
+        x.as-bytes.eq FF-FF-FF-FF-FF-FF-FF-FF
+      cant-divide
+        "the smallest i64 divided by minus one is past the largest i64"
+      quotiented
+  if. > quotiented
+    eq.
+      and.
+        ^.as-bytes.xor x.as-bytes
         80-00-00-00-00-00-00-00
-      as-bytes.
-        plus.
-          i64
-            not.
-              looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
-          i64 00-00-00-00-00-00-00-01
-      i64 quotient
+      80-00-00-00-00-00-00-00
+    as-bytes.
+      plus.
+        i64
+          not.
+            looped 63 00-00-00-00-00-00-00-00 00-00-00-00-00-00-00-00 >> quotient
+        i64 00-00-00-00-00-00-00-01
+    i64 quotient
   00-00-00-00-00-00-00-01.left i > [i] >> bit
   [^ index remainder quot] >> looped
     if. > @
@@ -111,14 +120,19 @@
       0.as-i64
       "recovered" > [message]
 
+  eq. ++> can-recover-from-min-divided-by-minus-one
+    "recovered"
+    div.
+      i64 80-00-00-00-00-00-00-00
+      -1.as-i64
+      "recovered" > [message]
+
   eq. ++> can-truncate-toward-zero
     -13.as-i64.div 5.as-i64
     -2.as-i64
 
-  eq. ++> can-wrap-min-divided-by-minus-one
-    div.
-      i64 80-00-00-00-00-00-00-00
-      -1.as-i64
-    i64 80-00-00-00-00-00-00-00
-
   2.as-i64.div 0.as-i64 --> stops-on-division-by-zero
+
+  div. --> stops-on-min-divided-by-minus-one
+    i64 80-00-00-00-00-00-00-00
+    -1.as-i64


### PR DESCRIPTION
`div` was careful about the division by zero and silent about the other one that has no answer: the smallest `i64` over minus one wrapped back to itself, which is not the quotient, and nothing told the caller.

It now takes the same `cant-divide` route as the division by zero. The test that pinned the wrapping is replaced by one that recovers and one that stops.

Closes #8049
