### PR TITLE
#8146: fail the clean goal when the directory stays

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Deleted.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Deleted.java
@@ -32,16 +32,21 @@ final class Deleted implements Supplier<Boolean> {
         return this.purge(this.target);
     }
 
+    // The answer of a child is the answer of the parent too: a directory that
+    // still holds a file nobody could delete is not deleted either, and the
+    // caller has to hear about it instead of reading a clean build that kept
+    // the files of the previous one (#8146).
     private boolean purge(final File dir) {
+        boolean state = true;
         if (dir.isDirectory()) {
             final File[] contents = dir.listFiles();
             if (null != contents) {
                 for (final File file : contents) {
-                    this.purge(file);
+                    state &= this.purge(file);
                 }
             }
         }
-        final boolean state = dir.delete();
+        state &= dir.delete();
         if (state) {
             Logger.debug(this, "The file or directory %[file]s purged", dir);
         }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjClean.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjClean.java
@@ -46,6 +46,13 @@ public class MjClean extends MjSafe {
                 "Deleted all files in the %[file]s directory",
                 this.targetDir
             );
+        } else {
+            throw new IllegalStateException(
+                String.format(
+                    "Failed to delete the directory %s, some files are still there",
+                    this.targetDir
+                )
+            );
         }
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjCleanTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjCleanTest.java
@@ -10,11 +10,15 @@ import com.yegor256.WeAreOnline;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import org.apache.maven.model.Dependency;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,6 +47,37 @@ final class MjCleanTest {
             !file.toFile().exists() && !small.toFile().exists(),
             Matchers.is(true)
         );
+    }
+
+    @Test
+    void complainsWhenTheDirectoryStays(@Mktmp final Path temp) throws IOException {
+        final Path dir = Files.createDirectories(temp.resolve("target"));
+        final Path kept = Files.createDirectories(dir.resolve("kept"));
+        Files.writeString(kept.resolve("stale.eo"), "# nothing");
+        try {
+            Files.setPosixFilePermissions(kept, Set.of(PosixFilePermission.OWNER_READ));
+        } catch (final UnsupportedOperationException ex) {
+            Assumptions.abort("this file system has no POSIX permissions");
+        }
+        Assumptions.assumeFalse(
+            Files.isWritable(kept), "this user deletes whatever the permissions say"
+        );
+        try {
+            Assertions.assertThrows(
+                Exception.class,
+                () -> new FakeMaven(temp).with("targetDir", dir.toFile()).execute(MjClean.class),
+                "a directory that could not be deleted must not pass for a clean one"
+            );
+        } finally {
+            Files.setPosixFilePermissions(
+                kept,
+                Set.of(
+                    PosixFilePermission.OWNER_READ,
+                    PosixFilePermission.OWNER_WRITE,
+                    PosixFilePermission.OWNER_EXECUTE
+                )
+            );
+        }
     }
 
     @Test


### PR DESCRIPTION
`MjClean` logged a line when the deletion answered `true` and did nothing at
all when it answered `false`, so a locked or unreadable file left the build
with a clean-looking `eo:clean` and the stale XMIR of the previous run still
in place. It throws now, naming the directory.

`Deleted.purge` also threw away the answer of every child, so a file nobody
could delete deep in the tree never reached the caller. The answer of a child
is the answer of the parent now.

The new test makes a directory the user cannot write to, runs the goal and
expects it to complain; it fails on master as it is.

Closes #8146
