### PR TITLE
#8246: refuse φ among the voids of an only-phi formation

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1364,6 +1364,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Formation head `[` with no closing `]` (R-3.4.12) | `formation is missing its closing bracket` |
 | Double space between parameter names in voids (R-3.4.5) | `parameter names in voids must be separated by exactly one space` |
 | Bracket-parameter name that is neither NAME, `@` nor `^` (§4.5) | `parameter names in voids must be NAME, @ or ^` |
+| `@` among the bracket parameters of an only-phi formation, which binds its φ from the left-hand side | `an only-phi formation binds φ from its left-hand side, so @ is not allowed among its voids` |
 | Bracket parameters on an atom head (R-3.4.10) | `an atom must declare its void attributes vertically, as ? > name lines` |
 | More than one space between meta parts (R-3.2.4) | `meta parts must be separated by exactly one space` |
 | Test attribute name is `@` (PHI) instead of NAME (R-6.3.5) | `test attribute name must be an identifier, not @` |

--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -246,6 +246,25 @@ final class Emissions {
         }
     }
 
+    /**
+     * Reject a bracket entry of an only-phi formation that names φ. Such a
+     * formation binds its φ from the left-hand side, so a {@code @} void
+     * would leave it holding two attributes of that name and the object
+     * would keep only one of them.
+     * @param raw The parameter text, as written
+     * @param line Source line (for error reporting)
+     * @param pos Source column of the parameter's first character
+     */
+    static void validPhiParam(final String raw, final int line, final int pos) {
+        Emissions.validParam(raw, line, pos);
+        if ("@".equals(raw)) {
+            throw new ParseError(
+                line, pos,
+                "an only-phi formation binds φ from its left-hand side, so @ is not allowed among its voids"
+            );
+        }
+    }
+
     private static void openBase(
         final Emit emit, final String name, final Value value, final int line
     ) {
@@ -488,7 +507,7 @@ final class Emissions {
         emit.baselessObject(name, line, column);
         int pcol = column + bracket + 1;
         for (final String param : Emissions.splitParams(params, line, pcol)) {
-            Emissions.validParam(param, line, pcol);
+            Emissions.validPhiParam(param, line, pcol);
             emit.voidParam(new VoidName(param).asString(), line, pcol);
             pcol = pcol + param.length() + 1;
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -342,7 +342,7 @@ final class LnOnlyPhi implements Line {
                 end = end + 1;
             }
             final String raw = text.substring(idx, end);
-            Emissions.validParam(raw, span.line(), span.indent() + origin + idx);
+            Emissions.validPhiParam(raw, span.line(), span.indent() + origin + idx);
             out.add(raw);
             if (end < text.length()) {
                 if (end + 1 < text.length() && text.charAt(end + 1) == ' ') {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-phi-among-its-voids.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/inline-phi-rejects-phi-among-its-voids.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'is not allowed among its voids')]
+input: |
+  [] > main
+    bar (a > [@]) > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-rejects-phi-among-its-voids.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-rejects-phi-among-its-voids.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'is not allowed among its voids')]
+input: |
+  [] > main
+    foo > [@] > bar


### PR DESCRIPTION
Closes #8246.

`foo > [@] > bar` was accepted and emitted a formation holding a void
named `φ` next to the `φ` bound from the left-hand side — two
attributes of one name in one object, which is exactly what
`validate-attribute-names.xsl` and `validate-voids.xsl` exist to
prevent and neither catches, since one side is a void and the other is
not.

`Emissions.validPhiParam` now sits in front of the bracket list of both
only-phi paths — `LnOnlyPhi.parseParams` for the line form and
`Emissions.inlinePhi` for `bar (a > [@]) > z` — and refuses `@` there.
A plain formation is untouched: it may leave its φ void, and `^` stays
legal on both.

The message has its §9.9 row, per R-9.9.3. Two `eo-syntax` packs, one
per path, both failing on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_