### PR TITLE
fix(#8020): reject leading, trailing and doubled space in inline-phi params

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -492,7 +492,7 @@ final class Emissions {
         }
         emit.baselessObject(name, line, column);
         int pcol = column + bracket + 1;
-        for (final String param : Emissions.splitParams(params)) {
+        for (final String param : Emissions.splitParams(params, line, pcol)) {
             Emissions.validParam(param, line, pcol);
             final String mapped;
             if ("@".equals(param)) {
@@ -512,8 +512,17 @@ final class Emissions {
         emit.close();
     }
 
-    private static List<String> splitParams(final String text) {
+    private static List<String> splitParams(
+        final String text, final int line, final int column
+    ) {
         final List<String> out = new java.util.ArrayList<>(0);
+        if (!text.isEmpty()
+            && (text.charAt(0) == ' ' || text.charAt(text.length() - 1) == ' ')) {
+            throw new ParseError(
+                line, column,
+                "formation brackets must not contain leading or trailing space"
+            );
+        }
         int idx = 0;
         while (idx < text.length()) {
             int end = idx;
@@ -522,6 +531,12 @@ final class Emissions {
             }
             out.add(text.substring(idx, end));
             if (end < text.length()) {
+                if (end + 1 < text.length() && text.charAt(end + 1) == ' ') {
+                    throw new ParseError(
+                        line, column + end,
+                        "parameter names in voids must be separated by exactly one space"
+                    );
+                }
                 idx = end + 1;
             } else {
                 idx = end;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-inline-phi-inside-parens.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-inline-phi-inside-parens.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  parameter names in voids must be separated by exactly one space
+input: |
+  foo (bar > [x  y]) > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/leading-space-in-inline-phi-inside-parens.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/leading-space-in-inline-phi-inside-parens.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  formation brackets must not contain leading or trailing space
+input: |
+  foo (bar > [ x]) > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-inline-phi-inside-parens.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/trailing-space-in-inline-phi-inside-parens.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  formation brackets must not contain leading or trailing space
+input: |
+  foo (bar > [x ]) > app


### PR DESCRIPTION
Closes #8020

`Emissions.splitParams` splits a void parameter list on ASCII space with no check for a leading, trailing or doubled space. It sits behind `Emissions.inlinePhi`, which is the reader that validates a bracket param list written inside a paren group, e.g. `foo (bar > [x ]) > app`.

`LnFormation.params` and `LnOnlyPhi.parseParams` already run those same two checks for the other two places a bracket param list can appear, so a paren-group list was validated more loosely than the same list written anywhere else. A trailing space slipped through entirely, since the loop simply stops at the end of the string once it advances past it. A leading or doubled space still failed, but for the wrong reason: the empty token it produces gets rejected by `validParam` with a message about the name, not the space that actually caused it.

This adds the same two checks to `splitParams` so all three readers agree on which bracket lists are legal, and report the same canonical text when they are not.

Added eo-typos yaml regression tests covering the leading, trailing and doubled space cases inside a paren-group inline-phi.