### PR TITLE
Install phino in rultor and demand lowering on merge and release

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -12,11 +12,20 @@ assets:
   settings.xml: yegor256/objectionary-secrets#settings.xml
   pubring.gpg: yegor256/objectionary-secrets#pubring.gpg
   secring.gpg: yegor256/objectionary-secrets#secring.gpg
+# The `lower` goal needs the exact phino version pinned in eo-lowering, and
+# the image carries no Haskell toolchain to build it with. The binary
+# published for Ubuntu 24.04, which this image is based on, is taken as it
+# is, and `--version` right after the download fails the build when the
+# wrong one arrives.
 install: |
   pdd --file=/dev/null
+  version=$(tr -d '[:space:]' < eo-lowering/src/main/resources/org/eolang/lowering/phino-version.txt)
+  curl --silent --show-error --fail --location --output /usr/local/bin/phino "http://phino.objectionary.com/releases/ubuntu-24.04/phino-${version}"
+  chmod +x /usr/local/bin/phino
+  phino --version
 merge:
   script: |
-    mvn clean install -ntp -DskipTests -Pqulice --errors -Dstyle.color=never
+    mvn clean install -ntp -DskipTests -Pqulice --errors -Dstyle.color=never -Deo.loweringRequired=true
 release:
   pre: false
   script: |-
@@ -26,5 +35,5 @@ release:
     mvn -ntp versions:set "-DnewVersion=${tag}" -Dstyle.color=never
     sed -i "s/npm install -g eolang@[0-9]\+\.[0-9]\+\.[0-9]\+/npm install -g eolang@${tag}/g" README.md
     git commit -am "${tag}"
-    mvn clean install -ntp -DskipTests -DskipITs -Dinvoker.skip
-    mvn clean deploy -ntp -DskipTests -DskipITs -Dinvoker.skip -Pobjectionary -Psonatype --errors --settings ../settings.xml -Dstyle.color=never
+    mvn clean install -ntp -DskipTests -DskipITs -Dinvoker.skip -Deo.loweringRequired=true
+    mvn clean deploy -ntp -DskipTests -DskipITs -Dinvoker.skip -Pobjectionary -Psonatype --errors --settings ../settings.xml -Dstyle.color=never -Deo.loweringRequired=true

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLower.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLower.java
@@ -45,11 +45,6 @@ import org.eolang.lowering.Phino;
  * that a diverging one is refused in milliseconds.</p>
  *
  * @since 0.76.0
- * @todo #8137:45min Install phino in <code>.rultor.yml</code> and pass
- *  <code>-Deo.loweringRequired=true</code> in its merge and release
- *  scripts, so that a release is never silently unlowered. The image
- *  rultor builds in has no Haskell toolchain and no build cache, so this
- *  needs either a prebuilt phino binary or an image that carries one.
  */
 @Mojo(
     name = "lower",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLowerTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLowerTest.java
@@ -143,6 +143,22 @@ final class MjLowerTest {
         );
     }
 
+    @Test
+    void removesTheMarkerWhenSkipping(@Mktmp final Path temp) throws IOException {
+        MjLowerTest.assumePhino(temp);
+        MatcherAssert.assertThat(
+            "a run without phino must take the marker of an earlier fold away, but it didnt",
+            Files.exists(
+                MjLowerTest.marker(
+                    MjLowerTest.lowered(temp)
+                        .with("binary", temp.resolve("no-such-phino").toString())
+                        .execute(MjLower.class)
+                )
+            ),
+            Matchers.is(false)
+        );
+    }
+
     private static void assumePhino(final Path temp) {
         Assumptions.assumeTrue(new Phino("phino", 7, temp).suitable());
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLowerTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLowerTest.java
@@ -110,6 +110,24 @@ final class MjLowerTest {
     }
 
     @Test
+    void skipsQuietlyWhenDisabledEvenWhenDemanded(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "eo.lowering set to false must outrank eo.loweringRequired, but it didnt",
+            Files.exists(
+                MjLowerTest.marker(
+                    new FakeMaven(temp)
+                        .withProgram(MjLowerTest.constant(), "foo", "foo.eo")
+                        .with("binary", temp.resolve("no-such-phino").toString())
+                        .with("lowering", false)
+                        .with("demanded", true)
+                        .execute(new PpLower())
+                )
+            ),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void removesTheMarkerWhenDisabled(@Mktmp final Path temp) throws IOException {
         MjLowerTest.assumePhino(temp);
         MatcherAssert.assertThat(


### PR DESCRIPTION
Rultor built releases without phino on the PATH, so the `lower` goal skipped itself and every artifact we published was silently unlowered. The image has no Haskell toolchain and no build cache, so building phino from source there is out of the question, but the project publishes a prebuilt binary per platform, and the image is based on Ubuntu 24.04. The install step now downloads the binary for the version pinned in `eo-lowering`, drops it into `/usr/local/bin` and runs `--version` right away, so a wrong or missing download fails the build before Maven starts.

With the binary in place, `-Deo.loweringRequired=true` goes into the merge script and into both Maven invocations of the release script, which turns a skipped lowering from a warning into a failure. That is the whole point of the flag: a release can no longer be published unlowered.

One interaction deserved a test. `eo.lowering` set to false turns the goal off entirely and outranks `eo.loweringRequired`, so the release scripts above would still pass while folding nothing. `MjLowerTest` now pins that precedence down.

Closes #8197
