### PR TITLE
Report chained inline-phi suffixes the same way inside parentheses

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -472,6 +472,13 @@ final class Emissions {
                 "only-phi parameter list missing closing `]`"
             );
         }
+        final int chained = Eo.topLevelGreaterBracketIndex(inner.substring(close + 1));
+        if (chained >= 0) {
+            throw new ParseError(
+                line, column + close + 1 + chained,
+                "chained inline-phi suffixes are not allowed"
+            );
+        }
         final String lhs = inner.substring(0, phi).stripTrailing();
         final String params = inner.substring(bracket + 1, close);
         final boolean suffixed = new Suffix(

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/chained-inline-phi-suffixes-inside-parens.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/chained-inline-phi-suffixes-inside-parens.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: |-
+  chained inline-phi suffixes are not allowed
+input: |
+  bar (a > [b] > [c]) > z


### PR DESCRIPTION
LnOnlyPhi.into already scans past the closing bracket of an only-phi parameter list for a second `> [` and rejects chained suffixes with a clear message pointing at the second marker. Emissions.inlinePhi, which parses the parenthesised spelling of the same construct, skipped that scan and instead handed the leftover text straight to Suffix, so a chained parenthesised form failed with "name suffix requires a name" at the wrong column instead of naming the real mistake.

This adds the same chained-bracket scan to inlinePhi, using the shared Eo.topLevelGreaterBracketIndex helper, before it builds a Suffix from what follows the closing bracket. Both spellings of the construct now report "chained inline-phi suffixes are not allowed" at the position of the second marker.

A yaml pack asserts the message for the parenthesised form, mirroring the existing pack for the bare form.

Closes #8250