### PR TITLE
fix(#8326): run the EC2 build on a schedule instead of a cancelled debounce

### DIFF
--- a/.github/workflows/ec2.yml
+++ b/.github/workflows/ec2.yml
@@ -4,20 +4,14 @@
 # yamllint disable rule:line-length
 name: ec2
 'on':
-  push:
-    branches:
-      - master
+  schedule:
+    - cron: '0 */4 * * *'
+  workflow_dispatch:
 concurrency:
   group: ec2-${{ github.ref }}
   cancel-in-progress: true
 jobs:
-  wait:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 70
-    steps:
-      - run: sleep 3600
   start-instance:
-    needs: wait
     runs-on: ubuntu-24.04
     outputs:
       label: ${{ steps.start.outputs.label }}
@@ -98,7 +92,7 @@ jobs:
         run: |
           set -e
           seconds=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
-            --jq '[ .jobs[] | select(.completed_at) | select(.name != "wait") ]
+            --jq '[ .jobs[] | select(.completed_at) ]
               | (map(.completed_at | fromdate) | max) - (map(.started_at | fromdate) | min)
               | [ ., 0 ] | max')
           echo "This run took ${seconds} seconds"
@@ -125,7 +119,7 @@ jobs:
         run: |
           set -e
           seconds=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" \
-            --jq '[ .jobs[] | select(.completed_at) | select(.name != "wait") ]
+            --jq '[ .jobs[] | select(.completed_at) ]
               | (map(.completed_at | fromdate) | max) - (map(.started_at | fromdate) | min)
               | [ ., 0 ] | max')
           echo "This run took ${seconds} seconds"

--- a/.github/workflows/ec2.yml
+++ b/.github/workflows/ec2.yml
@@ -5,7 +5,7 @@
 name: ec2
 'on':
   schedule:
-    - cron: '0 */4 * * *'
+    - cron: '0 3 * * *'
   workflow_dispatch:
 concurrency:
   group: ec2-${{ github.ref }}


### PR DESCRIPTION
Fixes #8326

The `wait` job debounced master pushes by an hour, and `cancel-in-progress` restarted that hour on every new push. A repository that merges more often than hourly never lets a run past the debounce: 39 of the last 40 runs were cancelled, so the only job that runs the suite at `-Deo.deadline=120 -Deo.maxmem=4G`, and the only one that builds the site and coverage, effectively never completed.

A schedule keeps what the debounce was for — one heavy run at a time, on the newest master, not one per commit — while guaranteeing it actually fires. It runs once a day, at 03:00 UTC. `workflow_dispatch` is added so a run can still be triggered by hand.

The `wait` job is removed along with the two `select(.name != \"wait\")` filters that existed only to keep its hour out of the reported elapsed time.
