### PR TITLE
Remove unreachable formation-must-start-with check in LnFormation

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -159,12 +159,6 @@ final class LnFormation implements Line {
     }
 
     private static int findClosing(final String body, final Span span) {
-        if (body.isEmpty() || body.charAt(0) != '[') {
-            throw new ParseError(
-                span.line(), span.indent(),
-                "formation must start with `[`"
-            );
-        }
         final int close = body.indexOf(']');
         if (close < 0) {
             throw new ParseError(

--- a/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnFormationTest.java
@@ -252,6 +252,19 @@ final class LnFormationTest {
     }
 
     @Test
+    void rejectsMissingClosingBracketWhenBodyLacksLeadingBracket() {
+        MatcherAssert.assertThat(
+            "a body with no `[` anywhere must still report the missing-bracket message",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnFormation(new Span("x", 1))
+                    .into(new Stack(), new Globals(), new Emit())
+            ).getMessage(),
+            Matchers.equalTo("formation is missing its closing bracket")
+        );
+    }
+
+    @Test
     void rejectsMissingClosingBracketWithNoSuffix() {
         MatcherAssert.assertThat(
             "a bare unclosed `[a` with no name suffix must report the same missing-bracket message",
@@ -364,6 +377,15 @@ final class LnFormationTest {
             "a `+>` test attribute preceded by one blank line must not emit any error",
             LnFormationTest.render(emit),
             Matchers.not(XhtmlMatchers.hasXPath("/object/errors"))
+        );
+    }
+
+    @Test
+    void locatesClosingBracketRegardlessOfLeadingCharacter() {
+        Assertions.assertDoesNotThrow(
+            () -> new LnFormation(new Span("x]", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "findClosing must search for `]` from the start, not require a leading `[`"
         );
     }
 


### PR DESCRIPTION
LnFormation.findClosing opens by rejecting a body whose first character is not
an opening bracket, throwing "formation must start with `[`". No input ever
reaches that branch.

Eo.classify is the only place that constructs a LnFormation, and it does so
for exactly three prefixes: `-->`, `[`, and `++>`. Inside LnFormation.into,
the two shorthand prefixes (`++>`, `-->`) are handled by an early branch that
returns before findClosing is ever called; the only route left to findClosing
is the one where the body already starts with `[`. So the guard describes a
state the classifier already prevents, and its message is one the parser can
never actually emit.

This removes the dead branch and lets findClosing start straight at
`body.indexOf(']')`, leaving the guarantee about the leading `[` where it
belongs: in the classifier. No behavior changes for any reachable input, and
no existing test exercised the removed branch, since none can construct one.

Closes #8023