### PR TITLE
fix(#8224): walk only regular files when collecting sources

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/WkDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/WkDefault.java
@@ -18,6 +18,15 @@ import org.cactoos.list.ListEnvelope;
 
 /**
  * Default implementation of {@link Walk}.
+ *
+ * <p>Only regular files are walked. A directory is not one, and neither is
+ * a FIFO, a socket, a device node or a link with nothing at the end of it,
+ * and a goal handed such an entry cannot make an EO program out of it: it
+ * would hash and read it, and reading a FIFO waits for a writer that never
+ * comes. A link to an ordinary file is still walked, since
+ * {@link Files#isRegularFile(Path, java.nio.file.LinkOption...)} follows
+ * links by default, and such a source reads exactly like the file it names.</p>
+ *
  * @since 0.1
  */
 final class WkDefault extends ListEnvelope<Path> implements Walk {
@@ -88,7 +97,7 @@ final class WkDefault extends ListEnvelope<Path> implements Walk {
 
     private static Collection<Path> regular(final Path dir) throws IOException {
         try (Stream<Path> walk = Files.walk(dir)) {
-            return walk.filter(file -> !file.toFile().isDirectory())
+            return walk.filter(Files::isRegularFile)
                 .collect(Collectors.toList());
         }
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/WkDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/WkDefaultTest.java
@@ -6,11 +6,16 @@ package org.eolang.maven;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -35,5 +40,53 @@ final class WkDefaultTest {
             new WkDefault(temp).includes(new ListOf<>(pattern)),
             Matchers.iterableWithSize(count)
         );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void skipsAnEntryThatIsNotARegularFile(@Mktmp final Path temp) throws Exception {
+        final Path pipe = temp.resolve("blocked.eo");
+        Assumptions.assumeTrue(
+            WkDefaultTest.fifo(pipe),
+            "mkfifo is not available here, can't test"
+        );
+        MatcherAssert.assertThat(
+            "a named pipe must not be walked, since reading it waits for a writer that never comes",
+            new WkDefault(temp),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void skipsALinkWithNothingAtTheEndOfIt(@Mktmp final Path temp) throws IOException {
+        Files.createSymbolicLink(temp.resolve("dangling.eo"), temp.resolve("gone.eo"));
+        MatcherAssert.assertThat(
+            "a link to a missing file must not be walked, since no source can be read through it",
+            new WkDefault(temp),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void keepsALinkToARegularFile(@Mktmp final Path temp) throws Exception {
+        new Saved("[] > foo", temp.resolve("foo.eo")).value();
+        Files.createSymbolicLink(temp.resolve("bar.eo"), temp.resolve("foo.eo"));
+        MatcherAssert.assertThat(
+            "a link to an ordinary file reads exactly like the file it names, so it must still be walked",
+            new WkDefault(temp),
+            Matchers.iterableWithSize(2)
+        );
+    }
+
+    private static boolean fifo(final Path path) throws Exception {
+        boolean made;
+        try {
+            made = new ProcessBuilder("mkfifo", path.toString()).start().waitFor() == 0;
+        } catch (final IOException ex) {
+            made = false;
+        }
+        return made;
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/WkDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/WkDefaultTest.java
@@ -45,9 +45,8 @@ final class WkDefaultTest {
     @Test
     @DisabledOnOs(OS.WINDOWS)
     void skipsAnEntryThatIsNotARegularFile(@Mktmp final Path temp) throws Exception {
-        final Path pipe = temp.resolve("blocked.eo");
         Assumptions.assumeTrue(
-            WkDefaultTest.fifo(pipe),
+            WkDefaultTest.fifo(temp.resolve("blocked.eo")),
             "mkfifo is not available here, can't test"
         );
         MatcherAssert.assertThat(


### PR DESCRIPTION
Fixes #8224.

`WkDefault.regular()` called an entry regular whenever `!file.toFile().isDirectory()`. That admits FIFOs, sockets, device nodes and links with nothing at the end of them. `eo:register` passed every such entry to `ChSource`, and reading a FIFO named `blocked.eo` waits for a writer that never arrives, so the goal hung instead of ignoring an entry no EO program can be read from.

The walk now filters with `Files::isRegularFile`, the same way the `.xmir` walks in `Inferring`, `Xmirs` and `Report` do since #8217.

The link policy is deliberate and written down in the class: `Files.isRegularFile` follows links by default, so a link to an ordinary file is still walked, because such a source reads exactly like the file it names. A dangling link is not, because nothing can be read through it.

Three tests hold it, all POSIX-only since none of the three entries can be made on Windows without privileges: a FIFO (with an assumption in case `mkfifo` is not on the box), a dangling link, and the control that a link to a real file is still collected.
