### PR TITLE
Free the ^ receiver's position in LnFormation/LnVoid javadoc

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -13,8 +13,8 @@ import java.util.List;
  * <p>Form: {@code [params] [> name [/sig]]}. Each parameter becomes a
  * void child (R-3.4.1). The standalone {@code @} parameter maps to
  * {@code φ} in XMIR (R-3.4.2 / R-9.3). The standalone {@code ^} maps to
- * {@code ρ} and declares the formation's receiver, which only the first
- * parameter may be (R-3.4.3 / R-3.4.11). No leading/trailing space inside the
+ * {@code ρ} and declares the formation's receiver; it may stand in any
+ * position among the parameters (R-3.4.3 / R-3.4.11). No leading/trailing space inside the
  * brackets (R-3.4.4); exactly one space between parameter names
  * (R-3.4.5). The line may carry an optional name suffix per §3.10,
  * including the atom-signature form {@code > name /sig}. The shorthand

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -42,12 +42,10 @@ import java.util.regex.Pattern;
  * rejected outside an atom.</p>
  *
  * <p>The name may also be {@code ^}, which declares the formation's
- * receiver and emits a void named {@code ρ} (R-3.4.11). A receiver has
- * to be the first attribute its formation declares — every caller fills
- * it first — so {@code ? > ^} is rejected under a head that already
- * carries bracket voids, and under a formation that has taken any other
- * attribute already. It carries a type annotation like any other void,
- * which is to say inside an atom only.</p>
+ * receiver and emits a void named {@code ρ} (R-3.4.11). Its position
+ * among the formation's voids is free — it may follow bracket voids or
+ * other {@code ?} lines. It carries a type annotation like any other
+ * void, which is to say inside an atom only.</p>
  *
  * <p>{@code ? > name}, {@code ? >> name} and {@code ? > ^} — each
  * optionally followed by one type annotation — are the only shapes the


### PR DESCRIPTION
The class docs for LnFormation and LnVoid said a formation's ^ receiver has to be the first parameter (or first void attribute), citing R-3.4.3 and R-3.4.11.

Both rules say the opposite now: R-3.4.3 reads "It may stand in any position", and R-3.4.11 reads "Its position among the voids is free". No code enforces the old positional claim either — LnFormation.mapParam just maps the glyph, and LnVoid.receiver builds the void without checking where it sits.

This reworks both docblocks to state that the receiver's position is free, matching the spec and the actual parsing behavior. Closes #8025.