### PR TITLE
fix(#8032): document THROWS form in Suffix.java javadoc

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -80,8 +80,9 @@ final class Suffix {
     private final Form form;
 
     /**
-     * Bound name for {@code NAME} / {@code TEST} forms; the file-local
-     * handle for a {@code >> name} {@code AUTO} suffix; empty otherwise.
+     * Bound name for {@code NAME} / {@code TEST} / {@code THROWS} forms;
+     * the file-local handle for a {@code >> name} {@code AUTO} suffix;
+     * empty otherwise.
      */
     private final String label;
 
@@ -139,7 +140,7 @@ final class Suffix {
 
     /**
      * The suffix form — one of {@code NONE}, {@code NAME}, {@code AUTO},
-     * {@code TEST}.
+     * {@code TEST}, {@code THROWS}.
      * @return Form
      */
     Form form() {


### PR DESCRIPTION
Suffix.form() and the label field both describe the suffix form as one of NONE, NAME, AUTO, TEST, leaving out THROWS. The Form enum itself already carries all five constants, and Suffix.test() stores a THROWS suffix's label through the same field the doc only credits to NAME and TEST.

This adds THROWS to both summaries so the accessor's contract matches what the enum and the parser actually do.

Closes #8032