### PR TITLE
Drop trailing ellipsis from void parameter name pattern

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -62,7 +62,7 @@ final class Emissions {
      * that glyph for auto-names.
      */
     private static final Pattern PARAM_NAME = Pattern.compile(
-        "[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*(?:\\.\\.\\.)?"
+        "[a-z][^ \\t,.|':;!?\\[\\]{}()\\x{1F335}]*"
     );
 
     /**

--- a/eo-parser/src/test/java/org/eolang/parser/EmissionsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmissionsTest.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Emissions}.
+ * @since 0.1
+ */
+final class EmissionsTest {
+
+    @Test
+    void acceptsPlainName() {
+        Assertions.assertDoesNotThrow(
+            () -> Emissions.validParam("args", 1, 4),
+            "a plain void parameter name was rejected"
+        );
+    }
+
+    @Test
+    void rejectsNameWithTrailingEllipsis() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> Emissions.validParam("args...", 1, 4),
+            "a void parameter name ending with ... was accepted"
+        );
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/EmissionsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EmissionsTest.java
@@ -29,4 +29,13 @@ final class EmissionsTest {
             "a void parameter name ending with ... was accepted"
         );
     }
+
+    @Test
+    void rejectsNameWithPartialTrailingDots() {
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> Emissions.validParam("args..", 1, 4),
+            "a void parameter name ending with .. was accepted"
+        );
+    }
 }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/varargs-inside.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/varargs-inside.yaml
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 2
+line: 1
 message: |-
-  [2:2] error: 'object inside formation must have a name'
-    "hello"
-    ^
+  [1:3] error: 'parameter names in voids must be NAME or @'
+  [a b... c] > hello
+     ^
 input: |
   [a b... c] > hello
     "hello"


### PR DESCRIPTION
Emissions.PARAM_NAME carried an optional \`(?:\.\.\.)?\` tail on top of the NAME character class, so a bracket parameter like \`[args...] > foo\` parsed clean and emitted a void child literally named \`args...\`.

Nothing in the grammar asks for that. The NAME token excludes \`.\`, the void parameter lists in R-3.4.2/R-3.4.3 have no optional tail, and no \`.eo\` source in the repo writes a parameter this way. The trailing group is dropped, which brings the pattern back to a plain NAME and makes \`validParam\` reject the trailing-dots form as it already rejects any other stray \`.\` in the name.

Closes #8021