### PR TITLE
Create the inference report directory before writing its index

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Report.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Report.java
@@ -66,6 +66,7 @@ public final class Report {
      * @throws IOException If a table or a file cannot be read or written
      */
     public int written(final Path out) throws IOException {
+        Files.createDirectories(out);
         final Map<String, Answer> told = new Answered(this.world, this.tables).all();
         final XSLDocument page = new XSLDocument(
             Report.class.getResourceAsStream("/org/eolang/inference/report/page.xsl")

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -64,6 +64,23 @@ final class ReportTest {
         );
     }
 
+    @Test
+    void writesAnIndexForAnEmptyProgram(@Mktmp final Path temp) throws IOException {
+        final Path xmirs = Files.createDirectories(temp.resolve("xmirs"));
+        final Path tables = temp.resolve("tables");
+        new Resolved(new Clues()).follow(xmirs, tables);
+        MatcherAssert.assertThat(
+            "an empty program must still produce its index",
+            new Report(xmirs, tables).written(temp.resolve("out")),
+            Matchers.equalTo(0)
+        );
+        MatcherAssert.assertThat(
+            "the index must be written even when there are no source pages",
+            Files.exists(temp.resolve("out").resolve("index.html")),
+            Matchers.equalTo(true)
+        );
+    }
+
     private static Path program(final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -69,11 +69,7 @@ final class ReportTest {
         final Path xmirs = Files.createDirectories(temp.resolve("xmirs"));
         final Path tables = temp.resolve("tables");
         new Resolved(new Clues()).follow(xmirs, tables);
-        MatcherAssert.assertThat(
-            "an empty program must still produce its index",
-            new Report(xmirs, tables).written(temp.resolve("out")),
-            Matchers.equalTo(0)
-        );
+        new Report(xmirs, tables).written(temp.resolve("out"));
         MatcherAssert.assertThat(
             "the index must be written even when there are no source pages",
             Files.exists(temp.resolve("out").resolve("index.html")),


### PR DESCRIPTION
## What happens

[`Report.written()`](https://github.com/objectionary/eo/blob/master/eo-inference/src/main/java/org/eolang/inference/Report.java#L72)
created output directories only inside its per-source-page loop. An empty
prepared XMIR directory produces no pages, so the loop did not run and the
following write to `out/index.html` failed because `out` did not exist.

## Changes

- Create the requested report directory before reading pages or writing the
  index.
- Add a regression test that prepares empty inference tables and verifies
  that `written()` returns zero while creating `index.html`.

## Verification

`mvn -T 2 -pl eo-inference test -Dtest=ReportTest -q`

Fixes #8067.
