### PR TITLE
Fix stale receiver-ordering claim in LnVoid javadoc

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -42,12 +42,12 @@ import java.util.regex.Pattern;
  * rejected outside an atom.</p>
  *
  * <p>The name may also be {@code ^}, which declares the formation's
- * receiver and emits a void named {@code ρ} (R-3.4.11). A receiver has
- * to be the first attribute its formation declares — every caller fills
- * it first — so {@code ? > ^} is rejected under a head that already
- * carries bracket voids, and under a formation that has taken any other
- * attribute already. It carries a type annotation like any other void,
- * which is to say inside an atom only.</p>
+ * receiver and emits a void named {@code ρ} (R-3.4.11). Its position
+ * among the voids is free — a dispatch looks it up by name, not by
+ * position — so it obeys the same R-3.4.9 ordering as every other void:
+ * it may not stand below an attribute the formation has already bound.
+ * It carries a type annotation like any other void, which is to say
+ * inside an atom only.</p>
  *
  * <p>{@code ? > name}, {@code ? >> name} and {@code ? > ^} — each
  * optionally followed by one type annotation — are the only shapes the


### PR DESCRIPTION
The class javadoc of LnVoid claimed a receiver (`? > ^`) has to be the first attribute its formation declares, and that it is rejected under a head that already carries bracket voids, or under a formation that has taken any other attribute already.

Neither rejection exists in the code. `LnVoid.receiver` pushes the level and emits `ρ` without consulting what the formation already holds, and the only ordering rule that fires on a vertical void is `Level.observeVoid`, the general R-3.4.9 rule forbidding a void below a bound attribute. It applies to every void and says nothing about receivers. `PARSER_SPEC.md` R-3.4.11 agrees with the code, not the docblock: the receiver's position among the voids is free, since a dispatch looks it up by name rather than position.

This rewrites the paragraph to say the position is free and that a receiver obeys R-3.4.9 like any other void. It's the vertical twin of the same stale sentence in `LnFormation`, both left over from #7212 removing `Level.receiver`; the `LnFormation` side is tracked separately in #8025.

Closes #8026