### PR TITLE
#8065: refuse trailing whitespace on a bytes continuation

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -188,6 +188,11 @@ final class Eo implements Iterable<Directive> {
         while (idx < spans.size()) {
             final Span next = spans.get(idx);
             final String trimmed = next.body().stripTrailing();
+            if (next.trailing()) {
+                emit.error(next.line(), 0, Eo.TRAILING);
+                broken = true;
+                break;
+            }
             if (new BytesIndent(next, head.indent(), above).reported(emit)) {
                 broken = true;
                 break;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/trailing-space-on-a-bytes-continuation-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/trailing-space-on-a-bytes-continuation-is-rejected.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'trailing whitespace at end of line')]
+input: "[] > app\n  CA-FE-\n  BE-BE \n"


### PR DESCRIPTION
The opener of a multi-line bytes literal is already guarded by `!span.trailing()` in the dispatch loop, so a space at its end reaches the ordinary path and is reported. A continuation line was not: `mergeBytesContinuation` called `stripTrailing()` before validating it, so the character was gone before any diagnostic could see it.

The continuation is now checked first, with the same `TRAILING` message every other line gets.

Closes #8065
