### PR TITLE
Skip inference reports without prepared XMIR files

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
@@ -51,23 +51,23 @@ final class Reporting implements Step {
 
     @Override
     public void exec() throws IOException {
-        if (!Files.exists(this.prepared)) {
-            Logger.info(
-                this, "The directory %[file]s is absent, nothing to draw from it",
-                this.prepared
-            );
-            return;
-        }
-        if (!Files.exists(this.tables)) {
+        if (Files.exists(this.tables)) {
+            if (Files.exists(this.prepared)) {
+                Logger.info(
+                    this, "Wrote %d page(s) to look at, they are in %[file]s",
+                    new Report(this.prepared, this.tables).written(this.pages), this.pages
+                );
+            } else {
+                Logger.info(
+                    this, "The directory %[file]s is absent, nothing to draw from it",
+                    this.prepared
+                );
+            }
+        } else {
             Logger.info(
                 this, "The directory %[file]s is absent, nothing to draw from it",
                 this.tables
             );
-            return;
         }
-        Logger.info(
-            this, "Wrote %d page(s) to look at, they are in %[file]s",
-            new Report(this.prepared, this.tables).written(this.pages), this.pages
-        );
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
@@ -51,10 +51,15 @@ final class Reporting implements Step {
 
     @Override
     public void exec() throws IOException {
-        if (Files.exists(this.tables)) {
+        if (Files.exists(this.tables) && Files.exists(this.prepared)) {
             Logger.info(
                 this, "Wrote %d page(s) to look at, they are in %[file]s",
                 new Report(this.prepared, this.tables).written(this.pages), this.pages
+            );
+        } else if (!Files.exists(this.prepared)) {
+            Logger.info(
+                this, "The directory %[file]s is absent, nothing to draw from it",
+                this.prepared
             );
         } else {
             Logger.info(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Reporting.java
@@ -51,21 +51,23 @@ final class Reporting implements Step {
 
     @Override
     public void exec() throws IOException {
-        if (Files.exists(this.tables) && Files.exists(this.prepared)) {
-            Logger.info(
-                this, "Wrote %d page(s) to look at, they are in %[file]s",
-                new Report(this.prepared, this.tables).written(this.pages), this.pages
-            );
-        } else if (!Files.exists(this.prepared)) {
+        if (!Files.exists(this.prepared)) {
             Logger.info(
                 this, "The directory %[file]s is absent, nothing to draw from it",
                 this.prepared
             );
-        } else {
+            return;
+        }
+        if (!Files.exists(this.tables)) {
             Logger.info(
                 this, "The directory %[file]s is absent, nothing to draw from it",
                 this.tables
             );
+            return;
         }
+        Logger.info(
+            this, "Wrote %d page(s) to look at, they are in %[file]s",
+            new Report(this.prepared, this.tables).written(this.pages), this.pages
+        );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ReportingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ReportingTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Reporting}.
+ * @since 0.71.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class ReportingTest {
+
+    @Test
+    void skipsMissingPreparedXmirs(@Mktmp final Path temp) throws IOException {
+        final Path pages = temp.resolve("pages");
+        new Reporting(
+            temp.resolve("missing"), Files.createDirectories(temp.resolve("tables")), pages
+        ).exec();
+        MatcherAssert.assertThat(
+            "a skipped report must not create any output pages",
+            Files.exists(pages),
+            Matchers.equalTo(false)
+        );
+    }
+}


### PR DESCRIPTION
## What happens

The standalone `eo:inference-report` goal checked only that its table
directory existed. If `preInferenceDir` was absent, it still entered
[`Report.written()`](https://github.com/objectionary/eo/blob/master/eo-inference/src/main/java/org/eolang/inference/Report.java#L71),
whose inference lookup walked the missing directory and exposed a raw
`NoSuchFileException`.

## Changes

- Require both inference tables and prepared XMIR files before drawing a
  report.
- Log the absent prepared directory and skip generation when it is missing,
  mirroring the existing treatment of absent tables.
- Add a direct `ReportingTest` for retained tables with a missing prepared
  directory.

## Verification

`mvn -T 2 -pl eo-maven-plugin test -Dtest=ReportingTest -q`

Fixes #8069.
