### PR TITLE
#8064: refuse a tab in a bytes continuation

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/BytesIndent.java
+++ b/eo-parser/src/main/java/org/eolang/parser/BytesIndent.java
@@ -7,10 +7,10 @@ package org.eolang.parser;
 /**
  * What is wrong with the indent of one line of a multi-line bytes literal.
  *
- * <p>A continuation must not de-indent below the line that opened the
- * literal, must not sit on an odd indent (R-2.2.1), and must not jump more
- * than one level deeper than the line above it, which is the same rule
- * every other block line obeys.</p>
+ * <p>A continuation is indented with spaces, must not de-indent below the
+ * line that opened the literal, must not sit on an odd indent (R-2.2.1), and
+ * must not jump more than one level deeper than the line above it, which is
+ * the same rule every other block line obeys.</p>
  *
  * @since 0.1
  */
@@ -61,6 +61,10 @@ final class BytesIndent {
         final String found;
         if (this.line.blank()) {
             found = "";
+        } else if (this.line.tab()) {
+            found = Eo.TAB;
+        } else if (this.line.alien()) {
+            found = Eo.ALIEN;
         } else if (this.line.indent() < this.head) {
             found = "multi-line bytes continuation must not de-indent";
         } else if (this.line.indent() % 2 == 1) {

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -37,6 +37,16 @@ final class Eo implements Iterable<Directive> {
     private static final String TRAILING = "trailing whitespace at end of line";
 
     /**
+     * What a line indented with a tab is told, wherever it is written.
+     */
+    static final String TAB = "tab character in leading whitespace";
+
+    /**
+     * What a line indented with neither a space nor a tab is told.
+     */
+    static final String ALIEN = "invalid character in leading whitespace";
+
+    /**
      * Raw EO source text.
      */
     private final String source;
@@ -257,10 +267,10 @@ final class Eo implements Iterable<Directive> {
         if (globals.inTextBlock()) {
             Eo.continueTextBlock(span, stack, globals, emit);
         } else if (span.tab() && !span.blank()) {
-            emit.error(span.line(), 0, "tab character in leading whitespace");
+            emit.error(span.line(), 0, Eo.TAB);
             failed = true;
         } else if (span.alien() && !span.blank()) {
-            emit.error(span.line(), 0, "invalid character in leading whitespace");
+            emit.error(span.line(), 0, Eo.ALIEN);
             failed = true;
         } else if (!span.blank() && span.indent() % 2 == 1) {
             emit.error(span.line(), 0, "unexpected odd indent");

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -32,11 +32,6 @@ import org.xembly.Directive;
 final class Eo implements Iterable<Directive> {
 
     /**
-     * What a line with a space at its end is told, wherever it is written.
-     */
-    private static final String TRAILING = "trailing whitespace at end of line";
-
-    /**
      * What a line indented with a tab is told, wherever it is written.
      */
     static final String TAB = "tab character in leading whitespace";
@@ -45,6 +40,11 @@ final class Eo implements Iterable<Directive> {
      * What a line indented with neither a space nor a tab is told.
      */
     static final String ALIEN = "invalid character in leading whitespace";
+
+    /**
+     * What a line with a space at its end is told, wherever it is written.
+     */
+    private static final String TRAILING = "trailing whitespace at end of line";
 
     /**
      * Raw EO source text.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tab-in-a-bytes-continuation-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/tab-in-a-bytes-continuation-is-rejected.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'tab character in leading whitespace')]
+input: "[] > app\n  CA-FE-\n\t\t\t\tBE-BE\n"


### PR DESCRIPTION
`Eo.mergeBytesContinuation` delegates its continuation checks to `BytesIndent`, which looked at the numeric indent and its parity but never at `Span.tab()` or `Span.alien()`. Four tabs counted as an even indent of four and were accepted, while the same tabs on an ordinary line are reported.

`BytesIndent` now asks those two questions first, with the same wording the ordinary path uses. The two messages moved into constants next to the existing `TRAILING` one, so there is a single copy of each.

Closes #8064
