### PR TITLE
#8148: let a classifier of the runtime not stand in for the runtime

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithRuntime.java
@@ -72,8 +72,22 @@ final class DpsWithRuntime implements Dependencies {
         return all.iterator();
     }
 
+    /**
+     * Whether this dependency is the runtime the transpiled Java compiles
+     * against.
+     *
+     * <p>A classifier names a different artifact of the same coordinates, so
+     * {@code org.eolang:eo-runtime:tests} carries none of the classes the
+     * generated code imports. Reading it as the runtime would leave the main
+     * jar out of the build for anybody who asks for a classifier beside it
+     * (#8148), so only the unclassified one counts.</p>
+     *
+     * @param other The dependency
+     * @return True when it is the EO runtime
+     */
     private static boolean isRuntime(final Dependency other) {
         return "org.eolang".equals(other.getGroupId())
-            && "eo-runtime".equals(other.getArtifactId());
+            && "eo-runtime".equals(other.getArtifactId())
+            && (other.getClassifier() == null || other.getClassifier().isEmpty());
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithRuntime.java
@@ -72,19 +72,11 @@ final class DpsWithRuntime implements Dependencies {
         return all.iterator();
     }
 
-    /**
-     * Whether this dependency is the runtime the transpiled Java compiles
-     * against.
-     *
-     * <p>A classifier names a different artifact of the same coordinates, so
-     * {@code org.eolang:eo-runtime:tests} carries none of the classes the
-     * generated code imports. Reading it as the runtime would leave the main
-     * jar out of the build for anybody who asks for a classifier beside it
-     * (#8148), so only the unclassified one counts.</p>
-     *
-     * @param other The dependency
-     * @return True when it is the EO runtime
-     */
+    // A classifier names a different artifact of the same coordinates, so
+    // "org.eolang:eo-runtime:tests" carries none of the classes the generated
+    // code imports. Reading it as the runtime would leave the main jar out of
+    // the build for anybody who asks for a classifier beside it (#8148), so
+    // only the unclassified one counts.
     private static boolean isRuntime(final Dependency other) {
         return "org.eolang".equals(other.getGroupId())
             && "eo-runtime".equals(other.getArtifactId())

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DpsWithRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DpsWithRuntimeTest.java
@@ -98,4 +98,22 @@ final class DpsWithRuntimeTest {
             )
         );
     }
+
+    @Test
+    void addsTheRuntimeBesideAClassifierOfIt() {
+        MatcherAssert.assertThat(
+            "a classifier of the runtime must not stand in for the runtime itself, but it did",
+            new DpsWithRuntime(
+                new ListOf<>(
+                    new Dep()
+                        .withGroupId("org.eolang")
+                        .withArtifactId("eo-runtime")
+                        .withVersion("0.30.0")
+                        .withClassifier("tests")
+                ),
+                Dependencies.Fake.runtimeDep()
+            ),
+            Matchers.iterableWithSize(2)
+        );
+    }
 }


### PR DESCRIPTION
`isRuntime` read the group and the artifact and nothing else, so a `+rt jvm`
naming `org.eolang:eo-runtime:tests` was taken for the runtime itself and the
main jar was never added. A classifier is a different artifact and carries
none of the classes the generated Java imports.

The new test asks for the runtime beside its `tests` classifier and expects
both; it fails on master as it is.

Closes #8148
