### PR TITLE
Keep the caller that passes on a void of its own

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Carried.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Carried.java
@@ -1,0 +1,106 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What a void handed on to another void carries into it.
+ *
+ * <p>{@link Landed} gives no landing to a filling that runs into a void, and
+ * {@link Fillings} therefore has a call site it cannot name a type for:
+ * {@code inc y}, written inside a formation that declares {@code y}. What
+ * arrives in {@code inc} is whatever arrives in {@code y}, one hop further
+ * along, and the tables know that as soon as they know the one — so the hop is
+ * walked here, and walked again, until no void learns anything new.</p>
+ *
+ * <p>A void whose source carries nothing carries nothing on, and that is not a
+ * hole in the answer: an argument written in a formation nobody ever copies is
+ * an argument nobody ever passes, and a program is looked at whole. So a void
+ * filled with an {@code oak} once and handed on from a formation nobody calls
+ * is filled with an {@code oak} and nothing else.</p>
+ *
+ * <p>Where the hop is all a void has, the far end of it is the answer, as
+ * {@link Var}. That says less than a forma and more than silence, and it is
+ * the truth about a pair of voids that are only ever filled together. It is
+ * also the last resort, so where a forma does arrive it wins: {@code Φ.map}'s
+ * inner {@code tup} used to be whatever {@code Φ.map.pairs} is and is now a
+ * {@code Φ.tuple}.</p>
+ *
+ * @since 0.70.0
+ */
+final class Carried {
+
+    /**
+     * The types every void is filled with by a call site that names one.
+     */
+    private final Map<String, Map<String, Type>> placed;
+
+    /**
+     * The voids handed on to every void, as the variables they are, by the
+     * locator of the void they were handed to.
+     */
+    private final Map<String, Map<String, Type>> handed;
+
+    /**
+     * Ctor.
+     * @param named What every void is filled with where the filling has a type
+     * @param hops The voids handed on to every void
+     */
+    Carried(
+        final Map<String, Map<String, Type>> named,
+        final Map<String, Map<String, Type>> hops
+    ) {
+        this.placed = named;
+        this.handed = hops;
+    }
+
+    /**
+     * What every void is filled with, the hops walked through.
+     * @return The types, by name, by the locator of the void
+     */
+    Map<String, Map<String, Type>> all() {
+        final Map<String, Map<String, Type>> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, Map<String, Type>> hollow : this.placed.entrySet()) {
+            found.put(hollow.getKey(), new LinkedHashMap<>(hollow.getValue()));
+        }
+        boolean grown = true;
+        while (grown) {
+            grown = false;
+            for (final Map.Entry<String, Map<String, Type>> hop : this.handed.entrySet()) {
+                if (this.arrived(hop.getKey(), found)) {
+                    grown = true;
+                }
+            }
+        }
+        for (final Map.Entry<String, Map<String, Type>> hop : this.handed.entrySet()) {
+            if (found.getOrDefault(hop.getKey(), Collections.emptyMap()).isEmpty()) {
+                found.put(hop.getKey(), hop.getValue());
+            }
+        }
+        return found;
+    }
+
+    private boolean arrived(final String hollow, final Map<String, Map<String, Type>> found) {
+        final Map<String, Type> brought = new LinkedHashMap<>(0);
+        for (final String source : this.handed.get(hollow).keySet()) {
+            brought.putAll(found.getOrDefault(source, Collections.emptyMap()));
+        }
+        boolean grown = false;
+        if (!brought.isEmpty()) {
+            final Map<String, Type> into = found.computeIfAbsent(
+                hollow, key -> new LinkedHashMap<>(0)
+            );
+            for (final Map.Entry<String, Type> type : brought.entrySet()) {
+                if (into.putIfAbsent(type.getKey(), type.getValue()) == null) {
+                    grown = true;
+                }
+            }
+        }
+        return grown;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -33,10 +33,12 @@ import java.util.Map;
  * five members where it had more than a cap's worth, and the five are worth
  * reading.</p>
  *
- * <p>A filling whose walk runs into a void is nobody's answer here — what
- * fills that void is a fact about another caller. Such a filling is kept aside
- * and used only where it is all there is, since a void whose every caller
- * passes on a void of its own is better described by that than by silence.</p>
+ * <p>A filling whose walk runs into a void is no type, and it is no silence
+ * either: it says this void is handed whatever another void is handed. So it
+ * is kept as the variable it is, beside the types the other callers bring,
+ * because a void that four callers fill with a {@code Φ.string} and a fifth
+ * fills with a void of its own is not the same void as one that four callers
+ * fill and nobody else touches.</p>
  *
  * @since 0.69.0
  */
@@ -72,23 +74,14 @@ final class Fillings {
         final Map<String, String> names = new Ends(pairs.all()).names();
         final Map<String, String> landings = new Landed(pairs, this.given).all();
         final Forms forms = new Forms(pairs.forms());
-        final Map<String, Map<String, Type>> placed = new LinkedHashMap<>(0);
-        final Map<String, Map<String, Type>> loose = new LinkedHashMap<>(0);
+        final Map<String, Map<String, Type>> chosen = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Collection<String>> bound : pairs.puts().entrySet()) {
             for (final String put : bound.getValue()) {
-                final String end = landings.get(put);
-                if (end == null) {
-                    final String stopped = names.getOrDefault(put, put);
-                    loose.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
-                        .putIfAbsent(forms.name(stopped), forms.type(stopped));
-                } else {
-                    placed.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
-                        .putIfAbsent(forms.name(end), forms.type(end));
-                }
+                final String end = landings.getOrDefault(put, names.getOrDefault(put, put));
+                chosen.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
+                    .putIfAbsent(forms.name(end), forms.type(end));
             }
         }
-        final Map<String, Map<String, Type>> chosen = new LinkedHashMap<>(loose);
-        chosen.putAll(placed);
         final Map<String, Collection<Type>> found = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Map<String, Type>> hollow : chosen.entrySet()) {
             found.put(hollow.getKey(), hollow.getValue().values());

--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -33,12 +33,12 @@ import java.util.Map;
  * five members where it had more than a cap's worth, and the five are worth
  * reading.</p>
  *
- * <p>A filling whose walk runs into a void is no type, and it is no silence
- * either: it says this void is handed whatever another void is handed. So it
- * is kept as the variable it is, beside the types the other callers bring,
- * because a void that four callers fill with a {@code Φ.string} and a fifth
- * fills with a void of its own is not the same void as one that four callers
- * fill and nobody else touches.</p>
+ * <p>A filling whose walk runs into a void has no type of its own to give, and
+ * it is not thereby nothing: what fills that void reaches this one too, a hop
+ * further along. {@link Carried} walks the hop, so a void filled with an
+ * {@code oak} by one caller and handed on from a void filled with a number is
+ * seen to hold both, and a void whose every caller passes on a void of its own
+ * is described by that rather than by silence.</p>
  *
  * @since 0.69.0
  */
@@ -74,16 +74,24 @@ final class Fillings {
         final Map<String, String> names = new Ends(pairs.all()).names();
         final Map<String, String> landings = new Landed(pairs, this.given).all();
         final Forms forms = new Forms(pairs.forms());
-        final Map<String, Map<String, Type>> chosen = new LinkedHashMap<>(0);
+        final Map<String, Map<String, Type>> placed = new LinkedHashMap<>(0);
+        final Map<String, Map<String, Type>> handed = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Collection<String>> bound : pairs.puts().entrySet()) {
             for (final String put : bound.getValue()) {
-                final String end = landings.getOrDefault(put, names.getOrDefault(put, put));
-                chosen.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
-                    .putIfAbsent(forms.name(end), forms.type(end));
+                final String end = landings.get(put);
+                if (end == null) {
+                    final String stopped = names.getOrDefault(put, put);
+                    handed.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
+                        .putIfAbsent(forms.name(stopped), forms.type(stopped));
+                } else {
+                    placed.computeIfAbsent(bound.getKey(), key -> new LinkedHashMap<>(0))
+                        .putIfAbsent(forms.name(end), forms.type(end));
+                }
             }
         }
         final Map<String, Collection<Type>> found = new LinkedHashMap<>(0);
-        for (final Map.Entry<String, Map<String, Type>> hollow : chosen.entrySet()) {
+        for (final Map.Entry<String, Map<String, Type>> hollow
+            : new Carried(placed, handed).all().entrySet()) {
             found.put(hollow.getKey(), hollow.getValue().values());
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Seen.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Seen.java
@@ -28,6 +28,11 @@ import java.util.stream.Collectors;
  * {@code union} of them, and to whoever asks what went in the difference
  * between the two is no difference at all.</p>
  *
+ * <p>A caller that passes on a void of its own is in the choice as a
+ * {@code var} and is read back as one, since a reader told that a void is
+ * filled with a {@code Φ.string} deserves to know that somebody also fills it
+ * with something nobody has looked into.</p>
+ *
  * <p>This is evidence and never a contract, exactly as {@link Witnessed}
  * says: nothing may work out the type of a void from what is read here.
  * It is read so that a reader who is told an object is whatever
@@ -77,6 +82,8 @@ final class Seen {
         for (final Xnav choice : told) {
             if ("ref".equals(Seen.kind(choice))) {
                 found.add(new Ref(new Noted(choice).says("loc")));
+            } else if ("var".equals(Seen.kind(choice))) {
+                found.add(new Var(new Noted(choice).says("id")));
             }
         }
         if (Seen.holds(told, "data")) {
@@ -91,15 +98,16 @@ final class Seen {
     private static Collection<Xnav> told(final Xnav hollow) {
         final Collection<Xnav> found = new ArrayList<>(0);
         for (final Xnav witnessed : Seen.choices(hollow, "witnessed")) {
-            for (final Xnav choice : Seen.choices(witnessed, "union", "ref", "data", "unknown")) {
-                if ("union".equals(Seen.kind(choice))) {
-                    found.addAll(Seen.choices(choice, "ref", "data", "unknown"));
-                } else {
-                    found.add(choice);
-                }
+            found.addAll(Seen.listed(witnessed));
+            for (final Xnav union : Seen.choices(witnessed, "union")) {
+                found.addAll(Seen.listed(union));
             }
         }
         return found;
+    }
+
+    private static List<Xnav> listed(final Xnav node) {
+        return Seen.choices(node, "ref", "var", "data", "unknown");
     }
 
     private static List<Xnav> choices(final Xnav node, final String... names) {

--- a/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
@@ -97,6 +97,12 @@ SPDX-License-Identifier: MIT
       <xsl:value-of select="@loc"/>
     </code>
   </xsl:template>
+  <xsl:template match="seen/var">
+    <xsl:text>void </xsl:text>
+    <code>
+      <xsl:value-of select="@id"/>
+    </code>
+  </xsl:template>
   <xsl:template match="seen/data">
     <xsl:text>a datum</xsl:text>
   </xsl:template>

--- a/eo-inference/src/test/java/org/eolang/inference/CarriedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/CarriedTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Carried}.
+ * @since 0.70.0
+ */
+final class CarriedTest {
+
+    @Test
+    void walksTwoHopsInARow() {
+        final Map<String, Map<String, Type>> handed = new LinkedHashMap<>(0);
+        handed.put(
+            "Φ.near.x", Collections.singletonMap("Φ.far.y", new Var("Φ.far.y"))
+        );
+        handed.put(
+            "Φ.far.y", Collections.singletonMap("Φ.end.z", new Var("Φ.end.z"))
+        );
+        MatcherAssert.assertThat(
+            "what fills the far void must reach the near one, but it stopped halfway",
+            new Carried(
+                Collections.singletonMap(
+                    "Φ.end.z", Collections.singletonMap("Φ.oak", new Ref("Φ.oak"))
+                ),
+                handed
+            ).all().get("Φ.near.x"),
+            Matchers.hasKey("Φ.oak")
+        );
+    }
+
+    @Test
+    void keepsTheVoidWhereNothingIsCarried() {
+        MatcherAssert.assertThat(
+            "a void whose only source is empty must name that source, but it named nothing",
+            new Carried(
+                Collections.emptyMap(),
+                Collections.singletonMap(
+                    "Φ.near.x", Collections.singletonMap("Φ.far.y", new Var("Φ.far.y"))
+                )
+            ).all().get("Φ.near.x"),
+            Matchers.hasKey("Φ.far.y")
+        );
+    }
+
+    @Test
+    void doesNotLoopOnAVoidHandedToItself() {
+        MatcherAssert.assertThat(
+            "a void that fills itself must be answered, but the walk never came back",
+            new Carried(
+                Collections.singletonMap(
+                    "Φ.self.x", Collections.singletonMap("Φ.oak", new Ref("Φ.oak"))
+                ),
+                Collections.singletonMap(
+                    "Φ.self.x", Collections.singletonMap("Φ.self.x", new Var("Φ.self.x"))
+                )
+            ).all().get("Φ.self.x"),
+            Matchers.hasKey("Φ.oak")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/SeenTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/SeenTest.java
@@ -51,6 +51,21 @@ final class SeenTest {
     }
 
     @Test
+    void readsBackTheCallerThatPassesOnAVoid() {
+        MatcherAssert.assertThat(
+            "the void a caller passes on must come back with its locator, but it didnt",
+            new Xembler(
+                SeenTest.drawn(
+                    "<provides><type id='Φ.bool.and'><attr name='x' type='Φ.bool.and.x'",
+                    " void='true'><witnessed><union><ref loc='Φ.true'/>",
+                    "<var id='Φ.app.y'/></union></witnessed></attr></type></provides>"
+                )
+            ).xmlQuietly(),
+            XhtmlMatchers.hasXPath("/seen/var[@id='Φ.app.y']")
+        );
+    }
+
+    @Test
     void keepsAVoidNobodyFillsInTheAnswer() {
         MatcherAssert.assertThat(
             "a void with no witnesses must still be listed, but it was left out",

--- a/eo-inference/src/test/java/org/eolang/inference/WitnessedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/WitnessedTest.java
@@ -65,6 +65,35 @@ final class WitnessedTest {
         );
     }
 
+    @Test
+    void keepsTheCallerThatPassesOnAVoidOfItsOwn(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("wood.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.inc' name='inc'>",
+                "<o base='∅' loc='Φ.inc.x' name='x'/></o>",
+                "<o loc='Φ.oak' name='oak'/>",
+                "<o base='Φ.inc' loc='Φ.app' name='app'>",
+                "<o as='α0' base='Φ.oak' loc='Φ.app.α0'/></o>",
+                "<o loc='Φ.bee' name='bee'>",
+                "<o base='∅' loc='Φ.bee.y' name='y'/>",
+                "<o as='φ' base='Φ.inc' loc='Φ.bee.φ'>",
+                "<o as='α0' base='ξ.y' loc='Φ.bee.φ.α0'/></o></o></object>"
+            )
+        );
+        new Witnessed(new Demanded(new Resolved(new Clues()))).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "a caller passing on a void of its own must stay in the choice, but it was dropped",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
+                "/provides/type[@id='Φ.inc']/attr[@name='x']/witnessed/union/var[@id='Φ.bee.y']"
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
     private static void program(final Path temp, final String... fillers) throws IOException {
         final StringBuilder text = new StringBuilder(
             String.join(

--- a/eo-inference/src/test/java/org/eolang/inference/WitnessedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/WitnessedTest.java
@@ -66,29 +66,31 @@ final class WitnessedTest {
     }
 
     @Test
-    void keepsTheCallerThatPassesOnAVoidOfItsOwn(@Mktmp final Path temp) throws IOException {
+    void carriesWhatTheVoidHandedOnIsFilledWith(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("wood.xmir"),
             String.join(
                 "",
                 "<object><o loc='Φ.inc' name='inc'>",
                 "<o base='∅' loc='Φ.inc.x' name='x'/></o>",
-                "<o loc='Φ.oak' name='oak'/>",
+                "<o loc='Φ.oak' name='oak'/><o loc='Φ.elm' name='elm'/>",
                 "<o base='Φ.inc' loc='Φ.app' name='app'>",
                 "<o as='α0' base='Φ.oak' loc='Φ.app.α0'/></o>",
                 "<o loc='Φ.bee' name='bee'>",
                 "<o base='∅' loc='Φ.bee.y' name='y'/>",
                 "<o as='φ' base='Φ.inc' loc='Φ.bee.φ'>",
-                "<o as='α0' base='ξ.y' loc='Φ.bee.φ.α0'/></o></o></object>"
+                "<o as='α0' base='ξ.y' loc='Φ.bee.φ.α0'/></o></o>",
+                "<o base='Φ.bee' loc='Φ.hut' name='hut'>",
+                "<o as='α0' base='Φ.elm' loc='Φ.hut.α0'/></o></object>"
             )
         );
         new Witnessed(new Demanded(new Resolved(new Clues()))).follow(
             temp.resolve("xmirs"), temp.resolve("tables")
         );
         MatcherAssert.assertThat(
-            "a caller passing on a void of its own must stay in the choice, but it was dropped",
+            "what fills the void handed on must arrive in the choice, but it didnt",
             new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
-                "/provides/type[@id='Φ.inc']/attr[@name='x']/witnessed/union/var[@id='Φ.bee.y']"
+                "/provides/type[@id='Φ.inc']/attr[@name='x']/witnessed/union/ref[@loc='Φ.elm']"
             ),
             Matchers.hasSize(1)
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-handed-on-carries-what-it-holds.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-handed-on-carries-what-it-holds.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `bee` puts an `oak` into `inc` and `wrap` passes on a void of its own, and
+# that void is filled with an `elm` by `app`. So an `elm` arrives in `inc` as
+# surely as the `oak` does, one hop further along, and both belong in the
+# choice. Saying only the `oak` would leave a void that two formas reach
+# looking like a void that one forma reaches.
+eo:
+  app.eo: |
+    [] > app
+      wrap elm > @
+  wrap.eo: |
+    [y] > wrap
+      inc y > @
+  bee.eo: |
+    [] > bee
+      inc oak > @
+  inc.eo: |
+    [x] > inc
+      x > @
+  oak.eo: |
+    [] > oak
+  elm.eo: |
+    [] > elm
+provides:
+  - "//type[@id='Φ.inc']/attr[@void='true']/witnessed/union/ref[@loc='Φ.oak']"
+  - "//type[@id='Φ.inc']/attr[@void='true']/witnessed/union/ref[@loc='Φ.elm']"


### PR DESCRIPTION
Closes #8229.

A call site that passes on a void of its own was gathered and then thrown away, so a void filled with a `Φ.tuple` by one caller and handed on from a void that holds a `Φ.tuple` too was written as if only the first caller existed. The fix is not to write the discarded call site down as a hole, but to follow it: what fills the far void reaches the near one, one hop along, and the tables know the one as soon as they know the other. `Carried` walks that hop, and walks it again, until no void learns anything new:

```java
for (final String source : this.handed.get(hollow).keySet()) {
    brought.putAll(found.getOrDefault(source, Collections.emptyMap()));
}
```

A void whose source holds nothing still gets nothing, and that stays right rather than becoming a gap. An argument written in a formation nobody ever copies is an argument nobody ever passes, and inference reads the program whole — which is what `one-expression-at-many-places-is-one-filling` says, and it passes untouched. Where the hop is all a void has, the far end of it is still the answer as a `var`, so `void-filled-only-from-voids-says-what-it-can` passes untouched too.

`Seen` was dropping every `var` it read, which is how that second pack's answer never reached the report, so it reads them now and the page prints them as `void Φ.one.y` beside the rest.

On a clean `eo-runtime` 35 voids gain a member they never had, and 32 trade a `var` or a dangling locator for a forma: `Φ.map`'s inner `tup` was whatever `Φ.map.pairs` is and is now a `Φ.tuple`, and `Φ.i8.as-bytes` was four locators that name nothing in the table and is now a `Φ.bytes`. Nothing loses its last witness. Voids known to hold exactly one named type go from 554 to 578, and that is the set #8230 may promote.
