### PR TITLE
#8217: walk only regular files when collecting .xmir inputs

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Report.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Report.java
@@ -110,6 +110,7 @@ public final class Report {
         if (Files.exists(this.world)) {
             try (Stream<Path> walked = Files.walk(this.world)) {
                 walked.filter(path -> path.toString().endsWith(".xmir"))
+                    .filter(Files::isRegularFile)
                     .sorted()
                     .forEach(found::add);
             }

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -258,6 +258,7 @@ final class Xmirs {
         try (Stream<Path> found = Files.walk(this.dir)) {
             return found
                 .filter(path -> path.toString().endsWith(".xmir"))
+                .filter(Files::isRegularFile)
                 .sorted()
                 .collect(Collectors.toList());
         }

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -77,6 +77,18 @@ final class ReportTest {
         );
     }
 
+    @Test
+    void ignoresADirectoryNamedLikeAnXmirFile(@Mktmp final Path temp) throws IOException {
+        final Path program = ReportTest.program(temp);
+        final Path tables = ReportTest.tables(temp);
+        Files.createDirectories(program.resolve("stale.xmir"));
+        MatcherAssert.assertThat(
+            "a folder whose name ends with .xmir must not become a page, but it did",
+            new Report(program, tables).written(temp.resolve("out")),
+            Matchers.equalTo(1)
+        );
+    }
+
     private static Path program(final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),

--- a/eo-inference/src/test/java/org/eolang/inference/XmirsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/XmirsTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Xmirs}.
+ * @since 0.73.4
+ */
+@ExtendWith(MktmpResolver.class)
+final class XmirsTest {
+
+    @Test
+    void ignoresADirectoryNamedLikeAnXmirFile(@Mktmp final Path temp) throws IOException {
+        final Path dir = Files.createDirectories(temp.resolve("xmirs"));
+        Files.writeString(
+            dir.resolve("cup.xmir"),
+            String.join(
+                "",
+                "<object><o line='1' loc='Φ.cup' name='cup' pos='0'>",
+                "<o line='2' loc='Φ.cup.lid' name='lid' pos='2'/></o></object>"
+            )
+        );
+        Files.createDirectories(dir.resolve("stale.xmir"));
+        MatcherAssert.assertThat(
+            "a folder whose name ends with .xmir must be left alone, but it was read",
+            new Xmirs(dir).formations(),
+            Matchers.hasSize(2)
+        );
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -150,6 +150,7 @@ final class Inferring implements Step {
         try (Stream<Path> found = Files.walk(this.input)) {
             return found
                 .filter(path -> path.toString().endsWith(".xmir"))
+                .filter(Files::isRegularFile)
                 .sorted()
                 .collect(Collectors.toList());
         }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -140,6 +140,24 @@ final class InferringTest {
         );
     }
 
+    @Test
+    void ignoresADirectoryNamedLikeAnXmirFile(@Mktmp final Path temp) throws IOException {
+        final Path sources = Files.createDirectories(temp.resolve("yard"));
+        Files.writeString(
+            sources.resolve("spade.xmir"),
+            new EoSyntax(
+                String.join(System.lineSeparator(), "[] > spade", "  [] > handle", "")
+            ).parsed().toString()
+        );
+        Files.createDirectories(sources.resolve("stale.xmir"));
+        new Inferring(sources, temp.resolve("pre"), temp.resolve("rows")).exec();
+        MatcherAssert.assertThat(
+            "a folder whose name ends with .xmir must be left alone, but it was read",
+            new XMLDocument(temp.resolve("rows").resolve("provides.xml")),
+            XhtmlMatchers.hasXPath("/provides/type[@id='Φ.spade']/attr[@name='handle']")
+        );
+    }
+
     private Map<String, String> sources(final Xtory pack) {
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final Map.Entry<?, ?> entry : ((Map<?, ?>) pack.map().get("eo")).entrySet()) {


### PR DESCRIPTION
Closes #8217

`Inferring.sources`, `Xmirs.sources` and `Report.sources` picked their inputs by suffix alone, so a directory named `stale.xmir` was handed to `XMLDocument` and the goal died parsing it. Each now also asks for a regular file, the way `Sha`, `Tabled` and `Fingerprint` already do; a symlink to a real `.xmir` still passes.

One test per site, each putting a `stale.xmir` directory beside a real file. Without the change all three fail with `SAXParseException` on that directory, and nothing else in either module moves.

Verified on JDK 21: `eo-inference` 97 tests, `eo-maven-plugin` 851 tests, `qulice` clean on both modules.

@yegor256
