### PR TITLE
#7945: drop the puzzle the rows key already answered

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Transpilation.java
@@ -212,14 +212,14 @@ final class Transpilation {
      *
      * <p>{@code purify.xsl} reads the tables and stamps {@code @pure}, which
      * {@code to-java.xsl} turns into {@code new PhSticky(...)}, so a source
-     * with different rows is different Java (#7627, #7945).</p>
+     * with different rows is different Java (#7627, #7945). The Java files
+     * of that source are keyed by the same segment: {@code Transpiling}
+     * derives the cache of one tojo from this and hands it to
+     * {@code JavaFiles}, so a class never comes back from a slot the rows
+     * of another build filled (#8001).</p>
      *
      * @param locators The locators of the objects the file holds
      * @return The version segment for {@link CachePath}
-     * @todo #7945:40min Key the Java files by the rows as well.
-     *  `Transpiling` still pools them in one directory made from
-     *  {@link #version()}, which knows nothing about the tables. Hand
-     *  `JavaFiles.total` the directory of the tojo, made here.
      */
     String version(final Collection<String> locators) {
         return String.format("%s-%s", this.version(), this.rows.digest(locators));


### PR DESCRIPTION
Closes #7945.

The issue asked the transpile cache key to fold what a transpiled file actually reads instead of the whole module's inference tables. `Transpilation.version(Collection)` does that already — it appends `Rows.digest(locators)` — and `Transpiling` derives the cache of one tojo from that segment and hands the very same cache to `JavaFiles`, so the generated Java is keyed by the rows too. `JavaFilesTest.missesTheJavaFileCachedUnderAnotherKey` pins it, and `a754c325` (#8001) is where it landed.

What stayed behind is the puzzle in the javadoc of that method, which claims `Transpiling` still pools the Java files in one directory made from `version()`. That is no longer true, and #8001 — the issue 0pdd raised from this very puzzle — is closed as completed, so the text is the last place the old shape survives. It goes, and the javadoc says instead where the Java files get their key.

No behaviour changes: the diff is one javadoc block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaEjcDX1Uy8xMo9yQ7sReX

---
_Generated by [Claude Code](https://claude.ai/code/session_01NaEjcDX1Uy8xMo9yQ7sReX)_