### PR TITLE
Mark every step of a dispatch chain in the inference report

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Pieces.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pieces.java
@@ -30,12 +30,15 @@ import org.xembly.Directives;
  *
  * <p>A chain of dispatches is the awkward case. {@code first.as-bytes.size}
  * is three objects and the XMIR gives all three the same column, because each
- * one is written where the chain ends rather than where it begins. So a chain
+ * one is written where the chain ends rather than where it begins. So a group
  * is walked leftward instead: the outermost keeps the column it was given, and
- * every receiver behind it takes the word before. A group of objects that is
- * not such a chain stays where it was put and shares one mark, which is right
+ * every object that is the receiver ({@code ρ}) of the one before it takes the
+ * word before, back to the {@code ^} a chain is often taken off. Anything else
+ * stays where the one before it was put and shares its mark, which is right
  * for a literal and the bytes it carries — to a reader those are one thing
- * written once.</p>
+ * written once — and right for a step whose own receiver the source never
+ * wrote, such as the {@code dataized} that a trailing {@code !} slips into the
+ * middle of a chain, since a reader has no word to hang it on.</p>
  *
  * @since 0.70.0
  */
@@ -96,13 +99,7 @@ final class Pieces {
     private Map<Integer, Collection<Written>> laid() {
         final Map<Integer, Collection<Written>> found = new LinkedHashMap<>(0);
         for (final Map.Entry<Integer, Collection<Written>> group : this.grouped().entrySet()) {
-            final List<Written> chain = Pieces.chained(group.getValue());
-            if (chain.isEmpty()) {
-                found.computeIfAbsent(group.getKey(), key -> new ArrayList<>(1))
-                    .addAll(group.getValue());
-            } else {
-                this.walked(found, group.getKey(), chain);
-            }
+            this.walked(found, group.getKey(), Pieces.sorted(group.getValue()));
         }
         return found;
     }
@@ -120,26 +117,30 @@ final class Pieces {
     private void walked(
         final Map<Integer, Collection<Written>> found,
         final int column,
-        final Iterable<Written> chain
+        final List<Written> chain
     ) {
         int place = column;
-        for (final Written link : chain) {
-            if (place < 0) {
-                break;
+        for (int step = 0; step < chain.size(); step = step + 1) {
+            final Written link = chain.get(step);
+            if (step > 0 && link.loc().equals(chain.get(step - 1).loc().concat(".ρ"))) {
+                place = this.leftward(place);
             }
             found.computeIfAbsent(place, key -> new ArrayList<>(1)).add(link.moved(place));
-            place = this.leftward(place);
         }
     }
 
     private int leftward(final int column) {
-        int start = Math.min(column, this.line.length());
+        final int edge = Math.min(column, this.line.length());
+        int start = edge;
         while (start > 0 && Pieces.wordy(this.line.charAt(start - 1))) {
             start = start - 1;
         }
+        if (start == edge && start > 0 && this.line.charAt(start - 1) == '^') {
+            start = start - 1;
+        }
         final int found;
-        if (start == Math.min(column, this.line.length())) {
-            found = -1;
+        if (start == edge) {
+            found = column;
         } else {
             if (start > 0 && this.line.charAt(start - 1) == '.') {
                 start = start - 1;
@@ -149,23 +150,13 @@ final class Pieces {
         return found;
     }
 
-    private static List<Written> chained(final Collection<Written> group) {
-        final List<Written> sorted = new ArrayList<>(group);
-        sorted.sort(
+    private static List<Written> sorted(final Collection<Written> group) {
+        final List<Written> found = new ArrayList<>(group);
+        found.sort(
             (first, second) -> Integer.compare(
                 Pieces.hops(first.loc()), Pieces.hops(second.loc())
             )
         );
-        boolean linked = sorted.size() > 1;
-        for (int step = 0; linked && step < sorted.size() - 1; step = step + 1) {
-            linked = sorted.get(step + 1).loc().equals(sorted.get(step).loc().concat(".ρ"));
-        }
-        final List<Written> found;
-        if (linked) {
-            found = sorted;
-        } else {
-            found = Collections.emptyList();
-        }
         return found;
     }
 

--- a/eo-inference/src/main/java/org/eolang/inference/Reach.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Reach.java
@@ -17,8 +17,10 @@ package org.eolang.inference;
  * the first character that cannot be part of one. A literal number carries its
  * digits, its hex letters, its sign and one decimal point. A string runs to
  * its closing quote, and a backslash inside it takes the next character with
- * it, so that {@code "a\"b"} is one string and not two. Anything else is one
- * character, which is the honest answer for a glyph nobody taught this
+ * it, so that {@code "a\"b"} is one string and not two. A dispatch takes its
+ * dot along with what follows it, be that a name or the {@code ^} of
+ * {@code .^}, since a dot alone marks nothing a reader can read. Anything else
+ * is one character, which is the honest answer for a glyph nobody taught this
  * about.</p>
  *
  * @since 0.70.0
@@ -63,7 +65,8 @@ final class Reach {
             found = this.numbered(column);
         } else if (Character.isLetterOrDigit(head) || head == '_') {
             found = this.named(column);
-        } else if (head == '.' && Character.isLetterOrDigit(this.after(column))) {
+        } else if (head == '.'
+            && (Character.isLetterOrDigit(this.after(column)) || this.after(column) == '^')) {
             found = 1 + this.from(column + 1);
         } else {
             found = 1;

--- a/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
@@ -40,6 +40,60 @@ final class PiecesTest {
     }
 
     @Test
+    void marksTheCaretAChainIsDispatchedOn() {
+        MatcherAssert.assertThat(
+            "the caret a walk is taken off must get a word of its own, but it stayed bare",
+            PiecesTest.drawn(
+                "  ^.walk",
+                Arrays.asList(
+                    new Written("Φ.w.α1", 3, "", new Answer("Φ.number", 3)),
+                    new Written("Φ.w.α1.ρ", 3, "ρ", new Answer("Φ.string", 3))
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/line/bit[text='^']/told[@where='Φ.string']",
+                "/line/bit[text='.walk']/told[@where='Φ.number']"
+            )
+        );
+    }
+
+    @Test
+    void marksADispatchTakenOffTheCaret() {
+        MatcherAssert.assertThat(
+            "the step .^ must carry its dot into the mark, but the dot was marked alone",
+            PiecesTest.drawn(
+                "* ^.^",
+                Arrays.asList(
+                    new Written("Φ.t.α1", 3, "", new Answer("Φ.number", 3)),
+                    new Written("Φ.t.α1.ρ", 3, "ρ", new Answer("Φ.string", 3))
+                )
+            ),
+            XhtmlMatchers.hasXPath("/line/bit[text='.^']/told[@where='Φ.number']")
+        );
+    }
+
+    @Test
+    void walksPastAStepTheSourceNeverWrote() {
+        MatcherAssert.assertThat(
+            "the steps above an unwritten one must keep their own words, but they piled onto one",
+            PiecesTest.drawn(
+                "    precise.as-bool.if > end!",
+                Arrays.asList(
+                    new Written("Φ.p.end", 19, "end", new Answer("Φ.bytes.as-bytes", 3)),
+                    new Written("Φ.p.end.ρ.α0", 19, "", new Answer("Φ.bool.if", 1)),
+                    new Written("Φ.p.end.ρ.α0.ρ", 19, "", new Answer("Φ.bytes.as-bool", 3)),
+                    new Written("Φ.p.end.ρ.α0.ρ.ρ", 19, "", new Answer("Φ.string", 3))
+                )
+            ),
+            XhtmlMatchers.hasXPaths(
+                "/line/bit[text='precise']/told[@where='Φ.string']",
+                "/line/bit[text='.as-bool']/told[@where='Φ.bytes.as-bool']",
+                "/line/bit[text='.if']/told[@label='end']"
+            )
+        );
+    }
+
+    @Test
     void keepsTextThatNoObjectClaims() {
         MatcherAssert.assertThat(
             "the brackets around a void are the author's text and must survive, but they didnt",

--- a/eo-inference/src/test/java/org/eolang/inference/ReachTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReachTest.java
@@ -69,6 +69,15 @@ final class ReachTest {
     }
 
     @Test
+    void keepsADispatchOfTheCaretWithItsDot() {
+        MatcherAssert.assertThat(
+            "the dispatch .^ is two characters counting its dot, but it wasnt",
+            new Reach("* ^.^").from(3),
+            Matchers.equalTo(2)
+        );
+    }
+
+    @Test
     void measuresNothingPastTheEndOfTheLine() {
         MatcherAssert.assertThat(
             "a column beyond the line cannot reach anything, but it claimed to",


### PR DESCRIPTION
Closes #8208.

A chain of dispatches gets one column for all of its objects, since each is written where the chain ends, so `Pieces` walks the group leftward and hands every link the word before. Two things made it give up half way. It only walked back over characters a name is made of, so a `^` looked like the start of the line and the rest of the chain was dropped; and it asked for the whole group to be a chain before walking any of it, which a trailing `!` breaks by slipping an unwritten `dataized` into the middle.

The walk now decides one step at a time and never throws a link away:

```java
final Written link = chain.get(step);
if (step > 0 && link.loc().equals(chain.get(step - 1).loc().concat(".ρ"))) {
    place = this.leftward(place);
}
found.computeIfAbsent(place, key -> new ArrayList<>(1)).add(link.moved(place));
```

A link that is the receiver of the one before it takes the word to the left, and anything else shares the word where it stands, which is what a reader wants for a literal and its bytes, or for a step whose own receiver was never typed. `leftward` treats a lone `^` as a word of one glyph, and `Reach` carries a dot into a following `^` the way it already carries one into a name, so `.^` is marked whole.

Three lines of `string/printf.eo` that the report used to mark badly now come out right: `^.walk` marks the caret and the dispatch apart, `precise.as-bool.if > end!` marks all three steps, and `* ^.^` marks `.^` rather than the dot alone.

One thing this leaves alone: a mark shared by several objects takes its colour from the first answer in it, so on that `end!` line a green `end` still hides the amber `.if` beside it. Taking the worst rung instead would be more honest, and is worth its own ticket.
