### PR TITLE
fix(#8329): cite the rule that states the atom-parent restriction

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Admission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Admission.java
@@ -8,7 +8,7 @@ package org.eolang.parser;
  * A line's naming suffix, as {@link Transition#apply} needs it: names
  * the pushed-or-replaced level when the line carries a name suffix, and
  * says whether the line shape is allowed to sit under an atom parent
- * (R-3.10.13).
+ * (R-5.3.4).
  *
  * @since 0.1
  */


### PR DESCRIPTION
Fixes #8329

`Admission` cited `R-3.10.13`, which `PARSER_SPEC.md` does not define — §3.10 ends at `R-3.10.12`. The restriction the class implements, on what may sit under an atom parent, is stated by `R-5.3.4` (Atom body), which is the rule `Level.patom` already cites for the same flag.

Javadoc only; no behaviour changes.