### PR TITLE
#8241: refuse an entry that unpacks through a link

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
@@ -18,6 +18,14 @@ import java.util.zip.ZipInputStream;
  * It lives here so that it can be exercised on any JAR, without first
  * resolving an artifact from a remote repository.</p>
  *
+ * <p>An entry is written only where its own name puts it, inside the
+ * destination. Two things can carry it out. A {@code ..} in the name
+ * leaves the normalized path no longer starting with the destination.
+ * A symbolic link already sitting below the destination takes the entry
+ * into whatever it points at, while the name itself never looks as
+ * though it left the tree. Both are refused, so nothing outside the
+ * destination is touched, not even a directory made on the way.</p>
+ *
  * @since 0.64
  */
 final class UnpackedJar {
@@ -53,7 +61,7 @@ final class UnpackedJar {
             ZipEntry entry = zis.getNextEntry();
             while (entry != null) {
                 final Path target = this.dest.resolve(entry.getName()).normalize();
-                if (!target.startsWith(home)) {
+                if (!target.startsWith(home) || UnpackedJar.linked(target, home)) {
                     throw new IOException(
                         String.format(
                             "Zip entry '%s' would unpack to '%s', outside of '%s'",
@@ -71,5 +79,15 @@ final class UnpackedJar {
                 entry = zis.getNextEntry();
             }
         }
+    }
+
+    private static boolean linked(final Path target, final Path home) {
+        Path probe = target;
+        boolean through = false;
+        while (!through && !probe.equals(home)) {
+            through = Files.isSymbolicLink(probe);
+            probe = probe.getParent();
+        }
+        return through;
     }
 }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/UnpackedJar.java
@@ -61,10 +61,18 @@ final class UnpackedJar {
             ZipEntry entry = zis.getNextEntry();
             while (entry != null) {
                 final Path target = this.dest.resolve(entry.getName()).normalize();
-                if (!target.startsWith(home) || UnpackedJar.linked(target, home)) {
+                if (!target.startsWith(home)) {
                     throw new IOException(
                         String.format(
                             "Zip entry '%s' would unpack to '%s', outside of '%s'",
+                            entry.getName(), target, home
+                        )
+                    );
+                }
+                if (UnpackedJar.linked(target, home)) {
+                    throw new IOException(
+                        String.format(
+                            "Zip entry '%s' would unpack to '%s' through a symbolic link inside '%s'",
                             entry.getName(), target, home
                         )
                     );

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnpackedJarTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnpackedJarTest.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link UnpackedJar}.
+ * @since 0.64
+ */
+@ExtendWith(MktmpResolver.class)
+final class UnpackedJarTest {
+
+    @Test
+    void unpacksAnEntryIntoTheDestination(@Mktmp final Path temp) throws IOException {
+        final Path dest = temp.resolve("into");
+        UnpackedJarTest.archived(temp.resolve("plain.jar"), "a/b.txt");
+        new UnpackedJar(temp.resolve("plain.jar"), dest).unpack();
+        MatcherAssert.assertThat(
+            "the entry must land under the destination, but it didnt",
+            Files.readString(dest.resolve("a/b.txt"), StandardCharsets.UTF_8),
+            Matchers.equalTo("hello")
+        );
+    }
+
+    @Test
+    void refusesAnEntryBehindALink(@Mktmp final Path temp) throws IOException {
+        final Path dest = temp.resolve("guarded");
+        Files.createDirectories(dest);
+        Files.createDirectories(temp.resolve("elsewhere"));
+        Files.createSymbolicLink(dest.resolve("linked"), temp.resolve("elsewhere"));
+        UnpackedJarTest.archived(temp.resolve("sneaky.jar"), "linked/result.txt");
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new UnpackedJar(temp.resolve("sneaky.jar"), dest).unpack(),
+            "an entry whose parent is a link out of the destination must be refused"
+        );
+    }
+
+    @Test
+    void writesNothingBehindALink(@Mktmp final Path temp) throws IOException {
+        final Path dest = temp.resolve("guarded");
+        final Path outside = temp.resolve("elsewhere");
+        Files.createDirectories(dest);
+        Files.createDirectories(outside);
+        Files.createSymbolicLink(dest.resolve("linked"), outside);
+        UnpackedJarTest.archived(temp.resolve("sneaky.jar"), "linked/result.txt");
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new UnpackedJar(temp.resolve("sneaky.jar"), dest).unpack(),
+            "the entry must be refused before anything is written"
+        );
+        MatcherAssert.assertThat(
+            "the directory the link points at must stay untouched, but it didnt",
+            Files.exists(outside.resolve("result.txt")),
+            Matchers.is(false)
+        );
+    }
+
+    private static void archived(final Path jar, final String entry) throws IOException {
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(jar))) {
+            zos.putNextEntry(new ZipEntry(entry));
+            zos.write("hello".getBytes(StandardCharsets.UTF_8));
+            zos.closeEntry();
+        }
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/UnpackedJarTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/UnpackedJarTest.java
@@ -59,16 +59,20 @@ final class UnpackedJarTest {
         Files.createDirectories(outside);
         Files.createSymbolicLink(dest.resolve("linked"), outside);
         UnpackedJarTest.archived(temp.resolve("sneaky.jar"), "linked/result.txt");
-        Assertions.assertThrows(
-            IOException.class,
-            () -> new UnpackedJar(temp.resolve("sneaky.jar"), dest).unpack(),
-            "the entry must be refused before anything is written"
-        );
         MatcherAssert.assertThat(
             "the directory the link points at must stay untouched, but it didnt",
-            Files.exists(outside.resolve("result.txt")),
+            UnpackedJarTest.leaked(temp.resolve("sneaky.jar"), dest, outside),
             Matchers.is(false)
         );
+    }
+
+    private static boolean leaked(final Path jar, final Path dest, final Path outside) {
+        Assertions.assertThrows(
+            IOException.class,
+            () -> new UnpackedJar(jar, dest).unpack(),
+            "the entry must be refused before anything is written"
+        );
+        return Files.exists(outside.resolve("result.txt"));
     }
 
     private static void archived(final Path jar, final String entry) throws IOException {


### PR DESCRIPTION
Closes #8241.

The lexical check catches a `..` in an entry name, but a symbolic link
already sitting below the destination needs no `..`: for a link
`linked` pointing outside, the entry `linked/result.txt` normalizes to
a path that still starts with the destination, and `Files.copy` wrote
the file into the linked directory instead.

`unpack()` now also refuses an entry with a link anywhere between the
destination and its target, so nothing outside the destination is
touched — not even a parent directory made on the way, since the check
runs before `createDirectories`. A link is refused whichever way it
points, which keeps the rule to one sentence: unpacking never writes
through a link.

New `UnpackedJarTest` with three cases — a plain entry lands where it
should, an entry behind a link is refused, and the linked directory
stays empty. The two link cases fail on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_