### PR TITLE
#8237: strip the separators dirname cuts through

### DIFF
--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -59,10 +59,12 @@
               if.
                 len.eq 0
                 ^.separator
-                as-bytes.
-                  text.slice
-                    0
-                    text.last-index-of ^.separator >> len!
+                ^.stripped
+                  string
+                    as-bytes.
+                      text.slice
+                        0
+                        text.last-index-of ^.separator >> len!
       tail.index-of ^.separator > first!
       ^.stripped ^.driveless > pth!
       and. > root
@@ -691,10 +693,25 @@
       path ""
     "."
 
+  eq. ++> can-return-the-dirname-collapsing-a-longer-run-of-separators
+    dirname.
+      path.posix "a///b"
+    "a"
+
+  eq. ++> can-return-the-dirname-collapsing-a-run-of-separators
+    dirname.
+      path.posix "a//b"
+    "a"
+
   eq. ++> can-return-the-dirname-ignoring-repeated-trailing-separators
     dirname.
       path.posix "foo//"
     "."
+
+  eq. ++> can-return-the-dirname-keeping-an-earlier-run-of-separators
+    dirname.
+      path.posix "a//b//c"
+    "a//b"
 
   eq. ++> can-return-the-dirname-of-a-directory-path
     dirname.
@@ -754,6 +771,11 @@
     dirname.
       path.win32 "\\\\server\\share\\folder"
     "\\\\server\\share"
+
+  eq. ++> can-return-the-dirname-of-an-absolute-path-with-a-run-of-separators
+    dirname.
+      path.posix "/a//b"
+    "/a"
 
   eq. ++> can-return-the-dirname-of-an-absolute-path-with-repeated-trailing-separators
     dirname.


### PR DESCRIPTION
Closes #8237.

`dirname` sliced up to the index of the *last* separator of a run, so
every earlier separator stayed on the end of the answer:
`"a//b".dirname` was `a/` and `"a///b".dirname` was `a//`, while
`basename` and `normalized` treat a run as one.

The slice now goes through `stripped`, the helper the object already
uses for the same job elsewhere. It removes trailing separators and
leaves a bare root alone, so `"/".dirname` and `"foo//".dirname` are
untouched.

Four tests, one per row of the report's table:

| call | before | now |
| --- | --- | --- |
| `"a//b"` | `a/` | `a` |
| `"a///b"` | `a//` | `a` |
| `"a//b//c"` | `a//b/` | `a//b` |
| `"/a//b"` | `/a/` | `/a` |

`TestEOpath` runs 95 tests: exactly those four fail without the fix and
all 95 pass with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_