### PR TITLE
Reject method continuation after a void attribute

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -870,6 +870,7 @@ R-5.2.3. **MethodDispatch line dispatch.** If the line's kind is `MethodDispatch
   - **(a) Extend:** If the top's openness ∈ {`open`, `vertical-completed`} AND the top's kind is **not** in the horizontally-completed set (Appendix A) AND the top's kind is **not** `inline-phi-formation`: extend the top's kind to `vmethod` (or to `vmethod-with-hargs` if the new line carries ≥1 hargs), update `named?` if the line carries a name suffix, leave openness `open` (or transition to `horizontal-completed` if the new kind is `vmethod-with-hargs`).
   - **(b) Reject — horizontally-completed predecessor:** If the top's openness is `horizontal-completed` (equivalently, kind ∈ horizontally-completed set): error `method continuation not allowed after horizontal application, try vertical application instead` (§9.9).
   - **(b′) Reject — only-phi predecessor:** If the top's kind is `inline-phi-formation` (whose bare-φ form is `open` but is not a method-chain host): error `method continuation not allowed after only-phi formation` (§9.9).
+  - **(b″) Reject — void predecessor:** If the top's kind is `void` (a `? > name` line declares an attribute, not an expression to dispatch on, even though its openness is `vertical-completed` like an ordinary wrappable kind): error `method continuation not allowed after void attribute` (§9.9).
 
 R-5.2.4. **Non-MethodDispatch same-indent line.** If the line's kind is **not** MethodDispatch: the top entry is a *completed previous sibling*. Run close-time checks (§5.3) on it, then **replace** it with a new entry built from the new line. The new entry's `parent_kind` is read from the stack entry below.
 
@@ -1354,6 +1355,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Deeper-indent under horizontally-completed line | `unexpected deeper-indent line — previous expression is closed for children` |
 | `.method` continuation on horizontally-completed previous | `method continuation not allowed after horizontal application, try vertical application instead` |
 | `.method` continuation on an only-phi formation | `method continuation not allowed after only-phi formation` |
+| `.method` continuation on a void attribute | `method continuation not allowed after void attribute` |
 | Name suffix on an only-phi φ's argument | `<name> cannot be a named attribute of only-phi formation <formation>, which binds only its φ decoratee` (the formation is described generically as `an only-phi formation` when anonymous) |
 | `.method` line at top level, deeper than parent, or with no same-indent sibling | `method continuation has no expression to attach to` |
 | Chained inline-phi suffix `expr > [a] > [b] > name` | `chained inline-phi suffixes are not allowed` |
@@ -1434,6 +1436,7 @@ R-9.9.3. New error conditions added to the spec must extend this table with a ca
 | `pipe-application` | 1 line (+ body if 0 hargs) | yes if 0 hargs (vertical form's args) | yes (after) | `\| [args] [> name]`; applies args to the same-indent named formation/pipe above (§3.14) |
 | `identity-object` | 1 line | yes (its vertical args) | yes (after) | a bare `I` (§3.16); a formation a pipe may apply args to, whose own children are arguments |
 | `text-block` | multi-line | n/a | yes (after closing `"""`) | `"""…"""` |
+| `void` | 1 line | **no** | **no** | `? > name` / `? >> name` / `? > ^`; declares an attribute, not an expression to dispatch on (R-5.2.3(b″)) |
 
 **Horizontally-completed kinds (the single source of truth)** — these never receive deeper children and cannot be wrapped by same-indent `.method`:
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -35,6 +35,9 @@ import java.util.List;
  * <li>R-6.6.4 — a {@code .method} continuation after a link that
  * carries an inline binding, which the continuation would leave on a
  * link the chain no longer ends with.</li>
+ * <li>R-5.2.3(b″) — {@code .method} as the receiver of a void
+ * attribute, which declares an attribute rather than an expression to
+ * dispatch on.</li>
  * </ul>
  *
  * <p>Emission follows §9.0.3: each chain link is a separate flat
@@ -150,6 +153,12 @@ final class LnMethod implements Line {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "method continuation not allowed after only-phi formation"
+            );
+        }
+        if (stack.top().kind() == Kind.VOID) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "method continuation not allowed after void attribute"
             );
         }
         if (stack.top().tied()) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -149,23 +149,26 @@ final class LnMethod implements Line {
                 "method continuation not allowed after horizontal application, try vertical application instead"
             );
         }
-        if (stack.top().kind() == Kind.ONLY_PHI) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "method continuation not allowed after only-phi formation"
-            );
-        }
-        if (stack.top().kind() == Kind.VOID) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "method continuation not allowed after void attribute"
-            );
-        }
+        this.precheckKind(stack.top().kind());
         if (stack.top().tied()) {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "inline binding allowed only on the last method in a chain"
             );
+        }
+    }
+
+    private void precheckKind(final Kind kind) {
+        final String message;
+        if (kind == Kind.ONLY_PHI) {
+            message = "method continuation not allowed after only-phi formation";
+        } else if (kind == Kind.VOID) {
+            message = "method continuation not allowed after void attribute";
+        } else {
+            message = "";
+        }
+        if (!message.isEmpty()) {
+            throw new ParseError(this.span.line(), this.span.indent(), message);
         }
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -43,6 +43,32 @@ final class LnMethodTest {
     }
 
     @Test
+    void rejectsAfterVoidAttribute() {
+        final Stack stack = new Stack();
+        new LnVoid(new Span("? > v", 1))
+            .into(stack, new Globals(), new Emit());
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnMethod(new Span(".foo", 2))
+                .into(stack, new Globals(), new Emit()),
+            "a `.method` line after a void attribute must be rejected per R-5.2.3(b″)"
+        );
+    }
+
+    @Test
+    void rejectsAfterReceiverVoid() {
+        final Stack stack = new Stack();
+        new LnVoid(new Span("? > ^", 1))
+            .into(stack, new Globals(), new Emit());
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnMethod(new Span(".foo", 2))
+                .into(stack, new Globals(), new Emit()),
+            "a `.method` line after a receiver void must be rejected per R-5.2.3(b″)"
+        );
+    }
+
+    @Test
     void extendsHeadToVmethodKind() {
         final Stack stack = new Stack();
         new LnApplication(new Span("foo > x", 1))

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/method-after-void.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/method-after-void.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 3
+message: |-
+  method continuation not allowed after void attribute
+input: |
+  [] > main
+    ? > v
+    .foo > y


### PR DESCRIPTION
LnMethod.precheck decides what a `.method` line may attach to by exclusion: it turns down an empty or shallower stack, a horizontally-completed predecessor, and an only-phi one, and lets everything else through. Kind.VOID is pushed VCOMPLETED by LnVoid, so it passed all of those checks and a void became a valid receiver of a method chain.

A `? > name` line declares an attribute, it is not an expression to dispatch on. This used to parse clean and leave the void as the base of a flat method chain:

```
[] > main
  ? > v
  .foo > y
```

The fix turns down Kind.VOID in precheck alongside ONLY_PHI, adds rule R-5.2.3(b'') to PARSER_SPEC.md, the missing `void` row in Appendix A, and the canonical error message in the R-9.9 table.

Closes #8186