### PR TITLE
fix(#8031): lowercase and inform binding label error in Tokens.java

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1384,6 +1384,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Mixed bindings in arg group | `argument bindings must be all-or-nothing` |
 | Receiver carrying binding | `reversed-dispatch receiver cannot carry a binding` |
 | Inline binding on non-last method in chain | `inline binding allowed only on the last method in a chain` |
+| Binding label (§3.12) that is neither a NAME-initial label nor a plain slot number | `binding label "<label>" must be a name or a slot number` (label substituted) |
 | Comment not on top of the file | `comment is allowed only on top of the file, before metas` |
 | Blank line inside the top comment block | `blank line inside the top comment block is not allowed` |
 | No blank line after the top comment block | `a blank line must separate the top comment block from the rest of the file` |

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -536,7 +536,10 @@ final class Tokens {
         if (!Tokens.validBinding(text)) {
             throw new ParseError(
                 span.line(), pos,
-                "Invalid bound object declaration"
+                String.format(
+                    "binding label \"%s\" must be a name or a slot number",
+                    text
+                )
             );
         }
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-binding.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/broken-binding.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 3
 message: |-
-  [3:7] error: 'Invalid bound object declaration'
+  [3:7] error: 'binding label "-1" must be a name or a slot number'
       42:-1
          ^
 input: |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-leading-zero.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-leading-zero.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 3
-message: "Invalid bound object declaration"
+message: "binding label \"00\" must be a name or a slot number"
 input: |
   [] > main
     x > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-uppercase.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-uppercase.yaml
@@ -3,7 +3,7 @@
 ---
 # yamllint disable rule:line-length
 line: 3
-message: "Invalid bound object declaration"
+message: "binding label \"A\" must be a name or a slot number"
 input: |
   [] > main
     x > y


### PR DESCRIPTION
\`Tokens.checkBinding\` in eo-parser rejects a malformed inline-binding label with the title-cased \`Invalid bound object declaration\`, the only capitalised message in the parser and one that doesn't say what the label should have looked like, even though the offending text is right there.

This changes the message to \`binding label "<label>" must be a name or a slot number\`, lowercase and naming the value that triggered it, matching the style of neighbouring messages like \`cactus emoji is reserved for auto-names; not allowed in identifiers\` and \`type variable must be one of A-F\`. Both call sites — \`Tokens.readBinding\` (inline binding) and \`LnFormation.outerBinding\` (a formation's outer binding) — share this check, so both get the fix.

PARSER_SPEC.md §9.9 had no row for this condition; added one. Updated the three golden-file fixtures that asserted the old text.

Closes #8031