### PR TITLE
#8144: pad the temporary prefix so a short name can be saved

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -96,6 +96,26 @@ final class Saved implements Scalar<Path> {
         this.target = target;
     }
 
+    /**
+     * The prefix of the temporary file written beside the target.
+     *
+     * <p>It starts with the name of the target, so that a file left behind by
+     * a build that died mid-write says which target it was going to become.
+     * {@link Files#createTempFile(Path, String, String)} refuses a prefix
+     * shorter than three characters, and a name that short is a valid name
+     * everywhere, so the name is padded rather than the save refused
+     * (#8144).</p>
+     *
+     * @return The prefix
+     */
+    private String prefix() {
+        final StringBuilder name = new StringBuilder(this.target.getFileName().toString());
+        while (name.length() < 3) {
+            name.append('-');
+        }
+        return name.toString();
+    }
+
     @Override
     public Path value() throws IOException {
         final Path abs = Objects.requireNonNull(this.target, "target").toAbsolutePath();
@@ -108,11 +128,7 @@ final class Saved implements Scalar<Path> {
             if (dir.toFile().mkdirs()) {
                 Logger.debug(this, "Directory created: %[file]s", dir);
             }
-            final Path tmp = Files.createTempFile(
-                dir,
-                this.target.getFileName().toString(),
-                ".tmp"
-            );
+            final Path tmp = Files.createTempFile(dir, this.prefix(), ".tmp");
             try {
                 bytes = new IoChecked<>(
                     new LengthOf(


### PR DESCRIPTION
`Files.createTempFile` refuses a prefix shorter than three characters, and
`Saved` handed it the target's own name, so saving to `x` or `ab` threw
`IllegalArgumentException` before a byte was written. The name is padded with
dashes up to three characters now; it still starts with the target's name, so
a temporary left behind by a build that died says which file it was going to
become.

Closes #8144
