### PR TITLE
#8155: report a tab between meta parts with the table text

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -43,6 +43,11 @@ final class LnMeta implements Line {
     private static final String ROOT = "Φ";
 
     /**
+     * The §9.9 text of R-3.2.4, for anything but one space between parts.
+     */
+    private static final String SEPARATOR = "meta parts must be separated by exactly one space";
+
+    /**
      * The meta line's span.
      */
     private final Span span;
@@ -179,7 +184,7 @@ final class LnMeta implements Line {
             if (tail.charAt(idx) == ' ') {
                 throw new ParseError(
                     span.line(), span.indent() + base + idx,
-                    "meta parts must be separated by exactly one space"
+                    LnMeta.SEPARATOR
                 );
             }
             int end = idx;
@@ -189,7 +194,7 @@ final class LnMeta implements Line {
             if (end < tail.length() && tail.charAt(end) != ' ') {
                 throw new ParseError(
                     span.line(), span.indent() + base + end,
-                    "meta parts must be separated by a single ASCII space"
+                    LnMeta.SEPARATOR
                 );
             }
             out.add(LnMeta.promoteQ(tail.substring(idx, end)));

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -43,11 +43,6 @@ final class LnMeta implements Line {
     private static final String ROOT = "Φ";
 
     /**
-     * The §9.9 text of R-3.2.4, for anything but one space between parts.
-     */
-    private static final String SEPARATOR = "meta parts must be separated by exactly one space";
-
-    /**
      * The meta line's span.
      */
     private final Span span;
@@ -100,9 +95,7 @@ final class LnMeta implements Line {
             parts = new ArrayList<>(0);
         } else {
             head = body.substring(1, space);
-            parts = LnMeta.split(
-                body.substring(space + 1), this.span, space + 1
-            );
+            parts = this.split(body.substring(space + 1), space + 1);
         }
         this.checkHead(head, parts);
         globals.seal(emit, this.span);
@@ -175,26 +168,18 @@ final class LnMeta implements Line {
         }
     }
 
-    private static List<String> split(
-        final String tail, final Span span, final int base
-    ) {
+    private List<String> split(final String tail, final int base) {
         final List<String> out = new ArrayList<>(2);
         int idx = 0;
         while (idx < tail.length()) {
-            if (tail.charAt(idx) == ' ') {
-                throw new ParseError(
-                    span.line(), span.indent() + base + idx,
-                    LnMeta.SEPARATOR
-                );
-            }
             int end = idx;
             while (end < tail.length() && !Character.isWhitespace(tail.charAt(end))) {
                 end = end + 1;
             }
-            if (end < tail.length() && tail.charAt(end) != ' ') {
+            if (end == idx || end < tail.length() && tail.charAt(end) != ' ') {
                 throw new ParseError(
-                    span.line(), span.indent() + base + end,
-                    LnMeta.SEPARATOR
+                    this.span.line(), this.span.indent() + base + end,
+                    "meta parts must be separated by exactly one space"
                 );
             }
             out.add(LnMeta.promoteQ(tail.substring(idx, end)));

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -212,6 +212,20 @@ final class LnMetaTest {
     }
 
     @Test
+    void reportsATabBetweenPartsWithTheCanonicalMessage() {
+        MatcherAssert.assertThat(
+            "a tab between meta parts must carry the §9.9 text of R-3.2.4, but it didnt",
+            Assertions.assertThrows(
+                ParseError.class,
+                () -> new LnMeta(new Span("+rt jvm\torg.eolang:eo-runtime:0.0.0", 1))
+                    .into(new Stack(), new Globals(), new Emit()),
+                "a tab between meta parts must be rejected per R-3.2.4"
+            ).getMessage(),
+            Matchers.equalTo("meta parts must be separated by exactly one space")
+        );
+    }
+
+    @Test
     void clearsPendingBlanksOnEmission() {
         final Globals globals = new Globals();
         globals.addComment(new Span("# doc", 1));

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/meta-parts-separated-by-a-tab-are-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/meta-parts-separated-by-a-tab-are-rejected.yaml
@@ -4,5 +4,5 @@
 sheets: []
 asserts:
   - /object/errors[count(error)=1]
-  - /object/errors/error[contains(text(),'single ASCII space')]
+  - /object/errors/error[contains(text(),'separated by exactly one space')]
 input: "+rt jvm\torg.eolang:eo-runtime:0.0.0\n\n[] > app\n  42 > x\n"


### PR DESCRIPTION
Closes #8155.

`LnMeta.split()` had two messages for the one §9.9 row of R-3.2.4: a
double space threw the table text, while a tab threw `meta parts must
be separated by a single ASCII space`, a string that appears in no row.

The two checks are now one. A part that ends at a whitespace character
which is not a space, and a part that is empty because a space stands
where a part should, are the same violation, so one `throw` carries the
table text and no constant is needed to keep two copies in step.
`split()` became an instance method while it was at it, since it reads
the span the line already holds.

The `eo-syntax` pack for a tab between parts asserted the old wording;
it now asserts the canonical one. A new `LnMetaTest` case pins the
message, and it fails on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2