### PR TITLE
fix(#8325): keep the temp directory of a test that did not pass

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -36,12 +37,19 @@ import org.junit.jupiter.api.io.TempDir;
  * gigabytes of heap and minutes of collecting it, for no more of the race than
  * four reach.</p>
  *
+ * <p>The temporary directory is kept when the test does not pass. A
+ * memory or deadline abort leaves the threads of this test still
+ * holding files open under it, and Windows refuses to delete a
+ * directory whose files are open, so an unconditional cleanup turns
+ * the abort JUnit intended as a skip into a failure of the run
+ * (#8325).</p>
+ *
  * @since 0.75.0
  */
 final class EOdirectoryEOmadeRaceTest {
 
     @RepeatedTest(10)
-    void makesOneDirectoryFromManyThreadsAtOnce(@TempDir final Path temp) {
+    void makesOneDirectoryFromManyThreadsAtOnce(@TempDir(cleanup = CleanupMode.ON_SUCCESS) final Path temp) {
         MatcherAssert.assertThat(
             "every thread racing for the same missing directory must be told it is there, since the one that loses the mkdir is the one the EEXIST branch rescues",
             new Together<>(

--- a/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOfileEOtouchedTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.io.CleanupMode;
 import org.junit.jupiter.api.io.TempDir;
 
 /**
@@ -22,12 +23,19 @@ import org.junit.jupiter.api.io.TempDir;
  * treated as a successful touch rather than as a failure from a later syscall
  * that overwrote {@code errno} (#7077).</p>
  *
+ * <p>The temporary directory is kept when the test does not pass. A
+ * memory or deadline abort leaves the threads of this test still
+ * holding files open under it, and Windows refuses to delete a
+ * directory whose files are open, so an unconditional cleanup turns
+ * the abort JUnit intended as a skip into a failure of the run
+ * (#8325).</p>
+ *
  * @since 0.75.0
  */
 final class EOfileEOtouchedTest {
 
     @RepeatedTest(20)
-    void keepsWhatAnotherThreadWroteInBetween(@TempDir final Path temp)
+    void keepsWhatAnotherThreadWroteInBetween(@TempDir(cleanup = CleanupMode.ON_SUCCESS) final Path temp)
         throws Exception {
         final Path target = temp.resolve("shared.txt");
         new Together<>(


### PR DESCRIPTION
Fixes #8325

`Maxmem` aborts an over-budget test and reports it as skipped. When that test has started threads of its own, they are still holding files open under its `@TempDir` when the abort is thrown, and Windows refuses to delete a directory whose files are open. JUnit then turns `DirectoryNotEmptyException` into `JUnitException: Failed to close extension context`, which surfaces as an error and fails the build — this is what `EOfileEOtouchedTest.keepsWhatAnotherThreadWroteInBetween` did to master on the `windows-2022` leg.

`CleanupMode.ON_SUCCESS` deletes the directory when the test passes and leaves it alone otherwise, so an abort stays an abort. Applied to both tests that take a `@TempDir` and start threads under it.

The wider question in the issue — that `Watched.settle` gives up after half a second and throws the abort whether or not the body actually stopped — is left alone here, since it changes how the memory guard behaves for every test rather than how these two clean up.