### PR TITLE
fix(#8247): reject leading-zero only-phi counts

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -307,6 +307,12 @@ final class LnOnlyPhi implements Line {
                 digits = false;
                 break;
             }
+            if (idx > from && lhs.charAt(from) == '0') {
+                throw new ParseError(
+                    span.line(), span.indent() + from,
+                    "integer literal must not have leading zeros"
+                );
+            }
             count = count * 10 + glyph - '0';
             if (count > Integer.MAX_VALUE) {
                 throw new ParseError(

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -280,15 +280,14 @@ final class LnOnlyPhiTest {
 
     @Test
     void rejectsCompactTupleCountWithLeadingZeros() {
-        final ParseError failure = Assertions.assertThrows(
-            ParseError.class,
-            () -> new LnOnlyPhi(new Span("seq *01 > [m] > bar", 1))
-                .into(new Stack(), new Globals(), new Emit()),
-            "an only-phi compact-tuple count with a leading zero must be rejected"
-        );
         MatcherAssert.assertThat(
             "the leading-zero diagnostic must match the sibling parser",
-            failure.getMessage(),
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnOnlyPhi(new Span("seq *01 > [m] > bar", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "an only-phi compact-tuple count with a leading zero must be rejected"
+            ).getMessage(),
             Matchers.containsString("integer literal must not have leading zeros")
         );
     }

--- a/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnOnlyPhiTest.java
@@ -278,6 +278,21 @@ final class LnOnlyPhiTest {
         );
     }
 
+    @Test
+    void rejectsCompactTupleCountWithLeadingZeros() {
+        final ParseError failure = Assertions.assertThrows(
+            ParseError.class,
+            () -> new LnOnlyPhi(new Span("seq *01 > [m] > bar", 1))
+                .into(new Stack(), new Globals(), new Emit()),
+            "an only-phi compact-tuple count with a leading zero must be rejected"
+        );
+        MatcherAssert.assertThat(
+            "the leading-zero diagnostic must match the sibling parser",
+            failure.getMessage(),
+            Matchers.containsString("integer literal must not have leading zeros")
+        );
+    }
+
     private static String render(final Emit emit) {
         return new Xembler(
             new Directives().add("object").append(emit.directives())

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-compact-tuple-count-with-leading-zero-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-compact-tuple-count-with-leading-zero-is-rejected.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'integer literal must not have leading zeros')]
+input: |
+  [] > root
+    seq *01 > [m] > bar


### PR DESCRIPTION
## Summary

- Reject multi-digit compact-tuple counts with leading zeros in `LnOnlyPhi.starCount`.
- Add a focused unit regression and an eo-syntax YAML regression pack.
- Closes #8247

## Test plan

- `mvn -pl eo-parser -Dtest=LnOnlyPhiTest test`
- `mvn -pl eo-parser -Dtest=EoSyntaxTest test`
- `mvn -pl eo-parser test`

All parser tests pass: 1562 tests, 0 failures, 0 errors, 11 skipped.

Full `mvn clean install -Pqulice` was blocked before tests because the environment provides Java 17 while Qulice requires Java 21.

@yegor256