### PR TITLE
#8152: close the meta header on a text-block opener

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -270,6 +270,7 @@ final class Eo implements Iterable<Directive> {
             failed = true;
         } else if (Eo.opensTextBlock(span)) {
             globals.seal(emit, span);
+            Blanks.enterAfterMeta(span, globals, emit);
             globals.openTextBlock(span.line(), span.indent());
             globals.markEmitted();
             globals.clearBlanks();

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closes-the-meta-header.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closes-the-meta-header.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='app' and @base='Φ.string']
+input: |
+  +foo
+
+  """
+  text
+  """ > app

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-right-after-the-meta-header.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-right-after-the-meta-header.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[@line='2']
+  - /object/errors/error[contains(text(),'exactly one blank line')]
+input: |
+  +foo
+  """
+  text
+  """ > app


### PR DESCRIPTION
Closes #8152.

The TEXT-opener branch of `Eo.process()` marked an object emitted and
called `globals.clearBlanks()`, but never `Blanks.enterAfterMeta()`, so
`inMetaHeader()` stayed true while the blank that closed the header was
wiped. The closing `"""` then reached `Blanks.checkPlain()` with a zero
blank count and drew `meta header must be followed by exactly one blank
line` against its own line.

The branch now calls `Blanks.enterAfterMeta()`, the way every `Line`
implementation does.

Two `eo-syntax` packs come with it: one where the blank is present and
the file must parse clean (it fails on `master`), and one where it is
missing and R-6.5.5 must be reported against the opener's line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_