### PR TITLE
Lower pure formations into synthetic atoms

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -1,0 +1,194 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * The Java body of one lowered fragment.
+ *
+ * <p>A protocol is a straight-line program, so its Java is a straight
+ * line too: one local per void a step reads, dataized through the public
+ * runtime API, one local per step, rendered by the format the {@link Op}
+ * table holds for its atom, and one return handing the answer to
+ * {@code Data.ToPhi}. The text is exactly what the {@code lambda()} of
+ * the generated atom class holds, indented for that spot, and it is the
+ * content the sidecar file is named after. A protocol that steps outside
+ * what the table renders — an operation with no Java column, a void of a
+ * forma the runtime cannot hand over — is refused, and the caller treats
+ * the refusal as one fragment staying unlowered.</p>
+ *
+ * @since 0.76.0
+ */
+public final class JavaAtom {
+
+    /**
+     * The protocol to render.
+     */
+    private final Protocol protocol;
+
+    /**
+     * The voids of the fragment: names to formas, in declaration order.
+     */
+    private final Map<String, String> voids;
+
+    /**
+     * Ctor.
+     * @param proto The protocol to render
+     * @param inputs The voids of the fragment: names to formas, in order
+     */
+    public JavaAtom(final Protocol proto, final Map<String, String> inputs) {
+        this.protocol = proto;
+        this.voids = inputs;
+    }
+
+    /**
+     * The body of the {@code lambda()} method.
+     * @return Java statements, one per line, without a trailing newline
+     */
+    public String text() {
+        final List<String> names = new ArrayList<>(this.voids.keySet());
+        final List<String> lines = new ArrayList<>(names.size());
+        for (final Integer index : this.used()) {
+            if (index >= names.size()) {
+                throw new IllegalStateException(
+                    String.format("The protocol reads void #%d, which the fragment lacks", index)
+                );
+            }
+            final String name = names.get(index);
+            lines.add(JavaAtom.reading(index, name, this.voids.get(name)));
+        }
+        for (final Step step : this.protocol.moves()) {
+            lines.add(JavaAtom.computed(step));
+        }
+        lines.add(
+            String.format(
+                "return new Data.ToPhi(%s);",
+                JavaAtom.expression(this.protocol.answer())
+            )
+        );
+        return lines.stream()
+            .map(line -> String.format("        %s", line))
+            .collect(Collectors.joining(System.lineSeparator()));
+    }
+
+    private SortedSet<Integer> used() {
+        final List<String> keys = new ArrayList<>(0);
+        for (final Step step : this.protocol.moves()) {
+            keys.addAll(step.keys());
+        }
+        keys.add(this.protocol.answer());
+        final SortedSet<Integer> out = new TreeSet<>();
+        for (final String key : keys) {
+            if (key.startsWith("sym:v")) {
+                out.add(Integer.parseInt(key.substring(5)));
+            }
+        }
+        return out;
+    }
+
+    private static String reading(final int index, final String name, final String forma) {
+        final String out;
+        if ("number".equals(forma)) {
+            out = String.format(
+                "final double v%d = new Dataized(this.take(\"%s\")).asNumber();",
+                index, name
+            );
+        } else if ("bytes".equals(forma)) {
+            out = String.format(
+                "final byte[] v%d = new Dataized(this.take(\"%s\")).take();",
+                index, name
+            );
+        } else {
+            throw new IllegalStateException(
+                String.format("The void '%s' of forma '%s' cannot be read in Java", name, forma)
+            );
+        }
+        return out;
+    }
+
+    private static String computed(final Step step) {
+        final Op operation = new Op(step.atom());
+        return String.format(
+            "final %s %s = %s;",
+            JavaAtom.typed(operation.forma()),
+            step.label(),
+            String.format(
+                operation.java(),
+                step.keys().stream().map(JavaAtom::expression).toArray(Object[]::new)
+            )
+        );
+    }
+
+    private static String typed(final String forma) {
+        final String out;
+        if ("number".equals(forma)) {
+            out = "double";
+        } else if ("bool".equals(forma)) {
+            out = "boolean";
+        } else if ("bytes".equals(forma)) {
+            out = "byte[]";
+        } else {
+            throw new IllegalStateException(
+                String.format("The forma '%s' has no Java type to carry it", forma)
+            );
+        }
+        return out;
+    }
+
+    private static String expression(final String key) {
+        final String out;
+        final String[] parts = key.split(":", 2);
+        if ("sym".equals(parts[0])) {
+            out = parts[1];
+        } else if ("number".equals(parts[0])) {
+            final String hex = parts[1].replace("-", "");
+            if (hex.length() != 16) {
+                throw new IllegalStateException(
+                    String.format("The number '%s' is not eight bytes", parts[1])
+                );
+            }
+            out = String.format("Double.longBitsToDouble(0x%sL)", hex);
+        } else if ("bool".equals(parts[0])) {
+            if ("01-".equals(parts[1])) {
+                out = "true";
+            } else if ("00-".equals(parts[1])) {
+                out = "false";
+            } else {
+                throw new IllegalStateException(
+                    String.format("The bool '%s' is not one byte", parts[1])
+                );
+            }
+        } else if ("bytes".equals(parts[0])) {
+            out = JavaAtom.array(parts[1]);
+        } else {
+            throw new IllegalStateException(
+                String.format("The operand '%s' has no Java expression", key)
+            );
+        }
+        return out;
+    }
+
+    private static String array(final String dashed) {
+        final List<String> cells = new ArrayList<>(0);
+        for (final String pair : dashed.split("-", -1)) {
+            if (!pair.isEmpty()) {
+                cells.add(String.format("(byte) 0x%s", pair));
+            }
+        }
+        final String out;
+        if (cells.isEmpty()) {
+            out = "new byte[0]";
+        } else {
+            out = String.format("new byte[] {%s}", String.join(", ", cells));
+        }
+        return out;
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Op.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Op.java
@@ -74,6 +74,27 @@ public final class Op {
     }
 
     /**
+     * The Java rendering of this operation, as a format string whose
+     * positional arguments are the receiver and then the arguments.
+     * An operation may have no rendering — {@code right} and {@code slice}
+     * coerce their bounds the way only the hand-written atoms can — and
+     * such an operation reduces fine but refuses to become Java.
+     * @return A format, such as {@code %1$s + %2$s}
+     */
+    public String java() {
+        final String[] row = this.row();
+        if (row.length < 6 || row[5].isEmpty()) {
+            throw new IllegalStateException(
+                String.format(
+                    "The atom '%s' has no faithful Java rendering",
+                    this.lambda
+                )
+            );
+        }
+        return row[5];
+    }
+
+    /**
      * The names of the arguments, in their positional order.
      * @return The names, such as {@code start} and {@code len}
      */

--- a/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
@@ -1,12 +1,12 @@
-L_number_plus	plus	number	number	x
-L_number_times	times	number	number	x
-L_number_div	div	number	number	x
-L_number_gt	gt	number	bool	x
-L_bytes_and	and	bytes	bytes	b
-L_bytes_or	or	bytes	bytes	b
-L_bytes_not	not	bytes	bytes
-L_bytes_concat	concat	bytes	bytes	b
-L_bytes_eq	eq	bytes	bool	b
+L_number_plus	plus	number	number	x	%1$s + %2$s
+L_number_times	times	number	number	x	%1$s * %2$s
+L_number_div	div	number	number	x	%1$s / %2$s
+L_number_gt	gt	number	bool	x	%1$s > %2$s
+L_bytes_and	and	bytes	bytes	b	new BytesOf(%1$s).and(new BytesOf(%2$s)).take()
+L_bytes_or	or	bytes	bytes	b	new BytesOf(%1$s).or(new BytesOf(%2$s)).take()
+L_bytes_not	not	bytes	bytes		new BytesOf(%1$s).not().take()
+L_bytes_concat	concat	bytes	bytes	b	java.nio.ByteBuffer.allocate(%1$s.length + %2$s.length).put(%1$s).put(%2$s).array()
+L_bytes_eq	eq	bytes	bool	b	java.util.Arrays.equals(%1$s, %2$s)
 L_bytes_right	right	bytes	bytes	x
-L_bytes_size	size	bytes	number
+L_bytes_size	size	bytes	number		%1$s.length
 L_bytes_slice	slice	bytes	bytes	start,len

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -1,0 +1,195 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link JavaAtom}.
+ *
+ * <p>The protocols here are built by hand, so the tests need no phino:
+ * they pin the exact Java text each shape of protocol renders into,
+ * which is what lands in a sidecar file and then, verbatim, in the
+ * {@code lambda()} of a generated atom class.</p>
+ *
+ * @since 0.76.0
+ */
+final class JavaAtomTest {
+
+    @Test
+    void rendersChainOfNumberSteps() {
+        MatcherAssert.assertThat(
+            "a chain of two steps must render one line each, but it doesnt",
+            new JavaAtom(
+                new Protocol(
+                    Arrays.asList(
+                        new Step(
+                            "s1", "L_number_plus",
+                            Arrays.asList("sym:v0", "number:40-00-00-00-00-00-00-00")
+                        ),
+                        new Step("s2", "L_number_times", Arrays.asList("sym:s1", "sym:v0"))
+                    ),
+                    "sym:s2",
+                    "number"
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final double v0 = new Dataized(this.take(\"x\")).asNumber();",
+                    "        final double s1 = v0 + Double.longBitsToDouble(0x4000000000000000L);",
+                    "        final double s2 = s1 * v0;",
+                    "        return new Data.ToPhi(s2);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void rendersBytesOperationsThroughPublicApi() {
+        MatcherAssert.assertThat(
+            "the bytes steps must go through BytesOf and length, but they dont",
+            new JavaAtom(
+                new Protocol(
+                    Arrays.asList(
+                        new Step(
+                            "s1", "L_bytes_and",
+                            Arrays.asList("sym:v0", "bytes:1F-")
+                        ),
+                        new Step("s2", "L_bytes_size", Collections.singletonList("sym:s1")),
+                        new Step(
+                            "s3", "L_number_gt",
+                            Arrays.asList("sym:s2", "number:40-00-00-00-00-00-00-00")
+                        )
+                    ),
+                    "sym:s3",
+                    "bool"
+                ),
+                Collections.singletonMap("b", "bytes")
+            ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final byte[] v0 = new Dataized(this.take(\"b\")).take();",
+                    String.format(
+                        "        final byte[] s1 = new BytesOf(v0)%s",
+                        ".and(new BytesOf(new byte[] {(byte) 0x1F})).take();"
+                    ),
+                    "        final double s2 = s1.length;",
+                    "        final boolean s3 = s2 > Double.longBitsToDouble(0x4000000000000000L);",
+                    "        return new Data.ToPhi(s3);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void answersVoidWithoutSteps() {
+        MatcherAssert.assertThat(
+            "an identity protocol must read the void and answer it, but it doesnt",
+            new JavaAtom(
+                new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final double v0 = new Dataized(this.take(\"x\")).asNumber();",
+                    "        return new Data.ToPhi(v0);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void answersLiteralWithoutReadingVoids() {
+        MatcherAssert.assertThat(
+            "a constant protocol must not dataize the unused void, but it does",
+            new JavaAtom(
+                new Protocol(
+                    Collections.emptyList(),
+                    "number:40-14-00-00-00-00-00-00",
+                    "number"
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.equalTo(
+                "        return new Data.ToPhi(Double.longBitsToDouble(0x4014000000000000L));"
+            )
+        );
+    }
+
+    @Test
+    void skipsVoidNoStepReads() {
+        final Map<String, String> voids = new LinkedHashMap<>();
+        voids.put("x", "number");
+        voids.put("y", "number");
+        MatcherAssert.assertThat(
+            "a void no step reads must not be dataized, but it is",
+            new JavaAtom(
+                new Protocol(
+                    Collections.singletonList(
+                        new Step(
+                            "s1", "L_number_plus",
+                            Arrays.asList("sym:v1", "number:3F-F0-00-00-00-00-00-00")
+                        )
+                    ),
+                    "sym:s1",
+                    "number"
+                ),
+                voids
+            ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final double v1 = new Dataized(this.take(\"y\")).asNumber();",
+                    "        final double s1 = v1 + Double.longBitsToDouble(0x3FF0000000000000L);",
+                    "        return new Data.ToPhi(s1);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void refusesOperationWithoutRendering() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new JavaAtom(
+                new Protocol(
+                    Collections.singletonList(
+                        new Step(
+                            "s1", "L_bytes_right",
+                            Arrays.asList("sym:v0", "number:40-00-00-00-00-00-00-00")
+                        )
+                    ),
+                    "sym:s1",
+                    "bytes"
+                ),
+                Collections.singletonMap("b", "bytes")
+            )::text,
+            "an operation without a Java rendering cannot make a body, but it did"
+        );
+    }
+
+    @Test
+    void refusesVoidOfForeignForma() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new JavaAtom(
+                new Protocol(Collections.emptyList(), "sym:v0", "string"),
+                Collections.singletonMap("s", "string")
+            )::text,
+            "a void of a foreign forma cannot be read, but it was"
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
@@ -61,6 +61,24 @@ final class OpTest {
     }
 
     @Test
+    void rendersAdditionAsJava() {
+        MatcherAssert.assertThat(
+            "the addition must render as the plus operator, but it doesnt",
+            String.format(new Op("L_number_plus").java(), "a", "b"),
+            Matchers.equalTo("a + b")
+        );
+    }
+
+    @Test
+    void refusesRenderingOfShift() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Op("L_bytes_right")::java,
+            "the shift has no faithful Java rendering, but one was given"
+        );
+    }
+
+    @Test
     void disownsUnknownLambda() {
         MatcherAssert.assertThat(
             "an atom outside the table cannot be listed, but it is",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Digest.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Digest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * The name of one sidecar file, computed from its content.
+ *
+ * <p>A lowered formation and the body of its {@code lambda()} method are
+ * written apart — the stamp into the XMIR, the body into a sidecar file —
+ * and the digest is what holds them together: twelve hex characters of
+ * the SHA-256 of the body, the exact shape {@code lowered.xsl} demands of
+ * the {@code lowered} attribute before it reads the file. Naming the file
+ * after its content also deduplicates for free: two fragments compiling
+ * into the same body share one sidecar, whatever files they came
+ * from.</p>
+ *
+ * @since 0.76.0
+ */
+final class Digest {
+
+    /**
+     * The content to digest.
+     */
+    private final String text;
+
+    /**
+     * Ctor.
+     * @param body The content to digest
+     */
+    Digest(final String body) {
+        this.text = body;
+    }
+
+    /**
+     * The digest.
+     * @return Twelve hex characters
+     */
+    String hex() {
+        try {
+            return String.format(
+                "%064x",
+                new BigInteger(
+                    1,
+                    MessageDigest.getInstance("SHA-256").digest(
+                        this.text.getBytes(StandardCharsets.UTF_8)
+                    )
+                )
+            ).substring(0, 12);
+        } catch (final NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 is not available", ex);
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Lowered.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Lowered.java
@@ -1,0 +1,265 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.log.Logger;
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import com.yegor256.xsline.Shift;
+import com.yegor256.xsline.TrDefault;
+import com.yegor256.xsline.Xsline;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
+import org.cactoos.scalar.Unchecked;
+import org.eolang.lowering.JavaAtom;
+import org.eolang.lowering.Phino;
+import org.eolang.lowering.Protocol;
+import org.eolang.lowering.Reduction;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Rewrite the pure formations of one XMIR into synthetic atoms.
+ *
+ * <p>A formation qualifies when {@code purify.xsl} stamps it pure, it is
+ * a named direct attribute of a top-level object, its body is voids plus
+ * one {@code φ} and nothing else — deleting the body must not change the
+ * object's interface — it neither declares nor reads {@code ρ}, and every
+ * void is witnessed in the tables of {@code eo:inference} as a number or
+ * as bytes, so a symbolic carrier can stand for it. Such a formation is
+ * reduced into a protocol, the protocol is rendered into a Java body, the
+ * body goes into a sidecar file named by its own digest, and the
+ * formation keeps only its voids, the digest, and a {@code λ} marker —
+ * the shape {@code lowered.xsl} later renders into an atom class.
+ * Whatever refuses along the way — an unwitnessed void, an operation
+ * outside the tables, a body that needs no computation — leaves the
+ * formation as written, the way {@code Lowering} treats every
+ * refusal.</p>
+ *
+ * @since 0.76.0
+ */
+final class Lowered {
+
+    /**
+     * The binary that dataizes.
+     */
+    private final Phino phino;
+
+    /**
+     * The train that stamps formations pure.
+     */
+    private final Xsline purity;
+
+    /**
+     * The witnessed data formas, by the locator of each void.
+     */
+    private final Unchecked<Map<String, String>> formas;
+
+    /**
+     * The directory for the sidecar bodies.
+     */
+    private final Path atoms;
+
+    /**
+     * Ctor.
+     * @param exe The binary that dataizes
+     * @param tables The directory with the tables of {@link MjInference}
+     * @param home The directory for the sidecar bodies
+     */
+    Lowered(final Phino exe, final Path tables, final Path home) {
+        this(
+            exe,
+            new Xsline(
+                new TrDefault<Shift>().with(
+                    new StPure("/org/eolang/maven/transpile/purify.xsl", tables)
+                )
+            ),
+            new Unchecked<>(
+                new Synced<>(
+                    new Sticky<>(() -> Lowered.witnessed(tables.resolve("provides.xml")))
+                )
+            ),
+            home
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param exe The binary that dataizes
+     * @param train The train that stamps formations pure
+     * @param table The witnessed data formas, by the locator of each void
+     * @param home The directory for the sidecar bodies
+     */
+    Lowered(final Phino exe, final Xsline train,
+        final Unchecked<Map<String, String>> table, final Path home) {
+        this.phino = exe;
+        this.purity = train;
+        this.formas = table;
+        this.atoms = home;
+    }
+
+    /**
+     * Rewrite every qualifying formation of the document, in place.
+     * @param doc The XMIR to rewrite
+     * @return How many formations became atoms
+     * @throws IOException If a sidecar cannot be written
+     */
+    int rewrite(final XMLDocument doc) throws IOException {
+        final Collection<Xnav> found = Lowered.candidates(doc);
+        int count = 0;
+        if (!found.isEmpty() && !this.formas.value().isEmpty()) {
+            final Set<String> pure = new HashSet<>(
+                this.purity.pass(doc).xpath("//o[@pure='true'][not(@base)]/@loc")
+            );
+            for (final Xnav node : found) {
+                final String place = node.attribute("loc").text().orElse("");
+                if (pure.contains(place) && this.lowered(node, place)) {
+                    ++count;
+                }
+            }
+        }
+        return count;
+    }
+
+    private boolean lowered(final Xnav node, final String place) throws IOException {
+        final Map<String, String> inputs = this.voids(node, place);
+        final List<Xnav> bodies = Lowered.bodies(node);
+        boolean done = false;
+        if (!inputs.isEmpty() && bodies.size() == 1
+            && Lowered.kids(node).size() == inputs.size() + 1) {
+            done = this.spliced(node, bodies.get(0), inputs);
+        }
+        return done;
+    }
+
+    private boolean spliced(final Xnav node, final Xnav body,
+        final Map<String, String> inputs) throws IOException {
+        String text = "";
+        String carrier = "";
+        try {
+            final Protocol protocol = new Reduction(this.phino, body, inputs, 8).protocol();
+            if (!protocol.moves().isEmpty()) {
+                text = new JavaAtom(protocol, inputs).text();
+                carrier = protocol.carrier();
+            }
+        } catch (final IllegalStateException | IOException ex) {
+            Logger.debug(this, "A formation stays unlowered: %s", ex.getMessage());
+        }
+        final boolean done = !carrier.isEmpty();
+        if (done) {
+            final String digest = new Digest(text).hex();
+            new Saved(text, this.atoms.resolve(String.format("%s.java", digest))).value();
+            new Xembler(
+                new Directives()
+                    .attr("pure", "true")
+                    .attr("lowered", digest)
+                    .xpath("o[@name='φ']").remove()
+                    .add("o")
+                    .attr("name", "λ")
+                    .attr("atom", String.format("Φ.%s", carrier))
+            ).applyQuietly(node.node());
+            for (final Xnav kid : Lowered.kids(node)) {
+                final String name = kid.attribute("name").text().orElse("");
+                if (inputs.containsKey(name)) {
+                    new Xembler(
+                        new Directives().attr(
+                            "type", String.format("Φ.%s", inputs.get(name))
+                        )
+                    ).applyQuietly(kid.node());
+                }
+            }
+        }
+        return done;
+    }
+
+    private Map<String, String> voids(final Xnav node, final String place) {
+        final Map<String, String> out = new LinkedHashMap<>();
+        for (final Xnav kid : Lowered.kids(node)) {
+            if (!"∅".equals(kid.attribute("base").text().orElse(""))) {
+                continue;
+            }
+            final String name = kid.attribute("name").text().orElse("");
+            final String forma = this.formas.value().getOrDefault(
+                String.format("%s.%s", place, name), ""
+            );
+            if ("ρ".equals(name) || forma.isEmpty()) {
+                out.clear();
+                break;
+            }
+            out.put(name, forma);
+        }
+        return out;
+    }
+
+    private static Collection<Xnav> candidates(final XMLDocument doc) {
+        final Collection<Xnav> out = new ArrayList<>(0);
+        for (final Xnav top : Lowered.kids(new Xnav(doc.inner()).element("object"))) {
+            if (top.attribute("base").text().isPresent()) {
+                continue;
+            }
+            for (final Xnav kid : Lowered.kids(top)) {
+                final String name = kid.attribute("name").text().orElse("");
+                if (kid.attribute("base").text().isEmpty()
+                    && !name.isEmpty() && !"λ".equals(name)) {
+                    out.add(kid);
+                }
+            }
+        }
+        return out;
+    }
+
+    private static List<Xnav> bodies(final Xnav node) {
+        return Lowered.kids(node).stream()
+            .filter(kid -> "φ".equals(kid.attribute("name").text().orElse("")))
+            .filter(kid -> !kid.attribute("base").text().orElse("").isEmpty())
+            .filter(kid -> !"∅".equals(kid.attribute("base").text().orElse("")))
+            .collect(Collectors.toList());
+    }
+
+    private static Map<String, String> witnessed(final Path table) throws IOException {
+        final Map<String, String> out = new HashMap<>(0);
+        if (Files.exists(table)) {
+            for (final XML row : new XMLDocument(table).nodes("/*/type[@id]")) {
+                out.putAll(Lowered.provided(row));
+            }
+        }
+        return out;
+    }
+
+    private static Map<String, String> provided(final XML row) {
+        final Map<String, String> out = new HashMap<>(0);
+        final String place = row.xpath("@id").get(0);
+        for (final XML attr : row.nodes("attr[@void='true'][witnessed]")) {
+            final Set<String> refs = new HashSet<>(attr.xpath("witnessed//ref/@loc"));
+            final String kind = String.join("", refs);
+            if (refs.size() == 1
+                && ("Φ.number".equals(kind) || "Φ.bytes".equals(kind))) {
+                out.put(
+                    String.format("%s.%s", place, attr.xpath("@name").get(0)),
+                    kind.substring(2)
+                );
+            }
+        }
+        return out;
+    }
+
+    private static List<Xnav> kids(final Xnav node) {
+        return node.elements(Filter.withName("o")).collect(Collectors.toList());
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Lowering.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Lowering.java
@@ -41,6 +41,13 @@ import org.xembly.Xembler;
  * folded is neither rewritten nor repointed, so a build without foldable
  * fragments leaves no trace of this step at all.</p>
  *
+ * <p>Before the constants, {@link Lowered} rewrites the pure formations
+ * whose value symbolic reduction can compute: their bodies become sidecar
+ * Java files, and the formations keep only their voids and a {@code λ}
+ * marker, so {@code lowered.xsl} later renders each one as an atom class.
+ * The same best-effort rule holds there: a formation that refuses stays
+ * as written.</p>
+ *
  * @since 0.76.0
  */
 final class Lowering implements Step {
@@ -78,21 +85,44 @@ final class Lowering implements Step {
     private final Phino phino;
 
     /**
+     * The rewriter of pure formations into synthetic atoms.
+     */
+    private final Lowered riser;
+
+    /**
      * Ctor.
      * @param srcs XMIR sources to fold
      * @param target The directory for the folded XMIR
      * @param exe The binary that dataizes
+     * @param tables The directory with the tables of {@link MjInference}
      */
-    Lowering(final Collection<TjForeign> srcs, final Path target, final Phino exe) {
+    Lowering(final Collection<TjForeign> srcs, final Path target,
+        final Phino exe, final Path tables) {
+        this(
+            srcs, target, exe,
+            new Lowered(exe, tables, target.resolve(Lowering.ATOMS))
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param srcs XMIR sources to fold
+     * @param target The directory for the folded XMIR
+     * @param exe The binary that dataizes
+     * @param atoms The rewriter of pure formations into synthetic atoms
+     */
+    Lowering(final Collection<TjForeign> srcs, final Path target,
+        final Phino exe, final Lowered atoms) {
         this.sources = srcs;
         this.home = target;
         this.phino = exe;
+        this.riser = atoms;
     }
 
     @Override
     public void exec() throws IOException {
         Logger.info(
-            this, "Folded %d constant fragment(s) in %d XMIR(s), into %[file]s",
+            this, "Folded or lowered %d fragment(s) in %d XMIR(s), into %[file]s",
             new Threaded<>(this.sources, this::folded).total(),
             this.sources.size(), this.home
         );
@@ -100,12 +130,12 @@ final class Lowering implements Step {
 
     private int folded(final TjForeign tojo) throws IOException {
         final XMLDocument doc = new XMLDocument(tojo.xmir());
+        int count = this.riser.rewrite(doc);
         final Collection<Xnav> found = new ArrayList<>(0);
         Lowering.selected(
             new Xnav(doc.inner()).element("object").element("o"),
             found
         );
-        int count = 0;
         for (final Xnav node : found) {
             if (this.spliced(node)) {
                 ++count;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjLower.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjLower.java
@@ -5,6 +5,7 @@
 package org.eolang.maven;
 
 import com.jcabi.log.Logger;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,10 +21,14 @@ import org.eolang.lowering.Phino;
  * the full object-graph cost at runtime for a value the compiler could
  * know. This goal computes such fragments through the external
  * {@code phino} binary and splices the values back as literals, so the
- * graphs are never built. It runs after {@link MjMerge} and before
- * {@link MjTranspile}, reading the XMIR of each object and repointing it
- * at the rewritten copy in {@link Lowering#DIR} — only when something in
- * it was actually folded.</p>
+ * graphs are never built. A pure formation whose voids are witnessed as
+ * data goes further: its body is reduced symbolically into a protocol,
+ * the protocol becomes the Java body of a synthetic atom in a sidecar
+ * file under {@link Lowering#ATOMS}, and the formation keeps only its
+ * voids and a {@code λ} marker. The goal runs after {@link MjMerge} and
+ * before {@link MjTranspile}, reading the XMIR of each object and
+ * repointing it at the rewritten copy in {@link Lowering#DIR} — only when
+ * something in it was actually folded or lowered.</p>
  *
  * <p>The goal is part of the normal chain but soft by default: without a
  * {@code phino} of the pinned version on the PATH it warns once and does
@@ -81,6 +86,21 @@ public final class MjLower extends MjSafe {
     private String binary;
 
     /**
+     * The directory with the tables that {@link MjInference} writes, read
+     * to learn which formations are pure and what data forma every void
+     * of them was witnessed as. A build that skips {@code eo:inference}
+     * leaves the directory absent, and then no formation is lowered while
+     * the constants still fold.
+     */
+    @Parameter(
+        alias = "inferenceDir",
+        property = "eo.inferenceDir",
+        required = true,
+        defaultValue = "${project.build.directory}/eo/6-inference"
+    )
+    private File tables;
+
+    /**
      * Ctor.
      */
     public MjLower() {
@@ -96,14 +116,17 @@ public final class MjLower extends MjSafe {
             if (phino.suitable()) {
                 try (TjsForeign tojos = this.tojos()) {
                     new Timed(
-                        new Lowering(tojos.standalone(), home, phino)
+                        new Lowering(tojos.standalone(), home, phino, this.tables.toPath())
                     ).exec();
                 }
                 new Saved(
                     String.format(
                         "lower-%s-%s",
                         phino.pin(),
-                        new Fingerprint("/org/eolang/lowering/universe.phi").get()
+                        new Fingerprint(
+                            "/org/eolang/lowering/universe.phi",
+                            "/org/eolang/lowering/ops.tsv"
+                        ).get()
                     ),
                     marker
                 ).value();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DigestTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DigestTest.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Digest}.
+ * @since 0.76.0
+ */
+final class DigestTest {
+
+    @Test
+    void digestsBodyIntoTwelveHexCharacters() {
+        MatcherAssert.assertThat(
+            "the digest must be the first twelve hex of SHA-256, but it isnt",
+            new Digest("return new Data.ToPhi(v0);").hex(),
+            Matchers.equalTo("6fb6af12ec09")
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.lowering.Phino;
 import org.eolang.lowering.Protocol;
@@ -121,17 +120,18 @@ final class LoweringTest {
         final Xtory story = new XtSticky(new XtYaml(yaml));
         Assumptions.assumeTrue(story.map().containsKey("java"));
         Assumptions.assumeTrue(new Phino("phino", 1000, this.temp).suitable());
-        try (Stream<Path> files = Files.list(LoweringTest.atoms(this.temp, story))) {
-            MatcherAssert.assertThat(
-                "the sidecar must hold the Java body the pack promises, but it doesnt",
-                Files.readString(files.findFirst().orElseThrow(IllegalStateException::new)),
-                Matchers.equalTo(
-                    story.map().get("java").toString().stripTrailing().lines()
-                        .map(line -> String.format("        %s", line))
-                        .collect(Collectors.joining(System.lineSeparator()))
+        final String body = story.map().get("java").toString().stripTrailing().lines()
+            .map(line -> String.format("        %s", line))
+            .collect(Collectors.joining(System.lineSeparator()));
+        MatcherAssert.assertThat(
+            "the sidecar must hold the Java body the pack promises, but it doesnt",
+            Files.readString(
+                LoweringTest.atoms(this.temp, story).resolve(
+                    String.format("%s.java", new Digest(body).hex())
                 )
-            );
-        }
+            ),
+            Matchers.equalTo(body)
+        );
     }
 
     private static Path atoms(final Path temp, final Xtory story) throws IOException {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -10,11 +10,13 @@ import com.jcabi.xml.XMLDocument;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eolang.jucs.ClasspathSource;
 import org.eolang.lowering.Phino;
 import org.eolang.lowering.Protocol;
@@ -113,18 +115,62 @@ final class LoweringTest {
         );
     }
 
+    @ParameterizedTest
+    @ClasspathSource(value = "org/eolang/maven/lowering-packs/", glob = "**.yaml")
+    void writesSidecarBody(final String yaml) throws IOException {
+        final Xtory story = new XtSticky(new XtYaml(yaml));
+        Assumptions.assumeTrue(story.map().containsKey("java"));
+        Assumptions.assumeTrue(new Phino("phino", 1000, this.temp).suitable());
+        try (Stream<Path> files = Files.list(LoweringTest.atoms(this.temp, story))) {
+            MatcherAssert.assertThat(
+                "the sidecar must hold the Java body the pack promises, but it doesnt",
+                Files.readString(files.findFirst().orElseThrow(IllegalStateException::new)),
+                Matchers.equalTo(
+                    story.map().get("java").toString().stripTrailing().lines()
+                        .map(line -> String.format("        %s", line))
+                        .collect(Collectors.joining(System.lineSeparator()))
+                )
+            );
+        }
+    }
+
+    private static Path atoms(final Path temp, final Xtory story) throws IOException {
+        return LoweringTest.maven(temp, story).execute(new PpLower())
+            .targetPath().resolve("4-lower").resolve("atoms");
+    }
+
     private static FakeMaven maven(final Path temp, final Xtory story) throws IOException {
-        return new FakeMaven(temp)
+        final FakeMaven maven = new FakeMaven(temp)
             .withProgram(story.map().get("input").toString(), "foo", "foo.eo");
+        final Object prelude = story.map().getOrDefault("prelude", Collections.emptyMap());
+        for (final Map.Entry<?, ?> entry : ((Map<?, ?>) prelude).entrySet()) {
+            maven.withProgram(
+                entry.getValue().toString(),
+                entry.getKey().toString().replace(".eo", ""),
+                entry.getKey().toString()
+            );
+        }
+        return maven;
     }
 
     private static Xnav formation(final Path temp, final Xtory story) throws IOException {
-        return new Xnav(
+        Xnav found = new Xnav(
             new XMLDocument(
                 LoweringTest.maven(temp, story).execute(MjParse.class)
                     .targetPath().resolve("1-parse").resolve("foo.xmir")
             ).inner()
         ).element("object").element("o");
+        final Object unit = story.map().get("unit");
+        if (unit != null) {
+            found = found.elements(Filter.withName("o"))
+                .filter(kid -> unit.toString().equals(kid.attribute("name").text().orElse("")))
+                .findFirst().orElseThrow(
+                    () -> new IllegalStateException(
+                        String.format("The program binds no '%s'", unit)
+                    )
+                );
+        }
+        return found;
     }
 
     private static Xnav fragment(final Xnav formation) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjLowerTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjLowerTest.java
@@ -80,6 +80,65 @@ final class MjLowerTest {
     }
 
     @Test
+    void transpilesLoweredFormationIntoAtomClass(@Mktmp final Path temp) throws IOException {
+        MjLowerTest.assumePhino(temp);
+        MatcherAssert.assertThat(
+            "the lowered formation must transpile into its own atom class, but it didnt",
+            Files.readString(
+                MjLowerTest.symbolic(temp)
+                    .execute(new PpLower())
+                    .execute(MjTranspile.class)
+                    .generatedPath()
+                    .resolve("org")
+                    .resolve("eolang")
+                    .resolve("EOfoo$EObump.java")
+            ),
+            Matchers.containsString(
+                "public final class EOfoo$EObump extends PhDefault implements Atom {"
+            )
+        );
+    }
+
+    @Test
+    void splicesSidecarBodyIntoLambda(@Mktmp final Path temp) throws IOException {
+        MjLowerTest.assumePhino(temp);
+        MatcherAssert.assertThat(
+            "the generated lambda must read the void through the public API, but it doesnt",
+            Files.readString(
+                MjLowerTest.symbolic(temp)
+                    .execute(new PpLower())
+                    .execute(MjTranspile.class)
+                    .generatedPath()
+                    .resolve("org")
+                    .resolve("eolang")
+                    .resolve("EOfoo$EObump.java")
+            ),
+            Matchers.containsString(
+                "final double v0 = new Dataized(this.take(\"x\")).asNumber();"
+            )
+        );
+    }
+
+    @Test
+    void generatesNoAtomClassWhenDisabled(@Mktmp final Path temp) throws IOException {
+        MjLowerTest.assumePhino(temp);
+        MatcherAssert.assertThat(
+            "a run disabled by eo.lowering must generate no atom class, but it did",
+            Files.exists(
+                MjLowerTest.symbolic(temp)
+                    .with("lowering", false)
+                    .execute(new PpLower())
+                    .execute(MjTranspile.class)
+                    .generatedPath()
+                    .resolve("org")
+                    .resolve("eolang")
+                    .resolve("EOfoo$EObump.java")
+            ),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void skipsQuietlyWithoutTheBinary(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "a machine without phino must build with no marker left behind, but one was left",
@@ -171,6 +230,21 @@ final class MjLowerTest {
         return new FakeMaven(temp)
             .withProgram(MjLowerTest.constant(), "foo", "foo.eo")
             .execute(new PpLower());
+    }
+
+    private static FakeMaven symbolic(final Path temp) throws IOException {
+        return new FakeMaven(temp).withProgram(
+            MjLowerTest.program(
+                "[] > foo",
+                "  [x] > bump",
+                "    (x.times 2).plus 1 > @",
+                "  bump 5 > @"
+            ),
+            "foo", "foo.eo"
+        ).withProgram(
+            MjLowerTest.program("[as-bytes] > number", "  as-bytes > @"),
+            "number", "number.eo"
+        );
     }
 
     private static String constant() {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/PpLower.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/PpLower.java
@@ -18,6 +18,7 @@ final class PpLower implements Iterable<Class<? extends AbstractMojo>> {
     public Iterator<Class<? extends AbstractMojo>> iterator() {
         return Arrays.<Class<? extends AbstractMojo>>asList(
             MjParse.class,
+            MjInference.class,
             MjMerge.class,
             MjLower.class
         ).iterator();

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/bool-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/bool-atom.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A comparison at the root of a lowered formation makes an atom that
+# answers a bool, and the λ marker says so.
+input: |
+  [] > foo
+    [x] > check
+      x.gt 3 > @
+    check 7 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: check
+voids:
+  x: number
+lowered: |
+  [] > foo
+    check 7 > @
+    [] > check /Q.bool
+      ? > x /Q.number
+protocol: |
+  s1 ← L_number_gt sym:v0 number:40-08-00-00-00-00-00-00
+  answer sym:s1 bool
+java: |
+  final double v0 = new Dataized(this.take("x")).asNumber();
+  final boolean s1 = v0 > Double.longBitsToDouble(0x4008000000000000L);
+  return new Data.ToPhi(s1);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/bytes-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/bytes-atom.yaml
@@ -1,0 +1,31 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void witnessed as bytes reads through take(), and the body goes
+# through the public Bytes API of the runtime.
+input: |
+  [] > foo
+    [b] > mask
+      (b.and 1F-).size > @
+    mask 2A- > @
+prelude:
+  bytes.eo: |
+    [data] > bytes
+      data > @
+unit: mask
+voids:
+  b: bytes
+lowered: |
+  [] > foo
+    mask 2A- > @
+    [] > mask /Q.number
+      ? > b /Q.bytes
+protocol: |
+  s1 ← L_bytes_and sym:v0 bytes:1F-
+  s2 ← L_bytes_size sym:s1
+  answer sym:s2 number
+java: |
+  final byte[] v0 = new Dataized(this.take("b")).take();
+  final byte[] s1 = new BytesOf(v0).and(new BytesOf(new byte[] {(byte) 0x1F})).take();
+  final double s2 = s1.length;
+  return new Data.ToPhi(s2);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/bytes-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/bytes-atom.yaml
@@ -1,31 +1,36 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# A void witnessed as bytes reads through take(), and the body goes
+# Voids witnessed as bytes read through take(), and the body goes
 # through the public Bytes API of the runtime.
 input: |
   [] > foo
-    [b] > mask
-      (b.and 1F-).size > @
-    mask 2A- > @
+    [a b] > mask
+      (a.and b).size > @
+    mask 2A- 1F- > @
 prelude:
   bytes.eo: |
     [data] > bytes
       data > @
 unit: mask
 voids:
+  a: bytes
   b: bytes
 lowered: |
   [] > foo
-    mask 2A- > @
+    mask > @
+      2A-
+      1F-
     [] > mask /Q.number
+      ? > a /Q.bytes
       ? > b /Q.bytes
 protocol: |
-  s1 ← L_bytes_and sym:v0 bytes:1F-
+  s1 ← L_bytes_and sym:v0 sym:v1
   s2 ← L_bytes_size sym:s1
   answer sym:s2 number
 java: |
-  final byte[] v0 = new Dataized(this.take("b")).take();
-  final byte[] s1 = new BytesOf(v0).and(new BytesOf(new byte[] {(byte) 0x1F})).take();
+  final byte[] v0 = new Dataized(this.take("a")).take();
+  final byte[] v1 = new Dataized(this.take("b")).take();
+  final byte[] s1 = new BytesOf(v0).and(new BytesOf(v1)).take();
   final double s2 = s1.length;
   return new Data.ToPhi(s2);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/helper-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/helper-atom.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A helper attribute is part of the formation's interface, and deleting
+# the body would delete it too, so the formation stays as written even
+# though it is pure.
+input: |
+  [] > foo
+    [x] > bump
+      x.times x > square
+      square.plus 1 > @
+    bump 5 > @
+lowered: |
+  [] > foo
+    bump 5 > @
+    [x] > bump
+      square.plus 1 > @
+      x.times x > square

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/unwitnessed.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/unwitnessed.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The formation is pure and reducible, but its void is filled with
+# another void rather than data, so no forma witnesses it and the
+# formation stays as written.
+input: |
+  [q] > foo
+    [x] > bump
+      x.plus 2 > @
+    bump q > @
+unit: bump
+voids:
+  x: number
+lowered: |
+  [q] > foo
+    bump q > @
+    x.plus 2 > [x] > bump
+protocol: |
+  s1 ← L_number_plus sym:v0 number:40-00-00-00-00-00-00-00
+  answer sym:s1 number

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/witnessed-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/witnessed-atom.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A pure formation whose void is witnessed as a number becomes a
+# synthetic atom: the body leaves for a sidecar of straight-line Java,
+# and only the voids and the λ marker stay in the EO.
+input: |
+  [] > foo
+    [x] > bump
+      (x.times 2).plus 1 > @
+    bump 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bump
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bump 5 > @
+    [] > bump /Q.number
+      ? > x /Q.number
+protocol: |
+  s1 ← L_number_times sym:v0 number:40-00-00-00-00-00-00-00
+  s2 ← L_number_plus sym:s1 number:3F-F0-00-00-00-00-00-00
+  answer sym:s2 number
+java: |
+  final double v0 = new Dataized(this.take("x")).asNumber();
+  final double s1 = v0 * Double.longBitsToDouble(0x4000000000000000L);
+  final double s2 = s1 + Double.longBitsToDouble(0x3FF0000000000000L);
+  return new Data.ToPhi(s2);


### PR DESCRIPTION
This is PR-3 of the plan in #8137: the first end-to-end symbolic lowering.
A pure formation whose body is voids plus one φ, with every void witnessed
  as number or bytes in the eo:inference tables, is reduced into a protocol
  by the #8271 engine, rendered into a Java lambda body by the new
  `JavaAtom` (the op table gains a Java-format column; `right` and `slice`
  deliberately have none, since `Int`/`Natural` coercion and the
  `cant-slice` fallback cannot be rendered faithfully), written as a
  content-addressed sidecar under `4-lower/atoms/<digest>.java`, and the
  formation keeps only its voids, the digest, and a λ marker — exactly the
  shape `lowered.xsl` (#8206) already renders into an atom class.

Only voids the protocol actually reads are dataized, so an unused input is
  never forced; every refusal — an unwitnessed void, a ρ void, a helper
  attribute, an operation outside the table, a body that needs no
  computation — leaves the formation as written.
`lower` now takes the `eo.inferenceDir` parameter (defaulting to the
  `6-inference` directory the `inference` goal writes) and folds the op
  table into its marker fingerprint, so a table change invalidates the
  cache.
Five new YAML packs show the source EO, the lowered EO, the protocol, and
  the Java body side by side.

Verified: 91 eo-lowering and 916 eo-maven-plugin tests green, qulice clean
  on both modules, simian clean, and the pipeline test transpiles a lowered
  formation into `EOfoo$EObump implements Atom` with the sidecar body
  spliced into `lambda()`.