### PR TITLE
#8116: re-enable the integration tests the release gap disabled

### DIFF
--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -20,22 +20,13 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Integration tests for transpile behavior.
  * @since 0.62
- * @todo #7182:30min Re-enable the two transpile tests after the next release.
- *  The sandbox pulls the released .eo sources of the runtime from the remote
- *  objectionary, and those predate the rule that every object carries a
- *  comment on top, so the build they take part in ends with [ERROR] lines
- *  and fails before the assertion is reached. Master already carries the
- *  comments, so drop this annotation once the remote objectionary serves
- *  sources that satisfy the rule.
  */
-@Disabled("pulled .eo sources predate the comment-on-top rule and emit [ERROR]")
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
 final class TranspileIT {

--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
@@ -17,26 +17,17 @@ import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.hamcrest.io.FileMatchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Integration tests for mojas.
  * @since 0.52
- * @todo #7182:30min Re-enable the assemble test after the next release.
- *  The sandbox pulls the released .eo sources of the runtime from the remote
- *  objectionary, and those predate the rule that every object carries a
- *  comment on top, so the build they take part in ends with [ERROR] lines
- *  and fails before the assertion is reached. Master already carries the
- *  comments, so drop this annotation once the remote objectionary serves
- *  sources that satisfy the rule.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
 final class MjAssembleIT {
 
-    @Disabled("pulled .eo sources predate the comment-on-top rule and emit [ERROR]")
     @Test
     void assemblesTogether(@Mktmp final Path temp) throws IOException {
         final String stdout = "target/eo/%s/io/stdout.%s";

--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -32,20 +32,12 @@ import org.eclipse.jetty.server.handler.ResourceHandler;
 import org.eclipse.jetty.util.resource.ResourceFactory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
  * @since 0.60
- * @todo #7182:30min Re-enable the proxy test after the next release.
- *  The sandbox pulls the released .eo sources of the runtime from the remote
- *  objectionary, and those predate the rule that every object carries a
- *  comment on top, so the build they take part in ends with [ERROR] lines
- *  and fails before the assertion is reached. Master already carries the
- *  comments, so drop this annotation once the remote objectionary serves
- *  sources that satisfy the rule.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith({WeAreOnline.class, MktmpResolver.class, MayBeSlow.class})
@@ -71,7 +63,6 @@ final class ProxyIT {
         }
     }
 
-    @Disabled("pulled .eo sources predate the comment-on-top rule and emit [ERROR]")
     @Test
     void checksThatWeCanCompileTheProgramWithProxySet(@Mktmp final Path tmp) throws Exception {
         final int port = ProxyIT.free();


### PR DESCRIPTION
The three tests were disabled because the sandbox pulled released .eo sources
that predated the comment-on-top rule, so the build they take part in ended
with [ERROR] lines. The released sources of 0.63.0 carry the comments now: a
sandbox project built with the released plugin pulls 135 objects and reports
no parse errors, so the annotations and their puzzles go away.

Closes #8116
Closes #8118
Closes #8121
