### PR TITLE
Walk the inference tables once instead of querying them

### DIFF
--- a/eo-inference/pom.xml
+++ b/eo-inference/pom.xml
@@ -16,6 +16,11 @@
   <description>XMIR Type Inference</description>
   <dependencies>
     <dependency>
+      <groupId>com.github.volodya-lombrozo</groupId>
+      <artifactId>xnav</artifactId>
+      <!-- version from parent POM -->
+    </dependency>
+    <dependency>
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-xml</artifactId>
       <!-- version from parent POM -->

--- a/eo-inference/src/main/java/org/eolang/inference/Asked.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Asked.java
@@ -4,10 +4,14 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * Every name the program asks, gathered on the object that answers it.
@@ -65,20 +69,26 @@ final class Asked {
      */
     Map<String, Map<String, String>> all() {
         final Map<String, Map<String, String>> found = new LinkedHashMap<>(0);
-        for (final XML attr : this.wanted.nodes("/needs/type/attr")) {
-            final String name = attr.xpath("@name").get(0);
-            final String step = ".".concat(name);
-            final String bearer = attr.xpath("../@id").get(0);
-            final String answer = this.owned.attribute(
-                this.names.getOrDefault(bearer, bearer), name
-            );
-            if (answer.endsWith(step)) {
-                found.computeIfAbsent(
-                    answer.substring(0, answer.length() - step.length()),
-                    key -> new LinkedHashMap<>(0)
-                ).put(name, answer);
+        for (final Xnav type : new Rows(this.wanted).all()) {
+            final String bearer = new Noted(type).says("id");
+            for (final Xnav attr : Asked.attrs(type)) {
+                final String name = new Noted(attr).says("name");
+                final String step = ".".concat(name);
+                final String answer = this.owned.attribute(
+                    this.names.getOrDefault(bearer, bearer), name
+                );
+                if (answer.endsWith(step)) {
+                    found.computeIfAbsent(
+                        answer.substring(0, answer.length() - step.length()),
+                        key -> new LinkedHashMap<>(0)
+                    ).put(name, answer);
+                }
             }
         }
         return Collections.unmodifiableMap(found);
+    }
+
+    private static List<Xnav> attrs(final Xnav type) {
+        return type.elements(Filter.withName("attr")).collect(Collectors.toList());
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Dead.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dead.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.inference;
 
-import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -29,14 +28,14 @@ import java.util.Map;
 final class Dead {
 
     /**
-     * The links table.
+     * What the links table says.
      */
-    private final XML table;
+    private final Pairs table;
 
     /**
      * Every dispatch of the program.
      */
-    private final Collection<XML> all;
+    private final Collection<Site> all;
 
     /**
      * The name every object goes by, once its chain of copies is walked.
@@ -45,11 +44,11 @@ final class Dead {
 
     /**
      * Ctor.
-     * @param links The links table
+     * @param links What the links table says
      * @param dispatches Every dispatch of the program
      * @param ends The name every object goes by
      */
-    Dead(final XML links, final Collection<XML> dispatches, final Map<String, String> ends) {
+    Dead(final Pairs links, final Collection<Site> dispatches, final Map<String, String> ends) {
         this.table = links;
         this.all = dispatches;
         this.names = ends;
@@ -60,15 +59,18 @@ final class Dead {
      * @return The locators, the dispatches on a termination among them
      */
     Collection<String> all() {
-        final Collection<String> found = new HashSet<>(
-            this.table.xpath("/links/type[terminator]/@id")
-        );
+        final Collection<String> found = new HashSet<>(0);
+        for (final Map.Entry<String, String> row : this.table.forms().entrySet()) {
+            if ("terminator".equals(row.getValue())) {
+                found.add(row.getKey());
+            }
+        }
         boolean grown = true;
         while (grown) {
             grown = false;
-            for (final XML dispatch : this.all) {
-                final String made = dispatch.xpath("@loc").get(0);
-                final String bearer = dispatch.xpath("o[not(@as)][1]/@loc").get(0);
+            for (final Site dispatch : this.all) {
+                final String made = dispatch.made();
+                final String bearer = dispatch.bearer();
                 if (!found.contains(made)
                     && found.contains(this.names.getOrDefault(bearer, bearer))) {
                     found.add(made);

--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -58,10 +58,10 @@ public final class Demanded implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
-        final XML links = new XMLDocument(tables.resolve("links.xml"));
-        final Map<String, String> names = new Ends(new Pairs(links).all()).names();
+        final Pairs links = new Pairs(new XMLDocument(tables.resolve("links.xml")));
+        final Map<String, String> names = new Ends(links.all()).names();
         final Collection<String> voids = given.xpath("//attr[@void='true']/@type");
-        final Map<String, Collection<String>> into = Demanded.into(links, names, voids);
+        final Map<String, Collection<String>> into = Demanded.into(links.puts(), names, voids);
         final Map<String, Map<String, String>> asked = new Asked(
             new XMLDocument(tables.resolve("needs.xml")),
             names,
@@ -69,7 +69,8 @@ public final class Demanded implements Clue {
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
             final Demands demands = new Demands(
-                asked, Demanded.roots(hollow.xpath("@type").get(0), into)
+                asked,
+                Demanded.roots(new Noted(hollow).says("type"), into)
             );
             if (demands.any()) {
                 new Xembler(demands.directives()).applyQuietly(hollow.inner());
@@ -79,15 +80,18 @@ public final class Demanded implements Clue {
     }
 
     private static Map<String, Collection<String>> into(
-        final XML links, final Map<String, String> names, final Collection<String> voids
+        final Map<String, Collection<String>> puts,
+        final Map<String, String> names,
+        final Collection<String> voids
     ) {
         final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
-        for (final XML bind : links.nodes("/links/type/ref/bind[ref]")) {
-            final String loc = bind.xpath("ref/@loc").get(0);
-            final String filler = names.getOrDefault(loc, loc);
-            if (voids.contains(filler)) {
-                found.computeIfAbsent(filler, key -> new LinkedHashSet<>(0))
-                    .add(bind.xpath("@void").get(0));
+        for (final Map.Entry<String, Collection<String>> bound : puts.entrySet()) {
+            for (final String put : bound.getValue()) {
+                final String filler = names.getOrDefault(put, put);
+                if (voids.contains(filler)) {
+                    found.computeIfAbsent(filler, key -> new LinkedHashSet<>(0))
+                        .add(bound.getKey());
+                }
             }
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -40,7 +40,7 @@ final class Dispatched {
     /**
      * Every dispatch of the program.
      */
-    private final Collection<XML> all;
+    private final Collection<Site> all;
 
     /**
      * The arguments of every application, from {@link Given}.
@@ -74,7 +74,7 @@ final class Dispatched {
      */
     Dispatched(
         final XML provides,
-        final Collection<XML> dispatches,
+        final Collection<Site> dispatches,
         final Map<String, List<String>> arguments,
         final Map<String, Map<String, String>> bindings,
         final Map<String, String> taken,
@@ -103,15 +103,12 @@ final class Dispatched {
             new Bound(this.args, this.named, this.receivers, pairs, owned).all()
         );
         final Map<String, String> found = new HashMap<>(0);
-        for (final XML dispatch : this.all) {
-            final String made = dispatch.xpath("@loc").get(0);
+        for (final Site dispatch : this.all) {
+            final String made = dispatch.made();
             if (!pairs.containsKey(made)) {
-                final String bearer = dispatch.xpath("o[not(@as)][1]/@loc").get(0);
+                final String bearer = dispatch.bearer();
                 final String kept = filled.instead(
-                    owned.attribute(
-                        names.getOrDefault(bearer, bearer),
-                        dispatch.xpath("@base").get(0).substring(1)
-                    ),
+                    owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name()),
                     bearer
                 );
                 if (!kept.isEmpty() && !kept.equals(made)) {

--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -7,7 +7,6 @@ package org.eolang.inference;
 import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -69,22 +68,21 @@ final class Fillings {
      *  nobody ever fills
      */
     Map<String, Collection<Type>> all() {
-        final Map<String, String> names = new Ends(new Pairs(this.table).all()).names();
-        final Map<String, String> landings = new Landed(this.table, this.given).all();
-        final Forms forms = new Forms(this.table);
+        final Pairs pairs = new Pairs(this.table);
+        final Map<String, String> names = new Ends(pairs.all()).names();
+        final Map<String, String> landings = new Landed(pairs, this.given).all();
+        final Forms forms = new Forms(pairs.forms());
         final Map<String, Map<String, Type>> placed = new LinkedHashMap<>(0);
         final Map<String, Map<String, Type>> loose = new LinkedHashMap<>(0);
-        for (final XML bind : this.table.nodes("/links/type/ref/bind")) {
-            final List<String> put = bind.xpath("ref/@loc");
-            if (!put.isEmpty()) {
-                final String hollow = bind.xpath("@void").get(0);
-                final String end = landings.get(put.get(0));
+        for (final Map.Entry<String, Collection<String>> bound : pairs.puts().entrySet()) {
+            for (final String put : bound.getValue()) {
+                final String end = landings.get(put);
                 if (end == null) {
-                    final String stopped = names.getOrDefault(put.get(0), put.get(0));
-                    loose.computeIfAbsent(hollow, key -> new LinkedHashMap<>(0))
+                    final String stopped = names.getOrDefault(put, put);
+                    loose.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
                         .putIfAbsent(forms.name(stopped), forms.type(stopped));
                 } else {
-                    placed.computeIfAbsent(hollow, key -> new LinkedHashMap<>(0))
+                    placed.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
                         .putIfAbsent(forms.name(end), forms.type(end));
                 }
             }

--- a/eo-inference/src/main/java/org/eolang/inference/Forms.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Forms.java
@@ -4,9 +4,7 @@
  */
 package org.eolang.inference;
 
-import com.jcabi.xml.XML;
-import java.util.Collection;
-import java.util.HashSet;
+import java.util.Map;
 
 /**
  * Which form of type the links table gives an object.
@@ -27,46 +25,17 @@ import java.util.HashSet;
 final class Forms {
 
     /**
-     * The objects that are data.
+     * The form every object was given, from {@link Pairs}.
      */
-    private final Collection<String> ground;
-
-    /**
-     * The objects that terminate.
-     */
-    private final Collection<String> dead;
-
-    /**
-     * The objects that are voids.
-     */
-    private final Collection<String> free;
+    private final Map<String, String> given;
 
     /**
      * Ctor.
-     * @param links The links table, as {@link Resolved} left it
+     * @param forms The form every object was given by the links table, by the
+     *  locator of the object
      */
-    Forms(final XML links) {
-        this(
-            new HashSet<>(links.xpath("/links/type[data]/@id")),
-            new HashSet<>(links.xpath("/links/type[terminator]/@id")),
-            new HashSet<>(links.xpath("/links/type[var]/@id"))
-        );
-    }
-
-    /**
-     * Ctor.
-     * @param data The objects that are data
-     * @param terminators The objects that terminate
-     * @param voids The objects that are voids
-     */
-    Forms(
-        final Collection<String> data,
-        final Collection<String> terminators,
-        final Collection<String> voids
-    ) {
-        this.ground = data;
-        this.dead = terminators;
-        this.free = voids;
+    Forms(final Map<String, String> forms) {
+        this.given = forms;
     }
 
     /**
@@ -76,11 +45,10 @@ final class Forms {
      *  that form is one type
      */
     String name(final String object) {
+        final String form = this.given.getOrDefault(object, "");
         final String found;
-        if (this.ground.contains(object)) {
-            found = "data";
-        } else if (this.dead.contains(object)) {
-            found = "terminator";
+        if ("data".equals(form) || "terminator".equals(form)) {
+            found = form;
         } else {
             found = object;
         }
@@ -93,12 +61,13 @@ final class Forms {
      * @return The type
      */
     Type type(final String object) {
+        final String form = this.given.getOrDefault(object, "");
         final Type found;
-        if (this.ground.contains(object)) {
+        if ("data".equals(form)) {
             found = new Data();
-        } else if (this.dead.contains(object)) {
+        } else if ("terminator".equals(form)) {
             found = new Terminator();
-        } else if (this.free.contains(object)) {
+        } else if ("var".equals(form)) {
             found = new Var(object);
         } else {
             found = new Ref(object);

--- a/eo-inference/src/main/java/org/eolang/inference/Given.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Given.java
@@ -4,11 +4,15 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * What every application puts into the voids of what it copies.
@@ -47,7 +51,11 @@ final class Given {
     Map<String, List<String>> arguments() {
         final Map<String, List<String>> found = new HashMap<>(0);
         for (final XML application : this.all) {
-            found.put(application.xpath("@loc").get(0), new Placed(application).args());
+            final Xnav node = new Xnav(application.inner());
+            found.put(
+                node.attribute("loc").text().orElse(""),
+                new Placed(Given.args(node)).args()
+            );
         }
         return found;
     }
@@ -60,14 +68,21 @@ final class Given {
     Map<String, Map<String, String>> named() {
         final Map<String, Map<String, String>> found = new HashMap<>(0);
         for (final XML application : this.all) {
+            final Xnav node = new Xnav(application.inner());
             final Map<String, String> args = new HashMap<>(0);
-            for (final XML arg : application.nodes(
-                "o[@as][not(starts-with(@as, 'α'))][@loc]"
-            )) {
-                args.put(arg.xpath("@as").get(0), arg.xpath("@loc").get(0));
+            for (final Xnav arg : Given.args(node)) {
+                final Optional<String> place = arg.attribute("as").text();
+                final Optional<String> loc = arg.attribute("loc").text();
+                if (place.isPresent() && loc.isPresent() && !place.get().startsWith("α")) {
+                    args.put(place.get(), loc.get());
+                }
             }
-            found.put(application.xpath("@loc").get(0), args);
+            found.put(node.attribute("loc").text().orElse(""), args);
         }
         return found;
+    }
+
+    private static List<Xnav> args(final Xnav application) {
+        return application.elements(Filter.withName("o")).collect(Collectors.toList());
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Held.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Held.java
@@ -46,11 +46,8 @@ final class Held {
     Map<String, String> all() {
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final XML attr : this.table.nodes("//attr[@void='true' and @holds]")) {
-            final String holds = attr.xpath("@holds").get(0);
-            found.put(
-                attr.xpath("@type").get(0),
-                holds.replace("?", "")
-            );
+            final Noted row = new Noted(attr);
+            found.put(row.says("type"), row.says("holds").replace("?", ""));
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Kept.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Kept.java
@@ -4,7 +4,8 @@
  */
 package org.eolang.inference;
 
-import com.jcabi.xml.XML;
+import com.github.lombrozo.xnav.Xnav;
+import org.w3c.dom.Node;
 import org.xembly.Directives;
 
 /**
@@ -24,25 +25,24 @@ final class Kept implements Type {
     /**
      * The row, as the document keeps it.
      */
-    private final XML row;
+    private final Xnav row;
 
     /**
      * Ctor.
      * @param written The row, as the document keeps it, rooted at the row
      *  itself and not at a document of its own
      */
-    Kept(final XML written) {
+    Kept(final Xnav written) {
         this.row = written;
     }
 
     @Override
     public Directives directives() {
         final Directives dirs = new Directives();
-        for (final XML held : this.row.nodes("*")) {
-            dirs.add(held.inner().getNodeName())
-                .append(Directives.copyOf(held.inner()))
-                .up();
-        }
+        this.row.elements()
+            .map(Xnav::node)
+            .filter(held -> held.getNodeType() == Node.ELEMENT_NODE)
+            .forEach(held -> dirs.add(held.getNodeName()).append(Directives.copyOf(held)).up());
         return dirs;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Landed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Landed.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.Collection;
 import java.util.HashSet;
@@ -36,9 +37,9 @@ import java.util.Map;
 final class Landed {
 
     /**
-     * The links table.
+     * What the links table says.
      */
-    private final XML links;
+    private final Pairs links;
 
     /**
      * The provides table.
@@ -47,11 +48,11 @@ final class Landed {
 
     /**
      * Ctor.
-     * @param table The links table, as {@link Resolved} left it
+     * @param table What the links table says, as {@link Resolved} left it
      * @param provides The provides table, which says what an atom comes back
      *  with and which objects are formations
      */
-    Landed(final XML table, final XML provides) {
+    Landed(final Pairs table, final XML provides) {
         this.links = table;
         this.given = provides;
     }
@@ -62,12 +63,16 @@ final class Landed {
      *  whose walk runs into a void
      */
     Map<String, String> all() {
-        final Collection<String> made = new HashSet<>(this.given.xpath("/provides/type/@id"));
-        final Collection<String> plain = new HashSet<>(
-            this.links.xpath("/links/type[data or terminator]/@id")
-        );
-        final Map<String, String> hops = new Pairs(this.links).all();
-        final Walked walked = new Walked(hops, this.comes());
+        final Collection<String> made = new HashSet<>(0);
+        final Map<String, String> comes = new LinkedHashMap<>(0);
+        for (final Xnav type : new Rows(this.given).all()) {
+            final String owner = new Noted(type).says("id");
+            made.add(owner);
+            type.attribute("returns").text().ifPresent(back -> comes.put(owner, back));
+        }
+        final Collection<String> plain = new HashSet<>(this.links.certain());
+        final Map<String, String> hops = this.links.all();
+        final Walked walked = new Walked(hops, comes);
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final String type : made) {
             found.put(type, type);
@@ -80,14 +85,6 @@ final class Landed {
             if (made.contains(end) || plain.contains(end)) {
                 found.put(start, end);
             }
-        }
-        return found;
-    }
-
-    private Map<String, String> comes() {
-        final Map<String, String> found = new LinkedHashMap<>(0);
-        for (final XML type : this.given.nodes("/provides/type[@returns]")) {
-            found.put(type.xpath("@id").get(0), type.xpath("@returns").get(0));
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Links.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Links.java
@@ -68,25 +68,26 @@ final class Links implements Clue {
         final Xmirs world = new Xmirs(xmirs);
         final Collection<String> made = new ArrayList<>(0);
         for (final XML formation : world.formations()) {
-            made.add(formation.xpath("@loc").get(0));
+            made.add(new Noted(formation).says("loc"));
         }
         final Scope scope = new Scope(new HashSet<>(world.locators()), new HashSet<>(made));
         final Map<String, Type> found = new LinkedHashMap<>(0);
         for (final XML reference : world.references()) {
-            final String from = reference.xpath("@loc").get(0);
-            final String target = scope.target(from, reference.xpath("@base").get(0));
+            final Noted ref = new Noted(reference);
+            final String from = ref.says("loc");
+            final String target = scope.target(from, ref.says("base"));
             if (!target.isEmpty()) {
                 found.put(from, new Ref(target));
             }
         }
         for (final XML datum : world.data()) {
-            found.put(datum.xpath("@loc").get(0), new Data());
+            found.put(new Noted(datum).says("loc"), new Data());
         }
         for (final XML dead : world.terminators()) {
-            found.put(dead.xpath("@loc").get(0), new Terminator());
+            found.put(new Noted(dead).says("loc"), new Terminator());
         }
         for (final XML hollow : world.voids()) {
-            found.put(hollow.xpath("@loc").get(0), new Var());
+            found.put(new Noted(hollow).says("loc"), new Var());
         }
         Files.createDirectories(tables);
         Files.write(

--- a/eo-inference/src/main/java/org/eolang/inference/Members.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Members.java
@@ -54,13 +54,14 @@ final class Members {
     void fill(final Tojos rows) {
         final Collection<String> owners = new HashSet<>(0);
         for (final XML formation : this.made) {
-            owners.add(formation.xpath("@loc").get(0));
+            owners.add(new Noted(formation).says("loc"));
         }
         for (final XML root : this.roots) {
-            final String type = root.xpath("@loc").get(0);
+            final Noted member = new Noted(root);
+            final String type = member.says("loc");
             final String owner = type.substring(0, type.lastIndexOf('.'));
             if (owners.contains(owner)) {
-                final String name = root.xpath("@name").get(0);
+                final String name = member.says("name");
                 rows.add(String.join(" ", owner, name))
                     .set("owner", owner)
                     .set("name", name)

--- a/eo-inference/src/main/java/org/eolang/inference/Needs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Needs.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.inference;
 
-import com.jcabi.xml.XML;
 import com.yegor256.tojos.MnMemory;
 import com.yegor256.tojos.TjDeferred;
 import com.yegor256.tojos.Tojos;
@@ -46,13 +45,13 @@ final class Needs implements Clue {
     @Override
     public void follow(final Path xmirs, final Path tables) throws IOException {
         try (Tojos rows = new TjDeferred(new MnMemory())) {
-            for (final XML dispatch : new Xmirs(xmirs).dispatches()) {
-                final String owner = dispatch.xpath("o[not(@as)][1]/@loc").get(0);
+            for (final Site dispatch : new Xmirs(xmirs).dispatches()) {
+                final String owner = dispatch.bearer();
                 rows.add(owner);
-                rows.add(String.join(" ", owner, dispatch.xpath("@base").get(0)))
+                rows.add(String.join(" ", owner, dispatch.name()))
                     .set("owner", owner)
-                    .set("name", dispatch.xpath("@base").get(0).substring(1))
-                    .set("type", dispatch.xpath("@loc").get(0));
+                    .set("name", dispatch.name())
+                    .set("type", dispatch.made());
             }
             Files.createDirectories(tables);
             Files.write(

--- a/eo-inference/src/main/java/org/eolang/inference/Noted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Noted.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+
+/**
+ * What is noted on one node of a document.
+ *
+ * <p>A rule reads a great many nodes and asks each of them for two or three of
+ * its attributes. Asking a document for an attribute is a question about the
+ * whole document and costs what the whole document costs, however small the
+ * answer is, so a node asked three times over forty thousand nodes is the most
+ * expensive thing a rule does. Reading the attribute off the node itself costs
+ * what the node costs, which is nothing.</p>
+ *
+ * <p>An attribute that is not there comes back empty rather than as a
+ * complaint. Every reader here already treats a missing attribute as a fact
+ * about the object rather than as a fault of the table.</p>
+ *
+ * @since 0.71.0
+ */
+final class Noted {
+
+    /**
+     * The node.
+     */
+    private final Xnav node;
+
+    /**
+     * Ctor.
+     * @param element The node
+     */
+    Noted(final XML element) {
+        this(new Xnav(element.inner()));
+    }
+
+    /**
+     * Ctor.
+     * @param element The node
+     */
+    Noted(final Xnav element) {
+        this.node = element;
+    }
+
+    /**
+     * What the node says about one of its attributes.
+     * @param attribute The name of the attribute
+     * @return What it says, empty when it says nothing
+     */
+    String says(final String attribute) {
+        return this.node.attribute(attribute).text().orElse("");
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Page.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Page.java
@@ -7,6 +7,7 @@ package org.eolang.inference;
 import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -65,12 +66,13 @@ final class Page {
     Directives directives(final String name) {
         final List<String> lines = this.lines();
         final Map<Integer, Collection<Written>> written = this.written();
+        final Map<Integer, Integer> counted = this.counted();
         final Directives dirs = new Directives()
             .add("page")
             .attr("file", name)
-            .attr("named", Integer.toString(this.counted(2)))
-            .attr("rooted", Integer.toString(this.counted(1)))
-            .attr("blank", Integer.toString(this.counted(0)));
+            .attr("named", Integer.toString(counted.getOrDefault(2, 0)))
+            .attr("rooted", Integer.toString(counted.getOrDefault(1, 0)))
+            .attr("blank", Integer.toString(counted.getOrDefault(0, 0)));
         for (int index = 0; index < lines.size(); index = index + 1) {
             dirs.add("line").attr("n", Integer.toString(index + 1));
             dirs.append(
@@ -100,22 +102,16 @@ final class Page {
     private Map<Integer, Collection<Written>> written() {
         final Map<Integer, Collection<Written>> found = new LinkedHashMap<>(0);
         for (final XML object : this.xmir.nodes("//o[@loc and @line and @pos]")) {
-            final String loc = object.xpath("@loc").get(0);
+            final Noted noted = new Noted(object);
+            final String loc = noted.says("loc");
             final Answer answer = this.answers.get(loc);
             if (answer != null) {
-                final List<String> called = object.xpath("@name");
-                final String name;
-                if (called.isEmpty()) {
-                    name = "";
-                } else {
-                    name = called.get(0);
-                }
                 found.computeIfAbsent(
-                    Integer.parseInt(object.xpath("@line").get(0)),
+                    Integer.parseInt(noted.says("line")),
                     key -> new ArrayList<>(1)
                 ).add(
                     new Written(
-                        loc, Integer.parseInt(object.xpath("@pos").get(0)), name, answer
+                        loc, Integer.parseInt(noted.says("pos")), noted.says("name"), answer
                     )
                 );
             }
@@ -123,12 +119,12 @@ final class Page {
         return found;
     }
 
-    private int counted(final int floor) {
-        int found = 0;
+    private Map<Integer, Integer> counted() {
+        final Map<Integer, Integer> found = new HashMap<>(3);
         for (final String loc : this.xmir.xpath("//o[@loc]/@loc")) {
             final Answer answer = this.answers.get(loc);
-            if (answer != null && (answer.rung() == floor || floor == 2 && answer.rung() > 2)) {
-                found = found + 1;
+            if (answer != null) {
+                found.merge(Math.min(answer.rung(), 2), 1, Integer::sum);
             }
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Pairs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pairs.java
@@ -4,22 +4,38 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.w3c.dom.Node;
 
 /**
- * What the links table says, pair by pair.
+ * What the links table says, row by row.
  *
  * <p>{@link Links} writes one row per name that is a copy of another, and
  * reading them back is how a later pass adds to them without losing what is
  * there. The order they were written in is kept, so a document read and written
  * again keeps the rules' rows where they were and carries the worked-out ones
  * after them.</p>
+ *
+ * <p>This is the only place the table is read, and it is read by walking it
+ * rather than by asking it questions. A table of a program of any size is a
+ * document of megabytes, and asking such a document a question costs the same
+ * whether one row comes back or forty thousand do, since the whole of it is
+ * looked through either way. Every question here is about all the rows anyway,
+ * so one walk answers all of them, and the rows of that walk are kept for
+ * whoever asks next.</p>
  *
  * @since 0.68.0
  */
@@ -31,11 +47,17 @@ final class Pairs {
     private final XML table;
 
     /**
+     * The rows of the table, once they have been walked.
+     */
+    private final List<List<Xnav>> read;
+
+    /**
      * Ctor.
      * @param links The links table
      */
     Pairs(final XML links) {
         this.table = links;
+        this.read = new ArrayList<>(1);
     }
 
     /**
@@ -49,8 +71,11 @@ final class Pairs {
      */
     Map<String, String> all() {
         final Map<String, String> found = new LinkedHashMap<>(0);
-        for (final XML link : this.table.nodes("/links/type[ref]")) {
-            found.put(link.xpath("@id").get(0), link.xpath("ref/@loc").get(0));
+        for (final Xnav row : this.rows()) {
+            final Optional<Xnav> ref = Pairs.ref(row);
+            if (ref.isPresent()) {
+                found.put(new Noted(row).says("id"), new Noted(ref.get()).says("loc"));
+            }
         }
         return found;
     }
@@ -67,7 +92,32 @@ final class Pairs {
      * @return The locators
      */
     Collection<String> certain() {
-        return this.table.xpath("/links/type[data or terminator]/@id");
+        final Collection<String> found = new ArrayList<>(0);
+        for (final Xnav row : this.rows()) {
+            final String form = Pairs.form(row);
+            if ("data".equals(form) || "terminator".equals(form)) {
+                found.add(new Noted(row).says("id"));
+            }
+        }
+        return found;
+    }
+
+    /**
+     * Which form of answer every row of the table holds.
+     *
+     * <p>A row holds one element and the element says what kind of answer it
+     * is, so its name is the form: a {@code data}, a {@code terminator}, a
+     * {@code var}, a {@code ref} to the object this one is a copy of, or
+     * whatever a pass we know nothing about has written there.</p>
+     *
+     * @return The form, by the locator of the object the row is about
+     */
+    Map<String, String> forms() {
+        final Map<String, String> found = new HashMap<>(0);
+        for (final Xnav row : this.rows()) {
+            found.put(new Noted(row).says("id"), Pairs.form(row));
+        }
+        return found;
     }
 
     /**
@@ -82,8 +132,10 @@ final class Pairs {
      */
     Map<String, Type> others() {
         final Map<String, Type> found = new LinkedHashMap<>(0);
-        for (final XML row : this.table.nodes("/links/type[not(ref)]")) {
-            found.put(row.xpath("@id").get(0), new Kept(row));
+        for (final Xnav row : this.rows()) {
+            if (!Pairs.ref(row).isPresent()) {
+                found.put(new Noted(row).says("id"), new Kept(row));
+            }
         }
         return found;
     }
@@ -101,11 +153,22 @@ final class Pairs {
      *  that filled them, without the objects that filled none
      */
     Map<String, Collection<String>> filled() {
+        final Map<String, String> hops = new LinkedHashMap<>(0);
         final Map<String, Collection<String>> own = new LinkedHashMap<>(0);
-        for (final XML link : this.table.nodes("/links/type[ref/bind]")) {
-            own.put(link.xpath("@id").get(0), link.xpath("ref/bind/@void"));
+        for (final Xnav row : this.rows()) {
+            final Optional<Xnav> ref = Pairs.ref(row);
+            if (ref.isPresent()) {
+                final String object = new Noted(row).says("id");
+                hops.put(object, new Noted(ref.get()).says("loc"));
+                final Collection<String> voids = ref.get()
+                    .elements(Filter.withName("bind"))
+                    .map(bind -> new Noted(bind).says("void"))
+                    .collect(Collectors.toList());
+                if (!voids.isEmpty()) {
+                    own.put(object, voids);
+                }
+            }
         }
-        final Map<String, String> hops = this.all();
         final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
         for (final String object : hops.keySet()) {
             final Collection<String> voids = new LinkedHashSet<>(0);
@@ -123,5 +186,73 @@ final class Pairs {
             }
         }
         return found;
+    }
+
+    /**
+     * What the table says went into every void.
+     *
+     * <p>A bind of a row names a void and what was put into it, and the same
+     * void is named by the row of every copy that filled it. What went in is
+     * gathered per void and not per row, since a void filled with a
+     * {@code number} at eleven call sites was filled one way eleven times.</p>
+     *
+     * @return The locators of what went in, by the locator of the void, in the
+     *  order the table names them, without the binds that put nothing
+     */
+    Map<String, Collection<String>> puts() {
+        final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
+        for (final Xnav row : this.rows()) {
+            final Optional<Xnav> ref = Pairs.ref(row);
+            if (ref.isPresent()) {
+                ref.get().elements(Filter.withName("bind")).forEach(
+                    bind -> Pairs.ref(bind).ifPresent(
+                        put -> found.computeIfAbsent(
+                            new Noted(bind).says("void"), key -> new LinkedHashSet<>(0)
+                        ).add(new Noted(put).says("loc"))
+                    )
+                );
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The reference of every pair of the table, as the document holds it.
+     *
+     * <p>A pass that adds to a reference writes into the document itself
+     * rather than building a new one, so what comes back is the node the table
+     * keeps and not a copy of it.</p>
+     *
+     * @return The references, by the locator of the object they are about
+     */
+    Map<String, Node> refs() {
+        final Map<String, Node> found = new LinkedHashMap<>(0);
+        for (final Xnav row : this.rows()) {
+            final Optional<Xnav> ref = Pairs.ref(row);
+            if (ref.isPresent()) {
+                found.putIfAbsent(new Noted(row).says("id"), ref.get().node());
+            }
+        }
+        return found;
+    }
+
+    private List<Xnav> rows() {
+        if (this.read.isEmpty()) {
+            this.read.add(new Rows(this.table).all());
+        }
+        return this.read.get(0);
+    }
+
+    private static Optional<Xnav> ref(final Xnav node) {
+        return node.elements(Filter.withName("ref")).findFirst();
+    }
+
+    private static String form(final Xnav row) {
+        return row.elements()
+            .map(Xnav::node)
+            .filter(held -> held.getNodeType() == Node.ELEMENT_NODE)
+            .map(Node::getNodeName)
+            .findFirst()
+            .orElse("");
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Placed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Placed.java
@@ -4,11 +4,13 @@
  */
 package org.eolang.inference;
 
-import com.jcabi.xml.XML;
+import com.github.lombrozo.xnav.Xnav;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * The arguments of one application, ordered by the place each one names.
@@ -23,16 +25,16 @@ import java.util.Map;
 final class Placed {
 
     /**
-     * The application.
+     * The objects bound inside the application.
      */
-    private final XML application;
+    private final Collection<Xnav> bound;
 
     /**
      * Ctor.
-     * @param app The application
+     * @param objects The objects bound inside the application
      */
-    Placed(final XML app) {
-        this.application = app;
+    Placed(final Collection<Xnav> objects) {
+        this.bound = objects;
     }
 
     /**
@@ -42,10 +44,14 @@ final class Placed {
     List<String> args() {
         final Map<Integer, String> byplace = new HashMap<>(1);
         int highest = -1;
-        for (final XML arg : this.application.nodes("o[starts-with(@as, 'α')][@loc]")) {
-            final int place = Integer.parseInt(arg.xpath("@as").get(0).substring(1));
-            byplace.put(place, arg.xpath("@loc").get(0));
-            highest = Math.max(highest, place);
+        for (final Xnav arg : this.bound) {
+            final Optional<String> place = arg.attribute("as").text();
+            final Optional<String> loc = arg.attribute("loc").text();
+            if (place.isPresent() && loc.isPresent() && place.get().startsWith("α")) {
+                final int index = Integer.parseInt(place.get().substring(1));
+                byplace.put(index, loc.get());
+                highest = Math.max(highest, index);
+            }
         }
         final List<String> args = new ArrayList<>(highest + 1);
         for (int place = 0; place <= highest; place += 1) {

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import com.yegor256.tojos.MnMemory;
 import com.yegor256.tojos.TjDeferred;
@@ -13,8 +15,10 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * What every object certainly has.
@@ -92,27 +96,7 @@ final class Provides implements Clue {
         final Collection<XML> made = world.formations();
         try (Tojos rows = new TjDeferred(new MnMemory())) {
             for (final XML formation : made) {
-                final String owner = formation.xpath("@loc").get(0);
-                final boolean whole = formation.nodes("o[@name='λ' or @name='φ']").isEmpty();
-                rows.add(owner).set("complete", Boolean.toString(whole));
-                for (final String back
-                    : formation.xpath("o[@name='λ']/@atom[starts-with(., 'Φ.')]")) {
-                    rows.add(owner).set("returns", back);
-                }
-                for (final XML attr : formation.nodes("o[@name and not(@name='λ')]")) {
-                    final String name = attr.xpath("@name").get(0);
-                    final Tojo row = rows.add(String.join(" ", owner, name))
-                        .set("owner", owner)
-                        .set("name", name)
-                        .set("type", attr.xpath("@loc").get(0));
-                    if (attr.xpath("@base").contains("∅")) {
-                        row.set("void", "true");
-                        final List<String> held = attr.xpath("@type[starts-with(., 'Φ.')]");
-                        if (!held.isEmpty()) {
-                            row.set("holds", held.get(0));
-                        }
-                    }
-                }
+                Provides.fill(rows, new Xnav(formation.inner()));
             }
             new Members(made, world.roots()).fill(rows);
             Files.createDirectories(tables);
@@ -121,5 +105,66 @@ final class Provides implements Clue {
                 new Grouped(rows, "provides").asXml().toString().getBytes(StandardCharsets.UTF_8)
             );
         }
+    }
+
+    private static void fill(final Tojos rows, final Xnav shape) {
+        final String owner = new Noted(shape).says("loc");
+        final List<Xnav> kids = shape.elements(Filter.withName("o")).collect(Collectors.toList());
+        rows.add(owner).set("complete", Boolean.toString(Provides.whole(kids)));
+        for (final String back : Provides.returns(kids)) {
+            rows.add(owner).set("returns", back);
+        }
+        for (final Xnav kid : Provides.named(kids)) {
+            final Noted attr = new Noted(kid);
+            final String name = attr.says("name");
+            final Tojo row = rows.add(String.join(" ", owner, name))
+                .set("owner", owner)
+                .set("name", name)
+                .set("type", attr.says("loc"));
+            if ("∅".equals(attr.says("base"))) {
+                row.set("void", "true");
+                final String held = attr.says("type");
+                if (held.startsWith("Φ.")) {
+                    row.set("holds", held);
+                }
+            }
+        }
+    }
+
+    private static Collection<Xnav> named(final Collection<Xnav> kids) {
+        final Collection<Xnav> found = new ArrayList<>(0);
+        for (final Xnav kid : kids) {
+            final String name = new Noted(kid).says("name");
+            if (!name.isEmpty() && !"λ".equals(name)) {
+                found.add(kid);
+            }
+        }
+        return found;
+    }
+
+    private static boolean whole(final Collection<Xnav> kids) {
+        boolean found = true;
+        for (final Xnav kid : kids) {
+            final String name = new Noted(kid).says("name");
+            if ("λ".equals(name) || "φ".equals(name)) {
+                found = false;
+                break;
+            }
+        }
+        return found;
+    }
+
+    private static Collection<String> returns(final Collection<Xnav> kids) {
+        final Collection<String> found = new ArrayList<>(0);
+        for (final Xnav kid : kids) {
+            final Noted attr = new Noted(kid);
+            if ("λ".equals(attr.says("name"))) {
+                final String back = attr.says("atom");
+                if (back.startsWith("Φ.")) {
+                    found.add(back);
+                }
+            }
+        }
+        return found;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Relayed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Relayed.java
@@ -13,10 +13,9 @@ import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import org.w3c.dom.Node;
 import org.xembly.Xembler;
 
 /**
@@ -64,20 +63,13 @@ public final class Relayed implements Clue {
         final Path table = tables.resolve("links.xml");
         final XML links = new XMLDocument(table);
         final XML given = new XMLDocument(tables.resolve("provides.xml"));
-        final Map<String, String> pairs = new Pairs(links).all();
+        final Pairs written = new Pairs(links);
+        final Map<String, String> pairs = written.all();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Provided owned = new Provided(given, new Ends(pairs).names(), voids);
         final Collection<String> hollows = new HashSet<>(voids);
-        final Map<String, Collection<String>> fillers = new LinkedHashMap<>(0);
-        for (final XML bind : links.nodes("/links/type/ref/bind[ref]")) {
-            fillers.computeIfAbsent(
-                bind.xpath("@void").get(0), key -> new LinkedHashSet<>(0)
-            ).add(bind.xpath("ref/@loc").get(0));
-        }
-        final Map<String, XML> rows = new LinkedHashMap<>(0);
-        for (final XML type : links.nodes("/links/type[ref]")) {
-            rows.putIfAbsent(type.xpath("@id").get(0), type.nodes("ref").get(0));
-        }
+        final Map<String, Collection<String>> fillers = written.puts();
+        final Map<String, Node> rows = written.refs();
         for (final Map.Entry<String, List<String>> application
             : new Given(new Xmirs(xmirs).applications()).arguments().entrySet()) {
             final String hollow = pairs.getOrDefault(application.getKey(), "");
@@ -88,7 +80,7 @@ public final class Relayed implements Clue {
                         fillers.getOrDefault(hollow, Collections.emptyList()),
                         application.getValue()
                     ).directives()
-                ).applyQuietly(rows.get(application.getKey()).inner());
+                ).applyQuietly(rows.get(application.getKey()));
             }
         }
         Files.write(table, links.toString().getBytes(StandardCharsets.UTF_8));

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -71,35 +71,33 @@ public final class Resolved implements Clue {
         final Path links = tables.resolve("links.xml");
         final Xmirs world = new Xmirs(xmirs);
         final XML given = new XMLDocument(tables.resolve("provides.xml"));
-        final Collection<XML> dispatches = world.dispatches();
+        final Collection<Site> dispatches = world.dispatches();
         final Given applied = new Given(world.applications());
         final Map<String, List<String>> args = applied.arguments();
         final Map<String, Map<String, String>> named = applied.named();
+        final Map<String, String> receivers = world.receivers();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
-        final XML table = new XMLDocument(links);
-        final Pairs written = new Pairs(table);
+        final Pairs written = new Pairs(new XMLDocument(links));
         final Map<String, String> pairs = new Settled(
-            new Dispatched(given, dispatches, args, named, world.receivers(), voids)
+            new Dispatched(given, dispatches, args, named, receivers, voids)
         ).from(
             new Settled(
                 new Dispatched(
-                    given, dispatches, args, named, world.receivers(), Collections.emptyList()
+                    given, dispatches, args, named, receivers, Collections.emptyList()
                 )
             ).from(written.all())
         );
+        final Map<String, String> names = new Ends(pairs).names();
         final Map<String, Type> rows = new Refs(
             pairs,
             new Bound(
-                args, named, world.receivers(), pairs,
-                new Provided(given, new Ends(pairs).names(), voids)
+                args, named, receivers, pairs, new Provided(given, names, voids)
             ).all()
         ).all();
         rows.putAll(written.others());
-        final Collection<String> dead = new Dead(
-            table, dispatches, new Ends(pairs).names()
-        ).all();
-        for (final XML dispatch : dispatches) {
-            final String made = dispatch.xpath("@loc").get(0);
+        final Collection<String> dead = new Dead(written, dispatches, names).all();
+        for (final Site dispatch : dispatches) {
+            final String made = dispatch.made();
             if (dead.contains(made)) {
                 rows.put(made, new Terminator());
             } else {

--- a/eo-inference/src/main/java/org/eolang/inference/Row.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Row.java
@@ -4,7 +4,7 @@
  */
 package org.eolang.inference;
 
-import com.jcabi.xml.XML;
+import com.github.lombrozo.xnav.Xnav;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.w3c.dom.NamedNodeMap;
@@ -24,13 +24,13 @@ final class Row {
     /**
      * The element of the document the row was written as.
      */
-    private final XML element;
+    private final Xnav element;
 
     /**
      * Ctor.
      * @param row The element of the document the row was written as
      */
-    Row(final XML row) {
+    Row(final Xnav row) {
         this.element = row;
     }
 
@@ -40,7 +40,7 @@ final class Row {
      */
     Map<String, String> cells() {
         final Map<String, String> found = new LinkedHashMap<>(0);
-        final NamedNodeMap named = this.element.inner().getAttributes();
+        final NamedNodeMap named = this.element.node().getAttributes();
         for (int cell = 0; cell < named.getLength(); cell = cell + 1) {
             found.put(named.item(cell).getNodeName(), named.item(cell).getNodeValue());
         }

--- a/eo-inference/src/main/java/org/eolang/inference/Rows.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Rows.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * The rows of a table, as the document holds them.
+ *
+ * <p>Every table a clue writes is one element per type under one root, so
+ * finding the rows is the same walk whichever table it is and whoever is
+ * reading. It is a walk and not a question, since a question about a document
+ * of megabytes costs what the whole document costs, and every reader here wants
+ * all the rows anyway.</p>
+ *
+ * @since 0.71.0
+ */
+final class Rows {
+
+    /**
+     * The table.
+     */
+    private final XML table;
+
+    /**
+     * Ctor.
+     * @param document The table, as a clue wrote it
+     */
+    Rows(final XML document) {
+        this.table = document;
+    }
+
+    /**
+     * Every row of the table.
+     * @return The rows, in the order the document holds them
+     */
+    List<Xnav> all() {
+        return new Xnav(this.table.inner())
+            .elements()
+            .flatMap(root -> root.elements(Filter.withName("type")))
+            .collect(Collectors.toList());
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Seen.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Seen.java
@@ -4,11 +4,16 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 /**
  * What callers were seen putting into every void of a program.
@@ -52,23 +57,71 @@ final class Seen {
      */
     Map<String, Collection<Type>> all() {
         final Map<String, Collection<Type>> found = new LinkedHashMap<>(0);
-        for (final XML hollow : this.given.nodes("//attr[@void='true']")) {
-            found.put(hollow.xpath("@type").get(0), Seen.members(hollow));
+        for (final Xnav type : new Rows(this.given).all()) {
+            for (final Xnav hollow : Seen.hollows(type)) {
+                found.put(new Noted(hollow).says("type"), Seen.members(hollow));
+            }
         }
         return found;
     }
 
-    private static Collection<Type> members(final XML hollow) {
+    private static List<Xnav> hollows(final Xnav type) {
+        return type.elements(Filter.withName("attr"))
+            .filter(attr -> "true".equals(new Noted(attr).says("void")))
+            .collect(Collectors.toList());
+    }
+
+    private static Collection<Type> members(final Xnav hollow) {
+        final Collection<Xnav> told = Seen.told(hollow);
         final Collection<Type> found = new ArrayList<>(0);
-        for (final String loc : hollow.xpath("witnessed/ref/@loc|witnessed/union/ref/@loc")) {
-            found.add(new Ref(loc));
+        for (final Xnav choice : told) {
+            if ("ref".equals(Seen.kind(choice))) {
+                found.add(new Ref(new Noted(choice).says("loc")));
+            }
         }
-        if (!hollow.nodes("witnessed/data|witnessed/union/data").isEmpty()) {
+        if (Seen.holds(told, "data")) {
             found.add(new Data());
         }
-        if (!hollow.nodes("witnessed/unknown").isEmpty()) {
+        if (Seen.holds(told, "unknown")) {
             found.add(new Unknown());
         }
         return found;
+    }
+
+    private static Collection<Xnav> told(final Xnav hollow) {
+        final Collection<Xnav> found = new ArrayList<>(0);
+        for (final Xnav witnessed : Seen.choices(hollow, "witnessed")) {
+            for (final Xnav choice : Seen.choices(witnessed, "union", "ref", "data", "unknown")) {
+                if ("union".equals(Seen.kind(choice))) {
+                    found.addAll(Seen.choices(choice, "ref", "data", "unknown"));
+                } else {
+                    found.add(choice);
+                }
+            }
+        }
+        return found;
+    }
+
+    private static List<Xnav> choices(final Xnav node, final String... names) {
+        return node.elements(
+            Filter.any(
+                Arrays.stream(names).map(Filter::withName).toArray(Filter[]::new)
+            )
+        ).collect(Collectors.toList());
+    }
+
+    private static boolean holds(final Iterable<Xnav> told, final String name) {
+        boolean found = false;
+        for (final Xnav choice : told) {
+            if (name.equals(Seen.kind(choice))) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+
+    private static String kind(final Xnav choice) {
+        return choice.node().getNodeName();
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Site.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Site.java
@@ -1,0 +1,68 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+
+/**
+ * One dispatch of a program, as the XMIR holds it.
+ *
+ * <p>Three things are ever asked of a dispatch: where it is written, which
+ * name it takes, and which object it takes that name from. {@link Settled}
+ * asks them of every dispatch of the program again on every turn it makes, so
+ * they are read off the node and never searched for in the document the node
+ * belongs to — a search knows nothing of where it was last time and looks
+ * through the whole file again to find one attribute of one object.</p>
+ *
+ * <p>The object the name is taken from is the child that is not an argument:
+ * {@code x.plus 5} takes {@code plus} from {@code x}, never from the
+ * {@code 5}.</p>
+ *
+ * @since 0.71.0
+ */
+final class Site {
+
+    /**
+     * The dispatch.
+     */
+    private final Xnav dispatch;
+
+    /**
+     * Ctor.
+     * @param made The dispatch, as the XMIR holds it
+     */
+    Site(final Xnav made) {
+        this.dispatch = made;
+    }
+
+    /**
+     * Where this dispatch is written.
+     * @return The locator of it
+     */
+    String made() {
+        return new Noted(this.dispatch).says("loc");
+    }
+
+    /**
+     * The object this dispatch takes its name from.
+     * @return The locator of it
+     */
+    String bearer() {
+        return this.dispatch
+            .elements(Filter.all(Filter.withName("o"), Filter.not(Filter.hasAttribute("as"))))
+            .findFirst()
+            .map(kid -> new Noted(kid).says("loc"))
+            .orElse("");
+    }
+
+    /**
+     * The name this dispatch takes.
+     * @return The name, without the dot that says it is a dispatch
+     */
+    String name() {
+        return new Noted(this.dispatch).says("base").substring(1);
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Ungrouped.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ungrouped.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -57,16 +59,16 @@ final class Ungrouped {
      */
     Map<String, Collection<Map<String, String>>> rows() {
         final Map<String, Collection<Map<String, String>>> found = new LinkedHashMap<>(0);
-        for (final XML type : this.table.nodes("/*/type")) {
+        for (final Xnav type : new Rows(this.table).all()) {
             final Map<String, String> cells = new Row(type).cells();
             final Collection<Map<String, String>> owned = found.computeIfAbsent(
                 this.names.getOrDefault(cells.get("id"), cells.get("id")),
                 key -> new ArrayList<>(1)
             );
             owned.add(cells);
-            for (final XML attr : type.nodes("attr")) {
-                owned.add(new Row(attr).cells());
-            }
+            type.elements(Filter.withName("attr")).forEach(
+                attr -> owned.add(new Row(attr).cells())
+            );
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
@@ -91,7 +91,7 @@ public final class Witnessed implements Clue {
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
             final Collection<Type> members = filled.getOrDefault(
-                hollow.xpath("@type").get(0), Collections.emptyList()
+                new Noted(hollow).says("type"), Collections.emptyList()
             );
             if (!members.isEmpty()) {
                 new Xembler(

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import com.jcabi.xml.XMLDocument;
 import java.io.IOException;
@@ -145,8 +147,12 @@ final class Xmirs {
      *  the code
      * @throws IOException If a file cannot be read
      */
-    Collection<XML> dispatches() throws IOException {
-        return this.matching("//o[starts-with(@base, '.')]");
+    Collection<Site> dispatches() throws IOException {
+        final Collection<Site> found = new ArrayList<>(0);
+        for (final XML dispatch : this.matching("//o[starts-with(@base, '.')]")) {
+            found.add(new Site(new Xnav(dispatch.inner())));
+        }
+        return found;
     }
 
     /**
@@ -210,15 +216,23 @@ final class Xmirs {
     Map<String, String> receivers() throws IOException {
         final Map<String, String> found = new HashMap<>(0);
         for (final XML xmir : this.documents()) {
-            for (final XML kid : xmir.nodes("//o[@loc]/o[@loc][not(@as)]")) {
-                final String owner = kid.xpath("../@loc").get(0);
-                final String loc = kid.xpath("@loc").get(0);
-                if (loc.equals(owner.concat(".ρ"))) {
-                    found.put(owner, loc);
-                }
+            for (final XML node : xmir.nodes("//o[@loc][o[@loc][not(@as)]]")) {
+                final Xnav owner = new Xnav(node.inner());
+                final String loc = new Noted(owner).says("loc");
+                Xmirs.bare(owner)
+                    .map(kid -> new Noted(kid).says("loc"))
+                    .filter(kid -> kid.equals(loc.concat(".ρ")))
+                    .findFirst()
+                    .ifPresent(kid -> found.put(loc, kid));
             }
         }
         return found;
+    }
+
+    private static Stream<Xnav> bare(final Xnav owner) {
+        return owner.elements(
+            Filter.all(Filter.withName("o"), Filter.not(Filter.hasAttribute("as")))
+        );
     }
 
     private Collection<XML> matching(final String xpath) throws IOException {

--- a/eo-inference/src/test/java/org/eolang/inference/KeptTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/KeptTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.matchers.XhtmlMatchers;
 import com.jcabi.xml.XMLDocument;
 import org.hamcrest.MatcherAssert;
@@ -25,9 +26,11 @@ final class KeptTest {
                 new Xembler(
                     new Directives().add("type").append(
                         new Kept(
-                            new XMLDocument(
-                                "<links><type id='a'><union k='1'><data/></union></type></links>"
-                            ).nodes("/links/type").get(0)
+                            new Xnav(
+                                new XMLDocument(
+                                    "<links><type id='a'><union k='1'><data/></union></type></links>"
+                                ).inner()
+                            ).element("links").element("type")
                         ).directives()
                     )
                 ).domQuietly()

--- a/eo-inference/src/test/java/org/eolang/inference/NotedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/NotedTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Noted}.
+ * @since 0.71.0
+ */
+final class NotedTest {
+
+    @Test
+    void readsWhatANodeSays() {
+        MatcherAssert.assertThat(
+            "the locator written on the node must come back, but it didnt",
+            new Noted(
+                new Xnav(
+                    new XMLDocument("<o loc='Φ.ω.k' name='next'/>").inner()
+                ).element("o")
+            ).says("loc"),
+            Matchers.equalTo("Φ.ω.k")
+        );
+    }
+
+    @Test
+    void saysNothingAboutAnAttributeNobodyWrote() {
+        MatcherAssert.assertThat(
+            "an attribute that is not there must come back empty, but it didnt",
+            new Noted(
+                new Xnav(
+                    new XMLDocument("<o loc='Φ.j'/>").inner()
+                ).element("o")
+            ).says("base"),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void readsWhatANodeOfADocumentSays() {
+        MatcherAssert.assertThat(
+            "the name written on a node found in a document must come back, but it didnt",
+            new Noted(
+                new XMLDocument("<object><o name='ζ'/></object>").nodes("/object/o").get(0)
+            ).says("name"),
+            Matchers.equalTo("ζ")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/RowsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/RowsTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.stream.Collectors;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Rows}.
+ * @since 0.71.0
+ */
+final class RowsTest {
+
+    @Test
+    void walksEveryRowOfATable() {
+        MatcherAssert.assertThat(
+            "every row of the table must come back in the order it was written, but it didnt",
+            new Rows(
+                new XMLDocument("<links><type id='Φ.q'/><type id='Φ.ω'/></links>")
+            ).all().stream().map(row -> new Noted(row).says("id")).collect(Collectors.toList()),
+            Matchers.contains("Φ.q", "Φ.ω")
+        );
+    }
+
+    @Test
+    void passesOverWhatIsNoRow() {
+        MatcherAssert.assertThat(
+            "an element that is not a type must be passed over, but it wasnt",
+            new Rows(
+                new XMLDocument("<provides><type id='Φ.k'/><told when='7'/></provides>")
+            ).all(),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void findsNothingInAnEmptyTable() {
+        MatcherAssert.assertThat(
+            "a table with no rows must come back with nothing, but it didnt",
+            new Rows(new XMLDocument("<needs/>")).all(),
+            Matchers.empty()
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/SiteTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/SiteTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Site}.
+ * @since 0.71.0
+ */
+final class SiteTest {
+
+    @Test
+    void tellsWhereItIsWritten() {
+        MatcherAssert.assertThat(
+            "the locator of the dispatch must come back, but it didnt",
+            new Site(
+                new Xnav(
+                    new XMLDocument("<o base='.plus' loc='Φ.ω.k'/>").inner()
+                ).element("o")
+            ).made(),
+            Matchers.equalTo("Φ.ω.k")
+        );
+    }
+
+    @Test
+    void tellsWhichNameItTakes() {
+        MatcherAssert.assertThat(
+            "the name must come back without the dot that says it is a dispatch, but it didnt",
+            new Site(
+                new Xnav(
+                    new XMLDocument("<o base='.eq' loc='Φ.j'/>").inner()
+                ).element("o")
+            ).name(),
+            Matchers.equalTo("eq")
+        );
+    }
+
+    @Test
+    void takesItsNameFromTheChildThatIsNoArgument() {
+        MatcherAssert.assertThat(
+            "the object the name is taken from must be the child with no place, but it wasnt",
+            new Site(
+                new Xnav(
+                    new XMLDocument(
+                        String.join(
+                            "",
+                            "<o base='.pow' loc='Φ.q'>",
+                            "<o as='α0' loc='Φ.q.α0'/>",
+                            "<o loc='Φ.q.ρ'/>",
+                            "</o>"
+                        )
+                    ).inner()
+                ).element("o")
+            ).bearer(),
+            Matchers.equalTo("Φ.q.ρ")
+        );
+    }
+}


### PR DESCRIPTION
The checker asked its questions of whole documents. An XPath over the ten-megabyte links table costs about four seconds whether one row comes back or forty thousand do, because the document is looked through either way, and a per-node XPath costs some seventy microseconds — against thirty-seven thousand objects, on every pass of the fixed point. That, and nothing else, is where the time went.

So the rules now walk each table once and read the attributes off the node they are standing on. Three small classes carry that: `Noted` is the one way an attribute is read, `Rows` the one way a table is walked, `Site` the one way a dispatch is asked where it is written and which name it takes.

```java
String says(final String attribute) {
    return this.node.attribute(attribute).text().orElse("");
}
```

`Pairs` keeps its place as the only reader of `links.xml`, and it now memoizes the walk, since every question it answers is about all the rows anyway. The HTML report got the same treatment: `Page` counted its lines with four document-wide queries and now makes one pass.

Measured on the eo-runtime corpus — 160 prepared XMIR files, 9.1 MB, 37,212 objects:

| | before | after |
| --- | --- | --- |
| inference chain | 127.4 s | 5.9 s |
| HTML report | 28.2 s | 2.9 s |

The tables and the pages come out byte-identical to what master produces, coverage is unchanged at 77.0% named / 15.2% rooted / 7.8% blank with depth 64.2%, and 80 unit tests pass.

What is left is library work — DOM parsing, building the Tojos rows, and serialising through Xembler and XSL — not XPath, so I stopped here.

Closes #7836
