### PR TITLE
Preserve EEXIST from an exclusive file touch

### DIFF
--- a/eo-runtime/src/main/eo/file/touched.eo
+++ b/eo-runtime/src/main/eo/file/touched.eo
@@ -8,17 +8,6 @@
 # whether or not its target exists; the exclusivity that guards the
 # plain-file race stays for every other path, and win32 keeps its exclusive
 # open unconditionally, since its reparse points do not share that rule.
-#
-# @todo #7077:60min Add a synchronization-based regression test that creates
-#  the target file between the exists() probe and the exclusive open below,
-#  so the race this fixes is actually exercised. A single-threaded EO `++>`
-#  test can't trigger it: `^.exists.if` always sees a consistent snapshot in
-#  one thread. It needs a JUnit test against the generated `EOtouched` class
-#  (see PhDefaultRaceTest.java for the com.yegor256.Together idiom this repo
-#  already uses for exactly this kind of interleaving), with one thread
-#  paused right after the exists() probe while another thread creates and
-#  writes to the file, then confirms the paused thread's touched() does not
-#  truncate it.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -33,8 +22,9 @@
     if.
       or.
         descriptor.gte 0
-        linked.not.and
+        and.
           errno.eq eexist
+          linked.not
       seq *
         if.
           descriptor.gte 0

--- a/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import com.yegor256.Together;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Test case for {@code file.touched} under concurrency.
+ *
+ * <p>One caller creates and writes the file while the other callers touch the
+ * same path. A losing exclusive open returns {@code EEXIST}; it must be
+ * treated as a successful touch rather than as a failure from a later syscall
+ * that overwrote {@code errno} (#7077).</p>
+ *
+ * @since 0.75.0
+ */
+final class EOfileEOtouchedTest {
+
+    @RepeatedTest(20)
+    void keepsWhatAnotherThreadWroteInBetween(@TempDir final Path temp)
+        throws Exception {
+        final Path target = temp.resolve("shared.txt");
+        new Together<>(
+            8,
+            thread -> {
+                if (thread == 0) {
+                    Files.writeString(target, "content", StandardCharsets.UTF_8);
+                } else {
+                    new Dataized(this.touched(target)).take();
+                }
+                return target;
+            }
+        ).asList();
+        MatcherAssert.assertThat(
+            "a touch that loses the creation race must not erase the other writer's data",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("content")
+        );
+    }
+
+    private Phi touched(final Path target) {
+        final Phi file = Phi.Φ.take("file").copy();
+        file.put(0, new Data.ToPhi(target.toString()));
+        return file.take("touched");
+    }
+}


### PR DESCRIPTION
Closes #7077

## What changes

- [Read `errno` before probing the path again](https://github.com/gemshrine/eo/blob/7077-fix-file-touched-race/eo-runtime/src/main/eo/file/touched.eo#L22-L45), preserving the error produced by the exclusive `open`.
- Add [a concurrent regression test](https://github.com/gemshrine/eo/blob/7077-fix-file-touched-race/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java) where one caller writes the file and seven others touch it.
- Remove the fulfilled `@todo #7077` from `file.touched`.

## Why

The [failing branch on `master`](https://github.com/objectionary/eo/blob/master/eo-runtime/src/main/eo/file/touched.eo#L33-L38) evaluates `linked` before it reads `errno`. `linked` calls `lstat`, which can overwrite the `EEXIST` left by the losing `open`; the touch then terminates even though another caller created the file successfully. Checking `errno` first makes the losing creation an ordinary successful touch, while the later symlink check still rejects the POSIX symlink case.

## Verification

The new test repeats the concurrent interleaving twenty times and verifies that the writer's content remains intact. Local Maven execution currently stops before tests because current `master` asks `eo-maven-plugin:1.0-SNAPSHOT` for the unavailable `lower` goal.