### PR TITLE
Fix label() javadoc for the AUTO suffix

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -147,7 +147,9 @@ final class Suffix {
     }
 
     /**
-     * Bound name. Empty for {@code AUTO} and {@code NONE}.
+     * Bound name. Empty for {@code NONE}; for {@code AUTO} it is the
+     * file-local handle of a {@code >> name} suffix, empty only for a
+     * bare {@code >>}.
      * @return Name
      */
     String label() {


### PR DESCRIPTION
\`Suffix.label()\` said its value is empty for both \`AUTO\` and \`NONE\`. That's only true for \`NONE\`.

For \`AUTO\`, \`Suffix.auto\` reads the file-local handle of a \`>> name\` suffix and stores it in the same \`label\` field, so \`>> foo\` returns \`foo\` from \`label()\`, not an empty string. The field's own javadoc already describes this correctly, and \`handle()\` exists specifically to hand out that same value under its proper name — so \`label()\`'s doc contradicted both the field it reads and its sibling accessor.

This fixes the doc comment to say the value is empty for \`NONE\`, and is the file-local handle for \`AUTO\` (empty only for a bare \`>>\`). No behavior change.

Closes #8033