### PR TITLE
#8164: pin down a dispatch on what printf answers

### DIFF
--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -392,10 +392,10 @@
       30-
 
   eq. ++> can-answer-the-length-of-the-formatted-text
+    2
     length.
       "%s".printf
         * "ab"
-    2
 
   eq. ++> can-answer-the-size-of-the-formatted-text
     size.

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -391,6 +391,12 @@
       number flags
       30-
 
+  eq. ++> can-answer-the-length-of-the-formatted-text
+    length.
+      "%s".printf
+        * "ab"
+    2
+
   eq. ++> can-answer-the-size-of-the-formatted-text
     size.
       "Hello, %s".printf
@@ -510,6 +516,14 @@
     "first second second is after first"
     "%s %s %2$s is after %1$s".printf
       * "first" "second"
+
+  eq. ++> can-format-the-length-of-another-formatted-text
+    "2"
+    "%d".printf
+      *
+        length.
+          "%s".printf
+            * "ab"
 
   eq. ++> can-ignore-extra-arguments
     "Hey"


### PR DESCRIPTION
Closes #8164.

The report does not reproduce on `master`. Both shapes it names answer
correctly, so this adds them as tests rather than changing `printf`:

- `("%s".printf * "ab").length` gives 2, the value the report asks for;
- that length handed to `"%d".printf`, which is the program in the
  report, gives `"2"`.

`TestEOstring` runs 428 tests, no failures, with `printf.eo` otherwise
untouched. The `eq` shape the report also mentions
(`("%d".printf * 1.5).eq "1"`) is already the receiver of about forty
tests in the file, and `can-answer-the-size-of-the-formatted-text`
already dispatches `size` on the answer, which is why only these two
were missing.

The report is against 0.63.0, so whatever fixed it landed since. Worth
closing once these run green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_