### PR TITLE
fix(#8141): frame fields in Rows digest

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Rows.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Rows.java
@@ -77,13 +77,21 @@ final class Rows {
                         && !row.getKey().startsWith(String.format("%s.", locator))) {
                         break;
                     }
-                    sha.update(row.getKey().getBytes(StandardCharsets.UTF_8));
-                    sha.update(row.getValue().getBytes(StandardCharsets.UTF_8));
+                    Rows.feed(sha, row.getKey());
+                    Rows.feed(sha, row.getValue());
                 }
             }
             return String.format("%064x", new BigInteger(1, sha.digest())).substring(0, 12);
         } catch (final NoSuchAlgorithmException ex) {
             throw new IllegalStateException("SHA-256 is not available", ex);
         }
+    }
+
+    private static void feed(final MessageDigest digest, final String value) {
+        final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        digest.update(
+            String.format("%d\0", bytes.length).getBytes(StandardCharsets.UTF_8)
+        );
+        digest.update(bytes);
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RowsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RowsTest.java
@@ -4,9 +4,11 @@
  */
 package org.eolang.maven;
 
+import com.jcabi.xml.XMLDocument;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -39,6 +41,40 @@ final class RowsTest {
             "an object whose locator merely starts with the same letters is somebody else",
             this.digest(temp.resolve("with"), "<type id=\"Q.foobar\"><attr name=\"x\"/></type>"),
             Matchers.equalTo(this.digest(temp.resolve("without"), ""))
+        );
+    }
+
+    @Test
+    void framesEveryDigestField(@Mktmp final Path temp) throws IOException {
+        final String locator = "Q.φ";
+        final Path dir = temp.resolve("framed");
+        Files.createDirectories(dir);
+        final Path table = dir.resolve("provides.xml");
+        Files.writeString(
+            table,
+            String.format(
+                "<provides><type id=\"%s\"><attr name=\"x\"/></type></provides>",
+                locator
+            )
+        );
+        final String value = String.format(
+            "provides.xml:%s",
+            new XMLDocument(table).nodes("/*/type[@id]").get(0)
+        );
+        MatcherAssert.assertThat(
+            "each locator and row value must carry its UTF-8 byte length into the digest",
+            new Rows(dir).digest(Collections.singletonList(locator)),
+            Matchers.equalTo(
+                new Hashed(
+                    String.format(
+                        "%d\0%s%d\0%s",
+                        locator.getBytes(StandardCharsets.UTF_8).length,
+                        locator,
+                        value.getBytes(StandardCharsets.UTF_8).length,
+                        value
+                    )
+                ).get()
+            )
         );
     }
 


### PR DESCRIPTION
Fixes #8141

## Summary
- Frame each locator and serialized row value with its UTF-8 byte length before hashing.
- Keep the existing sorted row selection, SHA-256 algorithm, and 12-character digest format.
- Add a regression test covering non-ASCII locators and exact serialized row framing.

## Test Plan
- mvn -ntp -pl eo-maven-plugin -Dtest=RowsTest,TranspilationTest test
- mvn -ntp -Pqulice --errors --batch-mode -Deo.skip=true clean process-classes qulice:check
- mvn -ntp -pl eo-maven-plugin -am test (2965 tests, 0 failures, 0 errors, 61 skipped)