### PR TITLE
#8133: bring the two typo fixtures up to the messages the parser emits

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-empty.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/formation-outer-binding-empty.yaml
@@ -5,7 +5,10 @@
 # #8029: a colon with no label after a vertical formation is not a binding
 # at all, so an empty label can never reach the emitter.
 line: 3
-message: "Invalid bound object declaration"
+message: |-
+  [3:7] error: 'binding label "" must be a name or a slot number'
+      []: > slot
+         ^
 input: |
   [] > main
     x > y

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/varargs-inside.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/varargs-inside.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:3] error: 'parameter names in voids must be NAME or @'
+  [1:3] error: 'parameter names in voids must be NAME, @ or ^'
   [a b... c] > hello
      ^
 input: |


### PR DESCRIPTION
`formation-outer-binding-empty.yaml` still expected "Invalid bound object
declaration", which the parser stopped emitting in `da44e4b9` when an absent
outer binding became an empty string; it now says `binding label "" must be a
name or a slot number`. `varargs-inside.yaml` expected `NAME or @`, while the
message gained `^` and its two sibling packs were updated but this one was not.

Both messages are now what the parser prints. `EoSyntaxTest` runs 770 tests
with no failures.

Closes #8133
