### PR TITLE
#8218: let a source digest decide whether the xmir is reusable

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Parsing.java
@@ -173,7 +173,9 @@ final class Parsing implements Step {
                 return new XMLDocument(node).toString();
             }
         ).apply(source, xmir);
-        tojo.withXmir(xmir).withVersion(Parsing.tojoVersion(xmir, refs));
+        tojo.withXmir(xmir)
+            .withVersion(Parsing.tojoVersion(xmir, refs))
+            .withDigest(new Sha(source).toString());
         final List<Xnav> errors = new Xnav(xmir)
             .element("object")
             .element("errors")

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjForeign.java
@@ -134,15 +134,12 @@ final class TjForeign {
      */
     boolean notParsed() {
         boolean res = true;
-        if (this.delegate.exists(TjsForeign.Attribute.XMIR.getKey())) {
-            final Path xmir = this.xmir();
-            if (xmir.toFile().lastModified() >= this.source().toFile().lastModified()) {
-                Logger.debug(
-                    this, "Already parsed %s to %[file]s (it's newer than the source)",
-                    this.identifier(), xmir
-                );
-                res = false;
-            }
+        if (this.delegate.exists(TjsForeign.Attribute.XMIR.getKey()) && this.unchanged()) {
+            Logger.debug(
+                this, "Already parsed %s to %[file]s (the source is the very same one)",
+                this.identifier(), this.xmir()
+            );
+            res = false;
         }
         return res;
     }
@@ -260,6 +257,16 @@ final class TjForeign {
     }
 
     /**
+     * Set the digest of the source the xmir was parsed from.
+     * @param digest The digest
+     * @return The tojo itself
+     */
+    TjForeign withDigest(final String digest) {
+        this.delegate.set(TjsForeign.Attribute.DIGEST.getKey(), digest);
+        return this;
+    }
+
+    /**
      * Set the version.
      * @param ver The version
      * @return The tojo itself
@@ -285,6 +292,13 @@ final class TjForeign {
      */
     String scope() {
         return this.attribute(TjsForeign.Attribute.SCOPE);
+    }
+
+    private boolean unchanged() {
+        return this.delegate.exists(TjsForeign.Attribute.DIGEST.getKey())
+            && this.source().toFile().exists()
+            && this.attribute(TjsForeign.Attribute.DIGEST)
+                .equals(new Sha(this.source()).toString());
     }
 
     private String attribute(final TjsForeign.Attribute attribute) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/TjsForeign.java
@@ -311,7 +311,14 @@ final class TjsForeign implements Closeable {
         /**
          * Git SHA of the object in the {@code objectionary/home}.
          */
-        HASH("hash");
+        HASH("hash"),
+
+        /**
+         * SHA-256 of the {@code .eo} source the XMIR was parsed from, which
+         * tells a changed source from an untouched one no matter what the
+         * modification time of either file says.
+         */
+        DIGEST("digest");
 
         /**
          * Attribute name.

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjParseTest.java
@@ -254,6 +254,35 @@ final class MjParseTest {
         );
     }
 
+    @Test
+    void parsesAgainWhenTheSourceChangesUnderTheSameTimestamp(@Mktmp final Path temp)
+        throws IOException {
+        final FakeMaven maven = new FakeMaven(temp);
+        final Path parsed = maven
+            .withHelloWorld()
+            .execute(new PpParse())
+            .result()
+            .get(String.format("target/%s/foo/x/main.%s", Parsing.DIR, MjAssemble.XMIR));
+        final Path source = temp.resolve(Paths.get("foo", "x", "main.eo"));
+        new Saved(
+            String.join(
+                System.lineSeparator(),
+                "+package foo.x",
+                "",
+                "[greeting] > main",
+                "  greeting > @"
+            ),
+            source
+        ).value();
+        Files.setLastModifiedTime(source, Files.getLastModifiedTime(parsed));
+        maven.execute(MjParse.class);
+        MatcherAssert.assertThat(
+            "the XMIR stayed as it was, while the source it came from had changed",
+            new XMLDocument(parsed),
+            XhtmlMatchers.hasXPaths("//o[@name='greeting']")
+        );
+    }
+
     /**
      * The test with high number of eo programs reveals concurrency problems of the ParseMojo.
      * Since other tests works only with single program - it's hard to find concurrency mistakes.


### PR DESCRIPTION
Closes #8218.

`TjForeign.notParsed()` decided by modification times alone, so a source that changed while keeping the timestamp of its xmir — a tree restored with preserved times, say — was filtered out of `Parsing` and every later goal read a stale xmir.

The tojo now carries `digest`, the SHA-256 of the source it was parsed from, written by `Parsing` next to `xmir` and `version`. Only an equal digest lets the xmir stand. `Sha` already lived in the package.

A row whose `.eo` is gone no longer counts as parsed either: it used to read `lastModified() == 0` and silently reuse the xmir, which is the same failure this ticket is about.

Test first: `parsesAgainWhenTheSourceChangesUnderTheSameTimestamp` parses, replaces the source, sets its timestamp to the xmir's and parses again. It failed before the fix and passes after.

`MjParseTest`, `TjsForeignTest`, `MjRegisterTest`, `MjLintTest` and `MjTranspileTest` pass, apart from `parsesWithCache`, which fails the same way on an untouched `master` here. `eo-runtime` builds twice in a row, parsing 172 sources in the first assemble cycle and none in the second, so the cache still skips what did not change. Qulice is clean.

@yegor256 Could you please take a look
