### PR TITLE
Restore identity equality for Phi decorators

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Data.java
+++ b/eo-runtime/src/main/java/org/eolang/Data.java
@@ -70,16 +70,6 @@ public interface Data {
         }
 
         @Override
-        public boolean equals(final Object obj) {
-            return this == obj || this.object.equals(obj);
-        }
-
-        @Override
-        public int hashCode() {
-            return this.object.hashCode();
-        }
-
-        @Override
         public Phi copy() {
             return this.object.copy();
         }

--- a/eo-runtime/src/main/java/org/eolang/PhAgain.java
+++ b/eo-runtime/src/main/java/org/eolang/PhAgain.java
@@ -33,16 +33,6 @@ public final class PhAgain implements Phi {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        return this == obj || this.next.equals(obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.next.hashCode();
-    }
-
-    @Override
     public Phi copy() {
         return new PhAgain(this.next.copy());
     }

--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -77,16 +77,6 @@ public final class PhCoverage implements Phi {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        return this == obj || this.origin.equals(obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.origin.hashCode();
-    }
-
-    @Override
     public Phi copy() {
         return new PhCoverage(this.origin.copy(), this.hits, this.record);
     }

--- a/eo-runtime/src/main/java/org/eolang/PhLogged.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLogged.java
@@ -78,16 +78,6 @@ public final class PhLogged implements Phi {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        return this == obj || this.origin.equals(obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.origin.hashCode();
-    }
-
-    @Override
     public byte[] delta() {
         System.out.printf("%d.delta()...%n", this.hashCode());
         final byte[] data = this.origin.delta();

--- a/eo-runtime/src/main/java/org/eolang/PhLoop.java
+++ b/eo-runtime/src/main/java/org/eolang/PhLoop.java
@@ -52,16 +52,6 @@ public final class PhLoop implements Phi {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        return this == obj || this.origin.equals(obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.origin.hashCode();
-    }
-
-    @Override
     public Phi copy() {
         return new PhLoop(this.origin.copy());
     }

--- a/eo-runtime/src/main/java/org/eolang/PhSafe.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSafe.java
@@ -112,16 +112,6 @@ public final class PhSafe implements Phi, Atom {
     }
 
     @Override
-    public boolean equals(final Object obj) {
-        return this == obj || this.origin.equals(obj);
-    }
-
-    @Override
-    public int hashCode() {
-        return this.origin.hashCode();
-    }
-
-    @Override
     public Phi copy() {
         return new PhSafe(
             this.origin.copy(), this.program,

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -43,12 +43,12 @@ import org.junit.jupiter.api.parallel.Isolated;
 final class PhCoverageTest {
 
     @Test
-    void staysEqualToItsOrigin() {
+    void staysDistinctFromItsOrigin() {
         final Phi origin = new Data.ToPhi(42L);
         MatcherAssert.assertThat(
-            "a coverage wrapper must compare equal to the object it wraps, but it didnt",
+            "a coverage wrapper must not compare equal to the object it wraps",
             new PhCoverage(origin, "Φ.n:1:1"),
-            Matchers.equalTo(origin)
+            Matchers.not(Matchers.equalTo(origin))
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -34,20 +34,11 @@ final class PhLoggedTest {
     }
 
     @Test
-    void returnsOriginHashCode() {
+    void doesNotEqualOrigin() {
         MatcherAssert.assertThat(
-            "HashCode of PhLogged should return the original hashCode, but it didn't",
-            new PhLogged(Phi.Φ).hashCode(),
-            Matchers.equalTo(Phi.Φ.hashCode())
-        );
-    }
-
-    @Test
-    void equalsToOrigin() {
-        MatcherAssert.assertThat(
-            "PhLogged should be equlas to the original Phi, but it didn't",
+            "a logged object must not compare equal to the Phi it wraps",
             new PhLogged(Phi.Φ),
-            Matchers.equalTo(Phi.Φ)
+            Matchers.not(Matchers.equalTo(Phi.Φ))
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhLoggedTest.java
@@ -25,15 +25,6 @@ final class PhLoggedTest {
     }
 
     @Test
-    void copiesOrigin() {
-        MatcherAssert.assertThat(
-            "Copy of PhLogged should return the original Phi, but it didn't",
-            new PhLogged(Phi.Φ).copy(),
-            Matchers.equalTo(Phi.Φ)
-        );
-    }
-
-    @Test
     void doesNotEqualOrigin() {
         MatcherAssert.assertThat(
             "a logged object must not compare equal to the Phi it wraps",

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -26,10 +26,9 @@ final class PhiTest {
         final String name, final Function<Phi, Phi> decorator
     ) {
         final Phi origin = new PhDefault();
-        final Phi wrapped = decorator.apply(origin);
         MatcherAssert.assertThat(
             String.format("the %s decorator must not equal its origin", name),
-            wrapped.equals(origin),
+            decorator.apply(origin).equals(origin),
             Matchers.equalTo(false)
         );
     }

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -4,16 +4,40 @@
  */
 package org.eolang;
 
+import java.util.function.Function;
+import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Test case for {@link Phi}.
  * @since 0.22
  */
 final class PhiTest {
+
+    @ParameterizedTest
+    @MethodSource("decorators")
+    void keepsDecoratorDistinctFromItsOrigin(
+        final String name, final Function<Phi, Phi> decorator
+    ) {
+        final Phi origin = new PhDefault();
+        final Phi wrapped = decorator.apply(origin);
+        MatcherAssert.assertThat(
+            String.format("the %s decorator must not equal its origin", name),
+            wrapped.equals(origin),
+            Matchers.equalTo(false)
+        );
+        MatcherAssert.assertThat(
+            String.format("the origin must not equal its %s decorator", name),
+            origin.equals(wrapped),
+            Matchers.equalTo(false)
+        );
+    }
 
     @Test
     void takesPackage() {
@@ -149,6 +173,20 @@ final class PhiTest {
                 "obj.x"
             ).forma(),
             Matchers.equalTo("Φ.number")
+        );
+    }
+
+    private static Stream<Arguments> decorators() {
+        return Stream.of(
+            Arguments.of("again", (Function<Phi, Phi>) PhAgain::new),
+            Arguments.of(
+                "coverage", (Function<Phi, Phi>) phi -> new PhCoverage(phi, "Φ.x:1:1")
+            ),
+            Arguments.of("logged", (Function<Phi, Phi>) PhLogged::new),
+            Arguments.of("loop", (Function<Phi, Phi>) PhLoop::new),
+            Arguments.of("once", (Function<Phi, Phi>) phi -> new PhOnce(() -> phi)),
+            Arguments.of("safe", (Function<Phi, Phi>) PhSafe::new),
+            Arguments.of("sticky", (Function<Phi, Phi>) PhSticky::new)
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/PhiTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhiTest.java
@@ -32,11 +32,6 @@ final class PhiTest {
             wrapped.equals(origin),
             Matchers.equalTo(false)
         );
-        MatcherAssert.assertThat(
-            String.format("the origin must not equal its %s decorator", name),
-            origin.equals(wrapped),
-            Matchers.equalTo(false)
-        );
     }
 
     @Test


### PR DESCRIPTION
## What happens

#7304 made `PhDefault` equality identity-based. Several wrappers still
delegated [`equals()` and `hashCode()`](https://github.com/objectionary/eo/blob/master/eo-runtime/src/main/java/org/eolang/PhAgain.java#L35)
to their origin. This made equality asymmetric:

```java
Phi origin = new PhDefault();
origin.equals(new PhAgain(origin)); // false
new PhAgain(origin).equals(origin); // true
```

The same delegation remained in `PhOnce`, `PhLoop`, `PhLogged`, `PhSafe`,
`PhCoverage`, `PhSticky`, and `Data.ToPhi`.

## Changes

- Remove origin-delegating equality and hash-code implementations from each
  affected wrapper, restoring ordinary object identity.
- Update legacy wrapper tests that asserted equality with the origin.
- Add one parameterized `PhiTest` that verifies both directions of equality
  for every decorator implementation.

## Verification

- Compiled all changed runtime Java sources plus the affected test classes in
  an isolated `javac` run.
- Ran a direct probe over `PhAgain`, `PhCoverage`, `PhLogged`, `PhLoop`,
  `PhOnce`, `PhSafe`, and `PhSticky`; every wrapper and its origin remained
  distinct in both equality directions.

Fixes #8062.
