### PR TITLE
Say an absent outer binding with an empty string, not null

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Bindings.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Bindings.java
@@ -120,7 +120,7 @@ final class Bindings {
      * R-3.12.3.</p>
      *
      * @param stack Indent stack (the new child is already on top)
-     * @param outer Outer binding label, or {@code null} when absent
+     * @param outer Outer binding label, empty when the line carries none
      * @param span Source span of the child line
      */
     static void observeChild(final Stack stack, final String outer, final Span span) {
@@ -130,7 +130,7 @@ final class Bindings {
         } else if (parent.kind() == Kind.BARE_REVERSED) {
             Bindings.observeReversedChild(parent, outer, span);
         } else if (Bindings.tracksBindings(parent.kind())) {
-            parent.observeBinding(outer != null, span);
+            parent.observeBinding(!outer.isEmpty(), span);
         }
     }
 
@@ -139,7 +139,7 @@ final class Bindings {
     }
 
     private static void rejectBinding(final String outer, final Span span) {
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             throw new ParseError(
                 span.line(), span.indent(),
                 "binding allowed only in argument position"
@@ -151,8 +151,8 @@ final class Bindings {
         final Level parent, final String outer, final Span span
     ) {
         if (parent.children() > 1) {
-            parent.observeBinding(outer != null, span);
-        } else if (outer != null) {
+            parent.observeBinding(!outer.isEmpty(), span);
+        } else if (!outer.isEmpty()) {
             throw new ParseError(
                 span.line(), span.indent(),
                 "reversed-dispatch receiver cannot carry a binding"

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -86,7 +86,7 @@ final class LnApplication implements Line {
         globals.clearBlanks();
         globals.markEmitted();
         this.emit(emit, suffix, head, chain, args);
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             emit.slot(Emissions.bindingTag(outer));
         }
     }
@@ -102,9 +102,14 @@ final class LnApplication implements Line {
      * R-6.6.4 — the binding would sit on a method the chain does not end
      * with.</p>
      *
+     * <p>A line that carries no binding gets the empty string, not
+     * {@code null}: §3.12 spells no empty label and
+     * {@link Tokens#readBinding()} rejects one, so the empty string
+     * names absence and nothing else (#8029).</p>
+     *
      * @param tokens Token reader
      * @param span Source span of the line
-     * @return The binding label, or {@code null}
+     * @return The binding label, empty when the line carries none
      */
     static String readOuterBinding(final Tokens tokens, final Span span) {
         final String label;
@@ -119,7 +124,7 @@ final class LnApplication implements Line {
                 );
             }
         } else {
-            label = null;
+            label = "";
         }
         return label;
     }
@@ -155,7 +160,7 @@ final class LnApplication implements Line {
         final String outer
     ) {
         if (head.group()
-            && chain.isEmpty() && args.isEmpty() && outer == null) {
+            && chain.isEmpty() && args.isEmpty() && outer.isEmpty()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "redundant parentheses around a top-level expression — drop the outer `(` and `)`"

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -53,7 +53,7 @@ final class LnFormation implements Line {
         final Suffix suffix;
         if (body.startsWith("++>") || body.startsWith("-->")) {
             params = new ArrayList<>(0);
-            binding = null;
+            binding = "";
             suffix = new Suffix(
                 body.substring(1), this.span, this.span.indent() + 1
             );
@@ -64,15 +64,10 @@ final class LnFormation implements Line {
             binding = LnFormation.outerBinding(
                 raw, this.span, this.span.indent() + close + 2
             );
-            final String tail;
-            if (binding == null) {
-                tail = raw;
-            } else {
-                tail = raw.substring(1 + binding.length());
-            }
+            final int width = LnFormation.bindingWidth(binding);
             suffix = new Suffix(
-                tail, this.span,
-                this.span.indent() + close + 1 + LnFormation.bindingWidth(binding)
+                raw.substring(width), this.span,
+                this.span.indent() + close + 1 + width
             );
         }
         this.checkAtomVoids(suffix, params);
@@ -98,14 +93,14 @@ final class LnFormation implements Line {
             label = raw.substring(1, idx);
             Tokens.checkBinding(label, span, pos);
         } else {
-            label = null;
+            label = "";
         }
         return label;
     }
 
     private static int bindingWidth(final String binding) {
         final int width;
-        if (binding == null) {
+        if (binding.isEmpty()) {
             width = 0;
         } else {
             width = binding.length() + 1;
@@ -142,7 +137,7 @@ final class LnFormation implements Line {
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());
         }
-        if (binding != null) {
+        if (!binding.isEmpty()) {
             emit.slot(Emissions.bindingTag(binding));
         }
         if (suffix.constant()) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -85,7 +85,7 @@ final class LnMethod implements Line {
             Blanks.checkPlain(this.span, globals, emit);
         }
         globals.seal(emit, this.span);
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             final Level under = stack.below();
             Bindings.checkReceiverUpgrade(under, this.span);
             under.upgradeArgBinding();
@@ -101,7 +101,7 @@ final class LnMethod implements Line {
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, this.span.line());
         }
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             emit.slot(Emissions.bindingTag(outer));
         }
         final Kind kind;
@@ -115,7 +115,7 @@ final class LnMethod implements Line {
         }
         top.become(kind);
         top.close(openness);
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             top.tie();
         }
         if (suffix.present()) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -146,7 +146,7 @@ final class LnReversed implements Line {
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, this.span.line());
         }
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             emit.slot(Emissions.bindingTag(outer));
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -71,7 +71,7 @@ final class LnTextBlock implements Line {
         this.transition(stack, suffix);
         Bindings.observeChild(stack, outer, this.span);
         this.emit(emit, suffix, chain, joined);
-        if (outer != null) {
+        if (!outer.isEmpty()) {
             emit.slot(Emissions.bindingTag(outer));
         }
         globals.closeTextBlock();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-empty.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-empty.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #8029: a colon with no label after a vertical formation is not a binding
+# at all, so an empty label can never reach the emitter.
+line: 3
+message: "Invalid bound object declaration"
+input: |
+  [] > main
+    x > y
+      []: > slot


### PR DESCRIPTION
Closes #8029.

An absent outer binding was spelled `null`, so the absence had to be re-stated everywhere the label travelled. `LnFormation` tested it twice on the way to the suffix and kept `bindingWidth` around mostly to answer zero for it; `Bindings.observeChild` documented `null` as a legal argument and branched on it three times; and `LnApplication`, `LnMethod`, `LnReversed` and `LnTextBlock` each guarded it once more before emitting the slot. Nine guards for one missing label, and every one of them a place a future caller can forget the check.

The empty string says the same thing and cannot be mistaken for a real label: §3.12 spells no empty label, and `Tokens.readBinding` rejects one outright with "expected binding label after `:`". So `readOuterBinding` and `LnFormation.outerBinding` now return `""` when there is nothing to read, and every guard downstream becomes an `isEmpty` test. `LnFormation` gets the better end of it — the suffix is now sliced off a single `width`, so the `binding == null` branch disappears entirely.

The one case the whole thing rests on had no test, so there is a new `eo-typos` pack for it: `[]:` with nothing after the colon is rejected as an invalid bound object declaration, which is what keeps `""` unreachable as a real value.

Behaviour is unchanged. I checked that by parsing every `.eo` file in the repo (187) and every `input:` block in the parser's yaml fixtures (421) with both the old and the new code and diffing the emitted Xembly directives — byte-identical on all 608.
