### PR TITLE
fix(#8236): check the regex flag section before splicing it in

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOcompile.java
@@ -22,6 +22,13 @@ import java.util.regex.PatternSyntaxException;
  * inside the flag group itself lands before that start and is reported
  * without an offset.</p>
  *
+ * <p>What stands after the closing slash is a flag section, and it is
+ * checked against the same alphabet the EO half of this object reads with
+ * ({@code [dimsux]}) before it is spliced between {@code (?} and {@code )}.
+ * Without that check a literal such as {@code /b/i)|(?:a} closed the flag
+ * group and injected its own alternation into the pattern, so the regex that
+ * ran was not the one that was written, and nothing reported it.</p>
+ *
  * @since 0.39.0
  * @checkstyle IllegalIdentifierNameCheck (6 lines)
  * @checkstyle TypeNameCheck (5 lines)
@@ -72,20 +79,36 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
     }
 
     private Phi compile(final String expression, final int last) {
+        final String modifiers = expression.substring(last + 1);
+        final Phi result;
+        if (modifiers.chars().anyMatch(chr -> "dimsux".indexOf(chr) < 0)) {
+            result = this.fallback(
+                String.format(
+                    "regex flags '%s' must be a sequence of 'd', 'i', 'm', 's', 'u' and 'x'",
+                    modifiers
+                )
+            );
+        } else {
+            result = this.pattern(expression, last, modifiers);
+        }
+        return result;
+    }
+
+    private Phi pattern(final String expression, final int last, final String modifiers) {
         final StringBuilder builder = new StringBuilder();
-        if (!expression.endsWith("/")) {
-            builder.append("(?").append(expression.substring(last + 1)).append(')');
+        if (!modifiers.isEmpty()) {
+            builder.append("(?").append(modifiers).append(')');
         }
         final int flags = builder.length();
         builder.append(expression, 1, last);
-        Phi result;
+        Phi outcome;
         try {
             final ByteArrayOutputStream baos = new ByteArrayOutputStream();
             final ObjectOutputStream ous = new ObjectOutputStream(baos);
             ous.writeObject(Pattern.compile(builder.toString()));
             ous.close();
-            result = this.take(Phi.RHO).take("pattern");
-            result.put(0, new Data.ToPhi(baos.toByteArray()));
+            outcome = this.take(Phi.RHO).take("pattern");
+            outcome.put(0, new Data.ToPhi(baos.toByteArray()));
         } catch (final PatternSyntaxException ex) {
             final int offset = ex.getIndex() - flags;
             final String reason;
@@ -97,10 +120,10 @@ public final class EOstring$EOregex$EOcompile extends PhDefault implements Atom 
                     ex.getDescription(), offset
                 );
             }
-            result = this.fallback(reason);
+            outcome = this.fallback(reason);
         } catch (final IOException ex) {
             throw new ExFailure("cannot serialize the compiled regex pattern", ex);
         }
-        return result;
+        return outcome;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/EOstringEOregexEOcompileTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOstringEOregexEOcompileTest.java
@@ -78,4 +78,35 @@ final class EOstringEOregexEOcompileTest {
             )
         );
     }
+
+    @Test
+    void refusesFlagsThatCarryRegexSyntax() {
+        MatcherAssert.assertThat(
+            "a flag section that closes its own group must be refused, not spliced into the pattern where it silently changes what the regex means",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new Data.ToPhi("/b/i)|(?:a").take("regex").take("compiled")
+                ).take()
+            ).toString(),
+            Matchers.containsString("regex flags 'i)|(?:a' must be a sequence")
+        );
+    }
+
+    @Test
+    void refusesAFlagLetterTheEoSideDoesNotRead() {
+        MatcherAssert.assertThat(
+            "an unknown flag letter must be reported as a flag, since the EO half of this object reads only [dimsux], rather than as whatever the engine makes of it",
+            Assertions.assertThrows(
+                ExAbstract.class,
+                () -> new Dataized(
+                    new Data.ToPhi("/b/z").take("regex").take("compiled")
+                ).take()
+            ).toString(),
+            Matchers.allOf(
+                Matchers.containsString("regex flags 'z' must be a sequence"),
+                Matchers.not(Matchers.containsString("Unknown inline modifier"))
+            )
+        );
+    }
 }


### PR DESCRIPTION
Fixes #8236.

`compile` spliced `expression.substring(last + 1)` between `(?` and `)` without looking at it, so a flag section carrying regex metacharacters closed the group and injected its own syntax. `"/b/i)|(?:a"` compiled as `(?i)|(?:a)b`: it matched the empty string, `next.exists` was `true`, and nothing anywhere reported that the pattern which ran was not the pattern that was written.

The EO half of the same object already disagreed. `matches` re-reads the literal with `/^\/([\s\S]*)\/([dimsux]*)$/`, which such a literal does not fit, and the mismatch surfaced as `Matched block does not exist, can't get groups`, a message about the internals of `match` rather than about the literal at fault.

The flag section is now checked against that same `[dimsux]` alphabet before it goes anywhere near the pattern, and a section that does not fit comes back through `cant-compile` naming the flags.

Two things this does not change: a valid flag section behaves exactly as before (`(?...)` is still prefixed, and the offset arithmetic that keeps `PatternSyntaxException` offsets pointing into the caller's pattern is untouched), and a literal with no flags is still detected the same way, since an empty section is exactly the case where the expression ends with a slash.

Side effect worth naming: an unknown flag letter such as `/b/z` used to be reported only because `(?z)` happened not to compile, as `Unknown inline modifier`. It is now reported as a flag, which is what it is. Both cases are covered by a test.
