### PR TITLE
Take a name written alone off the object around it

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -33,7 +33,9 @@ import java.util.Map;
  * <p>The receiver of a dispatch fills a void too, when the formation it
  * dispatches into declares one for it. That void is named {@code ρ} and is
  * not counted among the places, since it is answered by whoever dispatches
- * and not by an argument written to the right of the name.</p>
+ * and not by an argument written to the right of the name. A name written by
+ * itself dispatches as well, off the object it is written inside, and
+ * {@link Taken} answers for both.</p>
  *
  * @since 0.69.0
  */
@@ -50,7 +52,7 @@ final class Bound {
     private final Map<String, Map<String, String>> named;
 
     /**
-     * What every dispatch takes its attribute from, from {@link Xmirs}.
+     * What every dispatch takes its attribute from, from {@link Taken}.
      */
     private final Map<String, String> receivers;
 

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -53,7 +53,7 @@ final class Dispatched {
     private final Map<String, Map<String, String>> named;
 
     /**
-     * What every dispatch takes its attribute from, from {@link Xmirs}.
+     * What every dispatch takes its attribute from, from {@link Taken}.
      */
     private final Map<String, String> receivers;
 

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -85,9 +85,9 @@ public final class Resolved implements Clue {
         final Given applied = new Given(world.applications());
         final Map<String, List<String>> args = applied.arguments();
         final Map<String, Map<String, String>> named = applied.named();
-        final Map<String, String> receivers = world.receivers();
-        final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Pairs written = new Pairs(new XMLDocument(links));
+        final Map<String, String> receivers = new Taken(world, written).all();
+        final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Map<String, Type> kept = written.others();
         final Woven woven = new Woven(given, applied, receivers, voids);
         final Promoted promoted = new Promoted(woven, given, kept);

--- a/eo-inference/src/main/java/org/eolang/inference/Taken.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Taken.java
@@ -1,0 +1,89 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * What every object of a program is taken off.
+ *
+ * <p>A name written after a dot says in the text what it comes off, and the
+ * parser writes that down beside the name, which is what {@link Xmirs} reads. A
+ * name written by itself says the same thing silently: {@code grove} inside the
+ * body of {@code app} is the {@code grove} of that {@code app}, and nothing
+ * stands beside it to say so. Both are gathered here into one answer, since a
+ * formation that declares a receiver has it filled either way, and a body that
+ * reads through {@code ^} knows nothing until it is (#8278).</p>
+ *
+ * <p>What a name written by itself comes off is the object that binds it, which
+ * is the owner of the locator the name points at: {@code ξ.grove} points at
+ * {@code Φ.app.grove}, so it is taken off the {@code Φ.app}. That is why the
+ * table is read here instead of the walk outwards being made again —
+ * {@link Scope} made it once for {@link Links}, and a second walk is a second
+ * chance to disagree with the first.</p>
+ *
+ * <p>A fully-qualified name is taken off nothing, being what the whole program
+ * knows however deep it is written. Neither is {@code ^} taken off anything: it
+ * names the receiver rather than asking for something of it.</p>
+ *
+ * @since 0.71.0
+ */
+final class Taken {
+
+    /**
+     * The XMIR of the program.
+     */
+    private final Xmirs world;
+
+    /**
+     * The links table, where every name has been resolved already.
+     */
+    private final Pairs written;
+
+    /**
+     * Ctor.
+     * @param xmirs The XMIR of the program
+     * @param links The links table, as the rules wrote it, which says where
+     *  every name of the program points
+     */
+    Taken(final Xmirs xmirs, final Pairs links) {
+        this.world = xmirs;
+        this.written = links;
+    }
+
+    /**
+     * What every object of the program takes its attribute from.
+     * @return The locator of the object taken from, by the locator of the
+     *  object doing the taking, without the ones that take from nothing
+     * @throws IOException If a file cannot be read
+     */
+    Map<String, String> all() throws IOException {
+        final Map<String, String> found = new HashMap<>(this.world.receivers());
+        final Map<String, String> pairs = this.written.all();
+        for (final XML reference : this.world.references()) {
+            final Noted named = new Noted(reference);
+            final String owner = Taken.owner(named, pairs);
+            if (!owner.isEmpty()) {
+                found.put(named.says("loc"), owner);
+            }
+        }
+        return found;
+    }
+
+    private static String owner(final Noted named, final Map<String, String> pairs) {
+        final String base = named.says("base");
+        String found = "";
+        if (base.startsWith("ξ.") && !"ξ.ρ".equals(base)) {
+            final String target = pairs.getOrDefault(named.says("loc"), "");
+            if (target.contains(".")) {
+                found = target.substring(0, target.lastIndexOf('.'));
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Woven.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Woven.java
@@ -40,7 +40,7 @@ final class Woven {
     private final Given applied;
 
     /**
-     * What every dispatch takes its attribute from, from {@link Xmirs}.
+     * What every dispatch takes its attribute from, from {@link Taken}.
      */
     private final Map<String, String> receivers;
 

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -210,13 +210,25 @@ final class Xmirs {
      * that locator rather than by the absence alone, because a formation
      * bound inside a dispatch carries no {@code @as} either.</p>
      *
+     * <p>A name written by itself dispatches as well and has nothing beside it
+     * to be found, so it is not here; {@link Taken} adds it.</p>
+     *
+     * <p>A caret is left out, though the parser writes a receiver beside it
+     * like any other dispatch. What {@code ^} takes is the receiver of the
+     * object below it, and the object below it is not what put it there: the
+     * {@code ^} of an {@code inc} comes from whoever dispatched into that
+     * {@code inc}, so it is the caller's caller and never the {@code inc}
+     * itself. Reading a receiver says nothing about what fills one
+     * (#8281).</p>
+     *
      * @return The locator of the receiver, by the locator of the dispatch
      * @throws IOException If a file cannot be read
      */
     Map<String, String> receivers() throws IOException {
         final Map<String, String> found = new HashMap<>(0);
         for (final XML xmir : this.documents()) {
-            for (final XML node : xmir.nodes("//o[@loc][o[@loc][not(@as)]]")) {
+            for (final XML node
+                : xmir.nodes("//o[@loc][not(@base='.ρ')][o[@loc][not(@as)]]")) {
                 final Xnav owner = new Xnav(node.inner());
                 final String loc = new Noted(owner).says("loc");
                 Xmirs.bare(owner)

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caret-says-nothing-about-the-receiver-it-reads.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caret-says-nothing-about-the-receiver-it-reads.yaml
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A caret reads a receiver and fills none. `^` inside `leaf` is the `grove`
+# that `leaf` was taken off, and `^.^` is what the `grove` was taken off, so
+# taking a caret off a `grove` says what the `oak` around it holds and says
+# nothing about the `oak` itself: the `^` of an `oak` comes from whoever took
+# the `oak`, which is the `app`, and never from the `grove` inside it. Read the
+# caret as any other dispatch and the two answers arrive together, the `oak`
+# keeps a receiver nobody can name, and the `acorn` three carets up is lost.
+eo:
+  app.eo: |
+    [] > app
+      oak > @
+      [^] > oak
+        grove > @
+        [^] > grove
+          leaf > @
+          [^] > leaf
+            ^.^.^.acorn > @
+      [] > acorn
+provides:
+  - "//type[@id='Φ.app.oak']/attr[@name='ρ']/witnessed[count(ref)=1]/ref[@loc='Φ.app']"
+links:
+  - "/links/type[@id='Φ.app.oak.grove.leaf.φ']/ref[@loc='Φ.app.acorn']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-name-written-alone-is-taken-off-the-object-around-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-name-written-alone-is-taken-off-the-object-around-it.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name written by itself is an attribute taken off the object the name sits
+# in, the same as a name written after a dot: `grove` inside the body of `app`
+# is the `grove` of that `app`, so the void `grove` declares for its receiver
+# is filled with an `app`. Nothing else in the text says so, since the parser
+# writes no receiver beside such a name, and without it the body of `grove`
+# knows nothing about what it reads through `^`. With it, `^.oak` is the `oak`
+# of an `app`. The void keeps itself, as every void does.
+eo:
+  app.eo: |
+    [] > app
+      grove > @
+      [^] > grove
+        ^.oak > @
+      [] > oak
+links:
+  - "/links/type[@id='Φ.app.grove.φ']/ref[@loc='Φ.app.oak']"
+  - "/links/type[@id='Φ.app.grove.ρ']/var"


### PR DESCRIPTION
A name written by itself means the same thing as a name written after a dot: `grove` inside the body of `app` is the `grove` of that `app`. The parser writes the receiver down beside a dotted name and writes nothing beside a lone one, and `Xmirs.receivers()` was the only source of receiver-to-void fillings, so the `^` a lone name fills had no witness and everything its body read through `^` stayed a name rooted at an empty void. That is how every EO file writes its own inner objects, so it cost a lot: 322 of the 525 receiver voids of `eo-runtime` had no witness at all.

The new `Taken` answers for both kinds. What a lone name comes off is the object that binds it, which is the owner of the locator the name points at, and `Scope` has already worked that out for the links table — so the fact is read back from the table rather than walked out for a second time.

```java
if (base.startsWith("ξ.") && !"ξ.ρ".equals(base)) {
    final String target = pairs.getOrDefault(named.says("loc"), "");
    if (target.contains(".")) {
        found = target.substring(0, target.lastIndexOf('.'));
    }
}
```

Carets then started resolving, and that woke a second bug that had been sitting in the same map since it was written. `Xmirs.receivers()` took a caret for a dispatch like any other, but what `^` reads is the receiver of the object below it, and that object is not what put it there: the `^` of an `oak` comes from whoever took the `oak`, so it is the caller's caller and never the `oak` itself. Reading a receiver says nothing about what fills one. In `socket.eo` the two formations nested inside `listen` recorded the inner one as filling `listen`'s receiver eighteen times over, the void ended up with two answers that disagree, and fifty rows of the links table went to nothing known. One predicate on the XPath leaves the caret out and the receiver of a formation to the callers that actually fill it.

Across `eo-runtime`'s 172 files and 52,754 objects, the named share goes from 79.26% to 81.60% (41,816 to 43,050 objects), rooted-at-a-void falls from 10,897 to 9,663, and nothing-known stays at 41. Receiver voids with no witness drop from 322 to 92 of 525, other voids with no witness from 505 to 355 of 1,053. In `string/printf.eo` alone, 1,660 named and 245 rooted becomes 1,797 named and 108 rooted.

Two packs come with it, one per bug, each failing without its fix.

Closes #8278, closes #8281.
