### PR TITLE
#8058: keep a vertical application under a method continuation

### DIFF
--- a/eo-printer/src/main/java/org/eolang/printer/Node.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Node.java
@@ -168,13 +168,41 @@ final class Node {
      * @return The rendered block with its leading newlines
      */
     String indented(final Style style, final int indent) {
-        final StringBuilder block = new StringBuilder();
-        if (this.test) {
-            block.append('\n');
-        }
-        return block.append('\n')
+        return this.opened()
             .append(this.lined().print(style, indent))
             .toString();
+    }
+
+    /**
+     * Print this node on the lines below the head of its parent, keeping
+     * its own children beneath it whatever the penalties say.
+     *
+     * <p>A method continuation ({@code .y}, §3.5) parses only under a
+     * vertical application: it attaches to the lines above it and the
+     * horizontal form has no place for it. So an application a
+     * continuation hangs on stays vertical however cheap its one-line
+     * spelling looks, or the printer writes a file the next build cannot
+     * read (#8058).</p>
+     *
+     * @param style The style to lay out in
+     * @param indent The indentation level
+     * @return The rendered block with its leading newlines
+     */
+    String stacked(final Style style, final int indent) {
+        return this.opened()
+            .append(this.lined().vertical(style, indent))
+            .toString();
+    }
+
+    /**
+     * Whether this node is a nameless method-dispatch continuation
+     * ({@code .y}, {@code ?.y}), which dispatches on the lines above it
+     * instead of carrying a receiver of its own.
+     * @return True when this node continues the sibling above it
+     */
+    boolean continuation() {
+        return this.children.isEmpty() && this.tail.isEmpty()
+            && (this.base.startsWith(".") || this.base.startsWith("?."));
     }
 
     /**
@@ -383,6 +411,14 @@ final class Node {
      */
     boolean anonymous() {
         return this.children.stream().allMatch(Node::nameless);
+    }
+
+    private StringBuilder opened() {
+        final StringBuilder block = new StringBuilder();
+        if (this.test) {
+            block.append('\n');
+        }
+        return block.append('\n');
     }
 
     private String shaped(final Style style, final int indent) {

--- a/eo-printer/src/main/java/org/eolang/printer/Vertical.java
+++ b/eo-printer/src/main/java/org/eolang/printer/Vertical.java
@@ -15,7 +15,10 @@ import java.util.List;
  * itself through {@link Node#indented(Style, int)}. A child that carries
  * the bare {@code !} of an anonymous inline const (#5821) takes an
  * auto-name there, since the marker has no spelling on a line of its own
- * and this is the one place that puts a child there.</p>
+ * and this is the one place that puts a child there. A child a method
+ * continuation ({@code .y}) hangs on is laid out vertically whatever the
+ * penalties say, since the continuation has nothing to attach to under a
+ * one-line application (#8058).</p>
  *
  * @since 0.57.0
  */
@@ -50,8 +53,13 @@ final class Vertical {
     String print(final Style style, final int indent) {
         final StringBuilder block = new StringBuilder(style.indent(indent))
             .append(this.head);
-        for (final Node kid : this.kids) {
-            block.append(kid.indented(style, indent + 1));
+        for (int idx = 0; idx < this.kids.size(); ++idx) {
+            final Node kid = this.kids.get(idx);
+            if (idx + 1 < this.kids.size() && this.kids.get(idx + 1).continuation()) {
+                block.append(kid.stacked(style, indent + 1));
+            } else {
+                block.append(kid.indented(style, indent + 1));
+            }
         }
         return block.toString();
     }

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/method-continuation-keeps-the-vertical-application.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/method-continuation-keeps-the-vertical-application.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A method continuation parses only under a vertical application, so the
+# application it hangs on must stay vertical however few arguments it has.
+# Collapsing it onto one line leaves the `.y` below with nothing to attach
+# to and the printed file no longer parses (#8058).
+penalties:
+  INDENT: 2
+  BRACKET: 19
+  LEADING: 4
+  PHI: 15
+  IF: 50
+  EXCESS: 3
+  SYMBOL: 1
+  SPACE: 7
+  WIDTH: 80
+  STEP: 2
+origin: |
+  [] > m
+    x > z
+      1
+    .y


### PR DESCRIPTION
A method continuation parses only under a vertical application, but the
printer picked the horizontal form when the penalty was lower, so

```
[] > m
  x > z
    1
  .y
```

came back as `x 1 > z` with a `.y` under it, which the parser refuses. With
two arguments the vertical form already won on penalty, so the file survived
or not depending on how many arguments the line above happened to have.

Now a child that a continuation hangs on is laid out vertically whatever the
penalties say.

Closes #8058
