### PR TITLE
#8055: let a decorator equal only itself

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -19,6 +19,12 @@ import java.util.function.Supplier;
  * the wrapped object keeps a lazy expression lazy while it is dispatched
  * over.</p>
  *
+ * <p>An object of this class is equal to itself and to nothing else, the
+ * way {@code PhDefault} is. Answering on behalf of the wrapped object
+ * would make the answer one-sided: the decorator would say it equals the
+ * object it wraps, while that object says it does not equal the decorator,
+ * and {@code Object.equals} requires the two to agree.</p>
+ *
  * @since 0.1
  * @checkstyle DesignForExtensionCheck (200 lines)
  */
@@ -64,18 +70,6 @@ public class PhOnce implements Phi {
         this.object = () -> this.loaded(obj);
     }
 
-    /**
-     * Whether this is that very object.
-     *
-     * <p>An object is equal to itself and to nothing else, which is what
-     * {@code PhDefault} says too. Answering on behalf of the decorated
-     * object made the answer one-sided: the decorator said it equalled the
-     * object it wraps, while that object said it did not equal the
-     * decorator, and {@code Object.equals} requires the two to agree.</p>
-     *
-     * @param obj The object to compare with
-     * @return True if it is this very object
-     */
     @Override
     public boolean equals(final Object obj) {
         return this == obj;

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -64,14 +64,26 @@ public class PhOnce implements Phi {
         this.object = () -> this.loaded(obj);
     }
 
+    /**
+     * Whether this is that very object.
+     *
+     * <p>An object is equal to itself and to nothing else, which is what
+     * {@code PhDefault} says too. Answering on behalf of the decorated
+     * object made the answer one-sided: the decorator said it equalled the
+     * object it wraps, while that object said it did not equal the
+     * decorator, and {@code Object.equals} requires the two to agree.</p>
+     *
+     * @param obj The object to compare with
+     * @return True if it is this very object
+     */
     @Override
     public boolean equals(final Object obj) {
-        return this == obj || this.object.get().equals(obj);
+        return this == obj;
     }
 
     @Override
     public int hashCode() {
-        return this.object.get().hashCode();
+        return System.identityHashCode(this) + 1;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -43,6 +43,12 @@ import java.util.stream.Collectors;
  * and the cache is bounded, letting the entry asked for longest ago go
  * first.</p>
  *
+ * <p>An object of this class is equal to itself and to nothing else, the
+ * way {@code PhDefault} is. Answering on behalf of the decorated object
+ * would make the answer one-sided: the decorator would say it equals the
+ * object it wraps, while that object says it does not equal the decorator,
+ * and {@code Object.equals} requires the two to agree.</p>
+ *
  * @since 0.75
  */
 public final class PhSticky implements Phi {
@@ -125,18 +131,6 @@ public final class PhSticky implements Phi {
         this.guards = busy;
     }
 
-    /**
-     * Whether this is that very object.
-     *
-     * <p>An object is equal to itself and to nothing else, which is what
-     * {@code PhDefault} says too. Answering on behalf of the decorated
-     * object made the answer one-sided: the decorator said it equalled the
-     * object it wraps, while that object said it did not equal the
-     * decorator, and {@code Object.equals} requires the two to agree.</p>
-     *
-     * @param obj The object to compare with
-     * @return True if it is this very object
-     */
     @Override
     public boolean equals(final Object obj) {
         return this == obj;

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -125,14 +125,26 @@ public final class PhSticky implements Phi {
         this.guards = busy;
     }
 
+    /**
+     * Whether this is that very object.
+     *
+     * <p>An object is equal to itself and to nothing else, which is what
+     * {@code PhDefault} says too. Answering on behalf of the decorated
+     * object made the answer one-sided: the decorator said it equalled the
+     * object it wraps, while that object said it did not equal the
+     * decorator, and {@code Object.equals} requires the two to agree.</p>
+     *
+     * @param obj The object to compare with
+     * @return True if it is this very object
+     */
     @Override
     public boolean equals(final Object obj) {
-        return this == obj || this.origin.equals(obj);
+        return this == obj;
     }
 
     @Override
     public int hashCode() {
-        return this.origin.hashCode();
+        return System.identityHashCode(this) + 1;
     }
 
     @Override


### PR DESCRIPTION
Both decorators answered `equals` on behalf of the object they wrap, so `sticky.equals(origin)` was true while `origin.equals(sticky)` was false. `Object.equals` requires the two to agree, and anything keeping these in a `Set` or as keys in a `HashMap` depended on which of the two it asked first.

They are identity based now, the way `PhDefault` next to them already is, and `hashCode` follows.

Closes #8055
