### PR TITLE
fix(#8225): keep a snapshot of a table, not the name of its file

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/StPure.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/StPure.java
@@ -12,7 +12,12 @@ import com.yegor256.xsline.StEnvelope;
 import com.yegor256.xsline.StXSL;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
+import java.net.URI;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.locks.Lock;
@@ -50,6 +55,14 @@ import org.xml.sax.SAXException;
  * since those megabytes are hundreds once parsed and reading a table again is
  * better than running a build out of memory.</p>
  *
+ * <p>What is kept is one snapshot of a table, not the name of its file. The
+ * same Maven process runs {@code eo:inference} and then transpiles more than
+ * once, and the second inference writes its tables to the same paths, so a
+ * copy kept by URI alone would answer the second transpilation with what the
+ * first one read, and the Java it generates would be marked by types that
+ * have moved on. The modification time and the length of the file are kept
+ * beside the copy and asked again before it is handed over.</p>
+ *
  * @since 0.75.0
  */
 final class StPure extends StEnvelope {
@@ -58,6 +71,11 @@ final class StPure extends StEnvelope {
      * The tables read so far, by their URIs.
      */
     private static final Map<String, SoftReference<Node>> TABLES = new HashMap<>(0);
+
+    /**
+     * What each kept table looked like on disk when it was read, by URI.
+     */
+    private static final Map<String, String> STAMPS = new HashMap<>(0);
 
     /**
      * The lock on {@link #TABLES}, held while a table is being read, so that
@@ -104,19 +122,35 @@ final class StPure extends StEnvelope {
     private static Node table(final String href) throws TransformerException {
         StPure.LOCK.lock();
         try {
+            final String stamp = StPure.stamp(href);
             final SoftReference<Node> kept = StPure.TABLES.get(href);
             Node found = null;
-            if (kept != null) {
+            if (kept != null && stamp.equals(StPure.STAMPS.get(href))) {
                 found = kept.get();
             }
             if (found == null) {
                 found = StPure.parsed(href);
                 StPure.TABLES.put(href, new SoftReference<>(found));
+                StPure.STAMPS.put(href, stamp);
             }
             return found;
         } finally {
             StPure.LOCK.unlock();
         }
+    }
+
+    private static String stamp(final String href) {
+        String stamp;
+        try {
+            final BasicFileAttributes attrs = Files.readAttributes(
+                Paths.get(URI.create(href)), BasicFileAttributes.class
+            );
+            stamp = String.format("%s %d", attrs.lastModifiedTime(), attrs.size());
+        } catch (final IOException | IllegalArgumentException
+            | FileSystemNotFoundException ex) {
+            stamp = "";
+        }
+        return stamp;
     }
 
     private static Node parsed(final String href) throws TransformerException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/StPureTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/StPureTest.java
@@ -80,6 +80,44 @@ final class StPureTest {
         );
     }
 
+    @Test
+    void readsATableThatWasRewritten(@Mktmp final Path temp) throws IOException {
+        final Path parsed = Files.createDirectories(temp.resolve("parsed"));
+        Files.writeString(
+            parsed.resolve("number.xmir"),
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[as-bytes] > number", "  as-bytes > @", "  [x] > power", "    x > @", ""
+                )
+            ).parsed().toString()
+        );
+        final Path source = parsed.resolve("app.xmir");
+        Files.writeString(
+            source,
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(), "[] > app", "  2.power 63 > x", "  x > @", ""
+                )
+            ).parsed().toString()
+        );
+        final Path tables = temp.resolve("tables");
+        new Inferring(parsed, temp.resolve("pre"), tables).exec();
+        MatcherAssert.assertThat(
+            "the tables of this program mark the application, but nothing was marked",
+            StPureTest.stamped(tables, source).nodes("//o[@name='x' and @pure='true']"),
+            Matchers.not(Matchers.empty())
+        );
+        new Inferring(
+            Files.createDirectories(temp.resolve("none")), temp.resolve("again"), tables
+        ).exec();
+        MatcherAssert.assertThat(
+            "a table rewritten between two transpilations of one JVM must be read again, but the copy parsed first was handed over",
+            StPureTest.stamped(tables, source).nodes("//o[@name='x' and @pure='true']"),
+            Matchers.empty()
+        );
+    }
+
     private Collection<String> unmatched(final Xtory pack) throws IOException {
         final Collection<String> failed = new ArrayList<>(0);
         for (final Object key : pack.map().keySet()) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/StPureTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/StPureTest.java
@@ -81,33 +81,25 @@ final class StPureTest {
     }
 
     @Test
-    void readsATableThatWasRewritten(@Mktmp final Path temp) throws IOException {
-        final Path parsed = Files.createDirectories(temp.resolve("parsed"));
-        Files.writeString(
-            parsed.resolve("number.xmir"),
-            new EoSyntax(
-                String.join(
-                    System.lineSeparator(),
-                    "[as-bytes] > number", "  as-bytes > @", "  [x] > power", "    x > @", ""
-                )
-            ).parsed().toString()
-        );
-        final Path source = parsed.resolve("app.xmir");
-        Files.writeString(
-            source,
-            new EoSyntax(
-                String.join(
-                    System.lineSeparator(), "[] > app", "  2.power 63 > x", "  x > @", ""
-                )
-            ).parsed().toString()
-        );
+    void marksWhatTheTablesSay(@Mktmp final Path temp) throws IOException {
+        final Path parsed = StPureTest.program(temp);
         final Path tables = temp.resolve("tables");
         new Inferring(parsed, temp.resolve("pre"), tables).exec();
         MatcherAssert.assertThat(
-            "the tables of this program mark the application, but nothing was marked",
-            StPureTest.stamped(tables, source).nodes("//o[@name='x' and @pure='true']"),
+            "the tables of this program mark its application, but nothing was marked",
+            StPureTest.stamped(tables, parsed.resolve("app.xmir"))
+                .nodes("//o[@name='x' and @pure='true']"),
             Matchers.not(Matchers.empty())
         );
+    }
+
+    @Test
+    void readsATableThatWasRewritten(@Mktmp final Path temp) throws IOException {
+        final Path parsed = StPureTest.program(temp);
+        final Path tables = temp.resolve("tables");
+        final Path source = parsed.resolve("app.xmir");
+        new Inferring(parsed, temp.resolve("pre"), tables).exec();
+        StPureTest.stamped(tables, source);
         new Inferring(
             Files.createDirectories(temp.resolve("none")), temp.resolve("again"), tables
         ).exec();
@@ -149,6 +141,28 @@ final class StPureTest {
             }
         }
         return failed;
+    }
+
+    private static Path program(final Path temp) throws IOException {
+        final Path parsed = Files.createDirectories(temp.resolve("parsed"));
+        Files.writeString(
+            parsed.resolve("number.xmir"),
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(),
+                    "[as-bytes] > number", "  as-bytes > @", "  [x] > power", "    x > @", ""
+                )
+            ).parsed().toString()
+        );
+        Files.writeString(
+            parsed.resolve("app.xmir"),
+            new EoSyntax(
+                String.join(
+                    System.lineSeparator(), "[] > app", "  2.power 63 > x", "  x > @", ""
+                )
+            ).parsed().toString()
+        );
+        return parsed;
     }
 
     private static XML stamped(final Path tables, final Path source) throws IOException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/StPureTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/StPureTest.java
@@ -100,9 +100,7 @@ final class StPureTest {
         final Path source = parsed.resolve("app.xmir");
         new Inferring(parsed, temp.resolve("pre"), tables).exec();
         StPureTest.stamped(tables, source);
-        new Inferring(
-            Files.createDirectories(temp.resolve("none")), temp.resolve("again"), tables
-        ).exec();
+        new Inferring(StPureTest.alone(temp), temp.resolve("again"), tables).exec();
         MatcherAssert.assertThat(
             "a table rewritten between two transpilations of one JVM must be read again, but the copy parsed first was handed over",
             StPureTest.stamped(tables, source).nodes("//o[@name='x' and @pure='true']"),
@@ -161,6 +159,15 @@ final class StPureTest {
                     System.lineSeparator(), "[] > app", "  2.power 63 > x", "  x > @", ""
                 )
             ).parsed().toString()
+        );
+        return parsed;
+    }
+
+    private static Path alone(final Path temp) throws IOException {
+        final Path parsed = Files.createDirectories(temp.resolve("alone"));
+        Files.copy(
+            temp.resolve("parsed").resolve("app.xmir"),
+            parsed.resolve("app.xmir")
         );
         return parsed;
     }


### PR DESCRIPTION
Fixes #8225.

`StPure.table()` keyed the process-wide `TABLES` map by the `file:` URI, and no entry was ever invalidated. The key held neither the content of the table nor anything about its state on disk, and the resolver is installed for every new `StPure`, so building a fresh transpile train did not refresh anything either. A second transpilation in the same Maven JVM, after inference had rewritten a table at the same path, was handed the DOM parsed during the first run, and the generated Java kept or dropped `@pure` markings according to inference results that had moved on.

The modification time and the length of the file are now kept beside the copy and asked again before it is handed over. A table that has not changed is still read once and shared by every thread, which is what the cache is there for; one that has been rewritten is parsed again.

`stamp()` answers with an empty string for a path it cannot read attributes of. That covers the missing-table case, which the class already relies on: the resolver fails, `doc-available()` in the stylesheet hears it, and a build that skips `eo:inference` marks nothing. Nothing is ever cached for such a path, since `parsed()` throws before the entry is stored.

The test builds the tables of a program whose application is marked, checks the marking, runs inference again over an empty source tree so the tables at the same path are rewritten, and checks that the second stamping sees the new tables rather than the ones parsed first.
