### PR TITLE
Give MjTranspile back the constructor doclint wants

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -148,6 +148,13 @@ public final class MjTranspile extends MjSafe {
     )
     private File tables;
 
+    /**
+     * Ctor.
+     */
+    public MjTranspile() {
+        // nothing
+    }
+
     @Override
     public void exec() throws IOException {
         try (TjsForeign tojos = this.tojos()) {


### PR DESCRIPTION
The `site` job on master has been red since #6125 landed. `mvn clean site -Psite` dies in `eo-maven-plugin` with `Error generating maven-javadoc-plugin:3.12.0:javadoc report: Project contains Javadoc Warnings`, and the single warning behind it is `MjTranspile.java:42: warning: use of default constructor, which does not provide a comment`.

Moving `Transpiling` to `GlobalCache` in d7ed55c0d6 deleted the `guard` field and, with it, the only constructor `MjTranspile` had. The class was left with a compiler-generated default constructor, which doclint refuses to accept without a comment. Every other mojo in the package already declares an empty documented ctor, so this restores the same shape rather than inventing one.

I checked the rest of the sources for the same hole while I was in there: `Main` and `FpIfTargetOlder` are the only other public classes with no public ctor, and both declare one at narrower visibility, so doclint is satisfied there. `eo-runtime` and `eo-integration-tests` come after `eo-maven-plugin` in the reactor and the site build has never reached them, so it is worth watching whether the first green run turns up more warnings further down.
