### PR TITLE
Canonicalize the NaN a folded fragment carries

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Datum.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Datum.java
@@ -18,6 +18,16 @@ package org.eolang.lowering;
  * term empty, and such a value has no known forma — asking for it is
  * refused, since a guessed carrier would miscompile the program.</p>
  *
+ * <p>A number that is not a number comes back in one shape only. IEEE 754
+ * leaves the payload of a NaN open, and phino keeps whatever bits its
+ * host produced: an x86 division of zero by zero sets the sign bit and
+ * yields {@code FF-F8-00-00-00-00-00-00}, while an ARM one does not.
+ * EO knows a single {@code nan}, the object of the bytes
+ * {@code 7F-F8-00-00-00-00-00-00}, and the JVM runtime turns every NaN
+ * an atom computes into that very object, so a folded literal must carry
+ * the same bytes, or {@code (0.div 0).as-bytes} would stop being equal to
+ * {@code nan.as-bytes} once the fragment is folded at build time.</p>
+ *
  * @since 0.76.0
  */
 public final class Datum {
@@ -44,10 +54,20 @@ public final class Datum {
 
     /**
      * The bytes.
+     *
+     * <p>A NaN number is canonicalized to the bytes of {@code nan},
+     * every other value comes back exactly as phino printed it.</p>
+     *
      * @return Dash-joined hex pairs
      */
     public String bytes() {
-        return this.hex;
+        final String out;
+        if (this.numeric() && Datum.nan(this.hex)) {
+            out = "7F-F8-00-00-00-00-00-00";
+        } else {
+            out = this.hex;
+        }
+        return out;
     }
 
     /**
@@ -58,7 +78,7 @@ public final class Datum {
         final String out;
         if ("Φ.true".equals(this.term) || "Φ.false".equals(this.term)) {
             out = "bool";
-        } else if (this.term.startsWith("Φ.number")) {
+        } else if (this.numeric()) {
             out = "number";
         } else if (this.term.startsWith("Φ.bytes")) {
             out = "bytes";
@@ -71,5 +91,17 @@ public final class Datum {
             );
         }
         return out;
+    }
+
+    private boolean numeric() {
+        return this.term.startsWith("Φ.number");
+    }
+
+    private static boolean nan(final String hex) {
+        final String digits = hex.replace("-", "");
+        return digits.length() == 16
+            && Double.isNaN(
+                Double.longBitsToDouble(Long.parseUnsignedLong(digits, 16))
+            );
     }
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Datum.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Datum.java
@@ -62,7 +62,7 @@ public final class Datum {
      */
     public String bytes() {
         final String out;
-        if (this.numeric() && Datum.nan(this.hex)) {
+        if (this.numeric() && this.nan()) {
             out = "7F-F8-00-00-00-00-00-00";
         } else {
             out = this.hex;
@@ -97,8 +97,8 @@ public final class Datum {
         return this.term.startsWith("Φ.number");
     }
 
-    private static boolean nan(final String hex) {
-        final String digits = hex.replace("-", "");
+    private boolean nan() {
+        final String digits = this.hex.replace("-", "");
         return digits.length() == 16
             && Double.isNaN(
                 Double.longBitsToDouble(Long.parseUnsignedLong(digits, 16))

--- a/eo-lowering/src/test/java/org/eolang/lowering/ConstantTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ConstantTest.java
@@ -49,6 +49,32 @@ final class ConstantTest {
     }
 
     @Test
+    void foldsZeroByZeroIntoNan(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "the quotient of zero and zero must fold to the bytes of nan, whatever NaN the host makes, but it didnt",
+            new Constant(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='.div'>",
+                        "<o base='Φ.number'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>00-00-00-00-00-00-00-00</o></o>",
+                        "</o>",
+                        "<o as='α0' base='Φ.number'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>00-00-00-00-00-00-00-00</o></o>",
+                        "</o>",
+                        "</o>"
+                    )
+                ).element("o")
+            ).value().bytes(),
+            Matchers.equalTo("7F-F8-00-00-00-00-00-00")
+        );
+    }
+
+    @Test
     void namesFormaOfComparison(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());

--- a/eo-lowering/src/test/java/org/eolang/lowering/DatumTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/DatumTest.java
@@ -62,4 +62,52 @@ final class DatumTest {
             Matchers.equalTo("DE-AD-BE-EF")
         );
     }
+
+    @Test
+    void canonicalizesNanNumber() {
+        MatcherAssert.assertThat(
+            "a NaN with the sign bit set must fold to the bytes of nan, but it didnt",
+            new Datum(
+                "FF-F8-00-00-00-00-00-00",
+                "Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ FF-F8-00-00-00-00-00-00, ρ ↦ ∅ ⟧ ) )"
+            ).bytes(),
+            Matchers.equalTo("7F-F8-00-00-00-00-00-00")
+        );
+    }
+
+    @Test
+    void canonicalizesNanNumberWithPayload() {
+        MatcherAssert.assertThat(
+            "a NaN carrying a payload must fold to the bytes of nan, but it didnt",
+            new Datum(
+                "7F-F8-00-00-00-00-BE-EF",
+                "Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 7F-F8-00-00-00-00-BE-EF, ρ ↦ ∅ ⟧ ) )"
+            ).bytes(),
+            Matchers.equalTo("7F-F8-00-00-00-00-00-00")
+        );
+    }
+
+    @Test
+    void keepsInfinityVerbatim() {
+        MatcherAssert.assertThat(
+            "negative infinity is not a NaN, so its bytes must stay, but they didnt",
+            new Datum(
+                "FF-F0-00-00-00-00-00-00",
+                "Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ FF-F0-00-00-00-00-00-00, ρ ↦ ∅ ⟧ ) )"
+            ).bytes(),
+            Matchers.equalTo("FF-F0-00-00-00-00-00-00")
+        );
+    }
+
+    @Test
+    void keepsNanBytesOutsideNumber() {
+        MatcherAssert.assertThat(
+            "bytes that merely look like a NaN are not a number, so they must stay, but they didnt",
+            new Datum(
+                "FF-F8-00-00-00-00-00-00",
+                "Φ.bytes( data ↦ ⟦ Δ ⤍ FF-F8-00-00-00-00-00-00, ρ ↦ ∅ ⟧ )"
+            ).bytes(),
+            Matchers.equalTo("FF-F8-00-00-00-00-00-00")
+        );
+    }
 }


### PR DESCRIPTION
Fixes the `codecov` workflow, which has been failing on `TestEOnumber.can_expose_the_bytes_of_nan` since all-literal fragments started folding through phino: https://github.com/objectionary/eo/actions/runs/33796170335/job/100784268769

## What happened

`codecov` is the only workflow that runs the EO tests with `-Deo.loweringRequired=true`. Under it, the fragment `(0.div 0).as-bytes` in `number.eo` is all-literal and gets folded at build time through phino. Phino keeps whatever bits its host produced for the NaN, and on an x86 runner a zero-by-zero division yields `FF-F8-00-00-00-00-00-00` (sign bit set). EO knows a single `nan` object of `7F-F8-00-00-00-00-00-00`, and the JVM runtime turns every computed NaN into that object through `Data.ToPhi`. So the folded literal was no longer equal to `nan.as-bytes`, and the test failed only where lowering runs. The same test passes on the `ec2` workflow, which tracks coverage but does not lower.

## The fix

`Datum#bytes()` in `eo-lowering` now hands out the canonical `nan` bytes whenever the last atom answered with a number and the bytes encode a NaN, in any bit pattern. Infinities and every other value stay exactly as phino printed them, and bytes that merely look like a NaN but were not produced as a number are left alone.

## Tests

- `DatumTest`: canonicalizes a sign-bit NaN and a payload-carrying NaN, keeps negative infinity verbatim, keeps NaN-looking bytes of the `bytes` forma verbatim.
- `ConstantTest#foldsZeroByZeroIntoNan`: folds `0.div 0` through the real phino and expects the canonical bytes. It skips where phino is absent, like the neighbouring tests, and runs on the Linux leg of `mvn.yml` and in `codecov`.

`mvn -pl eo-lowering -Pqulice install` passes locally.

## Note

The upstream cause is that phino's `numToBts` does not canonicalize NaN the way `Double.doubleToLongBits` does, so a fragment that observes NaN bytes through a *bytes* atom (for example `((0.div 0).as-bytes).eq(...)`) would still fold differently from the runtime. That shape does not occur in the repository and would need a change in phino itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QccfzdRXSh7TFVE69tFNMY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QccfzdRXSh7TFVE69tFNMY)_