### PR TITLE
fix(#8216): treat a symbolic link as a leaf when pruning

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/EmptyDirectoriesIn.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/EmptyDirectoriesIn.java
@@ -6,10 +6,18 @@ package org.eolang.maven;
 
 import com.jcabi.log.Logger;
 import java.io.File;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 /**
  * Delete empty directories in provided root.
+ *
+ * <p>A symbolic link is a leaf here, whatever stands at the end of it. EO
+ * may remove a directory it made and then emptied, but the tree behind a
+ * link is somebody else's: descending through one would delete directories
+ * outside the build output that EO never created. A link is also something
+ * a directory holds, so a directory holding one is not empty.</p>
+ *
  * @since 0.55
  */
 final class EmptyDirectoriesIn {
@@ -54,7 +62,7 @@ final class EmptyDirectoriesIn {
         final File[] before = dir.listFiles();
         if (before != null) {
             for (final File file : before) {
-                if (file.isDirectory()) {
+                if (file.isDirectory() && !Files.isSymbolicLink(file.toPath())) {
                     this.delete(file);
                 }
             }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/EmptyDirectoriesInTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/EmptyDirectoriesInTest.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link EmptyDirectoriesIn}.
+ * @since 0.55
+ */
+@ExtendWith(MktmpResolver.class)
+final class EmptyDirectoriesInTest {
+
+    @Test
+    void deletesAnEmptyDirectory(@Mktmp final Path temp) throws IOException {
+        final Path classes = Files.createDirectories(temp.resolve("classes"));
+        final Path empty = Files.createDirectories(classes.resolve("org/eolang"));
+        new EmptyDirectoriesIn(classes).clear();
+        MatcherAssert.assertThat(
+            "an empty directory of the build output must be pruned, but it wasnt",
+            Files.exists(empty),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void keepsADirectoryBehindALink(@Mktmp final Path temp) throws IOException {
+        final Path outside = Files.createDirectories(temp.resolve("outside/keep-me"));
+        final Path classes = Files.createDirectories(temp.resolve("classes"));
+        Files.createSymbolicLink(classes.resolve("linked"), temp.resolve("outside"));
+        new EmptyDirectoriesIn(classes).clear();
+        MatcherAssert.assertThat(
+            "a directory reached through a link was never created by EO, so it must not be deleted, but it was",
+            Files.exists(outside),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void keepsTheLinkAndTheDirectoryHoldingIt(@Mktmp final Path temp) throws IOException {
+        final Path classes = Files.createDirectories(temp.resolve("classes"));
+        final Path holder = Files.createDirectories(classes.resolve("holder"));
+        final Path link = holder.resolve("linked");
+        Files.createSymbolicLink(link, Files.createDirectories(temp.resolve("outside")));
+        new EmptyDirectoriesIn(classes).clear();
+        MatcherAssert.assertThat(
+            "a link is something a directory holds, so neither it nor its directory is empty, but they were pruned",
+            Files.isSymbolicLink(link),
+            Matchers.equalTo(true)
+        );
+    }
+}


### PR DESCRIPTION
Fixes #8216.

`EmptyDirectoriesIn.delete()` decided what to recurse into with `File.isDirectory()`, which follows symbolic links. A link in the classes tree was therefore walked as an ordinary directory, and empty directories in the linked location were deleted. They sit outside the build output and were never created by EO. Both `eo:unplace` and `eo:unspile` call this traversal after their own cleanup, so either goal could prune somebody else's tree.

A link is now a leaf, whatever stands at the end of it. That also fixes the second half of the same behaviour: the traversal used to delete the link itself once the target listed empty, and the directory holding the link then counted as empty and went too. A link is something a directory holds, so neither is empty any more.

Three tests: the control that an empty directory of the build output is still pruned, the reported case, and the link-and-its-holder case. The two link tests are POSIX-only, since creating a link on Windows needs privileges the CI box does not have.
