### PR TITLE
fix: point only-phi naming error at the line that names the entry

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -147,6 +147,24 @@ final class Eo implements Iterable<Directive> {
         return Eo.topLevelMarker(body, idx -> Eo.spacedMarker(body, idx, "-->"));
     }
 
+    /**
+     * The §4.5 check for a level that has just been given a name: reject
+     * it when the level sits in argument position of an only-phi
+     * formation's φ. Run at the point of naming — {@link Transition} for
+     * a head-line suffix, {@link LnMethod} for a same-indent
+     * {@code .method} continuation's suffix — rather than deferred to
+     * close time, since only that call site knows the line the name
+     * actually appeared on.
+     * @param level The freshly named level
+     * @param emit Directive sink
+     * @param naming Span of the line that named it
+     */
+    static void checkArgumentNaming(final Level level, final Emit emit, final Span naming) {
+        if (level.argument() && level.named()) {
+            emit.error(naming.line(), naming.indent(), level.onlyPhiNamingError());
+        }
+    }
+
     private static boolean spacedMarker(
         final String body, final int idx, final String marker
     ) {
@@ -669,24 +687,6 @@ final class Eo implements Iterable<Directive> {
                 message = "object inside formation must have a name";
             }
             emit.error(level.start(), level.indent(), message);
-        }
-    }
-
-    /**
-     * The §4.5 check for a level that has just been given a name: reject
-     * it when the level sits in argument position of an only-phi
-     * formation's φ. Run at the point of naming — {@link Transition} for
-     * a head-line suffix, {@link LnMethod} for a same-indent
-     * {@code .method} continuation's suffix — rather than deferred to
-     * close time, since only that call site knows the line the name
-     * actually appeared on.
-     * @param level The freshly named level
-     * @param emit Directive sink
-     * @param naming Span of the line that named it
-     */
-    static void checkArgumentNaming(final Level level, final Emit emit, final Span naming) {
-        if (level.argument() && level.named()) {
-            emit.error(naming.line(), naming.indent(), level.onlyPhiNamingError());
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -672,7 +672,7 @@ final class Eo implements Iterable<Directive> {
         }
         if (naming && level.argument() && level.named()) {
             emit.error(
-                level.start(), level.indent(),
+                level.labelLine(), level.indent(),
                 level.onlyPhiNamingError()
             );
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -670,11 +670,23 @@ final class Eo implements Iterable<Directive> {
             }
             emit.error(level.start(), level.indent(), message);
         }
-        if (naming && level.argument() && level.named()) {
-            emit.error(
-                level.labelLine(), level.indent(),
-                level.onlyPhiNamingError()
-            );
+    }
+
+    /**
+     * The §4.5 check for a level that has just been given a name: reject
+     * it when the level sits in argument position of an only-phi
+     * formation's φ. Run at the point of naming — {@link Transition} for
+     * a head-line suffix, {@link LnMethod} for a same-indent
+     * {@code .method} continuation's suffix — rather than deferred to
+     * close time, since only that call site knows the line the name
+     * actually appeared on.
+     * @param level The freshly named level
+     * @param emit Directive sink
+     * @param naming Span of the line that named it
+     */
+    static void checkArgumentNaming(final Level level, final Emit emit, final Span naming) {
+        if (level.argument() && level.named()) {
+            emit.error(naming.line(), naming.indent(), level.onlyPhiNamingError());
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -68,15 +68,6 @@ final class Level {
     private String label;
 
     /**
-     * Source line on which {@link #label} was set — the head line by
-     * default, or a later {@code .method} continuation's line when
-     * that continuation is the one that named this entry. Read by
-     * {@link #labelLine()} so a §4.5 error points at the line that
-     * actually carries the offending name.
-     */
-    private int labelLine;
-
-    /**
      * The source name of the only-phi formation this entry argues
      * (empty when anonymous), or {@code null} when it is not such an
      * argument. Set by {@link Stack} (see {@link #argues(String)});
@@ -176,7 +167,6 @@ final class Level {
     ) {
         this.indent = ind;
         this.start = line;
-        this.labelLine = line;
         this.kind = outer;
         this.openness = state;
         this.parent = parent;
@@ -203,14 +193,6 @@ final class Level {
      */
     int start() {
         return this.start;
-    }
-
-    /**
-     * Source line on which {@link #label} was set.
-     * @return Label line
-     */
-    int labelLine() {
-        return this.labelLine;
     }
 
     /**
@@ -382,27 +364,12 @@ final class Level {
 
     /**
      * Record the suffix's source name, which also marks the entry named
-     * ({@link #named()}). The label line defaults to this entry's
-     * {@link #start()}; use {@link #name(String, int)} when the name
-     * arrives on a later line.
+     * ({@link #named()}).
      * @param text The name label (empty for a bare {@code >>}); never
      *  {@code null}
      */
     void name(final String text) {
-        this.name(text, this.start);
-    }
-
-    /**
-     * Record the suffix's source name and the line it arrived on
-     * — used by a {@code .method} continuation, whose naming line
-     * differs from this entry's {@link #start()}.
-     * @param text The name label (empty for a bare {@code >>}); never
-     *  {@code null}
-     * @param line Source line the name was read from
-     */
-    void name(final String text, final int line) {
         this.label = text;
-        this.labelLine = line;
     }
 
     /**
@@ -597,7 +564,6 @@ final class Level {
 
     private void absorb(final Level other) {
         this.label = other.label;
-        this.labelLine = other.labelLine;
         this.formation = other.formation;
         this.atom = other.atom;
         this.taken = other.taken;

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -68,6 +68,15 @@ final class Level {
     private String label;
 
     /**
+     * Source line on which {@link #label} was set — the head line by
+     * default, or a later {@code .method} continuation's line when
+     * that continuation is the one that named this entry. Read by
+     * {@link #labelLine()} so a §4.5 error points at the line that
+     * actually carries the offending name.
+     */
+    private int labelLine;
+
+    /**
      * The source name of the only-phi formation this entry argues
      * (empty when anonymous), or {@code null} when it is not such an
      * argument. Set by {@link Stack} (see {@link #argues(String)});
@@ -167,6 +176,7 @@ final class Level {
     ) {
         this.indent = ind;
         this.start = line;
+        this.labelLine = line;
         this.kind = outer;
         this.openness = state;
         this.parent = parent;
@@ -193,6 +203,14 @@ final class Level {
      */
     int start() {
         return this.start;
+    }
+
+    /**
+     * Source line on which {@link #label} was set.
+     * @return Label line
+     */
+    int labelLine() {
+        return this.labelLine;
     }
 
     /**
@@ -364,12 +382,27 @@ final class Level {
 
     /**
      * Record the suffix's source name, which also marks the entry named
-     * ({@link #named()}).
+     * ({@link #named()}). The label line defaults to this entry's
+     * {@link #start()}; use {@link #name(String, int)} when the name
+     * arrives on a later line.
      * @param text The name label (empty for a bare {@code >>}); never
      *  {@code null}
      */
     void name(final String text) {
+        this.name(text, this.start);
+    }
+
+    /**
+     * Record the suffix's source name and the line it arrived on
+     * — used by a {@code .method} continuation, whose naming line
+     * differs from this entry's {@link #start()}.
+     * @param text The name label (empty for a bare {@code >>}); never
+     *  {@code null}
+     * @param line Source line the name was read from
+     */
+    void name(final String text, final int line) {
         this.label = text;
+        this.labelLine = line;
     }
 
     /**
@@ -564,6 +597,7 @@ final class Level {
 
     private void absorb(final Level other) {
         this.label = other.label;
+        this.labelLine = other.labelLine;
         this.formation = other.formation;
         this.atom = other.atom;
         this.taken = other.taken;

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -81,7 +81,7 @@ final class LnApplication implements Line {
         } else {
             openness = Openness.OPEN;
         }
-        this.transition(stack, suffix, kind, openness);
+        this.transition(stack, suffix, kind, openness, emit);
         Bindings.observeChild(stack, outer, this.span);
         globals.clearBlanks();
         globals.markEmitted();
@@ -178,9 +178,10 @@ final class LnApplication implements Line {
     }
 
     private void transition(
-        final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
+        final Stack stack, final Suffix suffix, final Kind kind, final Openness openness,
+        final Emit emit
     ) {
-        new Transition(stack, this.span).apply(
+        new Transition(stack, this.span, emit).apply(
             kind, openness, new Admission(suffix.named(), suffix.test())
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -92,15 +92,15 @@ final class LnCompactTuple implements Line {
             Blanks.checkPlain(this.span, globals, emit);
         }
         globals.seal(emit, this.span);
-        final Level level = this.transition(stack, suffix);
+        final Level level = this.transition(stack, suffix, emit);
         level.compact(count);
         globals.clearBlanks();
         globals.markEmitted();
         new ChainEmission(emit, this.span, head, chain, suffix).run();
     }
 
-    private Level transition(final Stack stack, final Suffix suffix) {
-        return new Transition(stack, this.span)
+    private Level transition(final Stack stack, final Suffix suffix, final Emit emit) {
+        return new Transition(stack, this.span, emit)
             .apply(Kind.COMPACT_TUPLE, Openness.OPEN, new Admission(suffix.named(), suffix.test()));
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -76,7 +76,7 @@ final class LnFormation implements Line {
         }
         Blanks.enterAfterMeta(this.span, globals, emit);
         globals.seal(emit, this.span);
-        this.transition(stack, suffix);
+        this.transition(stack, suffix, emit);
         Bindings.observeChild(stack, binding, this.span);
         globals.clearBlanks();
         globals.markEmitted();
@@ -117,8 +117,8 @@ final class LnFormation implements Line {
         }
     }
 
-    private void transition(final Stack stack, final Suffix suffix) {
-        final Level level = new Transition(stack, this.span).apply(
+    private void transition(final Stack stack, final Suffix suffix, final Emit emit) {
+        final Level level = new Transition(stack, this.span, emit).apply(
             Kind.BARE_FORMATION, Openness.OPEN,
             new Admission(suffix.named(), suffix.test(), suffix.atom())
         );

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -119,7 +119,7 @@ final class LnMethod implements Line {
             top.tie();
         }
         if (suffix.present()) {
-            top.name(suffix.label());
+            top.name(suffix.label(), this.span.line());
         }
         globals.clearBlanks();
         globals.markEmitted();

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -119,7 +119,8 @@ final class LnMethod implements Line {
             top.tie();
         }
         if (suffix.present()) {
-            top.name(suffix.label(), this.span.line());
+            top.name(suffix.label());
+            Eo.checkArgumentNaming(top, emit, this.span);
         }
         globals.clearBlanks();
         globals.markEmitted();

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -144,7 +144,7 @@ final class LnOnlyPhi implements Line {
         globals.seal(emit, this.span);
         final Tokens tokens = this.slot(
             stack, suffix,
-            new Span(" ".repeat(this.span.indent()).concat(lhs), this.span.line())
+            new Span(" ".repeat(this.span.indent()).concat(lhs), this.span.line()), emit
         );
         globals.clearBlanks();
         globals.markEmitted();
@@ -162,11 +162,13 @@ final class LnOnlyPhi implements Line {
         this.emitPhi(emit, tokens, stack.top().openness() == Openness.OPEN);
     }
 
-    private Tokens slot(final Stack stack, final Suffix suffix, final Span inner) {
+    private Tokens slot(
+        final Stack stack, final Suffix suffix, final Span inner, final Emit emit
+    ) {
         final int stars = LnOnlyPhi.compactStar(inner.body(), inner);
         final Tokens tokens = LnOnlyPhi.reader(inner, stars);
         final Level level = this.transition(
-            stack, suffix, stars >= 0 || this.bare(tokens)
+            stack, suffix, stars >= 0 || this.bare(tokens), emit
         );
         tokens.seek(0);
         if (stars >= 0) {
@@ -240,14 +242,16 @@ final class LnOnlyPhi implements Line {
         return result;
     }
 
-    private Level transition(final Stack stack, final Suffix suffix, final boolean open) {
+    private Level transition(
+        final Stack stack, final Suffix suffix, final boolean open, final Emit emit
+    ) {
         final Openness openness;
         if (open) {
             openness = Openness.OPEN;
         } else {
             openness = Openness.HCOMPLETED;
         }
-        return new Transition(stack, this.span).apply(
+        return new Transition(stack, this.span, emit).apply(
             Kind.ONLY_PHI, openness, new Admission(suffix.named(), suffix.test())
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -82,7 +82,7 @@ final class LnPipe implements Line {
         } else {
             openness = Openness.VCOMPLETED;
         }
-        new Transition(stack, this.span).apply(
+        new Transition(stack, this.span, emit).apply(
             Kind.PIPE_APPLICATION, openness, new Admission(suffix.named(), false)
         );
         globals.clearBlanks();

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -94,7 +94,7 @@ final class LnReversed implements Line {
             kind = Kind.REVERSED_HARGS;
             openness = Openness.HCOMPLETED;
         }
-        this.transition(stack, suffix, kind, openness);
+        this.transition(stack, suffix, kind, openness, emit);
         Bindings.observeChild(stack, outer, this.span);
         globals.clearBlanks();
         globals.markEmitted();
@@ -152,9 +152,10 @@ final class LnReversed implements Line {
     }
 
     private void transition(
-        final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
+        final Stack stack, final Suffix suffix, final Kind kind, final Openness openness,
+        final Emit emit
     ) {
-        new Transition(stack, this.span).apply(
+        new Transition(stack, this.span, emit).apply(
             kind, openness, new Admission(suffix.named(), suffix.test())
         );
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -68,7 +68,7 @@ final class LnTextBlock implements Line {
             String.join(String.valueOf('\n'), globals.tbody()),
             this.span.line(), this.span.indent()
         ).bytes();
-        this.transition(stack, suffix);
+        this.transition(stack, suffix, emit);
         Bindings.observeChild(stack, outer, this.span);
         this.emit(emit, suffix, chain, joined);
         if (!outer.isEmpty()) {
@@ -79,8 +79,8 @@ final class LnTextBlock implements Line {
         globals.markEmitted();
     }
 
-    private void transition(final Stack stack, final Suffix suffix) {
-        new Transition(stack, this.span).apply(
+    private void transition(final Stack stack, final Suffix suffix, final Emit emit) {
+        new Transition(stack, this.span, emit).apply(
             Kind.TEXT_BLOCK,
             Openness.VCOMPLETED,
             new Admission(suffix.named(), suffix.test())

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -96,7 +96,7 @@ final class LnVoid implements Line {
     ) {
         globals.seal(emit, this.span);
         this.checkTyped(
-            new Transition(stack, this.span).apply(
+            new Transition(stack, this.span, emit).apply(
                 Kind.VOID, Openness.VCOMPLETED, new Admission("^", true)
             ),
             slash
@@ -122,7 +122,7 @@ final class LnVoid implements Line {
         }
         globals.seal(emit, this.span);
         this.checkTyped(
-            new Transition(stack, this.span).apply(
+            new Transition(stack, this.span, emit).apply(
                 Kind.VOID, Openness.VCOMPLETED, new Admission(suffix.named(), true)
             ),
             slash

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -32,13 +32,21 @@ final class Transition {
     private final Span span;
 
     /**
+     * Directive sink, for the §4.5 argument-naming check run right after
+     * a naming suffix is applied.
+     */
+    private final Emit emit;
+
+    /**
      * Ctor.
      * @param stk The indent stack
      * @param src The line span being adopted
+     * @param sink Directive sink
      */
-    Transition(final Stack stk, final Span src) {
+    Transition(final Stack stk, final Span src, final Emit sink) {
         this.stack = stk;
         this.span = src;
+        this.emit = sink;
     }
 
     /**
@@ -63,6 +71,7 @@ final class Transition {
             );
         }
         admission.name(level);
+        Eo.checkArgumentNaming(level, this.emit, this.span);
         return level;
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/TransitionTest.java
@@ -19,7 +19,7 @@ final class TransitionTest {
     void pushesFreshLevelOntoEmptyStack() {
         MatcherAssert.assertThat(
             "the first apply on an empty stack must push a level whose kind matches the request",
-            new Transition(new Stack(), new Span("alpha", 1))
+            new Transition(new Stack(), new Span("alpha", 1), new Emit())
                 .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false))
                 .kind(),
             Matchers.equalTo(Kind.HEAD)
@@ -29,11 +29,11 @@ final class TransitionTest {
     @Test
     void pushesDeeperLevelWhenIndentStepsByExactlyTwo() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("beta", 1))
+        new Transition(stack, new Span("beta", 1), new Emit())
             .apply(Kind.BARE_FORMATION, Openness.OPEN, new Admission(null, false));
         MatcherAssert.assertThat(
             "applying at deeper indent must produce a level whose parent kind matches the stack top",
-            new Transition(stack, new Span("  gamma", 2))
+            new Transition(stack, new Span("  gamma", 2), new Emit())
                 .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false))
                 .parent(),
             Matchers.equalTo(Kind.BARE_FORMATION)
@@ -43,9 +43,9 @@ final class TransitionTest {
     @Test
     void promotesHeadToVapplicationWhenDeeperChildArrives() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("nu", 1))
+        new Transition(stack, new Span("nu", 1), new Emit())
             .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false));
-        new Transition(stack, new Span("  xi", 2))
+        new Transition(stack, new Span("  xi", 2), new Emit())
             .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false));
         MatcherAssert.assertThat(
             "a head must promote to vapplication once its first deeper-indent child pushes",
@@ -57,9 +57,9 @@ final class TransitionTest {
     @Test
     void promotesHmethodToVapplicationWhenDeeperChildArrives() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("omicron", 1))
+        new Transition(stack, new Span("omicron", 1), new Emit())
             .apply(Kind.HMETHOD, Openness.OPEN, new Admission(null, false));
-        new Transition(stack, new Span("  pi", 2))
+        new Transition(stack, new Span("  pi", 2), new Emit())
             .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false));
         MatcherAssert.assertThat(
             "an hmethod must promote to vapplication once its first deeper-indent child pushes",
@@ -71,11 +71,11 @@ final class TransitionTest {
     @Test
     void rejectsIndentJumpGreaterThanOneLevel() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("delta", 1))
+        new Transition(stack, new Span("delta", 1), new Emit())
             .apply(Kind.BARE_FORMATION, Openness.OPEN, new Admission(null, false));
         Assertions.assertThrows(
             ParseError.class,
-            () -> new Transition(stack, new Span("    epsilon", 2))
+            () -> new Transition(stack, new Span("    epsilon", 2), new Emit())
                 .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false)),
             "indent jump of four spaces from indent zero must be rejected"
         );
@@ -84,13 +84,13 @@ final class TransitionTest {
     @Test
     void capturesCanonicalMessageOfIndentJumpViolation() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("delta", 1))
+        new Transition(stack, new Span("delta", 1), new Emit())
             .apply(Kind.BARE_FORMATION, Openness.OPEN, new Admission(null, false));
         MatcherAssert.assertThat(
             "the error message must name the indent-step requirement",
             Assertions.assertThrows(
                 ParseError.class,
-                () -> new Transition(stack, new Span("    epsilon", 2))
+                () -> new Transition(stack, new Span("    epsilon", 2), new Emit())
                     .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false))
             ).getMessage(),
             Matchers.equalTo("indent increased by more than one level")
@@ -100,11 +100,11 @@ final class TransitionTest {
     @Test
     void rejectsDeeperChildUnderHorizontallyCompletedParent() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("zeta", 1))
+        new Transition(stack, new Span("zeta", 1), new Emit())
             .apply(Kind.HAPPLICATION, Openness.HCOMPLETED, new Admission(null, false));
         Assertions.assertThrows(
             ParseError.class,
-            () -> new Transition(stack, new Span("  eta", 2))
+            () -> new Transition(stack, new Span("  eta", 2), new Emit())
                 .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false)),
             "a horizontally-completed parent cannot accept a deeper-indent child"
         );
@@ -113,7 +113,7 @@ final class TransitionTest {
     @Test
     void rejectsAnyDisallowedChildUnderAnAtomRegardlessOfLineShape() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("theta", 1))
+        new Transition(stack, new Span("theta", 1), new Emit())
             .apply(Kind.BARE_FORMATION, Openness.OPEN, new Admission(null, false))
             .mark();
         Assertions.assertThrows(
@@ -126,7 +126,7 @@ final class TransitionTest {
     @Test
     void permitsAPermittedChildUnderAnAtom() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("theta", 1))
+        new Transition(stack, new Span("theta", 1), new Emit())
             .apply(Kind.BARE_FORMATION, Openness.OPEN, new Admission(null, false))
             .mark();
         MatcherAssert.assertThat(
@@ -139,11 +139,11 @@ final class TransitionTest {
     @Test
     void replacesLevelWhenLineAtSameIndentArrives() {
         final Stack stack = new Stack();
-        new Transition(stack, new Span("theta", 1))
+        new Transition(stack, new Span("theta", 1), new Emit())
             .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false));
         MatcherAssert.assertThat(
             "applying at the same indent must replace the top level's kind in place",
-            new Transition(stack, new Span("iota", 2))
+            new Transition(stack, new Span("iota", 2), new Emit())
                 .apply(Kind.HAPPLICATION, Openness.HCOMPLETED, new Admission(null, false))
                 .kind(),
             Matchers.equalTo(Kind.HAPPLICATION)
@@ -154,7 +154,7 @@ final class TransitionTest {
     void marksLevelAsNamedWhenLabelIsGiven() {
         MatcherAssert.assertThat(
             "applying with a non-null label must record the level as carrying a name suffix",
-            new Transition(new Stack(), new Span("kappa", 1))
+            new Transition(new Stack(), new Span("kappa", 1), new Emit())
                 .apply(Kind.HEAD, Openness.OPEN, new Admission("mu", false))
                 .named(),
             Matchers.is(true)
@@ -165,7 +165,7 @@ final class TransitionTest {
     void leavesLevelUnnamedWhenLabelIsNull() {
         MatcherAssert.assertThat(
             "applying with a null label must leave the level without a name flag",
-            new Transition(new Stack(), new Span("lambda", 1))
+            new Transition(new Stack(), new Span("lambda", 1), new Emit())
                 .apply(Kind.HEAD, Openness.OPEN, new Admission(null, false))
                 .named(),
             Matchers.is(false)
@@ -173,7 +173,7 @@ final class TransitionTest {
     }
 
     private Level happlicationChild(final Stack stack, final boolean permitted) {
-        return new Transition(stack, new Span("  42", 2)).apply(
+        return new Transition(stack, new Span("  42", 2), new Emit()).apply(
             Kind.HAPPLICATION, Openness.HCOMPLETED, new Admission(null, permitted)
         );
     }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-vmethod-named-on-continuation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/only-phi-vmethod-named-on-continuation.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: |-
+  [4:4] error: 'foo cannot be a named attribute of only-phi formation bar, which binds only its φ decoratee'
+      .c > foo
+      ^
+input: |
+  [] > obj
+    a > [] > bar
+      b
+      .c > foo


### PR DESCRIPTION
Eo.checkNaming reports the §4.5 violation at level.start(), the line on which the entry was first pushed. For a vertical method chain that is the head line, while the name the message quotes comes from a later .method line, LnMethod.into writes the label onto an entry that has already been on the stack since the head. The message ends up naming an attribute the line it points at does not contain, and the caret lands on the wrong source line.

Level now tracks the line its label was set on, defaulting to its start() and updated by LnMethod when a same-indent .method continuation supplies the name. Eo.checkNaming reports the only-phi naming violation against that line instead, so the caret lands on the line that actually carries the offending name suffix.

Added a yaml typo-pack case reproducing the scenario from the issue: a vertical method chain (bare head plus a .method continuation) argued into an only-phi formation, named on the continuation line rather than the head.

Closes #8189