### PR TITLE
fix(#8242): stop when the prepared XMIRs survive the cleanup

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -91,6 +91,14 @@ final class Inferring implements Step {
     public void exec() throws IOException {
         if (Files.exists(this.input)) {
             new Deleted(this.prepared.toFile()).get();
+            if (Files.exists(this.prepared)) {
+                throw new IOException(
+                    Logger.format(
+                        "Can't clean up %[file]s: prepared XMIRs of an earlier run are still there, and inferring them together with the current ones would describe sources that no longer exist",
+                        this.prepared
+                    )
+                );
+            }
             final int ready = this.ready();
             final long start = System.currentTimeMillis();
             new Witnessed(new Relayed(new Demanded(new Resolved(new Clues()))))

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -12,6 +12,7 @@ import com.yegor256.MktmpResolver;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -25,7 +26,11 @@ import org.eolang.xax.XtYaml;
 import org.eolang.xax.Xtory;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 
@@ -155,6 +160,50 @@ final class InferringTest {
             "a folder whose name ends with .xmir must be left alone, but it was read",
             new XMLDocument(temp.resolve("rows").resolve("provides.xml")),
             XhtmlMatchers.hasXPath("/provides/type[@id='Φ.spade']/attr[@name='handle']")
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void stopsWhenPreparedXmirsSurviveTheCleanup(@Mktmp final Path temp) throws IOException {
+        final Path sources = Files.createDirectories(temp.resolve("yard"));
+        Files.writeString(
+            sources.resolve("spade.xmir"),
+            new EoSyntax(
+                String.join(System.lineSeparator(), "[] > spade", "  [] > handle", "")
+            ).parsed().toString()
+        );
+        final Path pre = temp.resolve("pre");
+        final Path locked = Files.createDirectories(pre.resolve("locked"));
+        Files.writeString(locked.resolve("old.xmir"), "<object/>");
+        Files.setPosixFilePermissions(locked, PosixFilePermissions.fromString("r-xr-xr-x"));
+        try {
+            Assumptions.assumeTrue(
+                !Files.isWritable(locked),
+                "read-only directories don't stop deletions for this user (root?), can't test"
+            );
+            Assertions.assertThrows(
+                IOException.class,
+                () -> new Inferring(sources, pre, temp.resolve("rows")).exec(),
+                "a prepared XMIR of an earlier run that could not be removed must stop inference, not be read together with the current ones"
+            );
+        } finally {
+            Files.setPosixFilePermissions(locked, PosixFilePermissions.fromString("rwxr-xr-x"));
+        }
+    }
+
+    @Test
+    void saysNothingWhenThereIsNothingToCleanUp(@Mktmp final Path temp) throws IOException {
+        final Path sources = Files.createDirectories(temp.resolve("shed"));
+        Files.writeString(
+            sources.resolve("rake.xmir"),
+            new EoSyntax(
+                String.join(System.lineSeparator(), "[] > rake", "  [] > teeth", "")
+            ).parsed().toString()
+        );
+        Assertions.assertDoesNotThrow(
+            () -> new Inferring(sources, temp.resolve("pre"), temp.resolve("rows")).exec(),
+            "a prepared directory that was never made is not a failed cleanup, but it was taken for one"
         );
     }
 


### PR DESCRIPTION
Fixes #8242.

`Inferring.exec()` called `new Deleted(this.prepared.toFile()).get()` and discarded the boolean. `Deleted` answers `false` when anything is left behind, so a stale `old.xmir` that could not be removed stayed in the prepared directory and was picked up by the later `sources()` walk together with the XMIRs of the current run. The tables and the report then described a source that no longer exists.

The goal now looks at the directory after the deletion and refuses to continue while anything is still in it.

The check is `Files.exists(this.prepared)` rather than the boolean, on purpose: `Deleted` also answers `false` for a directory that was never there, which is the ordinary first run. Testing the boolean would turn every clean build into a failure. What matters is whether anything survived, and that is what is asked.

Two tests: the reported case, a stale file inside a directory that is searchable but not writable (POSIX only, with the same root assumption `UnplacingTest` uses), and the control that a prepared directory which was never made still goes through silently.
