### PR TITLE
#8019: carry demands into a void handed on, however many it reaches

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -10,6 +10,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import org.xembly.Xembler;
 
@@ -52,20 +58,52 @@ public final class Demanded implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
-        final Map<String, String> names = new Ends(
-            new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()
-        ).names();
+        final XML links = new XMLDocument(tables.resolve("links.xml"));
+        final Map<String, String> names = new Ends(new Pairs(links).all()).names();
+        final Collection<String> voids = given.xpath("//attr[@void='true']/@type");
+        final Map<String, Collection<String>> into = Demanded.into(links, names, voids);
         final Map<String, Map<String, String>> asked = new Asked(
             new XMLDocument(tables.resolve("needs.xml")),
             names,
-            new Provided(given, names, given.xpath("//attr[@void='true']/@type"))
+            new Provided(given, names, voids)
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
-            final Demands demands = new Demands(asked, hollow.xpath("@type").get(0));
+            final Demands demands = new Demands(
+                asked, Demanded.roots(hollow.xpath("@type").get(0), into)
+            );
             if (demands.any()) {
                 new Xembler(demands.directives()).applyQuietly(hollow.inner());
             }
         }
         Files.write(table, given.toString().getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static Map<String, Collection<String>> into(
+        final XML links, final Map<String, String> names, final Collection<String> voids
+    ) {
+        final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
+        for (final XML bind : links.nodes("/links/type/ref/bind[ref]")) {
+            final String loc = bind.xpath("ref/@loc").get(0);
+            final String filler = names.getOrDefault(loc, loc);
+            if (voids.contains(filler)) {
+                found.computeIfAbsent(filler, key -> new LinkedHashSet<>(0))
+                    .add(bind.xpath("@void").get(0));
+            }
+        }
+        return found;
+    }
+
+    private static Collection<String> roots(
+        final String hollow, final Map<String, Collection<String>> into
+    ) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        final Deque<String> left = new ArrayDeque<>(Collections.singletonList(hollow));
+        while (!left.isEmpty()) {
+            final String walked = left.removeFirst();
+            if (found.add(walked)) {
+                left.addAll(into.getOrDefault(walked, Collections.emptyList()));
+            }
+        }
+        return found;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Demands.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demands.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.inference;
 
+import java.util.Collection;
 import java.util.Map;
 import org.xembly.Directives;
 
@@ -43,18 +44,20 @@ final class Demands {
     private final Map<String, Map<String, String>> asked;
 
     /**
-     * The void these demands are made of.
+     * The voids these demands are made of: this one, and every void it is
+     * handed into.
      */
-    private final String hollow;
+    private final Collection<String> roots;
 
     /**
      * Ctor.
      * @param all What is asked of every object, from {@link Asked}
-     * @param object The void these demands are made of
+     * @param objects The voids these demands are made of: the void itself,
+     *  and every void it is handed into
      */
-    Demands(final Map<String, Map<String, String>> all, final String object) {
+    Demands(final Map<String, Map<String, String>> all, final Collection<String> objects) {
         this.asked = all;
-        this.hollow = object;
+        this.roots = objects;
     }
 
     /**
@@ -93,6 +96,13 @@ final class Demands {
     }
 
     private boolean below(final String object) {
-        return object.equals(this.hollow) || object.startsWith(this.hollow.concat("."));
+        boolean found = false;
+        for (final String root : this.roots) {
+            if (object.equals(root) || object.startsWith(root.concat("."))) {
+                found = true;
+                break;
+            }
+        }
+        return found;
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
@@ -29,7 +29,9 @@ final class DemandsTest {
             "the name asked of the answer must stand beside the one that named it, but it didnt",
             new XMLDocument(
                 new Xembler(
-                    new Directives().add("attr").append(new Demands(asked, "Φ.inc.x").directives())
+                    new Directives().add("attr").append(
+                        new Demands(asked, Collections.singletonList("Φ.inc.x")).directives()
+                    )
                 ).xmlQuietly()
             ).nodes("/attr/demand[@of='Φ.inc.x.next' and @name='foo']"),
             Matchers.hasSize(1)
@@ -44,7 +46,7 @@ final class DemandsTest {
                 Collections.singletonMap(
                     "Φ.dec.y", Collections.singletonMap("prev", "Φ.dec.y.prev")
                 ),
-                "Φ.inc.x"
+                Collections.singletonList("Φ.inc.x")
             ).any(),
             Matchers.is(false)
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-handed-into-another-void.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-handed-into-another-void.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+eo:
+  a.eo: |
+    [pages] > book
+      pages.size > @
+
+    [stuff] > shelf
+      stuff.weight > w
+      book stuff > @
+provides:
+  - "/provides/type[@id='Φ.shelf']/attr[@name='stuff']/demand[@name='weight']"
+  - "/provides/type[@id='Φ.shelf']/attr[@name='stuff']/demand[@name='size']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-handed-into-two-voids.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-handed-into-two-voids.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+eo:
+  a.eo: |
+    [pages] > book
+      pages.size > @
+
+    [weight] > scale
+      weight.mass > @
+
+    [stuff] > shelf
+      book stuff > a
+      scale stuff > b
+provides:
+  - "/provides/type[@id='Φ.shelf']/attr[@name='stuff']/demand[@name='size']"
+  - "/provides/type[@id='Φ.shelf']/attr[@name='stuff']/demand[@name='mass']"


### PR DESCRIPTION
Closes #8019

`Demands.below` gathered a void's demands by string prefix alone, so a demand never crossed a `bind`: a `shelf` that keeps a `stuff` and writes `book stuff > @` hands that void whole into the `pages` of a `book`, and the `size` demanded of `Φ.book.pages` never reached `Φ.shelf.stuff`.

`Demanded` now reads the `bind` rows of `links.xml` whose filler resolves to a void, and walks from each void to every void it is handed into. The walk is a fan-out rather than a chain, because one void may reach several: a `stuff` put into the `pages` of a `book` and into the `weight` of a `scale` answers for both, and keeping one destination per void would record whichever `bind` came last and drop the rest. A void already seen is not walked again, so a void handed into itself terminates.

`Demands` takes that set of roots instead of a single locator.

Two packs, both from the report: one void handed into another, and one void handed into two. `eo-runtime` has 18 voids that reach two or more, `path.uri` reaching four.

This overlaps #8099, which fixes the same issue with a single destination per void.
