### PR TITLE
fix(maven-plugin): #8295 merge package members before transpiling

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Merging.java
@@ -43,6 +43,13 @@ import org.w3c.dom.NodeList;
  * places of the voids, and with them the meaning of applying the object to
  * arguments, stay as they were.</p>
  *
+ * <p>Merging twice does nothing the second time: a member that has already
+ * moved is marked as merged in the tojos and is not standalone any more, so
+ * the package it came from is no longer a package with members and nothing
+ * is spliced into the object again. That is what lets {@link MjTranspile}
+ * merge on its own without asking whether the {@link MjMerge} goal has
+ * already run.</p>
+ *
  * <p>The tests a member declares do not travel with it. A test is legal only
  * as a direct child of the top-level object of a file, which is what the
  * parser demands and what the transpiler reads when it writes the test class,
@@ -88,10 +95,14 @@ final class Merging implements Step {
         for (final String pkg : found) {
             done = done + this.spliced(pkg, all);
         }
-        Logger.info(
-            this, "Put %d member(s) into %d package object(s), XMIR is in %[file]s",
-            done, found.size(), this.dir
-        );
+        if (done == 0) {
+            Logger.debug(this, "No package member to put inside its object");
+        } else {
+            Logger.info(
+                this, "Put %d member(s) into %d package object(s), XMIR is in %[file]s",
+                done, found.size(), this.dir
+            );
+        }
     }
 
     private static Collection<String> deepest(final Map<String, TjForeign> all) {
@@ -112,7 +123,7 @@ final class Merging implements Step {
 
     private Map<String, TjForeign> indexed() {
         final Map<String, TjForeign> all = new HashMap<>(0);
-        for (final TjForeign tojo : this.tojos.withXmir()) {
+        for (final TjForeign tojo : this.tojos.standalone()) {
             all.put(tojo.identifier(), tojo);
         }
         return all;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -18,14 +18,15 @@ import org.apache.maven.plugins.annotations.Mojo;
  * the need to call each goal separately.</p>
  *
  * @since 0.52
- * @todo #6659:30min Let this goal merge the packages too. Since the merge
- *  became mandatory, a build that does not run {@link MjMerge} between this
- *  goal and {@link MjTranspile} names the atom of a package member after the
- *  member, while the runtime jar, merged when it was built, carries the name
- *  the merge gives it, and the generated Java does not compile. Every project
- *  has to list {@code merge} of its own accord today, this one and the README
- *  of the plugin included. Chain it here, once it is safe to run it twice,
- *  since {@code eo-runtime} lists it after this goal already.
+ * @todo #6659:30min Let this goal merge the packages too. The generated Java
+ *  compiles now whatever goals a project lists, since {@link MjTranspile}
+ *  merges before it writes anything, and {@link Merging} may be run as many
+ *  times as one likes. What is still worth having is the merge happening
+ *  earlier, right after the lint this goal runs, so that {@link MjInference}
+ *  and {@link MjLower} read the object in the shape it will be compiled in
+ *  and not in the shape the parser left. Chain it here and drop the
+ *  {@code merge} that {@code eo-runtime} lists after this goal, once its
+ *  inference tables are shown to come out the same either way.
  */
 @Mojo(
     name = "compile",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
@@ -28,6 +28,13 @@ import org.apache.maven.plugins.annotations.Mojo;
  * whose name no object carries keeps its members as objects of their own,
  * reached through the package namespace as before.</p>
  *
+ * <p>{@link MjTranspile} runs the same step itself, so a build that never
+ * names this goal still compiles merged objects. The goal is worth naming
+ * when a goal between {@link MjLint} and {@link MjTranspile}, such as
+ * {@link MjInference} or {@link MjLower}, has to read the object in the
+ * shape it will be compiled in. Naming it twice costs nothing: a member
+ * already inside its object is not moved again.</p>
+ *
  * @since 0.68.0
  */
 @Mojo(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjTranspile.java
@@ -32,6 +32,18 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
  * The resulting Java files are stored in the {@link Transpiling#DIR} directory.
  * The intermediate optimized XMIRs are stored in the {@link Transpiling#PRE} directory.</p>
  *
+ * <p>Before anything is written, the members of every package this build
+ * compiles an object for are put inside that object, the way {@link MjMerge}
+ * does it. The two are the same step and running both changes nothing, since
+ * {@link Merging} leaves a merged member alone; it is done here as well
+ * because the shape of an object decides the name of the Java class of every
+ * atom it holds, and a build that skipped the goal would name classes that
+ * the library it compiles against does not carry. {@code Φ.string.regex} is
+ * such an object: its atoms ship as {@code EOstring$EOregex$EOcompile} and
+ * friends, which is where they land once {@code regex} is an attribute of
+ * {@code string}, and nowhere near the {@code org.eolang.EO_string} package
+ * an unmerged {@code +package string} would compile it into (#8295).</p>
+ *
  * @since 0.1
  */
 @Mojo(
@@ -159,6 +171,9 @@ public final class MjTranspile extends MjSafe {
     @Override
     public void exec() throws IOException {
         try (TjsForeign tojos = this.tojos()) {
+            new Timed(
+                new Merging(tojos, this.targetDir.toPath().resolve(Merging.DIR))
+            ).exec();
             new Timed(
                 new Transpiling(
                     tojos.standalone(),

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjMergeTest.java
@@ -86,6 +86,21 @@ final class MjMergeTest {
     }
 
     @Test
+    void leavesAMergedMemberAloneWhenMergedAgain(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a member already inside its object must not arrive there a second time, since MjTranspile merges too",
+            new XMLDocument(
+                MjMergeTest.merged(temp)
+                    .execute(MjMerge.class)
+                    .foreignTojos()
+                    .find("foo")
+                    .xmir()
+            ).nodes("/object/o[@name='foo']/o[@name='bar']").size(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
     void leavesAPackageWithoutAnObjectAlone(@Mktmp final Path temp) throws Exception {
         MatcherAssert.assertThat(
             "a package no object is named after has nothing to merge into, so nothing may be written",

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -507,6 +507,34 @@ final class MjTranspileTest {
     }
 
     @Test
+    void namesTheAtomOfAPackageMemberInsideItsPackageObject(@Mktmp final Path temp)
+        throws Exception {
+        MatcherAssert.assertThat(
+            "the atom of a package member must be a class nested in the class of the package object, which is where the library that ships it puts it (#8295)",
+            new TextOf(
+                MjTranspileTest.withMember(temp)
+                    .execute(MjParse.class)
+                    .execute(MjTranspile.class)
+                    .result()
+                    .get("target/generated/org/eolang/EOfoo.java")
+            ).asString(),
+            Matchers.containsString("new EOfoo$EObar$EObaz()")
+        );
+    }
+
+    @Test
+    void compilesAPackageMemberAsAPartOfItsObject(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a member of a package this build compiles an object for must not be compiled apart, even when the merge goal was never named",
+            MjTranspileTest.withMember(temp)
+                .execute(MjParse.class)
+                .execute(MjTranspile.class)
+                .result(),
+            Matchers.not(Matchers.hasKey("target/generated/org/eolang/EO_foo/EObar.java"))
+        );
+    }
+
+    @Test
     void createsPackageInfoFilesForAllPackages(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
             "TranspileMojo must generate package-info.java files for all of the packages",
@@ -909,5 +937,31 @@ final class MjTranspileTest {
         ).pass(
             new EoSyntax(String.format("[] > %s%n  42 > @%n", name)).parsed()
         ).xpath("//@java-name").get(0);
+    }
+
+    // A workspace with an object and a member of its package, where the
+    // member holds an atom.
+    private static FakeMaven withMember(final Path temp) throws IOException {
+        return new FakeMaven(temp).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "[] > foo",
+                "  42 > @"
+            ),
+            "foo",
+            "foo.eo"
+        ).withProgram(
+            String.join(
+                System.lineSeparator(),
+                "+package foo",
+                "+rt jvm org.eolang:eo-runtime:0.0.0",
+                "",
+                "[] > bar",
+                "  [] > baz /bytes",
+                "    ? > x"
+            ),
+            "foo.bar",
+            "foo/bar.eo"
+        );
     }
 }


### PR DESCRIPTION
Closes #8295.

## The bug is real, but not where the issue says it is

A downstream project with a single trivial `.eo` file and `eo-runtime` as its only dependency, built with the goals `eo-maven-plugin/README.md` documents, fails exactly as reported:

```
target/generated-sources/org/eolang/EO_string/EOregex.java:[1296,24] cannot find symbol
  symbol: class EOregex$EOcompile
target/generated-sources/org/eolang/EO_string/EOregex.java:[1470,34] cannot find symbol
  symbol: class EOregex$EOpattern$EOmatch$EOmatched_from_index
```

The two atom classes are not misplaced, though. `eo-runtime` runs the `merge` goal (added in 0.68.0), which puts every member of a package inside the object that the package names, so `regex` is an attribute of `string` by the time the transpiler sees it, the class of `string` is `org.eolang.EOstring`, and the atom lands at `org.eolang.EOstring$EOregex$EOcompile` — exactly where the two hand-written files are. Moving them into `org/eolang/EO_string/`, as the issue proposes, would break the build of `eo-runtime` itself.

What is broken is that `merge` is optional. Only `eo-runtime` names it; a downstream build does not, so it compiles `regex` as an object of its own in an `EO_string` package and names atoms that nobody ships. The same package members also reach their receiver through `^` now (`[^] > regex`), which only works once they are merged, so an unmerged package member is wrong even when it holds no atom.

## The fix

`MjTranspile` merges on its own, before it writes anything: it is the goal that turns the shape of an object into Java class names, so it is the goal that must not see an unmerged package member.

`Merging` now indexes the tojos that are standalone rather than every tojo that has XMIR. A member already put inside its object is marked merged and stops being standalone, so the package it came from is no longer a package with members and nothing is spliced twice. That makes the step idempotent, so `eo-runtime` can keep naming `merge` explicitly before `inference` and `lower` and its pipeline is unchanged.

`Merging` also logs at `DEBUG` instead of `INFO` when there was nothing to merge, since every transpile now runs it.

### Why `transpile` and not `compile`

Master's `@todo #6659` on `MjCompile` asks for the merge to be chained into the `compile` goal once it is safe to run twice. It is safe now, but `compile` is not enough on its own: the goal list the plugin's README documents is `register`, `assemble`, `transpile` and never names `compile` at all. That chain is real — a sandbox built with it pulls the runtime's objects and transpiles them — so it needs the merge just as much. `transpile` is the one goal every chain ends at.

The puzzle is kept and reworded rather than dropped, because what it asks for is still worth having for its own sake: the merge right after the lint, so `inference` and `lower` read the object in the shape it will be compiled in. Doing that also moves the merge ahead of `inference` in `eo-runtime`'s pipeline, which deserves its own change and its own check that the inference tables come out the same.

## Verification

- **Reproduced end to end.** A sandbox project (trivial `.eo` referencing `Q.string.regex`, `eo-runtime` from this branch) fails with the two `cannot find symbol` errors above, at lines 1296 and 1470, with the plugin built without this change; with the change it transpiles 31 XMIRs and compiles clean. Verified with both goal chains: `register`/`compile`/`transpile` and the README's `register`/`assemble`/`transpile`. Running the compiled program (`"/[a-z]+/".regex.compiled.matches "hello"`) prints `[0x01] = true`.
- **`eo-runtime` still builds.** `mvn -DskipTests install -pl eo-runtime -am` succeeds; the log shows one `Put 122 member(s) into 12 package object(s)` from the explicit goal and no second merge from the transpile.
- **Tests.** Two new cases in `MjTranspileTest` (the atom of a package member is named inside its package object; the member is not compiled apart) fail without the change and pass with it. One new case in `MjMergeTest` covers merging twice. The whole `eo-maven-plugin` suite passes apart from six pre-existing environment failures in this container (no network to `repo.maven.apache.org`/objectionary, and a non-UTF-8 default locale that breaks the tests using non-ASCII file names). `mvn -Pqulice verify` on the module is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VBhQCURuC4HWyLQmfAUTF2