### PR TITLE
#8292: read a literal off the whole body

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -16,14 +16,24 @@ import java.util.regex.Pattern;
 public final class PhApplication extends PhOnce {
 
     /**
-     * Matcher of raw bytes inside a φ-term, like {@code [D> 40-45-00]}.
+     * Matcher of the whole body of a literal, like {@code 0->Φ.bytes(0->[D> 40-45])}.
+     *
+     * <p>It is the shape the transpiler emits for a literal and nothing
+     * else, so it is matched against the entire body rather than searched
+     * for inside it: the rendered text of a {@code string} binding is its
+     * own quoted text, and such text can spell a data block of its own
+     * (#8292). Only well-formed byte pairs are accepted, the way
+     * {@code PhDefault} prints them, so whatever matches here can be
+     * parsed back into bytes.</p>
      */
-    private static final Pattern DATA = Pattern.compile("\\[D> ([0-9A-F-]*)]");
+    private static final Pattern DATA = Pattern.compile(
+        "0->Φ\\.bytes\\(0->\\[D> (--|[0-9A-F]{2}-|(?:[0-9A-F]{2}-)+[0-9A-F]{2})]\\)"
+    );
 
     /**
-     * The dash that terminates a single-byte hex string.
+     * The dashes that separate the hex pairs of a data block.
      */
-    private static final Pattern TRAILING = Pattern.compile("-$");
+    private static final Pattern DASHES = Pattern.compile("-");
 
     /**
      * Ctor.
@@ -76,7 +86,7 @@ public final class PhApplication extends PhOnce {
         final String head = phi.φTerm();
         final String body = PhApplication.body(binds);
         final Matcher data = PhApplication.DATA.matcher(body);
-        final boolean literal = binds.length == 1 && binds[0].first() && data.find();
+        final boolean literal = binds.length == 1 && binds[0].first() && data.matches();
         final String string;
         if (literal && "Φ.string".equals(head)) {
             string = PhApplication.string(PhApplication.bytes(data.group(1)));
@@ -112,18 +122,10 @@ public final class PhApplication extends PhOnce {
     }
 
     private static byte[] bytes(final String hex) {
-        final byte[] bytes;
-        if (hex.isEmpty() || "--".equals(hex)) {
-            bytes = new byte[0];
-        } else {
-            final String[] parts = PhApplication.TRAILING
-                .matcher(hex)
-                .replaceAll("")
-                .split("-", -1);
-            bytes = new byte[parts.length];
-            for (int idx = 0; idx < parts.length; ++idx) {
-                bytes[idx] = (byte) Integer.parseInt(parts[idx], 16);
-            }
+        final String digits = PhApplication.DASHES.matcher(hex).replaceAll("");
+        final byte[] bytes = new byte[digits.length() / 2];
+        for (int idx = 0; idx < bytes.length; ++idx) {
+            bytes[idx] = (byte) Integer.parseInt(digits.substring(idx * 2, idx * 2 + 2), 16);
         }
         return bytes;
     }

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -5,6 +5,7 @@
 package org.eolang;
 
 import com.yegor256.Together;
+import java.nio.charset.StandardCharsets;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -181,6 +182,62 @@ final class PhApplicationTest {
                 )
             ).φTerm(),
             Matchers.equalTo("Φ.string(0->Φ.bytes(0->[D> C3-28]))")
+        );
+    }
+
+    @Test
+    void keepsAStringSpellingADataBlockStructural() {
+        MatcherAssert.assertThat(
+            "a string whose text spells a data block must render as its text, but it read as bytes",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "string"), 0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "string"), 0,
+                    new PhApplication(
+                        new PhDispatch(Phi.Φ, "bytes"), 0,
+                        new PhDefault("[D> 41-42]".getBytes(StandardCharsets.UTF_8))
+                    )
+                )
+            ).φTerm(),
+            Matchers.equalTo("Φ.string(0->\"[D> 41-42]\")")
+        );
+    }
+
+    @Test
+    void keepsAStringSpellingAMalformedDataBlockStructural() {
+        MatcherAssert.assertThat(
+            "a string whose text spells a malformed data block must render, but it died",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "string"), 0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "string"), 0,
+                    new PhApplication(
+                        new PhDispatch(Phi.Φ, "bytes"), 0,
+                        new PhDefault("[D> A--B]".getBytes(StandardCharsets.UTF_8))
+                    )
+                )
+            ).φTerm(),
+            Matchers.equalTo("Φ.string(0->\"[D> A--B]\")")
+        );
+    }
+
+    @Test
+    void keepsANumberSpellingADataBlockStructural() {
+        MatcherAssert.assertThat(
+            "a number applied to such a string must render as the application, but it didnt",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "number"), 0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "string"), 0,
+                    new PhApplication(
+                        new PhDispatch(Phi.Φ, "bytes"), 0,
+                        new PhDefault(
+                            "[D> 40-45-00-00-00-00-00-00]".getBytes(StandardCharsets.UTF_8)
+                        )
+                    )
+                )
+            ).φTerm(),
+            Matchers.equalTo("Φ.number(0->\"[D> 40-45-00-00-00-00-00-00]\")")
         );
     }
 


### PR DESCRIPTION
Closes #8292.

`PhApplication.applied()` decided that an application was a literal by searching the rendered body for `[D> ...]` anywhere inside it. The rendered text of a `string` binding is its own quoted text, and such text can spell a data block, so `Φ.string` applied to the string `[D> 41-42]` rendered as `"AB"`, and a malformed one like `[D> A--B]` left a raw `NumberFormatException` out of the very method that builds the text of a failure.

A literal is one positional binding of a data-carrying `Φ.bytes` and nothing else, which is the shape the transpiler emits, so the pattern is now anchored to the entire body and accepts only well-formed byte pairs, matched with `matches()` instead of `find()`. Well-formed literals render exactly as before; a string that merely looks like a data block renders as the application it is.

Since whatever matches is well-formed by construction, `bytes()` reads the hex pairs off the digits directly, which drops the trailing-dash strip, the `--` special case and the `parseInt` that used to fail.

Three tests reproduce the issue first: a `string` and a `number` applied to a string spelling a well-formed data block, and one applied to a malformed one that used to die.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaEjcDX1Uy8xMo9yQ7sReX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaEjcDX1Uy8xMo9yQ7sReX)_