### PR TITLE
Realign parser typo fixtures with the current error messages

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1363,7 +1363,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Leading or trailing space inside `[ ]` (R-3.4.4) | `formation brackets must not contain leading or trailing space` |
 | Formation head `[` with no closing `]` (R-3.4.12) | `formation is missing its closing bracket` |
 | Double space between parameter names in voids (R-3.4.5) | `parameter names in voids must be separated by exactly one space` |
-| Bracket-parameter name that is neither NAME nor `@` (§4.5) | `parameter names in voids must be NAME or @` |
+| Bracket-parameter name that is neither NAME, `@` nor `^` (§4.5) | `parameter names in voids must be NAME, @ or ^` |
 | Bracket parameters on an atom head (R-3.4.10) | `an atom must declare its void attributes vertically, as ? > name lines` |
 | More than one space between meta parts (R-3.2.4) | `meta parts must be separated by exactly one space` |
 | Test attribute name is `@` (PHI) instead of NAME (R-6.3.5) | `test attribute name must be an identifier, not @` |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-empty.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-empty.yaml
@@ -5,7 +5,7 @@
 # #8029: a colon with no label after a vertical formation is not a binding
 # at all, so an empty label can never reach the emitter.
 line: 3
-message: "Invalid bound object declaration"
+message: "binding label \"\" must be a name or a slot number"
 input: |
   [] > main
     x > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/varargs-inside.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/varargs-inside.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:3] error: 'parameter names in voids must be NAME or @'
+  [1:3] error: 'parameter names in voids must be NAME, @ or ^'
   [a b... c] > hello
      ^
 input: |

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
@@ -28,15 +28,9 @@ final class EOscanfDiagnosticTest {
     @Test
     void reportsSinglePercentForOversizedInteger() {
         final Phi scanf = new PhApplication(
-            new PhApplication(
-                new PhApplication(
-                    Phi.Φ.take("string.scanf").copy(),
-                    "format", new Data.ToPhi("%d")
-                ),
-                "read", new Data.ToPhi("99999999999999999999")
-            ).take("at").copy(),
-            "i", new Data.ToPhi(0)
-        );
+            new Data.ToPhi("%d").take("scanf").copy(),
+            "read", new Data.ToPhi("99999999999999999999")
+        ).take("head");
         MatcherAssert.assertThat(
             "scanf must report the %d conversion with one percent sign",
             Assertions.assertThrows(

--- a/eo-runtime/src/test/java/org/eolang/EO_string/package-info.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for the objects transpiled from string.eo.
+ * @since 0.75.0
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD


### PR DESCRIPTION
Master is red in three independent places, each one a merge that landed beside the change it contradicts. This branch fixes all three.

## 1. `eo-parser` — two typo fixtures pin messages the parser no longer emits

`EoSyntaxTest.checksTypoMessages` fails on two packs ([run 33479051614](https://github.com/objectionary/eo/actions/runs/33479051614/job/99764374125), 1597 tests, 2 failures). Both packs were written on branches cut before the rename that landed minutes earlier:

| Fixture | Pinned | Actually thrown |
| --- | --- | --- |
| `varargs-inside.yaml` (rewritten by #8082) | `parameter names in voids must be NAME or @` | `parameter names in voids must be NAME, @ or ^` (renamed in #8085) |
| `formation-outer-binding-empty.yaml` (added by #8097) | `Invalid bound object declaration` | `binding label "" must be a name or a slot number` (renamed in #8095) |

Neither message is wrong in the code: `Emissions.validParam` accepts `@` and `^` beside a NAME, and `Tokens.checkBinding` now names the offending label instead of the old blanket text. So the fixtures move to what the parser emits. The §9.9 canonical message table in `eo-parser/PARSER_SPEC.md` kept the pre-#8085 void-parameter row, which R-9.9.1 requires to match the emitted text, so it is corrected too.

## 2. `qulice` — a test package with no `package-info.java`

```
Checkstyle: eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java[1]:
  Missing package-info.java file. (JavadocPackageCheck)
```

Commit `6d0d553` (#6585) opened `org.eolang.EO_string` for one test and added nothing else, so the package has been undocumented — and the check red — on every branch cut since. Every other test package in `eo-runtime` carries a `package-info`; this one now does too, worded and suppressed the way its closest neighbour `org.eolang.EO_org.EO_eolang` is, since PMD does not accept the transpiler's package spelling.

## 3. `fast` — that same test cannot run

```
EOscanfDiagnosticTest.reportsSinglePercentForOversizedInteger:37 » ExFailure
  Error in "Φ.string.scanf" at .string:35:0; Can't #put("format", ...) to
  org.eolang.PhDefault@..., because the attribute is absent
```

`scanf` is `[^ read] > scanf`: the format string is its `^` and `read` is its only free attribute, so there is no `format` to put, and the test died before reaching the message it exists to check. It now builds `scanf` the way `scanf.eo`'s own tests and the neighbouring `EOstringEOregexEOcompileTest` build a package member — format string as the receiver, `read` applied to it — and reads the scanned value through `head`, the accessor those tests use. What it asserts is unchanged: the oversized-integer diagnostic names the conversion `'%d'`, never `'%%d'`.

## Verification

- `mvn -pl eo-parser test`: **1597 tests, 0 failures, 0 errors, 6 skipped** — the same test count CI reported, now green.
- `mvn -Pqulice -Deo.skip clean process-classes qulice:check` (the `qulice` job's own command): **BUILD SUCCESS** across all 7 modules; `eo-runtime` goes from 1 violation to 0.
- On this head, CI itself is green on every workflow, including the two that were red — [qulice](https://github.com/objectionary/eo/actions/runs/33486954359) and [fast](https://github.com/objectionary/eo/actions/runs/33486954383) (both matrix legs).
