### PR TITLE
#8066: name a source with URL separators on every platform

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Report.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Report.java
@@ -118,7 +118,7 @@ public final class Report {
     }
 
     private String named(final Path file) {
-        final String path = this.world.relativize(file).toString();
+        final String path = this.world.relativize(file).toString().replace('\\', '/');
         return path.substring(0, path.length() - ".xmir".length()).concat(".eo");
     }
 

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -65,6 +65,21 @@ final class ReportTest {
     }
 
     @Test
+    void linksANestedPageWithUrlSeparators(@Mktmp final Path temp) throws IOException {
+        final Path xmirs = ReportTest.program(temp);
+        Files.move(
+            xmirs.resolve("cup.xmir"),
+            Files.createDirectories(xmirs.resolve("deep")).resolve("cup.xmir")
+        );
+        new Report(xmirs, ReportTest.tables(temp)).written(temp.resolve("out"));
+        MatcherAssert.assertThat(
+            "a nested page must be linked with URL separators, but it wasnt",
+            Files.readString(temp.resolve("out").resolve("index.html")),
+            Matchers.containsString("deep/cup.eo.html")
+        );
+    }
+
+    @Test
     void writesAnIndexForAnEmptyProgram(@Mktmp final Path temp) throws IOException {
         final Path xmirs = Files.createDirectories(temp.resolve("xmirs"));
         final Path tables = temp.resolve("tables");


### PR DESCRIPTION
`Report.named()` handed the platform-native `Path.toString()` straight on as a web path, so on Windows a nested source became `nested\sample.eo`. Everything below it looks for `/`: `rooted()` splits on it and computed an empty `root` instead of `../`, `listed()` takes `lastIndexOf('/')` and put the page in the report root, and the `href` carried backslashes.

`named()` is the one place where a filesystem path turns into a name, so normalizing there fixes all three consumers.

Closes #8066

The added test moves the source into a subdirectory and asserts the index links it with `/`. On Linux it passes either way, since `relativize` never produces a backslash there; it has teeth on the Windows leg of CI, which is where the bug lives.
