### PR TITLE
#8303: refuse a receiverless reversed dispatch inside parentheses

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -26,10 +26,6 @@ import java.util.regex.Pattern;
  * {@link LnReversed#readHead} does.</p>
  *
  * @since 0.1
- * @todo #8244:30min Reject a receiverless reversed dispatch used as the
- *  phi of a parenthesised inline-phi formation, e.g.
- *  {@code bar (if. > [x]) > z}, the same way LnOnlyPhi now does for the
- *  vertical-body shape (see #8244).
  */
 final class Emissions {
 
@@ -520,6 +516,11 @@ final class Emissions {
             throw new ParseError(
                 line, column + lhs.lastIndexOf('*'),
                 "compact tuple marker is not allowed inside a parenthesised inline-phi"
+            );
+        }
+        if (LnOnlyPhi.receiverless(sub)) {
+            throw new ParseError(
+                line, column, "reversed dispatch missing receiver"
             );
         }
         emit.baselessObject(name, line, column);

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -174,6 +174,16 @@ final class LnOnlyPhi implements Line {
         return result;
     }
 
+    static boolean receiverless(final Span span) {
+        final Tokens tokens = new Tokens(span.body(), span);
+        boolean bare = false;
+        if (LnOnlyPhi.reversedAhead(tokens, tokens.readValue())) {
+            tokens.consumeDispatch();
+            bare = tokens.readArgs().isEmpty();
+        }
+        return bare;
+    }
+
     private Tokens slot(final Stack stack, final Suffix suffix, final Span inner) {
         final int stars = LnOnlyPhi.compactStar(inner.body(), inner);
         final Tokens tokens = LnOnlyPhi.reader(inner, stars);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/receiverless-reversed-dispatch-as-parenthesised-inline-phi.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/receiverless-reversed-dispatch-as-parenthesised-inline-phi.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'reversed dispatch missing receiver')]
+input: |
+  [] > main
+    bar (if. > [x]) > z


### PR DESCRIPTION
Closes #8303 (resolves the `@todo #8244:30min` puzzle in `Emissions.java`).

A reversed dispatch reads its receiver either from its first horizontal argument or from the body indented under it. A parenthesised inline-phi formation has neither: `bar (if. > [x]) > z` writes a dispatch that can never be given a receiver, and the parser used to emit it as `.if` with no children.

`Emissions.inlinePhi` now refuses it with `reversed dispatch missing receiver` — the same canonical text `Eo.checkOnClose` uses for the vertical shape of the mistake, so the two read alike (R-5.3.2, #8244). The question itself is answered by `LnOnlyPhi`, which already owns what an only-phi line may hold and already answers the neighbouring one about a compact tuple marker. A dispatch that does carry a receiver, as in `bar (if. x > [q]) > z`, is untouched.

## Tests

`receiverless-reversed-dispatch-as-parenthesised-inline-phi.yaml` reproduces the issue first: on `master` the XPath finds no error, with this change it does. All 1631 `eo-parser` tests pass, the 795 syntax packs included, `mvn -Pqulice verify -pl eo-parser` is clean, and no `.eo` source in the repo writes the refused shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NaEjcDX1Uy8xMo9yQ7sReX