### PR TITLE
Say a void is a void in the inference report

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Pieces.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pieces.java
@@ -26,7 +26,9 @@ import org.xembly.Directives;
  * a reader hovering over a word is told the same thing the tables hold: the
  * name it goes by, what it settled on, and, where it settled on nothing better
  * than somebody else's void, what the program was seen putting into that
- * void.</p>
+ * void. An object whose answer is its own locator is a void itself and is
+ * marked as one, since telling a reader that {@code args} is whatever
+ * {@code args} turns out to be is telling them nothing.</p>
  *
  * <p>A chain of dispatches is the awkward case. {@code first.as-bytes.size}
  * is three objects and the XMIR gives all three the same column, because each
@@ -180,6 +182,10 @@ final class Pieces {
                 .attr("band", Pieces.band(object.answer()))
                 .attr("where", object.answer().where())
                 .attr("loc", object.loc());
+            if (object.loc().equals(object.answer().where())
+                && "rooted".equals(Pieces.band(object.answer()))) {
+                dirs.attr("void", "true");
+            }
             Pieces.witnessed(dirs, object.answer().seen());
             dirs.up();
         }

--- a/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
@@ -66,36 +66,31 @@ SPDX-License-Identifier: MIT
       <b>
         <xsl:value-of select="@label"/>
       </b>
+      <xsl:text>: </xsl:text>
       <xsl:choose>
-        <xsl:when test="@band = 'named'">
-          <xsl:text> is a </xsl:text>
-          <code>
-            <xsl:value-of select="@where"/>
-          </code>
+        <xsl:when test="@void = 'true'">
+          <xsl:text>void</xsl:text>
         </xsl:when>
-        <xsl:when test="@band = 'rooted'">
-          <xsl:text> is whatever </xsl:text>
-          <code>
-            <xsl:value-of select="@where"/>
-          </code>
-          <xsl:text> turns out to be</xsl:text>
-          <xsl:apply-templates select="seen"/>
+        <xsl:when test="@band = 'blank'">
+          <xsl:text>unknown</xsl:text>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:text> — we know nothing about it</xsl:text>
+          <code>
+            <xsl:value-of select="@where"/>
+          </code>
         </xsl:otherwise>
       </xsl:choose>
+      <xsl:apply-templates select="seen"/>
     </span>
   </xsl:template>
   <xsl:template match="seen">
-    <xsl:text>, and callers were seen putting </xsl:text>
+    <xsl:text>, seen </xsl:text>
     <xsl:for-each select="*">
       <xsl:if test="position() &gt; 1">
         <xsl:text>, </xsl:text>
       </xsl:if>
       <xsl:apply-templates select="."/>
     </xsl:for-each>
-    <xsl:text> in it</xsl:text>
   </xsl:template>
   <xsl:template match="seen/ref">
     <code>

--- a/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
@@ -141,6 +141,25 @@ final class PiecesTest {
     }
 
     @Test
+    void tellsAVoidApartFromANameRootedInOne() {
+        MatcherAssert.assertThat(
+            "a void answered by its own locator must be said to be one, but it wasnt",
+            PiecesTest.drawn(
+                "[args] > printf",
+                Collections.singletonList(
+                    new Written(
+                        "Φ.printf.args", 1, "args",
+                        new Answer(
+                            "Φ.printf.args", 1, Collections.singletonList(new Ref("Φ.tuple"))
+                        )
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath("/line/bit/told[@void='true']")
+        );
+    }
+
+    @Test
     void saysWhatCallersWereSeenPassing() {
         MatcherAssert.assertThat(
             "an amber mark must say what turned up in the void, but it didnt",


### PR DESCRIPTION
Closes #8221.

The popover told a void that it is whatever itself turns out to be — `args is whatever Φ.string.printf.args turns out to be` — because every rung-one answer got the same sentence, and for a declared void the locator in that sentence is the object doing the talking. That is 1,578 of the 12,892 rung-one objects on a clean `eo-runtime`.

`Pieces` knows both halves it takes to tell them apart, so it now marks the ones that answer with their own locator:

```java
if (object.loc().equals(object.answer().where())
    && "rooted".equals(Pieces.band(object.answer()))) {
    dirs.attr("void", "true");
}
```

The page then drops the verbs everywhere, since the colour of the mark already says how deep the answer is and the prose was repeating it:

```
printf: Φ.string.printf
args: void, seen Φ.tuple
argument 0: Φ.bytes.as-bytes.ρ.eq.if, seen Φ.bytes, Φ.string.joined
x: unknown
```

Nothing about the bands or the tally moves — a void is still counted where it was, and whether it deserves a band of its own is a separate question.
