### PR TITLE
fix(#8223): refuse an address with a NUL in inet_addr

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import com.sun.jna.Native;
 import java.util.Collections;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -52,7 +52,9 @@ public final class InetAddrSyscall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.posix.take("return").copy();
-        final String address = new Dataized(params[0]).asString();
+        final String address = new Cstring(
+            "the 'address' argument of inet_addr", params[0]
+        ).it();
         final int converted = CStdLib.INSTANCE.inet_addr(address);
         if (converted == -1 && !InetAddrSyscall.BROADCAST.equals(address)) {
             Native.setLastError(22);

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -7,8 +7,8 @@ package org.eolang.win32;
 import com.sun.jna.Native;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
+import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
@@ -57,7 +57,9 @@ public final class InetAddrFuncCall implements Syscall {
     @Override
     public Phi make(final Phi... params) {
         final Phi result = this.win.take("return").copy();
-        final String address = new Dataized(params[0]).asString();
+        final String address = new Cstring(
+            "the 'address' argument of inet_addr", params[0]
+        ).it();
         final int converted = Winsock.INSTANCE.inet_addr(
             Native.toByteArray(address, StandardCharsets.UTF_8)
         );

--- a/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/InetAddrSyscallTest.java
@@ -8,9 +8,11 @@ import com.sun.jna.Native;
 import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -69,6 +71,24 @@ final class InetAddrSyscallTest {
             "A successful inet_addr conversion must not fabricate an error",
             Native.getLastError(),
             Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void refusesAnAddressWithNul() {
+        MatcherAssert.assertThat(
+            "the 'address' argument of inet_addr carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new InetAddrSyscall(Phi.Φ.take("posix").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "127.0.0.1", "suffix"))
+                ),
+                "an address whose NUL would make inet_addr convert only its prefix was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'address' argument of inet_addr"),
+                Matchers.containsString("NUL")
+            )
         );
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
@@ -84,17 +84,6 @@ final class InetAddrFuncCallTest {
         );
     }
 
-    private Double converted(final String address) {
-        return new Dataized(
-            this.made(address).take("code")
-        ).asNumber();
-    }
-
-    private Phi made(final String address) {
-        return new InetAddrFuncCall(Phi.Φ.take("win32").copy())
-            .make(new Data.ToPhi(address));
-    }
-
     @Test
     void refusesAnAddressWithNul() {
         MatcherAssert.assertThat(
@@ -111,5 +100,16 @@ final class InetAddrFuncCallTest {
                 Matchers.containsString("NUL")
             )
         );
+    }
+
+    private Double converted(final String address) {
+        return new Dataized(
+            this.made(address).take("code")
+        ).asNumber();
+    }
+
+    private Phi made(final String address) {
+        return new InetAddrFuncCall(Phi.Φ.take("win32").copy())
+            .make(new Data.ToPhi(address));
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/InetAddrFuncCallTest.java
@@ -8,9 +8,11 @@ import com.sun.jna.Native;
 import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.Dataized;
+import org.eolang.ExFailure;
 import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
 import org.junit.jupiter.api.condition.OS;
@@ -91,5 +93,23 @@ final class InetAddrFuncCallTest {
     private Phi made(final String address) {
         return new InetAddrFuncCall(Phi.Φ.take("win32").copy())
             .make(new Data.ToPhi(address));
+    }
+
+    @Test
+    void refusesAnAddressWithNul() {
+        MatcherAssert.assertThat(
+            "the 'address' argument of inet_addr carrying a NUL must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new InetAddrFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(String.join(String.valueOf((char) 0), "127.0.0.1", "suffix"))
+                ),
+                "an address whose NUL would make inet_addr convert only its prefix was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'address' argument of inet_addr"),
+                Matchers.containsString("NUL")
+            )
+        );
     }
 }


### PR DESCRIPTION
Fixes #8223.

`InetAddrSyscall` and `InetAddrFuncCall` read the address with `Dataized.asString()` and passed it to a C-string API. A C string ends at the first NUL, so `"127.0.0.1\0suffix"` was converted as `"127.0.0.1"`: the call succeeded, no error was reported, and the program acted on an address it had not named.

They were the last two string-taking native adapters that bypassed `Cstring`. #7570 introduced `Cstring` for exactly this and deliberately left `inet_addr` out while the address parsing was being reworked; that work has landed, so both adapters now take the address the same way `unlink`, `open`, `getenv`, `stat` and the rest do.

Behaviour that does not change: an ordinary address, the limited-broadcast `255.255.255.255` special case, the `EINVAL`/`WSAEINVAL` reporting and the unsigned widening are all untouched, and the existing tests for them still hold.

The NUL case is now held by a test on each side, asserting the failure names both the argument and the reason, like `UnlinkFuncCallTest` does.
