### PR TITLE
fix(#8228): follow links while hashing a directory

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Sha.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -23,6 +24,11 @@ import java.util.stream.Stream;
  * the amount of bytes read from it, so that trees differing in file names or in file boundaries
  * never collide. Only files speak into the digest, hence a directory holding none of them stays
  * invisible to the hash, the way Git also sees it.
+ * The walk follows symbolic links, because everything else here already does:
+ * a path is called a directory with {@link Files#isDirectory(Path, java.nio.file.LinkOption...)}
+ * and a file with {@link Files#isRegularFile(Path, java.nio.file.LinkOption...)}, and both look
+ * through a link. Without that, a link to a directory was walked but never entered, so the digest
+ * was the one of empty input, the same for every such link and unchanged by anything behind it.
  * @since 0.62.0
  */
 final class Sha {
@@ -72,7 +78,7 @@ final class Sha {
         } else {
             active = any -> true;
         }
-        try (Stream<Path> walk = Files.walk(this.path)) {
+        try (Stream<Path> walk = Files.walk(this.path, FileVisitOption.FOLLOW_LINKS)) {
             walk.filter(Files::isRegularFile)
                 .filter(active)
                 .sorted(Comparator.comparing(this::relative))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ShaTest.java
@@ -8,6 +8,7 @@ import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -15,6 +16,8 @@ import java.util.Base64;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -129,6 +132,58 @@ final class ShaTest {
             String.format("hashes of two identical dirs differ, seed=%d", seed),
             new Sha(temp.resolve("first")).toString(),
             Matchers.equalTo(new Sha(temp.resolve("second")).toString())
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void hashesADirectoryLinkLikeTheDirectoryItself(@Mktmp final Path temp) throws IOException {
+        final long seed = System.nanoTime();
+        new Saved(Long.toHexString(seed), temp.resolve("real/a.txt")).value();
+        Files.createSymbolicLink(temp.resolve("linked"), temp.resolve("real"));
+        MatcherAssert.assertThat(
+            String.format(
+                "a link to a directory was walked but never entered, so its hash was the one of empty input, seed=%d",
+                seed
+            ),
+            new Sha(temp.resolve("linked")).toString(),
+            Matchers.equalTo(new Sha(temp.resolve("real")).toString())
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void noticesAChangeBehindADirectoryLink(@Mktmp final Path temp) throws IOException {
+        final long seed = System.nanoTime();
+        new Saved(Long.toHexString(seed), temp.resolve("real/a.txt")).value();
+        Files.createSymbolicLink(temp.resolve("linked"), temp.resolve("real"));
+        final String before = new Sha(temp.resolve("linked")).toString();
+        new Saved(Long.toHexString(seed + 1L), temp.resolve("real/a.txt")).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "a cache keyed by this hash keeps serving output built from contents that have changed, seed=%d",
+                seed
+            ),
+            new Sha(temp.resolve("linked")).toString(),
+            Matchers.not(Matchers.equalTo(before))
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void seesAFileBehindALinkedSubdirectory(@Mktmp final Path temp) throws IOException {
+        final long seed = System.nanoTime();
+        new Saved(Long.toHexString(seed), temp.resolve("first/a.txt")).value();
+        new Saved(Long.toHexString(seed), temp.resolve("second/a.txt")).value();
+        new Saved(Long.toHexString(seed), temp.resolve("outside/b.txt")).value();
+        Files.createSymbolicLink(temp.resolve("second/sub"), temp.resolve("outside"));
+        MatcherAssert.assertThat(
+            String.format(
+                "a file reachable through a linked subdirectory speaks into the digest, so the two trees must not hash alike, seed=%d",
+                seed
+            ),
+            new Sha(temp.resolve("second")).toString(),
+            Matchers.not(Matchers.equalTo(new Sha(temp.resolve("first")).toString()))
         );
     }
 }


### PR DESCRIPTION
Fixes #8228.

`Sha.hash()` decided the path was a directory with `Files.isDirectory`, which looks through a symbolic link, and then walked it with `Files.walk`, which does not. A link to a directory was therefore visited and never entered. No file fed the digest, so the result was `47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=`, the digest of empty input, for every such path, and changing a file behind the link left it exactly as it was. A `Cache` keyed by that hash kept serving output compiled from contents that had moved on.

The walk now uses `FileVisitOption.FOLLOW_LINKS`. That is what the rest of the class already assumes: the path is called a directory with `Files.isDirectory` and its entries are called files with `Files.isRegularFile`, and both look through a link. A link to a regular file inside the tree was already hashed for the same reason; only directories were the exception.

Three tests: hashing a directory link now gives the same digest as hashing the directory, a change behind the link changes it, and a file reachable only through a linked subdirectory speaks into the digest. All POSIX-only, since creating a link on Windows needs privileges the CI box does not have.

One consequence worth naming: a link loop under a hashed directory now surfaces as `FileSystemLoopException` wrapped in the usual `Failed to compute SHA-256 hash`, rather than being silently walked past. A digest that cannot be computed is better said out loud than answered with the digest of nothing, which is what the old code did for the whole class of paths this fixes.
