### PR TITLE
Use web separators in inference report paths

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Report.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Report.java
@@ -118,7 +118,7 @@ public final class Report {
     }
 
     private String named(final Path file) {
-        final String path = this.world.relativize(file).toString();
+        final String path = this.world.relativize(file).toString().replace('\\', '/');
         return path.substring(0, path.length() - ".xmir".length()).concat(".eo");
     }
 

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -77,9 +77,30 @@ final class ReportTest {
         );
     }
 
+    @Test
+    void usesWebSeparatorsForNestedSourceNames(@Mktmp final Path temp) throws IOException {
+        new Report(ReportTest.program(temp, "nested\\cup.xmir"), ReportTest.tables(temp))
+            .written(temp.resolve("out"));
+        MatcherAssert.assertThat(
+            "a source path must become a nested web path even when it carries backslashes",
+            Files.exists(temp.resolve("out").resolve("nested").resolve("cup.eo.html")),
+            Matchers.equalTo(true)
+        );
+        MatcherAssert.assertThat(
+            "the index must link with URL separators rather than platform separators",
+            Files.readString(temp.resolve("out").resolve("index.html")),
+            Matchers.containsString("nested/cup.eo.html")
+        );
+    }
+
     private static Path program(final Path temp) throws IOException {
+        return ReportTest.program(temp, "cup.xmir");
+    }
+
+    private static Path program(final Path temp, final String name) throws IOException {
+        final Path file = temp.resolve("xmirs").resolve(name);
         Files.writeString(
-            Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),
+            Files.createDirectories(file.getParent()).resolve(file.getFileName()),
             String.join(
                 "",
                 "<object><listing>",

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -82,12 +82,7 @@ final class ReportTest {
         new Report(ReportTest.program(temp, "nested\\cup.xmir"), ReportTest.tables(temp))
             .written(temp.resolve("out"));
         MatcherAssert.assertThat(
-            "a source path must become a nested web path even when it carries backslashes",
-            Files.exists(temp.resolve("out").resolve("nested").resolve("cup.eo.html")),
-            Matchers.equalTo(true)
-        );
-        MatcherAssert.assertThat(
-            "the index must link with URL separators rather than platform separators",
+            "the index must link to the nested page with URL separators rather than platform separators",
             Files.readString(temp.resolve("out").resolve("index.html")),
             Matchers.containsString("nested/cup.eo.html")
         );


### PR DESCRIPTION
## What happens

[`Report.named()`](https://github.com/objectionary/eo/blob/master/eo-inference/src/main/java/org/eolang/inference/Report.java#L118)
used `Path.toString()` directly. On Windows, a nested XMIR name therefore
became `nested\\cup.eo`. The report then used that value as a filesystem path,
an HTML `href`, and input to its `/`-based root calculation, so nested report
links did not represent valid web paths.

## Changes

- Normalize backslashes to `/` immediately after making the XMIR path
  relative to the report world.
- Add a report test covering a nested source name expressed with a backslash;
  it verifies both the nested output page and its `index.html` URL.

## Verification

`mvn -T 2 -pl eo-inference test -Dtest=ReportTest -q`

Fixes #8066.
