### PR TITLE
name ^ in the void parameter error message

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -246,7 +246,7 @@ final class Emissions {
         if (!"@".equals(raw) && !"^".equals(raw) && !Emissions.PARAM_NAME.matcher(raw).matches()) {
             throw new ParseError(
                 line, pos,
-                "parameter names in voids must be NAME or @"
+                "parameter names in voids must be NAME, @ or ^"
             );
         }
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-invalid-void-param-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-invalid-void-param-name.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object/errors/error[contains(text(),'parameter names in voids must be NAME or @')]
+  - /object/errors/error[contains(text(),'parameter names in voids must be NAME, @ or ^')]
 input: |
   [] > main
     q.f (a > [X.Y 9z]) > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-rejects-invalid-void-param-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-rejects-invalid-void-param-name.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 sheets: []
 asserts:
-  - /object/errors/error[contains(text(),'parameter names in voids must be NAME or @')]
+  - /object/errors/error[contains(text(),'parameter names in voids must be NAME, @ or ^')]
 input: |
   [] > main
     a > [X.Y 9z] > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-cactus.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-cactus.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:1] error: 'parameter names in voids must be NAME or @'
+  [1:1] error: 'parameter names in voids must be NAME, @ or ^'
   [foo🌵] > main
    ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-name.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-param-name.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:1] error: 'parameter names in voids must be NAME or @'
+  [1:1] error: 'parameter names in voids must be NAME, @ or ^'
   [a,b] > obj
    ^
 input: |


### PR DESCRIPTION
The guard in Emissions.validParam accepts NAME, @ and ^ as void parameter
shapes, but the error it throws on a bad shape only names NAME and @. Since
#7212 relaxed R-3.4.3 and R-3.4.11, ^ is the ordinary way a formation
declares the object it dispatches off, so leaving it out of the message
sends the reader looking for the wrong fix.

This names all three accepted forms in the message text and updates the
four fixtures that pin that exact wording (two eo-typos cases, two
eo-syntax cases going through the inline-phi and only-phi paths).

Closes #8022