### PR TITLE
Carry a demand through a void handed into another void

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -10,6 +10,9 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import org.xembly.Xembler;
 
@@ -52,20 +55,49 @@ public final class Demanded implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
-        final Map<String, String> names = new Ends(
-            new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()
-        ).names();
+        final XML links = new XMLDocument(tables.resolve("links.xml"));
+        final Map<String, String> names = new Ends(new Pairs(links).all()).names();
+        final Collection<String> voids = given.xpath("//attr[@void='true']/@type");
+        final Map<String, String> into = this.into(links, names, voids);
         final Map<String, Map<String, String>> asked = new Asked(
             new XMLDocument(tables.resolve("needs.xml")),
             names,
-            new Provided(given, names, given.xpath("//attr[@void='true']/@type"))
+            new Provided(given, names, voids)
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
-            final Demands demands = new Demands(asked, hollow.xpath("@type").get(0));
+            final Demands demands = new Demands(
+                asked, this.roots(hollow.xpath("@type").get(0), into)
+            );
             if (demands.any()) {
                 new Xembler(demands.directives()).applyQuietly(hollow.inner());
             }
         }
         Files.write(table, given.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private Map<String, String> into(
+        final XML links, final Map<String, String> names, final Collection<String> voids
+    ) {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final XML bind : links.nodes("/links/type/ref/bind[ref]")) {
+            final String loc = bind.xpath("ref/@loc").get(0);
+            final String filler = names.getOrDefault(loc, loc);
+            if (voids.contains(filler)) {
+                found.put(filler, bind.xpath("@void").get(0));
+            }
+        }
+        return found;
+    }
+
+    private Collection<String> roots(final String hollow, final Map<String, String> into) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        String walked = hollow;
+        while (found.add(walked)) {
+            if (!into.containsKey(walked)) {
+                break;
+            }
+            walked = into.get(walked);
+        }
+        return found;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Demands.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demands.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.inference;
 
+import java.util.Collection;
 import java.util.Map;
 import org.xembly.Directives;
 
@@ -24,6 +25,9 @@ import org.xembly.Directives;
  * is a name rooted at the void, so all of them are gathered here, each demand
  * saying which one it is made of.</p>
  *
+ * <p>A void handed whole into another void is one more root to gather demands
+ * from, alongside the void itself.</p>
+ *
  * <p>They are written side by side rather than one inside the other, which
  * would have read better, because the chain is not always there to nest them
  * along: {@code while} hands its answers through several objects to the
@@ -43,18 +47,20 @@ final class Demands {
     private final Map<String, Map<String, String>> asked;
 
     /**
-     * The void these demands are made of.
+     * The voids these demands are made of: the void itself and every one it is
+     * ultimately handed into.
      */
-    private final String hollow;
+    private final Collection<String> roots;
 
     /**
      * Ctor.
      * @param all What is asked of every object, from {@link Asked}
-     * @param object The void these demands are made of
+     * @param objects The void these demands are made of, and every void it is
+     *  handed into
      */
-    Demands(final Map<String, Map<String, String>> all, final String object) {
+    Demands(final Map<String, Map<String, String>> all, final Collection<String> objects) {
         this.asked = all;
-        this.hollow = object;
+        this.roots = objects;
     }
 
     /**
@@ -93,6 +99,13 @@ final class Demands {
     }
 
     private boolean below(final String object) {
-        return object.equals(this.hollow) || object.startsWith(this.hollow.concat("."));
+        boolean found = false;
+        for (final String root : this.roots) {
+            if (object.equals(root) || object.startsWith(root.concat("."))) {
+                found = true;
+                break;
+            }
+        }
+        return found;
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/DemandedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandedTest.java
@@ -47,6 +47,34 @@ final class DemandedTest {
     }
 
     @Test
+    void carriesADemandThroughAVoidHandedIntoAnother(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("shelf.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.book' name='book'>",
+                "<o base='∅' loc='Φ.book.pages' name='pages'/>",
+                "<o base='.size' loc='Φ.book.φ' name='φ'>",
+                "<o base='ξ.pages' loc='Φ.book.φ.ρ'/></o></o>",
+                "<o loc='Φ.shelf' name='shelf'><o base='∅' loc='Φ.shelf.stuff' name='stuff'/>",
+                "<o base='Φ.book' loc='Φ.shelf.φ' name='φ'>",
+                "<o as='α0' base='ξ.stuff' loc='Φ.shelf.φ.α0'/></o></o></object>"
+            )
+        );
+        new Demanded(new Resolved(new Clues())).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "a void handed into another void must inherit its demands, but it didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
+                "/provides/type[@id='Φ.shelf']/attr[@name='stuff']/demand"
+                    .concat("[@of='Φ.book.pages' and @name='size']")
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
     void leavesAVoidNobodyAsksOfAlone(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("pipe.xmir"),

--- a/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
@@ -29,7 +29,9 @@ final class DemandsTest {
             "the name asked of the answer must stand beside the one that named it, but it didnt",
             new XMLDocument(
                 new Xembler(
-                    new Directives().add("attr").append(new Demands(asked, "Φ.inc.x").directives())
+                    new Directives().add("attr").append(
+                        new Demands(asked, Collections.singleton("Φ.inc.x")).directives()
+                    )
                 ).xmlQuietly()
             ).nodes("/attr/demand[@of='Φ.inc.x.next' and @name='foo']"),
             Matchers.hasSize(1)
@@ -44,7 +46,7 @@ final class DemandsTest {
                 Collections.singletonMap(
                     "Φ.dec.y", Collections.singletonMap("prev", "Φ.dec.y.prev")
                 ),
-                "Φ.inc.x"
+                Collections.singleton("Φ.inc.x")
             ).any(),
             Matchers.is(false)
         );


### PR DESCRIPTION
Closes #8019

A void's demands were gathered by string-prefix matching alone: `Demands.below` checked whether a bearer name started with the void's own locator. That misses the case where the body of a formation hands one of its own voids whole into another void it copies — `book stuff > @` inside a `shelf` that keeps a `stuff` hands that void into the `pages` of `book`. Nothing in the walk followed that `bind`, so `Φ.shelf.stuff` never picked up the `size` demanded of `Φ.book.pages`, even though `Φ.book.pages` is exactly what `Φ.shelf.stuff` will have to answer for.

`Demanded` now reads `links.xml` for `bind` rows whose filler is itself a void and builds a map from filler to the void it lands in, then walks that chain (once, so a void handed into itself doesn't loop) to get every root a void's demands should be gathered from. `Demands` takes that whole collection of roots instead of a single locator.

Covered by a new `DemandedTest` case built on the `book`/`shelf` example from the issue, plus updated `DemandsTest` call sites for the new constructor signature.