### PR TITLE
fix(#8024): make skipSpace consume all leading spaces like start does

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -597,7 +597,7 @@ final class Suffix {
 
     private static int skipSpace(final String tail, final int from) {
         int idx = from;
-        if (idx < tail.length() && tail.charAt(idx) == ' ') {
+        while (idx < tail.length() && tail.charAt(idx) == ' ') {
             idx = idx + 1;
         }
         return idx;

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -52,6 +52,15 @@ final class SuffixTest {
     }
 
     @Test
+    void parsesNameWithMultipleSpacesAfterMarker() {
+        MatcherAssert.assertThat(
+            "`>  foo` with two spaces after the marker must parse the same as one space (#8024)",
+            new Suffix(" >  foo", new Span("[] >  foo", 1), 2).label(),
+            Matchers.equalTo("foo")
+        );
+    }
+
+    @Test
     void parsesAutoName() {
         MatcherAssert.assertThat(
             "`>>` must yield Form.AUTO with no label",
@@ -79,6 +88,15 @@ final class SuffixTest {
     }
 
     @Test
+    void parsesTestNameWithMultipleSpacesAfterMarker() {
+        MatcherAssert.assertThat(
+            "`+>  bar` with two spaces after the marker must parse the same as one space (#8024)",
+            new Suffix(" +>  bar", new Span("[] +>  bar", 1), 2).label(),
+            Matchers.equalTo("bar")
+        );
+    }
+
+    @Test
     void parsesMinusGreaterAttribute() {
         MatcherAssert.assertThat(
             "`-> name` must yield Form.THROWS with the parsed name",
@@ -93,6 +111,15 @@ final class SuffixTest {
             "a throwing test suffix's label() must be the identifier after `->`",
             new Suffix(" -> on-add", new Span("[] -> on-add", 1), 2).label(),
             Matchers.equalTo("on-add")
+        );
+    }
+
+    @Test
+    void parsesThrowsNameWithMultipleSpacesAfterMarker() {
+        MatcherAssert.assertThat(
+            "`->  bar` with two spaces after the marker must parse the same as one space (#8024)",
+            new Suffix(" ->  bar", new Span("[] ->  bar", 1), 2).label(),
+            Matchers.equalTo("bar")
         );
     }
 
@@ -172,6 +199,15 @@ final class SuffixTest {
     }
 
     @Test
+    void parsesAtomSignatureWithMultipleSpacesBeforeSlash() {
+        MatcherAssert.assertThat(
+            "`> name  /sig` with two spaces before the slash must parse the same as one space (#8024)",
+            new Suffix(" > foo  /number", new Span("[] > foo  /number", 1), 2).sig(),
+            Matchers.equalTo("number")
+        );
+    }
+
+    @Test
     void marksAtomFlagWhenSigPresent() {
         MatcherAssert.assertThat(
             "atom() must report true once a /sig has been read",
@@ -240,6 +276,15 @@ final class SuffixTest {
         MatcherAssert.assertThat(
             "`>> fibo` must yield Form.AUTO carrying the file-local handle",
             new Suffix(" >> fibo", new Span("[] >> fibo", 1), 2).handle(),
+            Matchers.equalTo("fibo")
+        );
+    }
+
+    @Test
+    void parsesAutoNameHandleWithMultipleSpacesAfterMarker() {
+        MatcherAssert.assertThat(
+            "`>>  fibo` with two spaces after the marker must parse the same as one space (#8024)",
+            new Suffix(" >>  fibo", new Span("[] >>  fibo", 1), 2).handle(),
             Matchers.equalTo("fibo")
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -88,7 +88,7 @@ final class SuffixTest {
     }
 
     @Test
-    void parsesTestNameWithMultipleSpacesAfterMarker() {
+    void parsesPlusGreaterNameWithMultipleSpacesAfterMarker() {
         MatcherAssert.assertThat(
             "`+>  bar` with two spaces after the marker must parse the same as one space (#8024)",
             new Suffix(" +>  bar", new Span("[] +>  bar", 1), 2).label(),

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multiple-spaces-after-suffix-marker.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/multiple-spaces-after-suffix-marker.yaml
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 1
-message: |-
-  [1:6] error: 'unexpected content after name suffix'
-  [] >  foo
-        ^
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo']
 input: |
   [] >  foo


### PR DESCRIPTION
Suffix.start() loops over all leading spaces before the `>`/`>>`/`+>`/`->` marker, but Suffix.skipSpace() only advanced by one — it's used to step over the space right after the marker, and again before a `/` signature.

With two spaces after the marker, e.g. `[] >  foo`, skipSpace stopped on the first space, skipName saw nothing to read, and checkNamePresent waved the empty result through because the next character was itself a space. The result was a Suffix built with an empty label, which then failed later in endsClean with "unexpected content after name suffix", with the caret landing on `foo` instead of anywhere near the actual problem.

The fix makes skipSpace loop the same way start does, so any number of spaces are accepted symmetrically on both sides of the marker: `[] > foo`, `[]  > foo`, `[] >  foo` and `[] >   foo` now all parse identically.

Added tests in SuffixTest covering multiple spaces after `>`, `+>`, `->`, `>>` (handle), and before a `/signature`.

Closes #8024