### PR TITLE
fix(#8226): drop the catalog cache when the catalog file goes

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Catalogs.java
@@ -100,6 +100,21 @@ final class Catalogs {
         return this.all.computeIfAbsent(abs, f -> Catalogs.build(f, format));
     }
 
+    /**
+     * Forget the catalog of this file, if there is one.
+     *
+     * <p>The cache is keyed by path alone, so it outlives the file. Whoever
+     * deletes a catalog has to say so here, or the next {@link #make(Path)}
+     * for the same path answers with the rows that were just removed.</p>
+     *
+     * @param file The file
+     */
+    void drop(final Path file) {
+        final Path abs = file.toAbsolutePath();
+        this.all.remove(abs);
+        this.formats.remove(abs);
+    }
+
     private static Tojos build(final Path path, final String fmt) {
         Mono mono;
         if ("json".equals(fmt)) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjRegister.java
@@ -159,5 +159,6 @@ public final class MjRegister extends MjSafe {
                 new Deleted(file).get();
             }
         }
+        Catalogs.INSTANCE.drop(this.foreign.toPath());
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CatalogsTest.java
@@ -9,6 +9,8 @@ import com.yegor256.MktmpResolver;
 import com.yegor256.Together;
 import com.yegor256.tojos.Tojo;
 import com.yegor256.tojos.Tojos;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 import org.hamcrest.MatcherAssert;
@@ -80,6 +82,32 @@ final class CatalogsTest {
             IllegalStateException.class,
             () -> Catalogs.INSTANCE.make(file, "json"),
             "Asking for the same path with a different format must fail loudly"
+        );
+    }
+
+    @Test
+    void forgetsTheCatalogOfADeletedFile(@Mktmp final Path tmp) throws IOException {
+        final Path file = tmp.resolve("foreign.csv");
+        final Tojos catalog = Catalogs.INSTANCE.make(file, "csv");
+        catalog.add("first");
+        catalog.close();
+        Files.delete(file);
+        Catalogs.INSTANCE.drop(file);
+        MatcherAssert.assertThat(
+            "the cache is keyed by path alone, so after the file is gone the next catalog must start empty, but it kept the removed rows",
+            Catalogs.INSTANCE.make(file, "csv").select(tojo -> true),
+            Matchers.empty()
+        );
+    }
+
+    @Test
+    void letsADroppedPathTakeAnotherFormat(@Mktmp final Path tmp) throws IOException {
+        final Path file = tmp.resolve("foreign");
+        Catalogs.INSTANCE.make(file, "csv").close();
+        Catalogs.INSTANCE.drop(file);
+        Assertions.assertDoesNotThrow(
+            () -> Catalogs.INSTANCE.make(file, "json"),
+            "a path nobody holds a catalog for any more must be free to take another format"
         );
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjRegisterTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjRegisterTest.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.cactoos.io.ResourceOf;
 import org.hamcrest.MatcherAssert;
@@ -66,6 +67,24 @@ final class MjRegisterTest {
                 "sourcesDir should not be set and the %s should fail, but didn't",
                 MjRegister.class
             )
+        );
+    }
+
+    @Test
+    void forgetsASourceRemovedBetweenTwoRegistrations(@Mktmp final Path temp) throws IOException {
+        final Path source = temp.resolve("src/eo/org/eolang/maven/abc-def.eo");
+        new Saved(
+            new ResourceOf("org/eolang/maven/file-name/abc-def.eo"),
+            source
+        ).value();
+        final FakeMaven maven = new FakeMaven(temp)
+            .with("sourcesDir", temp.resolve("src/eo").toFile());
+        maven.execute(new PpRegister());
+        Files.delete(source);
+        MatcherAssert.assertThat(
+            "a source deleted between two registrations in one JVM must leave the catalog, but it stayed",
+            maven.execute(new PpRegister()).foreign().size(),
+            Matchers.equalTo(0)
         );
     }
 }


### PR DESCRIPTION
Fixes #8226.

`Catalogs.make()` caches by path with `computeIfAbsent`, and nothing ever evicts an entry, so the cached `Tojos` outlives the file it was built from. `MjRegister.removeOldFiles()` deletes the foreign catalog before rebuilding it; the in-memory copy stayed. A second `eo:register` in the same Maven JVM therefore started from exactly the rows that had just been removed, and a source deleted between the two runs stayed in the catalog for `eo:parse`, `eo:resolve` and `eo:transpile` to work on.

`Catalogs.drop(Path)` forgets a path, both its catalog and the format it was pinned to, and `removeOldFiles()` calls it after the deletion. Nothing else changes: `MjRegister` opens its catalog lazily, so the fresh one is built on first use, after the drop.

Tests: the reported sequence at the `Catalogs` level (add a row, close, delete the file, drop, ask again, get an empty catalog), the end-to-end case in `MjRegisterTest` (register a source, delete it, register again in the same JVM, the catalog is empty), and one that a dropped path is free to take another format, since `drop` clears the format pin as well.
