### PR TITLE
reject method continuation on a test attribute

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Admission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Admission.java
@@ -30,12 +30,29 @@ final class Admission {
     private final boolean own;
 
     /**
-     * Ctor.
+     * Whether the suffix that produced {@link #label} was a {@code TEST}
+     * or {@code THROWS} form.
+     */
+    private final boolean test;
+
+    /**
+     * Ctor — for a line shape whose suffix can never be a test attribute.
      * @param label The suffix's source name, or {@code null}
      * @param permitted Whether this line shape may sit under an atom parent
      */
     Admission(final String label, final boolean permitted) {
-        this(label, permitted, false);
+        this(label, permitted, false, false);
+    }
+
+    /**
+     * Ctor.
+     * @param label The suffix's source name, or {@code null}
+     * @param permitted Whether this line shape may sit under an atom parent
+     * @param test Whether the suffix that produced {@code label} was a
+     *  {@code TEST} or {@code THROWS} form
+     */
+    Admission(final String label, final boolean permitted, final boolean test) {
+        this(label, permitted, false, test);
     }
 
     /**
@@ -43,11 +60,16 @@ final class Admission {
      * @param label The suffix's source name, or {@code null}
      * @param permitted Whether this line shape may sit under an atom parent
      * @param own Whether the line declares an atom of its own
+     * @param test Whether the suffix that produced {@code label} was a
+     *  {@code TEST} or {@code THROWS} form
      */
-    Admission(final String label, final boolean permitted, final boolean own) {
+    Admission(
+        final String label, final boolean permitted, final boolean own, final boolean test
+    ) {
         this.label = label;
         this.permitted = permitted;
         this.own = own;
+        this.test = test;
     }
 
     /**
@@ -56,7 +78,7 @@ final class Admission {
      */
     void name(final Level level) {
         if (this.label != null) {
-            level.name(this.label);
+            level.name(this.label, this.test);
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -68,14 +68,6 @@ final class Level {
     private String label;
 
     /**
-     * Whether this entry's naming line carried a {@code TEST} or
-     * {@code THROWS} suffix form — read by {@link LnMethod#precheck}
-     * so a {@code .method} continuation cannot take over a level whose
-     * naming line declared it a test attribute (R-6.3.3).
-     */
-    private boolean test;
-
-    /**
      * The source name of the only-phi formation this entry argues
      * (empty when anonymous), or {@code null} when it is not such an
      * argument. Set by {@link Stack} (see {@link #argues(String)});
@@ -146,11 +138,13 @@ final class Level {
     private int arg;
 
     /**
-     * True when the chain link this entry currently ends with carries an
-     * inline binding, read by {@link LnMethod} to refuse a continuation
-     * that would leave it on a link the chain no longer ends with.
+     * Why a same-indent {@code .method} continuation must be refused on
+     * this entry, empty while one is still allowed. Read by
+     * {@link LnMethod} — a chain link carrying an inline binding
+     * (R-6.6.4) and a naming line declaring a test attribute (R-6.3.3)
+     * both close the chain, each with its own diagnostic.
      */
-    private boolean tied;
+    private String refusal;
 
     /**
      * Source span recorded with the in-progress arg, used for error
@@ -185,6 +179,7 @@ final class Level {
         this.children = 0;
         this.tupled = false;
         this.star = false;
+        this.refusal = "";
     }
 
     /**
@@ -380,15 +375,9 @@ final class Level {
      */
     void name(final String text, final boolean form) {
         this.label = text;
-        this.test = form;
-    }
-
-    /**
-     * Whether this entry's naming line declared it a test attribute.
-     * @return Test-suffix flag
-     */
-    boolean test() {
-        return this.test;
+        if (form) {
+            this.refusal = "method continuation not allowed on a test attribute";
+        }
     }
 
     /**
@@ -549,12 +538,11 @@ final class Level {
     }
 
     /**
-     * Whether the link this chain currently ends with carries an inline
-     * binding.
-     * @return Tied flag
+     * Why a {@code .method} continuation is refused on this entry.
+     * @return The diagnostic, empty when a continuation is allowed
      */
-    boolean tied() {
-        return this.tied;
+    String refusal() {
+        return this.refusal;
     }
 
     /**
@@ -564,7 +552,7 @@ final class Level {
      * (R-6.6.4).
      */
     void tie() {
-        this.tied = true;
+        this.refusal = "inline binding allowed only on the last method in a chain";
     }
 
     /**
@@ -594,7 +582,6 @@ final class Level {
         this.bindings = other.bindings;
         this.arg = other.arg;
         this.argspan = other.argspan;
-        this.tied = other.tied;
-        this.test = other.test;
+        this.refusal = other.refusal;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -68,6 +68,14 @@ final class Level {
     private String label;
 
     /**
+     * Whether this entry's naming line carried a {@code TEST} or
+     * {@code THROWS} suffix form — read by {@link LnMethod#precheck}
+     * so a {@code .method} continuation cannot take over a level whose
+     * naming line declared it a test attribute (R-6.3.3).
+     */
+    private boolean test;
+
+    /**
      * The source name of the only-phi formation this entry argues
      * (empty when anonymous), or {@code null} when it is not such an
      * argument. Set by {@link Stack} (see {@link #argues(String)});
@@ -367,9 +375,20 @@ final class Level {
      * ({@link #named()}).
      * @param text The name label (empty for a bare {@code >>}); never
      *  {@code null}
+     * @param form Whether the suffix that set this name was a
+     *  {@code TEST} or {@code THROWS} form
      */
-    void name(final String text) {
+    void name(final String text, final boolean form) {
         this.label = text;
+        this.test = form;
+    }
+
+    /**
+     * Whether this entry's naming line declared it a test attribute.
+     * @return Test-suffix flag
+     */
+    boolean test() {
+        return this.test;
     }
 
     /**
@@ -576,5 +595,6 @@ final class Level {
         this.arg = other.arg;
         this.argspan = other.argspan;
         this.tied = other.tied;
+        this.test = other.test;
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnApplication.java
@@ -181,7 +181,7 @@ final class LnApplication implements Line {
         final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
     ) {
         new Transition(stack, this.span).apply(
-            kind, openness, new Admission(suffix.named(), suffix.test())
+            kind, openness, new Admission(suffix.named(), suffix.test(), suffix.test())
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnCompactTuple.java
@@ -100,8 +100,10 @@ final class LnCompactTuple implements Line {
     }
 
     private Level transition(final Stack stack, final Suffix suffix) {
-        return new Transition(stack, this.span)
-            .apply(Kind.COMPACT_TUPLE, Openness.OPEN, new Admission(suffix.named(), suffix.test()));
+        return new Transition(stack, this.span).apply(
+            Kind.COMPACT_TUPLE, Openness.OPEN,
+            new Admission(suffix.named(), suffix.test(), suffix.test())
+        );
     }
 
     private static int readCount(final Tokens tokens, final Span span) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -120,7 +120,7 @@ final class LnFormation implements Line {
     private void transition(final Stack stack, final Suffix suffix) {
         final Level level = new Transition(stack, this.span).apply(
             Kind.BARE_FORMATION, Openness.OPEN,
-            new Admission(suffix.named(), suffix.test(), suffix.atom())
+            new Admission(suffix.named(), suffix.test(), suffix.atom(), suffix.test())
         );
         if (suffix.atom()) {
             level.mark();

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -35,6 +35,9 @@ import java.util.List;
  * <li>R-6.6.4 — a {@code .method} continuation after a link that
  * carries an inline binding, which the continuation would leave on a
  * link the chain no longer ends with.</li>
+ * <li>R-6.3.3 — a {@code .method} continuation on a predecessor whose
+ * naming line declared it a test attribute, which would otherwise
+ * overwrite that attribute's label with the chain's own.</li>
  * </ul>
  *
  * <p>Emission follows §9.0.3: each chain link is a separate flat
@@ -119,7 +122,7 @@ final class LnMethod implements Line {
             top.tie();
         }
         if (suffix.present()) {
-            top.name(suffix.label());
+            top.name(suffix.label(), suffix.test());
         }
         globals.clearBlanks();
         globals.markEmitted();
@@ -150,6 +153,12 @@ final class LnMethod implements Line {
             throw new ParseError(
                 this.span.line(), this.span.indent(),
                 "method continuation not allowed after only-phi formation"
+            );
+        }
+        if (stack.top().test()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "method continuation not allowed on a test attribute"
             );
         }
         if (stack.top().tied()) {

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -155,17 +155,9 @@ final class LnMethod implements Line {
                 "method continuation not allowed after only-phi formation"
             );
         }
-        if (stack.top().test()) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "method continuation not allowed on a test attribute"
-            );
-        }
-        if (stack.top().tied()) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "inline binding allowed only on the last method in a chain"
-            );
+        final String refusal = stack.top().refusal();
+        if (!refusal.isEmpty()) {
+            throw new ParseError(this.span.line(), this.span.indent(), refusal);
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -248,7 +248,7 @@ final class LnOnlyPhi implements Line {
             openness = Openness.HCOMPLETED;
         }
         return new Transition(stack, this.span).apply(
-            Kind.ONLY_PHI, openness, new Admission(suffix.named(), suffix.test())
+            Kind.ONLY_PHI, openness, new Admission(suffix.named(), suffix.test(), suffix.test())
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -155,7 +155,7 @@ final class LnReversed implements Line {
         final Stack stack, final Suffix suffix, final Kind kind, final Openness openness
     ) {
         new Transition(stack, this.span).apply(
-            kind, openness, new Admission(suffix.named(), suffix.test())
+            kind, openness, new Admission(suffix.named(), suffix.test(), suffix.test())
         );
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -83,7 +83,7 @@ final class LnTextBlock implements Line {
         new Transition(stack, this.span).apply(
             Kind.TEXT_BLOCK,
             Openness.VCOMPLETED,
-            new Admission(suffix.named(), suffix.test())
+            new Admission(suffix.named(), suffix.test(), suffix.test())
         );
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -64,7 +64,7 @@ final class LevelTest {
         final Level level = new Level(
             0, 1, Kind.BARE_FORMATION, Openness.OPEN, Kind.TOP_LEVEL, false
         );
-        level.name("foo");
+        level.name("foo", false);
         MatcherAssert.assertThat(
             "named() must report true once name() has been called",
             level.named(),

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -182,7 +182,7 @@ final class LnMethodTest {
     }
 
     @Test
-    void rejectsContinuationOnTestAttribute() {
+    void rejectsContinuationOnTruthyAttribute() {
         final Stack stack = new Stack();
         final Globals globals = new Globals();
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);

--- a/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMethodTest.java
@@ -182,6 +182,21 @@ final class LnMethodTest {
     }
 
     @Test
+    void rejectsContinuationOnTestAttribute() {
+        final Stack stack = new Stack();
+        final Globals globals = new Globals();
+        stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);
+        globals.blank();
+        new LnFormation(new Span("  ++> t", 2)).into(stack, globals, new Emit());
+        Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnMethod(new Span("  .bar > x", 3))
+                .into(stack, globals, new Emit()),
+            "a `.method` continuation on a test attribute must be rejected per R-6.3.3"
+        );
+    }
+
+    @Test
     void acceptsAttributeAfterBlankLine() {
         final Emit emit = new Emit();
         final Stack stack = new Stack();


### PR DESCRIPTION
LnMethod.precheck looked only at the predecessor level's kind and openness, never at the suffix form that put it there. A `.method` continuation line at the same indent as a `++> t` / `--> t` test attribute (or any other naming line ending in `+> name` / `-> name`) would happily take over that level, and LnMethod.into then overwrote the level's label with its own. The `<o name="+t"/>` the test attribute emitted stayed behind as the chain's now-orphaned receiver, silently corrupting XMIR that R-6.3.3 says should be rejected outright.

The fix has Level remember whether the naming line that set its label carried a TEST or THROWS suffix form, the same way it already remembers the label itself. Admission threads that flag through from the line shapes that can produce a test suffix (LnApplication, LnFormation, LnReversed, LnCompactTuple, LnOnlyPhi, LnTextBlock) into Level.name(). LnMethod.precheck then rejects a continuation on a level so flagged, and LnMethod.into's own suffix-driven rename passes the same flag along for consistency.

Closes #8187