### PR TITLE
#8147: read the group too before taking the runtime out

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithoutRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithoutRuntime.java
@@ -5,6 +5,7 @@
 package org.eolang.maven;
 
 import java.util.Iterator;
+import org.apache.maven.model.Dependency;
 import org.cactoos.iterator.Filtered;
 
 /**
@@ -30,8 +31,25 @@ final class DpsWithoutRuntime implements Dependencies {
     @Override
     public Iterator<Dep> iterator() {
         return new Filtered<>(
-            dep -> !"eo-runtime".equals(dep.get().getArtifactId()),
+            dep -> !DpsWithoutRuntime.isRuntime(dep.get()),
             this.delegate.iterator()
         );
+    }
+
+    /**
+     * Whether this dependency is the EO runtime.
+     *
+     * <p>An artifact id is not unique in Maven, so the group has to be read
+     * too: a dependency of somebody else named {@code eo-runtime} is not the
+     * runtime this class removes, and dropping it would change the classpath
+     * of a build that asked for nothing of the sort (#8147). This is the same
+     * pair {@code DpsWithRuntime} decides by.</p>
+     *
+     * @param dep The dependency
+     * @return True when it is the EO runtime
+     */
+    private static boolean isRuntime(final Dependency dep) {
+        return "org.eolang".equals(dep.getGroupId())
+            && "eo-runtime".equals(dep.getArtifactId());
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithoutRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithoutRuntime.java
@@ -36,18 +36,11 @@ final class DpsWithoutRuntime implements Dependencies {
         );
     }
 
-    /**
-     * Whether this dependency is the EO runtime.
-     *
-     * <p>An artifact id is not unique in Maven, so the group has to be read
-     * too: a dependency of somebody else named {@code eo-runtime} is not the
-     * runtime this class removes, and dropping it would change the classpath
-     * of a build that asked for nothing of the sort (#8147). This is the same
-     * pair {@code DpsWithRuntime} decides by.</p>
-     *
-     * @param dep The dependency
-     * @return True when it is the EO runtime
-     */
+    // An artifact id is not unique in Maven, so the group has to be read
+    // too: a dependency of somebody else named "eo-runtime" is not the
+    // runtime this class removes, and dropping it would change the classpath
+    // of a build that asked for nothing of the sort (#8147). This is the
+    // same pair DpsWithRuntime decides by.
     private static boolean isRuntime(final Dependency dep) {
         return "org.eolang".equals(dep.getGroupId())
             && "eo-runtime".equals(dep.getArtifactId());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DpsWithoutRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DpsWithoutRuntimeTest.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link DpsWithoutRuntime}.
+ * @since 0.29
+ */
+final class DpsWithoutRuntimeTest {
+
+    @Test
+    void removesTheRuntimeOfEo() {
+        MatcherAssert.assertThat(
+            "the EO runtime must be taken out of the list, but it wasnt",
+            new DpsWithoutRuntime(
+                () -> new ListOf<>(
+                    new Dep()
+                        .withGroupId("org.eolang")
+                        .withArtifactId("eo-runtime")
+                        .withVersion("0.30.0")
+                ).iterator()
+            ),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void keepsTheRuntimeOfSomebodyElse() {
+        MatcherAssert.assertThat(
+            "a dependency of another group named eo-runtime must stay, but it didnt",
+            new DpsWithoutRuntime(
+                () -> new ListOf<>(
+                    new Dep()
+                        .withGroupId("com.example")
+                        .withArtifactId("eo-runtime")
+                        .withVersion("1.0.0")
+                ).iterator()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+}


### PR DESCRIPTION
`DpsWithoutRuntime` filtered on the artifact id alone, so a dependency of
another group that happens to be named `eo-runtime` was removed together with
the EO one. Artifact ids are not unique in Maven, and `DpsWithRuntime` already
decides by the pair `org.eolang:eo-runtime`, so this one does too now.

The new test keeps `com.example:eo-runtime` in the list and drops
`org.eolang:eo-runtime`; the second one fails on master as it is.

Closes #8147
