### PR TITLE
#5747: write the console read and write blocks once

### DIFF
--- a/eo-runtime/src/main/eo/console.eo
+++ b/eo-runtime/src/main/eo/console.eo
@@ -35,10 +35,12 @@
 # prints it to the operating system console and returns the next output block
 # ready to `write` again.
 #
-# Console operations are platform-specific, with different implementations
-# for POSIX and Windows systems. Each access to the `console` object creates
-# a new console instance, so reusing returned input/output blocks improves
-# performance by maintaining the same console session:
+# One implementation does the reading and the writing, and the platform
+# enters it as an adapter carrying the raw syscall object and, for each of
+# the two streams, the name of the call and the descriptor. Each access
+# to the `console` object creates a new console instance, so reusing the
+# returned input/output blocks improves performance by maintaining the
+# same console session:
 #
 # Efficient (recommended):
 # ```
@@ -64,8 +66,8 @@
 
 [] > console
   os.is-windows.if > @
-    [] >>
-      [size] > read
+    [sys] >> impl
+      [^ size] > read
         @. > @
           read.
             [^ buffer] >> input-block
@@ -80,13 +82,13 @@
                   received
                   ^.^.input-block chunk
                 called. > received
-                  win32 *1
-                    "_read"
-                    win32.stdin
+                  ^.^.^.sys.raw *1
+                    ^.^.^.sys.input.name
+                    ^.^.^.sys.input.descriptor
                     size
             | --
             size
-      [buffer] > write
+      [^ buffer] > write
         @. > @
           write.
             [^] >> output-block
@@ -101,9 +103,9 @@
                   code
                   remainder
                 code. > code
-                  win32 *1
-                    "_write"
-                    win32.stdout
+                  ^.^.^.sys.raw *1
+                    ^.^.^.sys.output.name
+                    ^.^.^.sys.output.descriptor
                     buffer
                     buffer.size
                 if. > remainder
@@ -112,54 +114,24 @@
                     buffer.slice code (buffer.size.minus code)
                   ^.^.output-block
             buffer
-    [] >>
-      [size] > read
-        @. > @
-          read.
-            [^ buffer] >> input-block
-              buffer > @
-              [^ size] > read
-                seq * > @
-                  if. >> chunk!
-                    received.code.eq -1
-                    T
-                      "Failed to read from standard input"
-                    received.output
-                  received
-                  ^.^.input-block chunk
-                called. > received
-                  posix *1
-                    "read"
-                    posix.stdin
-                    size
-            | --
-            size
-      [buffer] > write
-        @. > @
-          write.
-            [^] >> output-block
-              true > @
-              [^ buffer] > write
-                seq * > @
-                  if. >>!
-                    code.eq -1
-                    T
-                      "Failed to write to standard output"
-                    ^.^.output-block
-                  code
-                  remainder
-                code. > code
-                  posix *1
-                    "write"
-                    posix.stdout
-                    buffer
-                    buffer.size
-                if. > remainder
-                  code.lt buffer.size
-                  ^.^.output-block.write
-                    buffer.slice code (buffer.size.minus code)
-                  ^.^.output-block
-            buffer
+    |
+      []
+        [] > input
+          win32.stdin > descriptor
+          "_read" > name
+        [] > output
+          win32.stdout > descriptor
+          "_write" > name
+        win32 > raw
+    impl
+      []
+        [] > input
+          posix.stdin > descriptor
+          "read" > name
+        [] > output
+          posix.stdout > descriptor
+          "write" > name
+        posix > raw
 
   ++> can-chain-writes-across-output-blocks
     seq * > @


### PR DESCRIPTION
Closes #5747.

Both branches of `os.is-windows.if` in `console.eo` held the same `read`/`input-block` and `write`/`output-block` structure, differing only in the syscall object, the two function names and the two descriptors. One `impl` now takes a `sys` adapter carrying them as `sys.raw`, `sys.input.name`/`sys.input.descriptor` and `sys.output.name`/`sys.output.descriptor`, following the shape `socket.eo` already uses. 61 lines become 33.

`read` and `write` declare `^` now, since the inner blocks reach `^.^.^.sys` through them.

`TestEOconsole` (6), `TestEOstdout` and `TestEOstderr` pass; the `format` goal leaves the file byte-identical. The read path has no `++>` coverage — `console.read` reaches the real file descriptor 0, as `stdin.eo` explains — so I drove it against the transpiled classes with piped input: `console.read 5` answers `Hello` and the chained `.read 6` answers `World!`, which is what the `reads-via-console` snippet asserts.

Same adapter shape as #8279, which does this for `stderr.eo`.

@yegor256 Could you please take a look