### PR TITLE
#8134: give the EO_string test package its package-info

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/EO_string/package-info.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/package-info.java
@@ -1,0 +1,11 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for the objects of the string package, transpiled.
+ * @since 0.61.0
+ * @checkstyle TrailingCommentCheck (3 lines)
+ */
+package org.eolang.EO_string; // NOPMD


### PR DESCRIPTION
`org.eolang.EO_string` holds one test and no `package-info.java`, so
checkstyle's `JavadocPackageCheck` fails the `qulice` job on every pull
request. The file follows the one in `org.eolang.EO_org.EO_eolang`, which is
the same kind of transpiled-name test package.

Closes #8134
