### PR TITLE
#8154: discharge the blank counter on the recovery path

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -325,6 +325,7 @@ final class Eo implements Iterable<Directive> {
         } catch (final ParseError err) {
             point.apply();
             globals.restore(saved);
+            globals.clearBlanks();
             emit.error(err.line(), err.pos(), err.getMessage(), true);
             failed = true;
         }

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovered-line-does-not-fake-a-consecutive-blank.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/recovered-line-does-not-fake-a-consecutive-blank.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[@line='3']
+input: |
+  +a x
+
+  +b y
+
+  [] > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/rejected-meta-header-does-not-fake-a-consecutive-blank.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/rejected-meta-header-does-not-fake-a-consecutive-blank.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[@line='2']
+input: |
+
+  +foo
+
+  [] > x


### PR DESCRIPTION
Closes #8154.

`Eo.dispatch()` restores the whole `Globals` savepoint after a
`ParseError`, and the pending-blank count rode along. The failed line
never reached its own `clearBlanks()`, so the blank above it survived
and `LnBlank.into()` read the next blank as a second one in a row —
reporting an R-6.5.3 error that is nowhere in the file.

The recovery path now clears the blank bookkeeping after the restore.
The failed line was itself non-blank and did separate the blanks around
it, and the comment rollback #7199 asked for is untouched.

Two `eo-syntax` packs, both failing on `master`: a blank between two
metas, and a leading blank before the meta header. Each must report
exactly one error, on the line the author got wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_