### PR TITLE
Type a void from the one thing the program puts in it

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answer.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answer.java
@@ -22,12 +22,14 @@ import java.util.Collections;
  * sure that cannot happen is for both to read the same answer.</p>
  *
  * <p>An object that settled on nothing better than somebody else's void
- * carries what the program was seen putting into that void as well. It is
- * evidence and not an answer — the callers of today do not oblige the one
- * written tomorrow — but a reader told that their object is whatever
- * {@code Φ.bool.and.x} turns out to be has nowhere to go next, and a reader
- * told that {@code Φ.true} and {@code Φ.false} have both been put there has.
- * The rung is untouched by it.</p>
+ * carries what the program was seen putting into that void as well. A void
+ * filled one way and no other is that one thing and settles there instead, so
+ * what is carried here is what the walk could not settle on — several types at
+ * once, or a single one naming nothing a reader could go and look at. A reader
+ * told that their object is whatever {@code Φ.bool.and.x} turns out to be has
+ * nowhere to go next, and a reader told that {@code Φ.true} and
+ * {@code Φ.false} have both been put there has. The rung is untouched by
+ * it.</p>
  *
  * @since 0.70.0
  */

--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -35,11 +35,18 @@ import java.util.Map;
  * already worked out on the way to the rung. Whoever counts the program and
  * whoever shows it to somebody read the same one.</p>
  *
- * <p>A name rooted at a void goes back with what {@link Seen} found in that
- * void besides. Nothing in the walk reads it and no rung moves because of it:
- * a void filled with a {@code number} at every call site is still a void, and
- * saying otherwise would turn the habits of today's callers into a promise
- * nobody made.</p>
+ * <p>A void the program fills one way and no other is that one thing, and
+ * stands where it stands: {@code Φ.string.printf.args} is a {@code Φ.tuple}
+ * because every call site in the program puts one there, and a build reads the
+ * program whole, library and all. A void filled several ways is still a void —
+ * {@code Φ.bool.and.x} is seven things and therefore none of them — and so is
+ * a void whose one filling names nothing a reader could go and look at, since
+ * a rung above the first has to be a name.</p>
+ *
+ * <p>Where the void keeps itself, what {@link Seen} found in it goes back
+ * beside it, for a reader who is told their object is whatever
+ * {@code Φ.bool.and.x} turns out to be and would rather be told that
+ * {@code Φ.true} and {@code Φ.false} have both been put there.</p>
  *
  * @since 0.69.0
  */
@@ -97,6 +104,7 @@ final class Answers {
     Answer of(final String locator, final Collection<String> filled) {
         final String end = this.ends.getOrDefault(locator, locator);
         final String root = this.root(end);
+        final String sole = this.sole(end);
         final Answer found;
         if (this.ground.contains(end)) {
             found = new Answer(end, 4);
@@ -104,8 +112,24 @@ final class Answers {
             found = new Answer(end, this.depth(end, this.free(end, filled)));
         } else if (root.isEmpty()) {
             found = new Answer(end, 0);
-        } else {
+        } else if (sole.isEmpty()) {
             found = new Answer(end, 1, this.hollows.get(root));
+        } else {
+            found = new Answer(sole, this.depth(sole, this.free(sole, filled)));
+        }
+        return found;
+    }
+
+    private String sole(final String end) {
+        final Collection<Type> told = this.hollows.getOrDefault(
+            end, Collections.emptyList()
+        );
+        String found = "";
+        if (told.size() == 1) {
+            found = told.iterator().next().names();
+        }
+        if (!this.table.containsKey(found)) {
+            found = "";
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Ref.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ref.java
@@ -51,6 +51,11 @@ final class Ref implements Type {
     }
 
     @Override
+    public String names() {
+        return this.loc;
+    }
+
+    @Override
     public Directives directives() {
         final Directives dirs = new Directives().add("ref").attr("loc", this.loc);
         for (final Map.Entry<String, String> bind : this.filled.entrySet()) {

--- a/eo-inference/src/main/java/org/eolang/inference/Seen.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Seen.java
@@ -33,11 +33,12 @@ import java.util.stream.Collectors;
  * filled with a {@code Φ.string} deserves to know that somebody also fills it
  * with something nobody has looked into.</p>
  *
- * <p>This is evidence and never a contract, exactly as {@link Witnessed}
- * says: nothing may work out the type of a void from what is read here.
- * It is read so that a reader who is told an object is whatever
- * {@code Φ.bool.and.x} turns out to be can also be told what the program was
- * seen putting there.</p>
+ * <p>What is read here is what {@link Answers} types a void from, exactly as
+ * {@link Witnessed} says: one member and the void is that member, several and
+ * it is still a void. So it is read twice over — to type the voids that can be
+ * typed, and to tell a reader who is told their object is whatever
+ * {@code Φ.bool.and.x} turns out to be what the program was seen putting
+ * there.</p>
  *
  * @since 0.70.0
  */

--- a/eo-inference/src/main/java/org/eolang/inference/Type.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Type.java
@@ -19,6 +19,13 @@ import org.xembly.Directives;
  * <p>What comes back leaves the cursor where it found it, since a row holds
  * one type and the row that follows starts beside it.</p>
  *
+ * <p>A type is also asked which object of the program it names, and most of
+ * them name none: a datum names the ground every literal stands on, a
+ * variable names a void nobody has looked into, a choice names several at
+ * once. Only a copy has a locator a reader can go and look at, so only a copy
+ * gives one back, and asking is how a reader learns whether there is anything
+ * to go and look at without having to know which kind of type it is holding.</p>
+ *
  * @since 0.69.0
  */
 @FunctionalInterface
@@ -29,4 +36,12 @@ interface Type {
      * @return The directives
      */
     Directives directives();
+
+    /**
+     * The object of the program this type names.
+     * @return The locator, empty where the type names no one object
+     */
+    default String names() {
+        return "";
+    }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
@@ -33,12 +33,17 @@ import org.xembly.Xembler;
  *   &lt;/witnessed&gt;
  * &lt;/attr&gt;</pre>
  *
- * <p>This is evidence of callers and never a contract. Nothing may work out
- * the type of a void from it: the callers a program happens to have today do
- * not oblige the one written tomorrow, and a void filled with a
- * {@code number} everywhere is still a void. It is written because it is true
- * and because whoever reads the tables wants it, which is the whole of the
- * reason.</p>
+ * <p>Where the choice has one member, that member is the type of the void, and
+ * {@link Answers} says so. There is no tomorrow for such a claim to leak into:
+ * a build parses the library it uses along with the program, transpiles it
+ * again, and keys the cache on the rows it wrote, so a caller who passes
+ * something else is in a run of their own, where the void has two witnesses
+ * and is a void again. What a program does with a void everywhere is a fact
+ * about that program, and refusing to read it is refusing to know it.</p>
+ *
+ * <p>A choice of several stays a choice. {@code Φ.bool.and.x} is filled with a
+ * {@code Φ.true}, with a {@code Φ.false} and with five other things, and
+ * naming any one of them would be picking a favourite among facts.</p>
  *
  * <p>A choice longer than the cap is written as {@code unknown} instead of its
  * members. {@code Φ.tuple.head} is filled with 56 different types, and a

--- a/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
@@ -96,6 +96,71 @@ final class AnswersTest {
     }
 
     @Test
+    void answersAVoidWithTheOneTypeThatFillsIt() {
+        MatcherAssert.assertThat(
+            "a void the whole program fills with a tuple must answer that it is one, but it didnt",
+            new Answers(
+                AnswersTest.formation("Φ.tuple"),
+                Collections.singletonMap(
+                    "Φ.printf.args", Collections.singletonList(new Ref("Φ.tuple"))
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.printf.args", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.tuple")
+        );
+    }
+
+    @Test
+    void takesTheRungOfTheTypeThatFillsTheVoid() {
+        MatcherAssert.assertThat(
+            "a void filled with a whole formation must stand where it stands, but it stayed below",
+            new Answers(
+                AnswersTest.formation("Φ.tuple"),
+                Collections.singletonMap(
+                    "Φ.printf.args", Collections.singletonList(new Ref("Φ.tuple"))
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.printf.args", Collections.emptyList()).rung(),
+            Matchers.equalTo(4)
+        );
+    }
+
+    @Test
+    void leavesAVoidSeveralTypesFillAlone() {
+        MatcherAssert.assertThat(
+            "a void two formas fill cannot be either of them, but it was named one",
+            new Answers(
+                AnswersTest.formation("Φ.tuple"),
+                Collections.singletonMap(
+                    "Φ.i8.as-bytes",
+                    Arrays.asList(new Ref("Φ.tuple"), new Ref("Φ.string"))
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.i8.as-bytes", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.i8.as-bytes")
+        );
+    }
+
+    @Test
+    void leavesAVoidFilledFromAnotherVoidAlone() {
+        MatcherAssert.assertThat(
+            "a void filled from a void names no forma, so it must stay itself, but it moved",
+            new Answers(
+                AnswersTest.formation("Φ.tuple"),
+                Collections.singletonMap(
+                    "Φ.one.x", Collections.singletonList(new Var("Φ.two.y"))
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.one.x", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.one.x")
+        );
+    }
+
+    @Test
     void doesNotCountTheReceiverAmongTheVoidsFilled() {
         final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
         final Map<String, String> whole = new LinkedHashMap<>(0);
@@ -118,5 +183,12 @@ final class AnswersTest {
             ).of("Φ.app.half", Collections.singletonList("Φ.grow.ρ")).rung(),
             Matchers.equalTo(2)
         );
+    }
+
+    private static Map<String, Collection<Map<String, String>>> formation(final String locator) {
+        final Map<String, String> whole = new LinkedHashMap<>(0);
+        whole.put("id", locator);
+        whole.put("complete", "true");
+        return Collections.singletonMap(locator, Collections.singletonList(whole));
     }
 }


### PR DESCRIPTION
Inference reads a program whole. A build parses the library along with the sources, transpiles it again, and keys its cache on the rows it wrote — so when every call site in a program puts a `tuple` into `string.printf.args`, that is not a habit of today's callers, it is a fact about the program in front of us. `Answers.of` refused to read it, and answered every such void with its own locator on the first rung.

Now it promotes: a void whose witnesses name exactly one object of the program becomes that object, at that object's rung. A void several types fill stays a void, and so does one whose single witness names nothing a reader could go and look at — a datum, another void, a locator absent from the table.

```java
} else if (sole.isEmpty()) {
    found = new Answer(end, 1, this.hollows.get(root));
} else {
    found = new Answer(sole, this.depth(sole, this.free(sole, filled)));
}
```

Asking a type which object it names is new. `Type.names()` defaults to nothing and only `Ref` overrides it, which keeps `Answers` free of casts and of a fifth attribute.

Measured on eo-runtime, against tables written by the current master: 448 voids get typed, and 1322 objects in all leave the amber band, since an object whose chain of copies ends at a promoted void moves with it. Coverage goes from 75.50% to 77.99%; the blank band does not move, and nothing descends. `string.printf.args` is a `tuple`, `string.printf.ρ` is a `string`, `bool.and.x` is still seven things and still a void.

The three docblocks that forbade this — `Witnessed`, `Seen`, `Answer` — say the new rule instead. `i8.as-bytes` had to leave them as the example of a void filled many ways: #8229 collapsed its four dangling locators into one `bytes`, so it is typed now too.

Closes #8230.

The report still prints each object on its own, one pass. A void typed here does not yet teach the dispatches rooted at it, which is #8231.
