### PR TITLE
Let the clue chain use a void it has typed

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -35,13 +35,10 @@ import java.util.Map;
  * already worked out on the way to the rung. Whoever counts the program and
  * whoever shows it to somebody read the same one.</p>
  *
- * <p>A void the program fills one way and no other is that one thing, and
- * stands where it stands: {@code Φ.string.printf.args} is a {@code Φ.tuple}
- * because every call site in the program puts one there, and a build reads the
- * program whole, library and all. A void filled several ways is still a void —
- * {@code Φ.bool.and.x} is seven things and therefore none of them — and so is
- * a void whose one filling names nothing a reader could go and look at, since
- * a rung above the first has to be a name.</p>
+ * <p>A void the program fills one way and no other is that one thing and
+ * climbs the ladder as that thing, which is {@link Sole}'s question. A void
+ * that keeps itself stays on the rung where a name rooted at a void belongs,
+ * true of every caller and concrete for none.</p>
  *
  * <p>Where the void keeps itself, what {@link Seen} found in it goes back
  * beside it, for a reader who is told their object is whatever
@@ -121,17 +118,9 @@ final class Answers {
     }
 
     private String sole(final String end) {
-        final Collection<Type> told = this.hollows.getOrDefault(
-            end, Collections.emptyList()
-        );
-        String found = "";
-        if (told.size() == 1) {
-            found = told.iterator().next().names();
-        }
-        if (!this.table.containsKey(found)) {
-            found = "";
-        }
-        return found;
+        return new Sole(
+            this.hollows.getOrDefault(end, Collections.emptyList()), this.table.keySet()
+        ).names();
     }
 
     private int depth(final String type, final int free) {

--- a/eo-inference/src/main/java/org/eolang/inference/Promoted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Promoted.java
@@ -45,6 +45,15 @@ import java.util.Map;
  * here as though the one witness were all there is.</p>
  *
  * @since 0.71.0
+ * @todo #8231:90min Settle the voids without the XML in the middle.
+ *  Every pass renders the whole table through {@link Types#asXml()} and
+ *  {@link Fillings} reads it straight back out with {@link Pairs}, which
+ *  costs about 320ms of a pass on {@code eo-runtime}, and it takes 45
+ *  passes there to name 510 voids. Then every void named asks all 11,314
+ *  dispatches again from scratch, where only the ones rooted at that void
+ *  can have changed. Between them the two turn 7s of inference into 28s.
+ *  Let {@link Fillings} take the rows themselves, and ask again only the
+ *  dispatches the new name reaches.
  */
 final class Promoted {
 

--- a/eo-inference/src/main/java/org/eolang/inference/Promoted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Promoted.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What a void the program fills one way is worth to the dispatches rooted at
+ * it.
+ *
+ * <p>A dispatch on a void is answered by the void's own name and no further:
+ * {@code x.leaf} inside a formation that takes {@code x} is a different object
+ * for every caller, so {@link Dispatched} calls it the {@code leaf} of
+ * {@code Φ.inc.x} and stops, having nowhere to look up what a {@code leaf} is.
+ * Where every caller in the program puts an {@code oak} into that void there is
+ * somewhere to look, and the next dispatch along the chain is answered too — the
+ * point of the whole exercise, since a chain that stops at the first step
+ * carries no further facts.</p>
+ *
+ * <p>{@link Sole} decides what a void is worth and this asks it, of every void
+ * at once, off the table {@link Woven} builds from the pairs settled so far.
+ * Being asked off a table is what makes the answer improve as the passes go on:
+ * an argument whose own type was worked out this pass is a filling with a type
+ * next pass, and a void nothing could be said about becomes a void filled one
+ * way.</p>
+ *
+ * <p>A void keeps itself all the same, and none of this is ever written down as
+ * a row. What goes into a void is gathered from its callers and is a fact about
+ * them; the void is still whatever the next caller puts there, and a row saying
+ * it is a copy of an {@code oak} would tell a reader of the tables something the
+ * program does not say. What is written down is the dispatches this answers,
+ * which are facts about the objects they are dispatches of.</p>
+ *
+ * <p>Only what the tables have seen is counted, and they have not seen
+ * everything: a caller that passes on a void of its own is a caller nobody has
+ * looked into, and {@link Fillings} leaves it out of the choice without saying
+ * that it did (#8226). So a void with one witness and such a caller is promoted
+ * here as though the one witness were all there is.</p>
+ *
+ * @since 0.71.0
+ */
+final class Promoted {
+
+    /**
+     * The rows that follow from a set of pairs.
+     */
+    private final Woven table;
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * The rows of the links table that are not pairs, from {@link Pairs}.
+     */
+    private final Map<String, Type> others;
+
+    /**
+     * Ctor.
+     * @param woven The rows that follow from a set of pairs
+     * @param provides The provides table, which says where a filling can land
+     * @param kept The rows of the links table that are not pairs, without which
+     *  a filling that arrives at a literal is not seen to be one
+     */
+    Promoted(final Woven woven, final XML provides, final Map<String, Type> kept) {
+        this.table = woven;
+        this.given = provides;
+        this.others = kept;
+    }
+
+    /**
+     * The voids these pairs turn out to have named, beyond the ones named
+     * already.
+     * @param pairs The pairs, each object against the one it is a copy of
+     * @return The voids answered this time, each against the one object the
+     *  program puts into it, empty when no void is worth anything further
+     */
+    Map<String, String> from(final Map<String, String> pairs) {
+        final Collection<String> known = this.known();
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, Collection<Type>> hollow
+            : new Fillings(this.links(pairs), this.given).all().entrySet()) {
+            final String sole = new Sole(hollow.getValue(), known).names();
+            if (!sole.isEmpty() && !pairs.containsKey(hollow.getKey())) {
+                found.put(hollow.getKey(), sole);
+            }
+        }
+        return found;
+    }
+
+    private XML links(final Map<String, String> pairs) {
+        final Map<String, Type> rows = this.table.rows(pairs);
+        rows.putAll(this.others);
+        return new Types(rows).asXml();
+    }
+
+    private Collection<String> known() {
+        final Collection<String> found = new HashSet<>(0);
+        for (final Xnav type : new Rows(this.given).all()) {
+            found.add(new Noted(type).says("id"));
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -42,6 +42,16 @@ import java.util.Map;
  * argument lands in means knowing which formation is being copied, and that is
  * what the pairs have just settled.</p>
  *
+ * <p>A dispatch on a void waits for the callers of the formation it sits in,
+ * and where they all put the same object there it waits for nothing: the whole
+ * program is read at once, so {@link Promoted} can say what a void holds and
+ * the chain can go on past it. That belongs inside the passes rather than
+ * before or after them, since a void named this way answers dispatches, and a
+ * dispatch answered may be what names the next void. It buys nothing for a
+ * reader of the table, though, and leaves no row of its own: what goes into a
+ * void is gathered from its callers and is a fact about them, so the voids are
+ * written down exactly as the rules wrote them.</p>
+ *
  * <p>So is the admission that a dispatch could not be worked out, for the same
  * reason in reverse: only here, when the passes have stopped adding pairs, is
  * it known that no pass will answer it. A row saying nothing is known is worth
@@ -78,23 +88,23 @@ public final class Resolved implements Clue {
         final Map<String, String> receivers = world.receivers();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Pairs written = new Pairs(new XMLDocument(links));
+        final Map<String, Type> kept = written.others();
+        final Woven woven = new Woven(given, applied, receivers, voids);
+        final Promoted promoted = new Promoted(woven, given, kept);
         final Map<String, String> pairs = new Settled(
-            new Dispatched(given, dispatches, args, named, receivers, voids)
+            new Dispatched(given, dispatches, args, named, receivers, voids), promoted
         ).from(
             new Settled(
                 new Dispatched(
                     given, dispatches, args, named, receivers, Collections.emptyList()
-                )
+                ),
+                promoted
             ).from(written.all())
         );
         final Map<String, String> names = new Ends(pairs).names();
-        final Map<String, Type> rows = new Refs(
-            pairs,
-            new Bound(
-                args, named, receivers, pairs, new Provided(given, names, voids)
-            ).all()
-        ).all();
-        rows.putAll(written.others());
+        final Map<String, Type> rows = woven.rows(pairs);
+        rows.keySet().removeAll(voids);
+        rows.putAll(kept);
         final Collection<String> dead = new Dead(written, dispatches, names).all();
         for (final Site dispatch : dispatches) {
             final String made = dispatch.made();

--- a/eo-inference/src/main/java/org/eolang/inference/Settled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Settled.java
@@ -15,6 +15,13 @@ import java.util.Map;
  * nothing. Pairs are only ever added, of which there are finitely many, so it
  * settles.</p>
  *
+ * <p>There are two things to ask, and the second is asked only when the first
+ * has nothing left to say. A dispatch is answered from what the tables hold
+ * and costs a walk of them; what a void holds is answered from the whole of
+ * the program's call sites and costs a table built to be read once, so it is
+ * worth asking when a pass would otherwise be the last. Every void it names
+ * opens the dispatches rooted at that void, and the passes go round again.</p>
+ *
  * @since 0.69.0
  */
 final class Settled {
@@ -25,11 +32,18 @@ final class Settled {
     private final Dispatched made;
 
     /**
+     * What the voids the program fills one way turn out to be.
+     */
+    private final Promoted more;
+
+    /**
      * Ctor.
      * @param dispatched What every dispatch turns out to be
+     * @param promoted What the voids the program fills one way turn out to be
      */
-    Settled(final Dispatched dispatched) {
+    Settled(final Dispatched dispatched, final Promoted promoted) {
         this.made = dispatched;
+        this.more = promoted;
     }
 
     /**
@@ -39,10 +53,18 @@ final class Settled {
      */
     Map<String, String> from(final Map<String, String> pairs) {
         final Map<String, String> found = new LinkedHashMap<>(pairs);
-        Map<String, String> answers = this.made.answers(found);
+        Map<String, String> answers = this.answers(found);
         while (!answers.isEmpty()) {
             found.putAll(answers);
-            answers = this.made.answers(found);
+            answers = this.answers(found);
+        }
+        return found;
+    }
+
+    private Map<String, String> answers(final Map<String, String> pairs) {
+        Map<String, String> found = this.made.answers(pairs);
+        if (found.isEmpty()) {
+            found = this.more.from(pairs);
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Sole.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Sole.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+
+/**
+ * The one object a void holds, where the program puts one thing in it.
+ *
+ * <p>A void holds whatever a caller puts in it, and a program that puts one
+ * thing in it everywhere has said what it holds: {@code Φ.string.printf.args}
+ * is a {@code Φ.tuple} because every call site puts one there, and a build
+ * reads the program whole, library and all, so there is no tomorrow for another
+ * caller to arrive from.</p>
+ *
+ * <p>A void filled several ways is still a void. {@code Φ.bool.and.x} is filled
+ * with a {@code Φ.true}, with a {@code Φ.false} and with five other things, and
+ * naming any one of them would be picking a favourite among facts.</p>
+ *
+ * <p>So is a void whose one filling names nothing the provides table has a row
+ * for — a datum, another void, an object the walk could not place. What is
+ * worth having here is a locator a reader can go and look at, and whoever asks
+ * what that object has needs a row to read the answer off.</p>
+ *
+ * @since 0.71.0
+ */
+final class Sole {
+
+    /**
+     * What the program was seen putting into the void, from {@link Fillings}.
+     */
+    private final Collection<Type> told;
+
+    /**
+     * The objects the provides table has a row for.
+     */
+    private final Collection<String> known;
+
+    /**
+     * Ctor.
+     * @param witnesses What the program was seen putting into the void, from
+     *  {@link Fillings}
+     * @param objects The objects the provides table has a row for
+     */
+    Sole(final Collection<Type> witnesses, final Collection<String> objects) {
+        this.told = witnesses;
+        this.known = objects;
+    }
+
+    /**
+     * The object this void holds.
+     * @return The locator, empty where the void is filled several ways or its
+     *  one filling names nothing a reader could go and look at
+     */
+    String names() {
+        String found = "";
+        if (this.told.size() == 1) {
+            found = this.told.iterator().next().names();
+        }
+        if (!this.known.contains(found)) {
+            found = "";
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Woven.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Woven.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ * The rows that follow from a set of pairs.
+ *
+ * <p>What an object is a copy of and which voids that copy has filled are two
+ * halves of one row, and putting the halves together takes the provides table,
+ * every application of the program and the pairs themselves. {@link Refs} joins
+ * them, {@link Bound} works out what went where and {@link Provided} says which
+ * voids there were to fill; this is the four of them wired up, so that whoever
+ * has pairs and wants rows says so in one line.</p>
+ *
+ * <p>Rows are asked for twice over. Once at the end, for the table the build
+ * writes down, and once for every provisional table a fact is read off before
+ * that: what the program puts into a void is written in the rows of the objects
+ * that put it there, so learning it means having the rows already. Both come
+ * from here, because a fact read off a table the build does not go on to
+ * publish would be a fact nobody can check.</p>
+ *
+ * @since 0.71.0
+ */
+final class Woven {
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * What every application of the program gives, from {@link Given}.
+     */
+    private final Given applied;
+
+    /**
+     * What every dispatch takes its attribute from, from {@link Xmirs}.
+     */
+    private final Map<String, String> receivers;
+
+    /**
+     * The locator of every void, from {@link Hollows}.
+     */
+    private final Collection<String> hollows;
+
+    /**
+     * Ctor.
+     * @param provides The provides table, as {@link Provides} wrote it
+     * @param applications What every application of the program gives
+     * @param taken What every dispatch takes its attribute from
+     * @param voids The locator of every void
+     */
+    Woven(
+        final XML provides,
+        final Given applications,
+        final Map<String, String> taken,
+        final Collection<String> voids
+    ) {
+        this.given = provides;
+        this.applied = applications;
+        this.receivers = taken;
+        this.hollows = voids;
+    }
+
+    /**
+     * These pairs as the rows of the links table.
+     * @param pairs The pairs, each object against the one it is a copy of
+     * @return The types, by the locator of the object they are about, in the
+     *  order the pairs came in
+     */
+    Map<String, Type> rows(final Map<String, String> pairs) {
+        return new Refs(
+            pairs,
+            new Bound(
+                this.applied.arguments(),
+                this.applied.named(),
+                this.receivers,
+                pairs,
+                new Provided(this.given, new Ends(pairs).names(), this.hollows)
+            ).all()
+        ).all();
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/SoleTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/SoleTest.java
@@ -1,0 +1,74 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Sole}.
+ * @since 0.71.0
+ */
+final class SoleTest {
+
+    @Test
+    void namesTheOneThingEveryCallerPutsIn() {
+        MatcherAssert.assertThat(
+            "a void every caller hands an oak must be the oak, but it named something else",
+            new Sole(
+                Collections.singletonList(new Ref("Φ.oak")),
+                Collections.singletonList("Φ.oak")
+            ).names(),
+            Matchers.equalTo("Φ.oak")
+        );
+    }
+
+    @Test
+    void namesNothingWhereCallersDisagree() {
+        MatcherAssert.assertThat(
+            "a void handed an oak and an elm cannot be either of them, but one was named",
+            new Sole(
+                Arrays.asList(new Ref("Φ.oak"), new Ref("Φ.elm")),
+                Arrays.asList("Φ.oak", "Φ.elm")
+            ).names(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void namesNothingWhereNobodyPutsAnythingIn() {
+        MatcherAssert.assertThat(
+            "a void nobody ever fills cannot be anything, but something was named",
+            new Sole(Collections.emptyList(), Collections.singletonList("Φ.oak")).names(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void namesNothingWhereTheTableHasNoSuchRow() {
+        MatcherAssert.assertThat(
+            "a locator with no row to read cannot be an answer, but it was named",
+            new Sole(
+                Collections.singletonList(new Ref("Φ.grove.oak")),
+                Collections.singletonList("Φ.oak")
+            ).names(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void namesNothingWhereTheOneFillingIsALiteral() {
+        MatcherAssert.assertThat(
+            "a void handed bytes has no row to read them off, but something was named",
+            new Sole(
+                Collections.singletonList(new Data()), Collections.singletonList("Φ.oak")
+            ).names(),
+            Matchers.emptyString()
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caller-says-what-the-receiver-holds.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caller-says-what-the-receiver-holds.yaml
@@ -1,12 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Inside the body of `halved` there is nothing to say about `^` but the void
-# declared for it, since every caller may hand over something different. At a
-# call site there is: `42.halved` says the receiver is a number, so what the
-# body reads through `^` can be followed from there. The answer in the body
-# stays rooted at the void and the answer at the call site does not, which is
-# the same substitution an argument already gets.
+# A dispatch says what the receiver of the body holds: `42.halved` fills the
+# void `halved` declares for `^`, exactly as an argument fills the void it is
+# written against. Since that is the only caller `halved` has in the whole
+# program, the body knows what it reads through `^` as well — `^.plus` is the
+# `plus` of `Φ.number` and not a name rooted at the void, and `.as-bytes` back
+# at the call site follows the chain all the way through `plus` to what a
+# number holds. The void keeps itself all the same, since a number arriving in
+# it is a fact about the caller.
 eo:
   app.eo: |
     [] > app
@@ -19,5 +21,7 @@ eo:
       [^] > halved
         ^.plus 0 > @
 links:
-  - "/links/type[@id='Φ.number.halved.φ']/ref[@loc='Φ.number.halved.ρ.plus']"
-  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.number.plus.x.as-bytes']"
+  - "/links/type[@id='Φ.app.φ.ρ']/ref[@loc='Φ.number.halved']/bind[@void='Φ.number.halved.ρ']"
+  - "/links/type[@id='Φ.number.halved.φ']/ref[@loc='Φ.number.plus']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.number.as-bytes']"
+  - "/links/type[@id='Φ.number.halved.ρ']/var"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-the-program-fills-one-way-is-that.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-the-program-fills-one-way-is-that.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name taken from a void is a different object at every call site, and stays
+# rooted at the void for want of anything truer to say. Where the program fills
+# that void one way and no other there is something truer: every copy of `inc`
+# hands it an `oak`, so `x.leaf` is the `leaf` of an `oak`. The void keeps
+# itself all the same, and no row says a void is a copy of anything, since what
+# goes into one is gathered from the callers and is not what the void is.
+eo:
+  app.eo: |
+    [] > app
+      inc oak > @
+  inc.eo: |
+    [x] > inc
+      x.leaf > @
+  oak.eo: |
+    [] > oak
+      [] > leaf
+links:
+  - "/links/type[@id='Φ.inc.φ']/ref[@loc='Φ.oak.leaf']"
+  - "/links[not(type[@id='Φ.inc.x']/ref)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/note-example.yaml
@@ -3,12 +3,13 @@
 ---
 # The program of the design note, and everything the rules can say about it.
 # `t` does have `next`, but the object attached to `next` has nothing, so
-# `x.next.foo` asks for something that will never be there. Every fact needed
-# to know that is in the rows below — that the `next` of a `t` is complete and
-# empty, that `foo` is asked of what `next` gives, that the `x` it is asked of
-# is the `t` — and no row says it. Reading them together is what was parked in
-# #6661. The links now name the two computed objects as well: `x.next` is the
-# `next` of whatever fills `x`, and `x.next.foo` the `foo` of that.
+# `x.next.foo` asks for something that will never be there. Most of what is
+# needed to see that now stands in one row: `inc` is handed a `t` by the only
+# caller it has, so `x.next` is the `next` of a `t` and not a name rooted at
+# `x`, and `foo` asked of that complete and empty object is a dispatch nothing
+# answers at all. Calling the last row a complaint rather than an admission is
+# what was parked in #6661. The void keeps itself either way, since a `t`
+# arriving in it is a fact about the caller.
 eo:
   app.eo: |
     [] > app
@@ -33,5 +34,6 @@ links:
   - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.app.inc']"
   - "/links/type[@id='Φ.app.φ.α0']/ref[@loc='Φ.app.t']"
   - "/links/type[@id='Φ.app.inc.φ.ρ.ρ']/ref[@loc='Φ.app.inc.x']"
-  - "/links/type[@id='Φ.app.inc.φ.ρ']/ref[@loc='Φ.app.inc.x.next']"
-  - "/links/type[@id='Φ.app.inc.φ']/ref[@loc='Φ.app.inc.x.next.foo']"
+  - "/links/type[@id='Φ.app.inc.φ.ρ']/ref[@loc='Φ.app.t.next']"
+  - "/links/type[@id='Φ.app.inc.φ']/unknown"
+  - "/links/type[@id='Φ.app.inc.x']/var"


### PR DESCRIPTION
Closes #8231.

A dispatch on a void stopped at the void. Inside `printf`, `^` is a different
object for every caller, so `Dispatched` called `^.as-bytes` the `as-bytes` of
`Φ.string.printf.ρ` and had nowhere to look up what an `as-bytes` is. The next
step of the chain was then rooted at that name too, and so on: a chain that
stops at the first step carries no further facts. #8230 already established
that a void every caller fills the same way is that one thing, but only for the
report — the chain never got to use it.

Now it does. `Promoted` asks `Sole` of every void at once, off a provisional
table `Woven` builds from the pairs settled so far, and hands back the voids the
program fills one way. It is asked inside `Settled`, not before or after it, and
only when `Dispatched` has nothing left to say: a void named this way opens the
dispatches rooted at it, and a dispatch answered may be what names the next
void, so the two have to take turns.

```java
private Map<String, String> answers(final Map<String, String> pairs) {
    Map<String, String> found = this.made.answers(pairs);
    if (found.isEmpty()) {
        found = this.more.from(pairs);
    }
    return found;
}
```

The fixed point has to live in memory, since repeating the whole clue chain over
disk would not do it: `Provides` and `Links` rebuild their tables from the XMIR
on every run, wiping whatever the derived clues had marked. And none of it is
written down as a row. What goes into a void is gathered from its callers and is
a fact about them — the void is still whatever the next caller puts there — so
`Resolved` drops the void rows before writing and restores the ones the rules
wrote. A new pack asserts exactly that: the dispatch resolves, the void stays a
`<var/>`.

On a clean `eo-runtime` (172 XMIRs, 52,754 objects) 510 of the program's 1,578
voids are named by their one filling, over 43 productive rounds. Named goes
78.0% to 79.3%, rooted at a void 21.9% to 20.7%, depth 67.5% to 68.1%. The two
packs whose answers were rooted names now read concretely, and their comments
say so.

Inference goes 7s to 28s on that program, and none of that is the new rule
itself. It is the provisional table rendered to XML and read straight back each
pass, and all 11,314 dispatches asked again for every single void named. Both
are the shape of the loop rather than of the answer, and both are left as a
puzzle on `Promoted`.
