### PR TITLE
Pin down +> test attribute blank-line placement in vertical method chains

### DIFF
--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/vertical-method-chain-test-blank-above-attribute-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/vertical-method-chain-test-blank-above-attribute-line.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #8188: a vertical method chain (`foo` / `.bar`) that ends in a `+>`
+# test attribute is one expression spread over two lines; the mandatory
+# R-6.5.3 blank line before the attribute belongs directly above the
+# `.method` line that carries it, not above the chain's plain head.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='main']/o[@base='Φ.foo.bar' and @name='+t']
+input: |
+  [] > main
+    foo
+
+    .bar +> t

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/vertical-method-chain-test-blank-above-master-head.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/vertical-method-chain-test-blank-above-master-head.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #8188: when the chain's head is itself a master (a bare formation),
+# R-6.5.3's "zero or one blank line before a master object" and its
+# "exactly one blank line before a `+>` test attribute" happen to share
+# the same blank line, so this spelling parses cleanly today.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - /object/o[@name='main']/o[@name='f']
+  - /object/o[@name='main']/o[@base='ξ.f.x' and @name='+t']
+input: |
+  [] > main
+
+    [] > f
+
+    .x +> t

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/vertical-method-chain-blank-above-plain-head-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/vertical-method-chain-blank-above-plain-head-is-rejected.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #8188: a blank line placed above a plain (non-master) chain head is
+# rejected as a stray sibling blank, even though the chain it opens
+# goes on to carry a `+>` test attribute two lines later. The mandatory
+# blank belongs directly above the `.method` line instead — see
+# vertical-method-chain-test-blank-above-attribute-line.yaml.
+line: 3
+message: |-
+  [3:2] error: 'blank line not allowed between non-master siblings'
+    foo
+    ^
+input: |
+  [] > main
+
+    foo
+    .bar +> t

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/vertical-method-chain-no-blank-before-attribute-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/vertical-method-chain-no-blank-before-attribute-is-rejected.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #8188: no blank line anywhere around a vertical method chain that
+# carries a `+>` test attribute is unambiguously rejected with a single
+# error, unlike the double-error shape in
+# vertical-method-chain-blank-above-plain-head-is-rejected.yaml.
+line: 3
+message: |-
+  [3:2] error: 'missing blank line before a `+>` test attribute (R-6.5.3); exactly one blank line must precede every test attribute'
+    .bar +> t
+    ^
+input: |
+  [] > main
+    foo
+    .bar +> t


### PR DESCRIPTION
I verified the behavior reported in #8188 directly by compiling eo-parser with javac and driving `EoSyntax` against each shape from the issue, without running an mvn build. Here is what the parser actually does today:

A blank line placed directly above the `.method +> name` line (the tail of a vertical method chain) already parses cleanly and produces correct XMIR — this is the one spelling that satisfies R-6.5.3 today. A blank line placed above the chain's head is also fine when that head is itself a master object (a bare formation), because R-6.5.3's "zero or one blank before a master" and "exactly one blank before a `+>` test attribute" happen to land on the same blank line. A blank line placed above the chain's head is rejected with two errors at once when the head is a plain, non-master application: `checkPlain`'s "blank line not allowed between non-master siblings" and `checkTest`'s "missing blank line before a `+>` test attribute" both fire, because each check reads the pending-blank count at a different line of the same multi-line expression. No blank anywhere is correctly and unambiguously rejected with a single "missing blank line" error.

So a plain-headed chain already has one working spelling (blank directly above the `.method +>` line). Making the head-blank spelling legal too would mean deferring the plain-vs-master decision until the chain's continuation lines are known, which reaches into `Level`, `Stack`, `LnApplication`, `LnMethod` and `LnReversed` — real state-machine work, not a small fix.

This PR adds four eo-parser test fixtures (two in `eo-syntax/`, two in `eo-typos/empty-lines/`) that pin down all four shapes above as regression tests, so the currently-correct behavior and the currently-inconsistent double-error case both stay documented and covered.

Closes #8188