### PR TITLE
#8243: stop when the old catalog stays

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -155,10 +155,10 @@ public final class MjRegister extends MjSafe {
             this.targetDir.toPath().resolve(MjResolve.DIR).toFile(),
         };
         for (final File file : files) {
-            if (file.exists() && !new Deleted(file).get()) {
+            if (file.exists() && !new Deleted(file).get() && file.exists()) {
                 throw new IllegalStateException(
                     String.format(
-                        "Failed to delete %s, so the sources of the previous build would stay registered",
+                        "Failed to delete %s, so the previous build would leak into this one",
                         file
                     )
                 );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -155,8 +155,13 @@ public final class MjRegister extends MjSafe {
             this.targetDir.toPath().resolve(MjResolve.DIR).toFile(),
         };
         for (final File file : files) {
-            if (file.exists()) {
-                new Deleted(file).get();
+            if (file.exists() && !new Deleted(file).get()) {
+                throw new IllegalStateException(
+                    String.format(
+                        "Failed to delete %s, so the sources of the previous build would stay registered",
+                        file
+                    )
+                );
             }
         }
     }


### PR DESCRIPTION
Closes #8243.

`MjRegister.removeOldFiles()` called `new Deleted(file).get()` and threw
the answer away, so a catalog or a generated dependency directory that
could not be removed was silently kept. `Deleted` says in its own
comment (#8146) that the caller has to hear about a file nobody could
delete; `MjClean` already does. `MjRegister` now does too.

No test, and I would rather say why than ship one that proves nothing.
The report's scenario — a non-writable parent directory with a readable
catalog — cannot be built as root, which is how this container runs, and
I could not find a portable substitute:

- I made the catalog immutable (`chattr +i`) so that only the delete
  fails. The goal then throws on `master` as well, because the catalog
  cannot be rewritten either, so the assertion passes with or without
  this change.
- A read-only parent directory has the same problem on a non-root
  runner: it blocks the rewrite as much as the delete, so
  `assertThrows` would be green on `master`.

That is also worth knowing about the report itself: the steps as written
do not distinguish the two failures. The dropped `Deleted` answer is
plain in the code, and the change only turns a silent failure into a
loud one, so it seemed better to land it than to add a test that cannot
fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8EZhrjv59XgfcR7eWNtd2)_