### PR TITLE
#8025: say that the receiver may stand anywhere

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -13,8 +13,9 @@ import java.util.List;
  * <p>Form: {@code [params] [> name [/sig]]}. Each parameter becomes a
  * void child (R-3.4.1). The standalone {@code @} parameter maps to
  * {@code φ} in XMIR (R-3.4.2 / R-9.3). The standalone {@code ^} maps to
- * {@code ρ} and declares the formation's receiver, which only the first
- * parameter may be (R-3.4.3 / R-3.4.11). No leading/trailing space inside the
+ * {@code ρ} and declares the formation's receiver; its position among the
+ * parameters is free, since a dispatch resolves the receiver by name rather
+ * than by position (R-3.4.3 / R-3.4.11). No leading/trailing space inside the
  * brackets (R-3.4.4); exactly one space between parameter names
  * (R-3.4.5). The line may carry an optional name suffix per §3.10,
  * including the atom-signature form {@code > name /sig}. The shorthand


### PR DESCRIPTION
The class javadoc said the receiver "only the first parameter may be" and pointed at R-3.4.3 and R-3.4.11, which both say the opposite: the position is free. `mapParam` checks nothing about position, and `LnFormationTest.emitsRhoForALaterParameter` already pins `[x ^] > foo` emitting `ρ` in second place. The sentence was the last place the rule removed by #7212 survived.

The issue also mentions `LnVoid`, but it was corrected already and now reads the way R-3.4.11 does, so this touches only `LnFormation`.

Closes #8025
