### PR TITLE
Give the re-enabled integration tests the world they run in

### DIFF
--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -25,6 +25,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Integration tests for transpile behavior.
+ *
+ * <p>The sandbox compiles the {@code .eo} sources of the runtime it depends
+ * on, so it runs the merge the runtime's own build runs. A member of a
+ * package is an attribute of the object the package names only after the
+ * merge, and the name of the class an atom of such a member transpiles to
+ * follows: unmerged, {@code string.regex.compile} asks for a
+ * {@code org.eolang.EO_string.EOregex$EOcompile} that the runtime jar,
+ * merged when it was built, does not carry.</p>
+ *
  * @since 0.62
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
@@ -72,7 +81,7 @@ final class TranspileIT {
         );
         new EoMavenPlugin(farea).appended()
             .execution("transpile-it")
-            .goals("register", "compile", "transpile")
+            .goals("register", "compile", "merge", "transpile")
             .configuration()
             .set("failOnWarning", "false")
             .set("skipLinting", "true");

--- a/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/MjAssembleIT.java
@@ -30,7 +30,7 @@ final class MjAssembleIT {
 
     @Test
     void assemblesTogether(@Mktmp final Path temp) throws IOException {
-        final String stdout = "target/eo/%s/io/stdout.%s";
+        final String stdout = "target/eo/%s/stdout.%s";
         final String parsed = String.format(stdout, "1-parse", "xmir");
         final String pulled = String.format(stdout, "2-pull", "eo");
         new Farea(temp).together(
@@ -108,12 +108,12 @@ final class MjAssembleIT {
     private static String program() {
         return String.join(
             System.lineSeparator(),
-            "+alias stdout io.stdout",
             "+package foo.x",
             "+version 0.1.1",
             "",
             "[x] > main",
-            "  (stdout \"Hello World!\" x).print > @"
+            "  Q.stdout > @",
+            "    x"
         );
     }
 

--- a/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
+++ b/eo-integration-tests/src/test/java/org/eolang/maven/ProxyIT.java
@@ -37,6 +37,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * This tests checks how eo-maven-plugin works when a proxy is set.
+ *
+ * <p>The sandbox is walled off from the network: the only repository it is
+ * given is a Jetty serving the local {@code ~/.m2/repository}, so every
+ * artifact it asks for has to be in there already. It is taken no further
+ * than {@code process-sources}, the last phase the four goals under test are
+ * bound to, because the phases after it bind plugins of their own, at the
+ * versions Maven defaults to rather than the ones this build pins, and the
+ * one missing from the local repository fails the sandbox before the proxy
+ * is ever exercised.</p>
+ *
  * @since 0.60
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
@@ -75,7 +85,7 @@ final class ProxyIT {
             new Farea(tmp).together(
                 f -> {
                     ProxyIT.setupForProxy(f, port, ProxyIT.port(repo));
-                    f.exec("package");
+                    f.exec("process-sources");
                     log[0] = f.log().content();
                 }
             );

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -18,6 +18,14 @@ import org.apache.maven.plugins.annotations.Mojo;
  * the need to call each goal separately.</p>
  *
  * @since 0.52
+ * @todo #6659:30min Let this goal merge the packages too. Since the merge
+ *  became mandatory, a build that does not run {@link MjMerge} between this
+ *  goal and {@link MjTranspile} names the atom of a package member after the
+ *  member, while the runtime jar, merged when it was built, carries the name
+ *  the merge gives it, and the generated Java does not compile. Every project
+ *  has to list {@code merge} of its own accord today, this one and the README
+ *  of the plugin included. Chain it here, once it is safe to run it twice,
+ *  since {@code eo-runtime} lists it after this goal already.
  */
 @Mojo(
     name = "compile",


### PR DESCRIPTION
Fixes the red [`ec2` build](https://github.com/objectionary/eo/actions/runs/33749840729/job/100649597391), where `eo-integration-tests` ended with `Tests run: 36, Failures: 1, Errors: 3`. All four are the tests that #8130 re-enabled for #8116: they describe a runtime that has moved on since they were switched off, and each fails for a reason of its own.

### `TranspileIT` (2 errors)

The sandbox runs `register`, `compile`, `transpile` and compiles the `.eo` sources of the runtime it depends on. None of those goals merges a package into the object it names, so `string.regex` stays an object of its own and its atom is transpiled as `org.eolang.EO_string.EOregex$EOcompile`, while `eo-runtime` — merged when it was built — ships `org.eolang.EOstring$EOregex$EOcompile`. `javac` then reports `cannot find symbol` twice and the sandbox build dies in `setup`.

The 0.62.1 jar carries `org/eolang/EO_string/EOregex$EOcompile.class`; the 0.63.0 one carries `org/eolang/EOstring$EOregex$EOcompile.class`. The rename came with the merge going mandatory (#6659), and `eo-runtime` lists `merge` in its own execution. The sandbox now does the same, between `compile` and `transpile`, the way `EoSourceRun` already does for `SnippetIT`.

### `MjAssembleIT.assemblesTogether` (1 failure)

It writes `+alias stdout io.stdout` and then waits for `target/eo/1-parse/io/stdout.xmir`. `stdout` moved to the root package in July (`Move stdin and stdout to the root package, add stderr`), and `objectionary.lst` has no `objects/io/` at all, so nothing was ever pulled under that name and the assertion could only fail. The program asks for `Q.stdout` now and the two assertions look for `stdout.xmir` and `stdout.eo`.

### `ProxyIT.checksThatWeCanCompileTheProgramWithProxySet` (1 error)

The sandbox is given one repository — a Jetty serving the local `~/.m2/repository` — and then taken to `package`. The phases after `process-sources` bind plugins at the versions Maven defaults to, not the ones this build pins, and `maven-jar-plugin:3.5.0` is a version nothing here ever downloads, so it is missing from the mirror and the sandbox fails with `PluginResolutionException` before the proxy is exercised at all. The four goals under test are bound no later than `process-sources`, so the sandbox stops there and needs no plugin beyond `eo-maven-plugin` itself.

### One puzzle left behind

A user project hits the first failure too: the plugin README still documents `register`, `assemble`, `transpile`, and that chain names atoms the runtime jar does not carry. Rather than reorder `eo-runtime`'s goals here — `merge` sits after `inference` there, and `Merging` is not safe to run twice — the gap is recorded as a `@todo` on `MjCompile`.

`JarIT`'s three disabled tests carry a `@todo #6658` blaming the same symptom on the release gap. If the diagnosis above holds, adding `merge` to their goal list is all they need; they are left alone here, since a disabled test cannot be verified by this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCoRSQUxcXzmhSRCh9151S

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCoRSQUxcXzmhSRCh9151S)_