### PR TITLE
Clamp reported column to line end in name-suffix and token errors

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -333,6 +333,19 @@ final class Suffix {
         return promoted;
     }
 
+    /**
+     * Clamp a reported column to the last character of its line — R-9.9.2
+     * makes {@code pos} a 0-indexed column, so a value equal to the line
+     * length names no column at all and drops the caret from the error
+     * report.
+     * @param pos Column, possibly one past the last character
+     * @param span Line the column is reported against
+     * @return Column, no greater than the line's last index
+     */
+    private static int clamped(final int pos, final Span span) {
+        return Math.min(pos, span.text().length() - 1);
+    }
+
     private static String phi(final String raw) {
         final String mapped;
         if ("@".equals(raw)) {
@@ -390,7 +403,7 @@ final class Suffix {
         idx = Suffix.skipName(tail, idx);
         if (start == idx) {
             throw new ParseError(
-                span.line(), home + start,
+                span.line(), Suffix.clamped(home + start, span),
                 "test attribute requires a name"
             );
         }
@@ -502,7 +515,7 @@ final class Suffix {
     ) {
         if (Suffix.blank(tail, from)) {
             throw new ParseError(
-                span.line(), home + from,
+                span.line(), Suffix.clamped(home + from, span),
                 "name suffix requires a name"
             );
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -333,15 +333,6 @@ final class Suffix {
         return promoted;
     }
 
-    /**
-     * Clamp a reported column to the last character of its line — R-9.9.2
-     * makes {@code pos} a 0-indexed column, so a value equal to the line
-     * length names no column at all and drops the caret from the error
-     * report.
-     * @param pos Column, possibly one past the last character
-     * @param span Line the column is reported against
-     * @return Column, no greater than the line's last index
-     */
     private static int clamped(final int pos, final Span span) {
         return Math.min(pos, span.text().length() - 1);
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -597,15 +597,6 @@ final class Tokens {
         return idx;
     }
 
-    /**
-     * Clamp a reported column to the last character of its line — R-9.9.2
-     * makes {@code pos} a 0-indexed column, so a value equal to the line
-     * length names no column at all and drops the caret from the error
-     * report.
-     * @param pos Column, possibly one past the last character
-     * @param source Line the column is reported against
-     * @return Column, no greater than the line's last index
-     */
     private static int clamped(final int pos, final Span source) {
         return Math.min(pos, source.text().length() - 1);
     }

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -175,7 +175,7 @@ final class Tokens {
         final int start = this.cursor;
         if (this.atEnd()) {
             throw new ParseError(
-                this.span.line(), this.span.indent() + start,
+                this.span.line(), Tokens.clamped(this.span.indent() + start, this.span),
                 "expected identifier"
             );
         }
@@ -496,7 +496,7 @@ final class Tokens {
         }
         if (this.cursor == start) {
             throw new ParseError(
-                this.span.line(), this.span.indent() + start,
+                this.span.line(), Tokens.clamped(this.span.indent() + start, this.span),
                 "expected binding label after `:`"
             );
         }
@@ -595,6 +595,19 @@ final class Tokens {
             idx = idx + 1;
         }
         return idx;
+    }
+
+    /**
+     * Clamp a reported column to the last character of its line — R-9.9.2
+     * makes {@code pos} a 0-indexed column, so a value equal to the line
+     * length names no column at all and drops the caret from the error
+     * report.
+     * @param pos Column, possibly one past the last character
+     * @param source Line the column is reported against
+     * @return Column, no greater than the line's last index
+     */
+    private static int clamped(final int pos, final Span source) {
+        return Math.min(pos, source.text().length() - 1);
     }
 
     private static boolean singleToken(final String inside) {

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -469,6 +469,34 @@ final class SuffixTest {
     }
 
     @Test
+    void clampsColumnWhenNamedSuffixHasNoNameAtLineEnd() {
+        final ParseError error = Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix(" >", new Span("[] >", 1), 2),
+            "`>` with nothing after it at line end must be rejected"
+        );
+        MatcherAssert.assertThat(
+            "the reported column must stay on the last character of the line, not past it",
+            error.pos(),
+            Matchers.equalTo(3)
+        );
+    }
+
+    @Test
+    void clampsColumnWhenTestSuffixHasNoNameAtLineEnd() {
+        final ParseError error = Assertions.assertThrows(
+            ParseError.class,
+            () -> new Suffix("+>", new Span("[] +>", 1), 3),
+            "`+>` with nothing after it at line end must be rejected"
+        );
+        MatcherAssert.assertThat(
+            "the reported column must stay on the last character of the line, not past it",
+            error.pos(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
     void reportsAutoFlagOnDoubleArrow() {
         MatcherAssert.assertThat(
             "auto() must report true for `>>` suffix",

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -470,28 +470,26 @@ final class SuffixTest {
 
     @Test
     void clampsColumnWhenNamedSuffixHasNoNameAtLineEnd() {
-        final ParseError error = Assertions.assertThrows(
-            ParseError.class,
-            () -> new Suffix(" >", new Span("[] >", 1), 2),
-            "`>` with nothing after it at line end must be rejected"
-        );
         MatcherAssert.assertThat(
             "the reported column must stay on the last character of the line, not past it",
-            error.pos(),
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new Suffix(" >", new Span("[] >", 1), 2),
+                "`>` with nothing after it at line end must be rejected"
+            ).pos(),
             Matchers.equalTo(3)
         );
     }
 
     @Test
     void clampsColumnWhenPlusGreaterSuffixHasNoNameAtLineEnd() {
-        final ParseError error = Assertions.assertThrows(
-            ParseError.class,
-            () -> new Suffix("+>", new Span("[] +>", 1), 3),
-            "`+>` with nothing after it at line end must be rejected"
-        );
         MatcherAssert.assertThat(
             "the reported column must stay on the last character of the line, not past it",
-            error.pos(),
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new Suffix("+>", new Span("[] +>", 1), 3),
+                "`+>` with nothing after it at line end must be rejected"
+            ).pos(),
             Matchers.equalTo(4)
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/SuffixTest.java
@@ -483,7 +483,7 @@ final class SuffixTest {
     }
 
     @Test
-    void clampsColumnWhenTestSuffixHasNoNameAtLineEnd() {
+    void clampsColumnWhenPlusGreaterSuffixHasNoNameAtLineEnd() {
         final ParseError error = Assertions.assertThrows(
             ParseError.class,
             () -> new Suffix("+>", new Span("[] +>", 1), 3),

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -508,6 +508,38 @@ final class TokensTest {
     }
 
     @Test
+    void clampsColumnWhenBindingLabelIsMissingAtLineEnd() {
+        final Tokens tokens = new Tokens("foo a:", new Span("foo a:", 1));
+        tokens.readName();
+        final ParseError error = Assertions.assertThrows(
+            ParseError.class,
+            tokens::readArgs,
+            "a `:` with nothing after it at line end must be rejected"
+        );
+        MatcherAssert.assertThat(
+            "the reported column must stay on the last character of the line, not past it",
+            error.pos(),
+            Matchers.equalTo(5)
+        );
+    }
+
+    @Test
+    void clampsColumnWhenMethodNameIsMissingAtLineEnd() {
+        final Tokens tokens = new Tokens("foo.", new Span("foo.", 1));
+        tokens.readName();
+        final ParseError error = Assertions.assertThrows(
+            ParseError.class,
+            tokens::readChain,
+            "a trailing `.` with no method name after it must be rejected"
+        );
+        MatcherAssert.assertThat(
+            "the reported column must stay on the last character of the line, not past it",
+            error.pos(),
+            Matchers.equalTo(3)
+        );
+    }
+
+    @Test
     void readsParenGroup() {
         MatcherAssert.assertThat(
             "readGroup must round-trip the bracketed text including parentheses",

--- a/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TokensTest.java
@@ -511,14 +511,13 @@ final class TokensTest {
     void clampsColumnWhenBindingLabelIsMissingAtLineEnd() {
         final Tokens tokens = new Tokens("foo a:", new Span("foo a:", 1));
         tokens.readName();
-        final ParseError error = Assertions.assertThrows(
-            ParseError.class,
-            tokens::readArgs,
-            "a `:` with nothing after it at line end must be rejected"
-        );
         MatcherAssert.assertThat(
             "the reported column must stay on the last character of the line, not past it",
-            error.pos(),
+            Assertions.assertThrows(
+                ParseError.class,
+                tokens::readArgs,
+                "a `:` with nothing after it at line end must be rejected"
+            ).pos(),
             Matchers.equalTo(5)
         );
     }
@@ -527,14 +526,13 @@ final class TokensTest {
     void clampsColumnWhenMethodNameIsMissingAtLineEnd() {
         final Tokens tokens = new Tokens("foo.", new Span("foo.", 1));
         tokens.readName();
-        final ParseError error = Assertions.assertThrows(
-            ParseError.class,
-            tokens::readChain,
-            "a trailing `.` with no method name after it must be rejected"
-        );
         MatcherAssert.assertThat(
             "the reported column must stay on the last character of the line, not past it",
-            error.pos(),
+            Assertions.assertThrows(
+                ParseError.class,
+                tokens::readChain,
+                "a trailing `.` with no method name after it must be rejected"
+            ).pos(),
             Matchers.equalTo(3)
         );
     }


### PR DESCRIPTION
Suffix.named and Suffix.test, along with Tokens.readName and Tokens.readBinding, report a missing-name column as home + from — a value that can land one past the last character of the line when the offending token is absent right at end of line. MsgUnderlined then finds from >= origin.length() and prints an empty underline, so the caret line comes out blank with nothing pointing at the token the reader needs to fix.

This clamps the reported column at each of those four throw sites to the line's last index, so the caret always lands on the last real character (the `>`, `+>` marker, `:`, or `.` the user actually needs to look at) instead of past it.

Closes #8190