### PR TITLE
#8104: check the sockaddr_in padding before the structure is built

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/MacSockaddrIn.java
+++ b/eo-runtime/src/main/java/org/eolang/MacSockaddrIn.java
@@ -57,12 +57,26 @@ public final class MacSockaddrIn extends Structure {
     public MacSockaddrIn(
         final short family, final short port, final int addr, final byte[] zero
     ) {
+        this(new Padding(zero).bytes(), family, port, addr);
+    }
+
+    /**
+     * Primary ctor, receiving an already validated padding. The padding
+     * comes first so this signature differs from the public one above.
+     * @param zero Validated padding
+     * @param family Family
+     * @param port Port
+     * @param addr Address
+     */
+    private MacSockaddrIn(
+        final byte[] zero, final short family, final short port, final int addr
+    ) {
         super();
         this.len = MacSockaddrIn.LENGTH;
         this.family = (byte) family;
         this.port = port;
         this.addr = addr;
-        this.zero = Arrays.copyOf(zero, zero.length);
+        this.zero = zero;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/Padding.java
+++ b/eo-runtime/src/main/java/org/eolang/Padding.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.Arrays;
+
+/**
+ * The padding a C {@code sockaddr_in} ends with.
+ *
+ * <p>The structure is sixteen bytes long whatever the platform lays out in
+ * front of that padding, so the padding itself is always eight bytes. Anything
+ * else changes the size of the structure a native socket call receives, and
+ * an empty one is refused by JNA later on with a message about arrays of
+ * length zero, far from the caller that gave it. {@link #bytes()} answers the
+ * padding only when it is the right length, so there is no way to hold an
+ * unchecked one.</p>
+ *
+ * @since 0.75
+ */
+final class Padding {
+
+    /**
+     * How many bytes of padding a {@code sockaddr_in} carries.
+     */
+    private static final int SIZE = 8;
+
+    /**
+     * The bytes given.
+     */
+    private final byte[] given;
+
+    /**
+     * Ctor.
+     * @param bytes The bytes given
+     */
+    Padding(final byte[] bytes) {
+        this.given = Arrays.copyOf(bytes, bytes.length);
+    }
+
+    /**
+     * The padding, when it is the right length.
+     * @return The bytes of the padding
+     */
+    byte[] bytes() {
+        if (this.given.length != Padding.SIZE) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The sockaddr_in padding must contain exactly %d bytes, not %d",
+                    Padding.SIZE, this.given.length
+                )
+            );
+        }
+        return Arrays.copyOf(this.given, this.given.length);
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/SockaddrIn.java
+++ b/eo-runtime/src/main/java/org/eolang/SockaddrIn.java
@@ -89,5 +89,4 @@ public final class SockaddrIn extends Structure {
     public List<String> getFieldOrder() {
         return Arrays.asList("family", "port", "addr", "zero");
     }
-
 }

--- a/eo-runtime/src/main/java/org/eolang/SockaddrIn.java
+++ b/eo-runtime/src/main/java/org/eolang/SockaddrIn.java
@@ -66,7 +66,7 @@ public final class SockaddrIn extends Structure {
      * @param zero Zero 8 bytes
      */
     public SockaddrIn(final short family, final short port, final int addr, final byte[] zero) {
-        this(SockaddrIn.checked(zero), family, port, addr);
+        this(new Padding(zero).bytes(), family, port, addr);
     }
 
     /**
@@ -90,15 +90,4 @@ public final class SockaddrIn extends Structure {
         return Arrays.asList("family", "port", "addr", "zero");
     }
 
-    private static byte[] checked(final byte[] zero) {
-        if (zero.length != SockaddrIn.PADDING_SIZE) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "The sockaddr_in padding must contain exactly %d bytes, not %d",
-                    SockaddrIn.PADDING_SIZE, zero.length
-                )
-            );
-        }
-        return Arrays.copyOf(zero, zero.length);
-    }
 }

--- a/eo-runtime/src/test/java/org/eolang/MacSockaddrInTest.java
+++ b/eo-runtime/src/test/java/org/eolang/MacSockaddrInTest.java
@@ -8,6 +8,7 @@ package org.eolang;
 import com.sun.jna.Structure;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -24,6 +25,24 @@ final class MacSockaddrInTest {
             "the length must come first there and the family second, but they didnt",
             struct.getPointer().getByteArray(0, 2),
             Matchers.equalTo(new byte[] {(byte) 16, (byte) 2})
+        );
+    }
+
+    @Test
+    void refusesPaddingOfAWrongLength() {
+        Assertions.assertThrows(
+            IllegalArgumentException.class,
+            () -> new MacSockaddrIn((short) 2, (short) 0, 0, new byte[0]),
+            "a padding that is not eight bytes long must be refused, but it wasnt"
+        );
+    }
+
+    @Test
+    void keepsTheLayoutOfSixteenBytes() {
+        MatcherAssert.assertThat(
+            "the structure must stay as long as a sockaddr_in is, but it didnt",
+            new MacSockaddrIn((short) 2, (short) 0, 0, new byte[8]).size(),
+            Matchers.equalTo(16)
         );
     }
 }


### PR DESCRIPTION
`MacSockaddrIn` took a padding of any length, so `new byte[0]` passed the
constructor and failed later inside JNA with "Arrays of length zero not
allowed", and a wrong length changed the size of the structure a native
socket call receives. `SockaddrIn` already refused the same input.

The check now lives in `Padding`, which answers the bytes only when there are
eight of them, and both structures get their padding from it.

Closes #8104
