### PR TITLE
fix(#8030): cite R-3.4.9 not R-3.4.7 for the void-ordering rule in Level

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -89,7 +89,7 @@ final class Level {
 
     /**
      * True once a non-void child has been added under this entry —
-     * after which a {@link Kind#VOID} child is rejected (R-3.4.7,
+     * after which a {@link Kind#VOID} child is rejected (R-3.4.9,
      * voids must precede every other attribute).
      */
     private boolean plain;
@@ -388,7 +388,7 @@ final class Level {
 
     /**
      * Observe a child of the given {@code kind} being added under this
-     * entry, enforcing the void-ordering rule (R-3.4.7): a
+     * entry, enforcing the void-ordering rule (R-3.4.9): a
      * {@link Kind#VOID} child is rejected once a non-void child has
      * appeared, and every non-void child records that fact.
      * @param shape Kind of the child being added

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -171,4 +171,57 @@ final class LevelTest {
             Matchers.equalTo(2)
         );
     }
+
+    @Test
+    void acceptsVoidBeforeAnyPlainChild() {
+        final Level level = new Level(
+            0, 1, Kind.HEAD, Openness.OPEN, Kind.TOP_LEVEL, false
+        );
+        Assertions.assertDoesNotThrow(
+            () -> level.observeVoid(Kind.VOID, 2, 3),
+            "observeVoid must not reject a void child that has no plain sibling yet"
+        );
+    }
+
+    @Test
+    void acceptsPlainChildAfterVoid() {
+        final Level level = new Level(
+            0, 1, Kind.HEAD, Openness.OPEN, Kind.TOP_LEVEL, false
+        );
+        level.observeVoid(Kind.VOID, 2, 3);
+        Assertions.assertDoesNotThrow(
+            () -> level.observeVoid(Kind.HEAD, 4, 5),
+            "observeVoid must not reject a plain child that follows a void one"
+        );
+    }
+
+    @Test
+    void rejectsVoidAfterPlainChild() {
+        final Level level = new Level(
+            0, 1, Kind.HEAD, Openness.OPEN, Kind.TOP_LEVEL, false
+        );
+        level.observeVoid(Kind.HEAD, 2, 3);
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> level.observeVoid(Kind.VOID, 4, 5),
+            "observeVoid must reject a void child once a plain sibling has appeared"
+        );
+    }
+
+    @Test
+    void positionsVoidOrderingErrorAtOffendingVoid() {
+        final Level level = new Level(
+            0, 1, Kind.HEAD, Openness.OPEN, Kind.TOP_LEVEL, false
+        );
+        level.observeVoid(Kind.HEAD, 2, 3);
+        MatcherAssert.assertThat(
+            "error must be positioned at the line of the void that broke the ordering rule",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> level.observeVoid(Kind.VOID, 9, 4),
+                "observeVoid must reject a misplaced void with a ParseError"
+            ).line(),
+            Matchers.equalTo(9)
+        );
+    }
 }


### PR DESCRIPTION
Level.observeVoid's javadoc, and the plain field's javadoc it draws from, both cited R-3.4.7 for the void-ordering rule. R-3.4.7 is a different rule: it introduces the vertical void syntax (a `? > name` body line), covering the auto-name form, the receiver spelling and the shapes the marker may take.

The rule the method actually enforces is R-3.4.9, "Vertical voids must stay on top," which is where the message it throws — `a void attribute must be declared above all other attributes` — comes from verbatim. Fixed both citations to point at R-3.4.9.

Also added LevelTest coverage for observeVoid's edge cases: a void accepted before any plain child, a plain child accepted after a void, a void rejected once a plain child has appeared, and the thrown error positioned at the offending void's line.

Closes #8030