### PR TITLE
#8149: normalize the format before it becomes the cache identity

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
@@ -87,20 +87,20 @@ final class Catalogs {
      */
     Tojos make(final Path file, final String fmt) {
         final Path abs = file.toAbsolutePath();
-        final String before = this.formats.putIfAbsent(abs, fmt);
-        if (before != null && !before.equals(fmt)) {
+        final String format = fmt.trim().toLowerCase(Locale.ENGLISH);
+        final String before = this.formats.putIfAbsent(abs, format);
+        if (before != null && !before.equals(format)) {
             throw new IllegalStateException(
                 String.format(
                     "The file '%s' was already cached with format '%s', can't reuse it with format '%s'",
-                    abs, before, fmt
+                    abs, before, format
                 )
             );
         }
-        return this.all.computeIfAbsent(abs, f -> Catalogs.build(f, fmt));
+        return this.all.computeIfAbsent(abs, f -> Catalogs.build(f, format));
     }
 
-    private static Tojos build(final Path path, final String format) {
-        final String fmt = format.trim().toLowerCase(Locale.ENGLISH);
+    private static Tojos build(final Path path, final String fmt) {
         Mono mono;
         if ("json".equals(fmt)) {
             mono = new MnJson(path);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsTest.java
@@ -61,6 +61,18 @@ final class CatalogsTest {
     }
 
     @Test
+    void reusesTheCatalogWhateverTheSpellingOfTheFormat(@Mktmp final Path tmp) {
+        final Path file = tmp.resolve("foreign");
+        Assertions.assertDoesNotThrow(
+            () -> {
+                Catalogs.INSTANCE.make(file, " CSV ");
+                Catalogs.INSTANCE.make(file, "csv");
+            },
+            "The same format spelled differently must reuse the same catalog"
+        );
+    }
+
+    @Test
     void rejectsADisagreeingFormatForAnAlreadyCachedPath(@Mktmp final Path tmp) {
         final Path file = tmp.resolve("foreign");
         Catalogs.INSTANCE.make(file, "csv");


### PR DESCRIPTION
`make` kept the format as the caller spelled it, while `build` trimmed it and
lowered its case, so `" CSV "` and `"csv"` meant the same catalog to one and
two different ones to the other:

```
The file '...' was already cached with format ' CSV ', can't reuse it with format 'csv'
```

The format is normalized once now, in `make`, before it is recorded, compared
and handed to `build`.

Closes #8149
