### PR TITLE
#8300: merge the packages inside the compile goal

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Compiling.java
@@ -7,10 +7,11 @@ package org.eolang.maven;
 import java.io.IOException;
 
 /**
- * Core compilation orchestration: runs Assembling, Linting, Resolving, and Placing in sequence.
+ * Core compilation orchestration: runs Assembling, Linting, Merging, Resolving
+ * and Placing in sequence.
  *
- * <p>This class combines {@link Assembling}, {@link Linting}, {@link Resolving} and
- * {@link Placing} steps into a single sequential execution.
+ * <p>This class combines {@link Assembling}, {@link Linting}, {@link Merging},
+ * {@link Resolving} and {@link Placing} steps into a single sequential execution.
  * See their documentation for more details.</p>
  *
  * @since 0.61.0
@@ -28,6 +29,11 @@ final class Compiling implements Step {
     private final Step linting;
 
     /**
+     * Merging step.
+     */
+    private final Step merging;
+
+    /**
      * Resolving step.
      */
     private final Step resolving;
@@ -41,17 +47,20 @@ final class Compiling implements Step {
      * Constructor.
      * @param asmbl Assembling step
      * @param lnt Linting step
+     * @param mrg Merging step
      * @param rslv Resolving step
      * @param plc Placing step
      */
     Compiling(
         final Step asmbl,
         final Step lnt,
+        final Step mrg,
         final Step rslv,
         final Step plc
     ) {
         this.assembling = asmbl;
         this.linting = lnt;
+        this.merging = mrg;
         this.resolving = rslv;
         this.placing = plc;
     }
@@ -60,6 +69,7 @@ final class Compiling implements Step {
     public void exec() throws IOException {
         this.assembling.exec();
         this.linting.exec();
+        this.merging.exec();
         this.resolving.exec();
         this.placing.exec();
     }

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCompile.java
@@ -11,22 +11,20 @@ import org.apache.maven.plugins.annotations.Mojo;
 /**
  * Compile and lint all EO files.
  *
- * <p>This goal combines {@link MjAssemble}, {@link MjLint}, {@link MjResolve} and
- * {@link MjPlace} goals.
+ * <p>This goal combines {@link MjAssemble}, {@link MjLint}, {@link MjMerge},
+ * {@link MjResolve} and {@link MjPlace} goals.
  * See their documentation to find out more details.
  * The {@link MjCompile} is useful to run the whole compilation process in one go without
  * the need to call each goal separately.</p>
  *
+ * <p>The merge happens right after the lint, so that every goal between this
+ * one and {@link MjTranspile}, such as {@link MjInference} or {@link MjLower},
+ * reads the object in the shape it will be compiled in and not in the shape
+ * the parser left. A project therefore never has to name {@code merge}
+ * between them, and naming it changes nothing: a member already inside its
+ * object is not moved again.</p>
+ *
  * @since 0.52
- * @todo #6659:30min Let this goal merge the packages too. The generated Java
- *  compiles now whatever goals a project lists, since {@link MjTranspile}
- *  merges before it writes anything, and {@link Merging} may be run as many
- *  times as one likes. What is still worth having is the merge happening
- *  earlier, right after the lint this goal runs, so that {@link MjInference}
- *  and {@link MjLower} read the object in the shape it will be compiled in
- *  and not in the shape the parser left. Chain it here and drop the
- *  {@code merge} that {@code eo-runtime} lists after this goal, once its
- *  inference tables are shown to come out the same either way.
  */
 @Mojo(
     name = "compile",
@@ -66,6 +64,12 @@ public final class MjCompile extends MjSafe {
                             this.failOnWarning,
                             this.lintAsPackage,
                             this.skipLinting
+                        )
+                    ),
+                    new Timed(
+                        new Merging(
+                            tojos,
+                            this.targetDir.toPath().resolve(Merging.DIR)
                         )
                     ),
                     new Timed(

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjMerge.java
@@ -28,12 +28,11 @@ import org.apache.maven.plugins.annotations.Mojo;
  * whose name no object carries keeps its members as objects of their own,
  * reached through the package namespace as before.</p>
  *
- * <p>{@link MjTranspile} runs the same step itself, so a build that never
- * names this goal still compiles merged objects. The goal is worth naming
- * when a goal between {@link MjLint} and {@link MjTranspile}, such as
- * {@link MjInference} or {@link MjLower}, has to read the object in the
- * shape it will be compiled in. Naming it twice costs nothing: a member
- * already inside its object is not moved again.</p>
+ * <p>{@link MjCompile} runs the same step right after its lint, and
+ * {@link MjTranspile} runs it again before it writes anything, so a build
+ * that never names this goal still compiles merged objects, and every goal
+ * between the two reads them merged. Naming it anyway costs nothing: a
+ * member already inside its object is not moved again.</p>
  *
  * @since 0.68.0
  */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CompilingTest.java
@@ -4,9 +4,14 @@
  */
 package org.eolang.maven;
 
+import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import org.cactoos.set.SetOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -16,6 +21,25 @@ import org.junit.jupiter.api.io.TempDir;
  * @since 0.61.0
  */
 final class CompilingTest {
+
+    @Test
+    void runsEveryStepInTheOrderItIsGiven() throws IOException {
+        final Collection<String> done = new ArrayList<>(5);
+        new Compiling(
+            () -> done.add("assembling"),
+            () -> done.add("linting"),
+            () -> done.add("merging"),
+            () -> done.add("resolving"),
+            () -> done.add("placing")
+        ).exec();
+        MatcherAssert.assertThat(
+            "every step must run once, in the order it was handed over, but they didnt",
+            done,
+            Matchers.contains(
+                "assembling", "linting", "merging", "resolving", "placing"
+            )
+        );
+    }
 
     @Test
     void runsWithoutExceptions(@TempDir final Path temp) {
@@ -56,6 +80,7 @@ final class CompilingTest {
                     false,
                     true
                 ),
+                new Merging(new TjsForeign(), temp.resolve(Merging.DIR)),
                 new Resolving(
                     new TjsForeign(),
                     temp.resolve("resolve"),

--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -277,7 +277,6 @@
               <goal>compile</goal>
               <goal>inference</goal>
               <goal>inference-report</goal>
-              <goal>merge</goal>
               <goal>lower</goal>
               <goal>transpile</goal>
               <goal>atoms-table</goal>


### PR DESCRIPTION
Closes #8300 (resolves the `@todo #6659:30min` puzzle in `MjCompile.java`).

## What it does

`MjCompile` now chains `Merging` right after its lint, so every goal between `compile` and `transpile` — `inference` and `lower` — reads the object in the shape it will be compiled in, rather than in the shape the parser left. `eo-runtime` no longer lists the `merge` goal between them.

## The condition the puzzle set

The puzzle asked for the `merge` goal to be dropped "once its inference tables are shown to come out the same either way". They do. Two `mvn clean install -PskipITs -DskipTests -Deo.transpileTests=false` builds of `eo-runtime`, one before this change and one after:

```
24704de3694139aa26a4a200cbe72d9a  6-inference/links.xml
3da30845d34af35c3e1d261a09141659  6-inference/needs.xml
502ff91618158c038f038022e24b36d7  6-inference/provides.xml
```

Byte for byte identical on both. The rest of the pipeline agrees too: `Put 122 member(s) into 12 package object(s)` and `Transpiled 50 XMIRs, created 48 Java files` in both, and 25 atom return types in `atoms.csv`. That is what one expects from `Merging`, which moves nodes without rewriting a name or a locator, so a row keyed by a locator lands in the same place either way. The log of the second build shows the merge inside the goal:

```
[INFO] --- eo:1.0-SNAPSHOT:compile (compile) @ eo-runtime ---
[INFO] Put 122 member(s) into 12 package object(s), XMIR is in eo-runtime/target/eo/4-merge
[INFO] --- eo:1.0-SNAPSHOT:inference (compile) @ eo-runtime ---
```

## Tests

`CompilingTest.runsEveryStepInTheOrderItIsGiven` pins the order of the chain, `CompilingTest` and `MjMergeTest` pass, and `MjMergeTest.leavesAMergedMemberAloneWhenMergedAgain` already covers the case a project that still names `merge` now hits. `mvn -Pqulice verify -pl eo-maven-plugin` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaEjcDX1Uy8xMo9yQ7sReX