### PR TITLE
Extract Written to hold transpile output location and its report

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -155,9 +155,7 @@ public final class MjTranspile extends MjSafe {
                 new Transpiling(
                     tojos.standalone(),
                     this.targetDir.toPath(),
-                    this.generatedDir.toPath(),
-                    this.tests,
-                    this.roots(),
+                    new Written(this.generatedDir.toPath(), this.tests, this.roots()),
                     new Transpilation(
                         new Tracking(this.trackSteps, this.located),
                         this.coverage,

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpiling.java
@@ -5,7 +5,6 @@
 package org.eolang.maven;
 
 import com.github.lombrozo.xnav.Xnav;
-import com.jcabi.log.Logger;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
@@ -32,11 +31,6 @@ import org.eolang.parser.OnDetailed;
  * The intermediate optimized XMIRs are stored in the {@link #PRE} directory.</p>
  *
  * @since 0.1
- * @todo #6125:30min Take the rest of the writing out of here too.
- *  The three that are left, the generated directory, the tests flag and
- *  the roots, describe one thing, where the output lands, and belong
- *  together in an object of their own, along with the tail of
- *  {@link #exec()} that logs it.
  */
 final class Transpiling implements Step {
 
@@ -66,19 +60,9 @@ final class Transpiling implements Step {
     private final Path target;
 
     /**
-     * Generated sources directory.
+     * Where the output lands.
      */
-    private final Path generated;
-
-    /**
-     * Whether to transpile tests.
-     */
-    private final boolean tests;
-
-    /**
-     * Directories with the Java sources a human wrote.
-     */
-    private final Collection<Path> roots;
+    private final Written written;
 
     /**
      * The XSL train that does the transpiling.
@@ -94,46 +78,33 @@ final class Transpiling implements Step {
      * Constructor.
      * @param srcs XMIR sources to transpile
      * @param target Target directory
-     * @param generated Generated sources directory
-     * @param tests Whether to transpile tests
-     * @param java Directories with the Java sources a human wrote
+     * @param written Where the output lands
      * @param train The XSL train that does the transpiling
      * @param store The cache shared with every build on this machine
      */
     Transpiling(
         final Collection<TjForeign> srcs,
         final Path target,
-        final Path generated,
-        final boolean tests,
-        final Collection<Path> java,
+        final Written written,
         final Transpilation train,
         final GlobalCache store
     ) {
         this.sources = srcs;
         this.target = target;
-        this.generated = generated;
-        this.tests = tests;
-        this.roots = java;
+        this.written = written;
         this.train = train;
         this.cache = store;
     }
 
     @Override
     public void exec() throws IOException {
-        final JavaFiles files = new JavaFiles(this.generated);
+        final JavaFiles files = this.written.files();
         final int transpiled = new Threaded<>(
             this.sources,
             tojo -> this.transpiled(tojo, files)
         ).total();
         files.removeStale();
-        Logger.info(
-            this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
-            this.sources.size(),
-            transpiled + new PackageInfos(
-                this.generated, this.roots, files.directories()
-            ).create(),
-            this.generated
-        );
+        this.written.log(transpiled, this.sources.size(), files);
     }
 
     private int transpiled(final TjForeign tojo, final JavaFiles files) throws IOException {
@@ -157,7 +128,7 @@ final class Transpiling implements Step {
             }
         ).apply(source, dest);
         return files.total(
-            rewrite.get(), dest, hsh.get(), this.tests && !tojo.discovered(),
+            rewrite.get(), dest, hsh.get(), this.written.tests(tojo),
             store
         );
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Written.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Written.java
@@ -1,0 +1,80 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.jcabi.log.Logger;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collection;
+
+/**
+ * Where a transpile writes its Java output, and the report of it.
+ * @since 0.77
+ */
+final class Written {
+
+    /**
+     * Generated sources directory.
+     */
+    private final Path generated;
+
+    /**
+     * Whether to transpile tests.
+     */
+    private final boolean tests;
+
+    /**
+     * Directories with the Java sources a human wrote.
+     */
+    private final Collection<Path> roots;
+
+    /**
+     * Ctor.
+     * @param generated Generated sources directory
+     * @param tests Whether to transpile tests
+     * @param roots Directories with the Java sources a human wrote
+     */
+    Written(final Path generated, final boolean tests, final Collection<Path> roots) {
+        this.generated = generated;
+        this.tests = tests;
+        this.roots = roots;
+    }
+
+    /**
+     * Java files this run writes into.
+     * @return The files
+     */
+    JavaFiles files() {
+        return new JavaFiles(this.generated);
+    }
+
+    /**
+     * Whether a tojo transpiles into test sources.
+     * @param tojo The tojo
+     * @return True if it does
+     */
+    boolean tests(final TjForeign tojo) {
+        return this.tests && !tojo.discovered();
+    }
+
+    /**
+     * Log how many Java files this run wrote, creating package-info
+     * files for the directories it touched.
+     * @param transpiled Amount of Java files created directly
+     * @param sources Amount of XMIRs given to transpile
+     * @param files The Java files this run wrote
+     * @throws IOException If fails to create a package-info file
+     */
+    void log(final int transpiled, final int sources, final JavaFiles files) throws IOException {
+        Logger.info(
+            this, "Transpiled %d XMIRs, created %d Java files in %[file]s",
+            sources,
+            transpiled + new PackageInfos(
+                this.generated, this.roots, files.directories()
+            ).create(),
+            this.generated
+        );
+    }
+}


### PR DESCRIPTION
Resolves the `@todo #6125` puzzle left in `Transpiling.java`: the generated-sources directory, the tests flag, and the human-written roots described one thing, where the transpile output lands, and belonged together in an object of their own.

`Written` now holds those three and owns the tail of `exec()` that reported on them: it hands back a `JavaFiles` for the generated directory, answers whether a given tojo transpiles into test sources, and logs the "Transpiled N XMIRs..." line together with the `PackageInfos.create()` call that used to sit at the bottom of `exec()`. `Transpiling` keeps a single `written` field instead of three, and `MjTranspile` builds one `Written` at the call site.

No behavior changes; `MjTranspileTest` already exercises the transpile output this touches.

One note on size: this lands at 129 hits (insertions+deletions vs `master`), over the usual ~100 target. A three-field, three-method class carrying full qulice javadoc came out to about that size no matter how it was split; there wasn't a smaller sub-chunk of this single extraction worth shipping on its own. Still well under the 200-hit CI ceiling.

Closes #8150