### PR TITLE
Name the generated check classes the way the transpiler does

### DIFF
--- a/eo-integration-tests/src/test/java/integration/TranspileIT.java
+++ b/eo-integration-tests/src/test/java/integration/TranspileIT.java
@@ -48,7 +48,7 @@ final class TranspileIT {
                 MatcherAssert.assertThat(
                     "User-written test sources must be generated",
                     TranspileIT.generatedNames(temp),
-                    Matchers.hasItem("EOsimpleTest.java")
+                    Matchers.hasItem("TestEOsimple.java")
                 );
             }
         );
@@ -64,7 +64,7 @@ final class TranspileIT {
                 MatcherAssert.assertThat(
                     "EO runtime test sources must not be generated in a user project",
                     TranspileIT.generatedNames(temp),
-                    Matchers.not(Matchers.hasItem(Matchers.containsString("EOstringTest")))
+                    Matchers.not(Matchers.hasItem(Matchers.containsString("TestEOstring")))
                 );
             }
         );


### PR DESCRIPTION
Follow-up to #8294, which took the merge gap out of `TranspileIT`'s way. With the sandbox build reaching the assertions at last, a second stale expectation shows itself:

```
User-written test sources must be generated
Expected: a collection containing "EOsimpleTest.java"
     but: mismatches were: [was "TestEOsimple.java"]
```

`eo:test-class-name` puts the mark in front of the class and not after it since #7762 — an object called `xTest` used to give the same `EOxTest` the tests of an object called `x` gave. `TranspileIT` was disabled at the time and still asks for the old shape: `generatesSourcesForUserWrittenChecks` looks for `EOsimpleTest.java`, and `doesNotGenerateRuntimeCheckSourcesForUserProject` guards against `EOstringTest`, a name nothing can produce any more, so that assertion holds vacuously. Both are named the way the transpiler names them now.

Verified against a locally built runtime — the whole of the three classes the `ec2` build was red on:

```
ProxyIT       Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
MjAssembleIT  Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
TranspileIT   Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

Worth noting that `mvn` and `fast` both run with `-PskipITs`, so none of this is exercised by pull-request CI — only by `ec2` on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCoRSQUxcXzmhSRCh9151S

---
_Generated by [Claude Code](https://claude.ai/code/session_01XCoRSQUxcXzmhSRCh9151S)_