### PR TITLE
Reject tabs in multi-line bytes continuations

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/BytesIndent.java
+++ b/eo-parser/src/main/java/org/eolang/parser/BytesIndent.java
@@ -61,6 +61,8 @@ final class BytesIndent {
         final String found;
         if (this.line.blank()) {
             found = "";
+        } else if (this.line.tab()) {
+            found = "tab character in leading whitespace";
         } else if (this.line.indent() < this.head) {
             found = "multi-line bytes continuation must not de-indent";
         } else if (this.line.indent() % 2 == 1) {

--- a/eo-parser/src/test/java/org/eolang/parser/BytesIndentTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BytesIndentTest.java
@@ -27,11 +27,6 @@ final class BytesIndentTest {
         );
     }
 
-    /**
-     * Parse rows and return their XMIR.
-     * @param rows EO source rows
-     * @return XMIR
-     */
     private static String render(final String... rows) {
         final StringBuilder source = new StringBuilder(rows.length * 16);
         for (final String row : rows) {

--- a/eo-parser/src/test/java/org/eolang/parser/BytesIndentTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/BytesIndentTest.java
@@ -1,0 +1,46 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link BytesIndent}.
+ * @since 0.1
+ */
+final class BytesIndentTest {
+
+    @Test
+    void rejectsTabInContinuation() {
+        MatcherAssert.assertThat(
+            "a tab must not become legal indentation only because a BYTES literal continues",
+            BytesIndentTest.render("foo > main", "  CA-FE-", "\t\tBE-BE"),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'tab character in leading whitespace')]"
+            )
+        );
+    }
+
+    /**
+     * Parse rows and return their XMIR.
+     * @param rows EO source rows
+     * @return XMIR
+     */
+    private static String render(final String... rows) {
+        final StringBuilder source = new StringBuilder(rows.length * 16);
+        for (final String row : rows) {
+            source.append(row).append((char) 10);
+        }
+        return new Xembler(
+            new Directives().add("object").append(
+                new Eo(source.toString()).directives()
+            )
+        ).xmlQuietly();
+    }
+}

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -933,17 +933,6 @@ final class EoTest {
     }
 
     @Test
-    void rejectsTabInMultiLineBytesContinuation() {
-        MatcherAssert.assertThat(
-            "a tab must not become legal indentation only because a BYTES literal continues",
-            EoTest.render("foo > main", "  CA-FE-", "\t\tBE-BE"),
-            XhtmlMatchers.hasXPath(
-                "/object/errors/error[contains(text(),'tab character in leading whitespace')]"
-            )
-        );
-    }
-
-    @Test
     void leavesSingleLineBytesAlone() {
         MatcherAssert.assertThat(
             "a single-line BYTES literal without trailing dash must NOT consume the next line",

--- a/eo-parser/src/test/java/org/eolang/parser/EoTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoTest.java
@@ -933,6 +933,17 @@ final class EoTest {
     }
 
     @Test
+    void rejectsTabInMultiLineBytesContinuation() {
+        MatcherAssert.assertThat(
+            "a tab must not become legal indentation only because a BYTES literal continues",
+            EoTest.render("foo > main", "  CA-FE-", "\t\tBE-BE"),
+            XhtmlMatchers.hasXPath(
+                "/object/errors/error[contains(text(),'tab character in leading whitespace')]"
+            )
+        );
+    }
+
+    @Test
     void leavesSingleLineBytesAlone() {
         MatcherAssert.assertThat(
             "a single-line BYTES literal without trailing dash must NOT consume the next line",


### PR DESCRIPTION
## What happens

A non-blank EO line with leading tabs is normally rejected by
[`Eo.process()`](https://github.com/objectionary/eo/blob/master/eo-parser/src/main/java/org/eolang/parser/Eo.java#L268).
However, a continuation of a multi-line bytes literal is handled directly by
[`Eo.mergeBytesContinuation()`](https://github.com/objectionary/eo/blob/master/eo-parser/src/main/java/org/eolang/parser/Eo.java#L189).
That path consulted `BytesIndent` only for level changes, so a line such as
`\t\tBE-BE` was accepted as indentation and became part of the literal.

## Changes

- Make `BytesIndent` reject tabs with the same diagnostic used by ordinary
  parser lines before it evaluates the continuation's numeric indentation.
- Add an `EoTest` regression case for a tab-indented second line of
  `CA-FE-` bytes.

## Verification

`mvn -T 2 -pl eo-parser test -Dtest=EoTest -q`

Fixes #8064.
