### PR TITLE
Fold the three copies of the void parameter mapping into one object

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -494,15 +494,7 @@ final class Emissions {
         int pcol = column + bracket + 1;
         for (final String param : Emissions.splitParams(params)) {
             Emissions.validParam(param, line, pcol);
-            final String mapped;
-            if ("@".equals(param)) {
-                mapped = "φ";
-            } else if ("^".equals(param)) {
-                mapped = "ρ";
-            } else {
-                mapped = param;
-            }
-            emit.voidParam(mapped, line, pcol);
+            emit.voidParam(new VoidName(param).asString(), line, pcol);
             pcol = pcol + param.length() + 1;
         }
         final Span sub = new Span(" ".repeat(column).concat(lhs), line);

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -214,14 +214,6 @@ final class LnFormation implements Line {
 
     private static String mapParam(final String raw, final Span span, final int pos) {
         Emissions.validParam(raw, span.line(), pos);
-        final String mapped;
-        if ("@".equals(raw)) {
-            mapped = "φ";
-        } else if ("^".equals(raw)) {
-            mapped = "ρ";
-        } else {
-            mapped = raw;
-        }
-        return mapped;
+        return new VoidName(raw).asString();
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -187,15 +187,7 @@ final class LnOnlyPhi implements Line {
     private void emitVoids(final Emit emit, final List<String> params, final int origin) {
         int column = this.span.indent() + origin;
         for (final String param : params) {
-            final String mapped;
-            if ("@".equals(param)) {
-                mapped = "φ";
-            } else if ("^".equals(param)) {
-                mapped = "ρ";
-            } else {
-                mapped = param;
-            }
-            emit.voidParam(mapped, this.span.line(), column);
+            emit.voidParam(new VoidName(param).asString(), this.span.line(), column);
             column = column + param.length() + 1;
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -337,14 +337,6 @@ final class Suffix {
         return promoted;
     }
 
-    /**
-     * The name a {@code > name} suffix is emitted under. Only the
-     * {@code @} half of §9.3 reaches here — a label is either {@code @}
-     * or a lowercase-initial {@code NAME} — so this is not a void and
-     * does not go through {@link VoidName}, which promotes {@code ^} too.
-     * @param raw The label, as the source wrote it
-     * @return The emitted name
-     */
     private static String phi(final String raw) {
         final String mapped;
         if ("@".equals(raw)) {

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -337,6 +337,14 @@ final class Suffix {
         return promoted;
     }
 
+    /**
+     * The name a {@code > name} suffix is emitted under. Only the
+     * {@code @} half of §9.3 reaches here — a label is either {@code @}
+     * or a lowercase-initial {@code NAME} — so this is not a void and
+     * does not go through {@link VoidName}, which promotes {@code ^} too.
+     * @param raw The label, as the source wrote it
+     * @return The emitted name
+     */
     private static String phi(final String raw) {
         final String mapped;
         if ("@".equals(raw)) {

--- a/eo-parser/src/main/java/org/eolang/parser/VoidName.java
+++ b/eo-parser/src/main/java/org/eolang/parser/VoidName.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.cactoos.Text;
+
+/**
+ * The XMIR name a void parameter is emitted under.
+ *
+ * <p>A parameter written as {@code @} declares the formation's decoratee
+ * and is emitted as {@code φ}; one written as {@code ^} declares its
+ * receiver and is emitted as {@code ρ} (R-3.4.2 / R-3.4.11 / R-9.3).
+ * Every other token names itself. The §9.3 table is the single source of
+ * truth for these promotions, so every parameter loop that emits a void
+ * asks this object rather than deciding for itself.</p>
+ *
+ * @since 0.74.0
+ */
+final class VoidName implements Text {
+
+    /**
+     * The parameter, as the source wrote it.
+     */
+    private final String raw;
+
+    /**
+     * Ctor.
+     * @param token The parameter, as the source wrote it
+     */
+    VoidName(final String token) {
+        this.raw = token;
+    }
+
+    @Override
+    public String asString() {
+        final String mapped;
+        if ("@".equals(this.raw)) {
+            mapped = "φ";
+        } else if ("^".equals(this.raw)) {
+            mapped = "ρ";
+        } else {
+            mapped = this.raw;
+        }
+        return mapped;
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/VoidNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/VoidNameTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Tests {@link VoidName}.
- *
  * @since 0.74.0
  */
 final class VoidNameTest {

--- a/eo-parser/src/test/java/org/eolang/parser/VoidNameTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/VoidNameTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link VoidName}.
+ *
+ * @since 0.74.0
+ */
+final class VoidNameTest {
+
+    @Test
+    void promotesPhiToken() {
+        MatcherAssert.assertThat(
+            "a `@` parameter must be emitted as `φ` per R-3.4.2 / R-9.3",
+            new VoidName("@").asString(),
+            Matchers.equalTo("φ")
+        );
+    }
+
+    @Test
+    void promotesRhoToken() {
+        MatcherAssert.assertThat(
+            "a `^` parameter must be emitted as `ρ` per R-3.4.11 / R-9.3",
+            new VoidName("^").asString(),
+            Matchers.equalTo("ρ")
+        );
+    }
+
+    @Test
+    void keepsOrdinaryName() {
+        MatcherAssert.assertThat(
+            "a parameter that is not a scope token must name itself",
+            new VoidName("x").asString(),
+            Matchers.equalTo("x")
+        );
+    }
+}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-head-promotes-rho-param.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-head-promotes-rho-param.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='bar']/o[1][@name='ρ' and @base='∅']
+  - //o[@name='bar']/o[2][@name='x' and @base='∅']
+input: |
+  [] > obj
+    foo > [^ x] > bar


### PR DESCRIPTION
The `@` → `φ` and `^` → `ρ` void mapping was written out three times, as the same if / else-if / else block: in `LnFormation.mapParam`, in `LnOnlyPhi.emitVoids`, and inside the parameter loop of `Emissions.inlinePhi`. That third copy is the one #7314 had to add, because the site carried the `@` branch and was missing the `^` one. All three now ask a `VoidName`, so §9.3 has a single implementation and the next parameter loop has something to call instead of something to copy.

`VoidName` is a small `Text` in `eo-parser`, next to `AutoName`, which does the same job for the cactus name. It deliberately did not go into `Emissions` — that class is already reported as a God Class in #7394, and this change takes eight lines out of it.

`Suffix.phi` stays as it is. It maps `@` in a `> name` suffix, which is a label rather than a void: `checkLowercaseStart` only lets `@` or a lowercase-initial `NAME` through, so `^` never reaches it, and routing it through `VoidName` would widen a rule that has no `^` half. I left a note there saying so, since the asymmetry is otherwise a fair thing to wonder about.

While wiring the sites up I found that the only-phi head had no test covering a promoted parameter at all — `[^ x]` in a `> [params]` head was live code that nothing exercised — so there is a new `eo-syntax` yaml for it, alongside unit tests for the object itself. I checked the emitted XMIR for all four shapes against the parser running on this branch: `[^ x] > lt`, `foo > [^ x] > bar`, `q.f (a > [^ x]) > z` and `[@] > foo` each emit what §9.3 asks for.

Closes #8027
