### PR TITLE
#7489: answer a zero mantissa before the scale is applied

### DIFF
--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -106,15 +106,16 @@
       mantissa.length.minus > places
         dot.plus 1
       if. > [^ value power] > raised
-        and.
+        ^.scalable value
+        if.
           power.gt 200
-          ^.scalable value
-        ^.raised
+          ^.raised
+            value.times
+              10.power 200
+            power.minus 200
           value.times
-            10.power 200
-          power.minus 200
-        value.times
-          10.power power
+            10.power power
+        value
       and. > [value] > scalable
         not.
           value.eq 0
@@ -497,6 +498,11 @@
     "00009223372036854775808"
 
   "%l".scanf "error" --> stops-on-a-wrong-format
+
+  eq. ++> can-scan-a-zero-mantissa-with-an-out-of-range-exponent
+    0
+    head.
+      "%f".scanf "0e309"
 
   eq. ++> can-scan-a-float-in-scientific-notation
     1000


### PR DESCRIPTION
`raised` guarded only its recursion with `scalable`, so a zero mantissa failed
that guard on the first call and fell through to the unguarded last step. With
an exponent past 308 that step is `0 * Infinity`, which is `nan`, so
`"%f".scanf "0e309"` answered `nan` instead of `0`.

The guard now decides whether to scale at all: a value that cannot be moved is
answered as it is, and only a scalable one goes on to the step or the recursion.

Verified in a sandbox program on the released plugin: `"%f".scanf "0e309"` is
`nan` before the change and `0` after it. The EO test added to `scanf.eo`
covers the same input.

Closes #7489
