### PR TITLE
Encode TRUE as FF- instead of 01-

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Folded.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Folded.java
@@ -87,7 +87,7 @@ public final class Folded implements Rewrite {
             element.setAttribute("base", "Φ.number");
             element.appendChild(Folded.wrapped(element.getOwnerDocument(), value));
         } else if ("bool".equals(forma)) {
-            if ("01-".equals(value)) {
+            if ("FF-".equals(value)) {
                 element.setAttribute("base", "Φ.true");
             } else if ("00-".equals(value)) {
                 element.setAttribute("base", "Φ.false");

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -263,7 +263,7 @@ public final class JavaAtom {
             }
             out = String.format("Double.longBitsToDouble(0x%sL)", hex);
         } else if ("bool".equals(parts[0])) {
-            if ("01-".equals(parts[1])) {
+            if ("FF-".equals(parts[1])) {
                 out = "true";
             } else if ("00-".equals(parts[1])) {
                 out = "false";

--- a/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
@@ -49,7 +49,7 @@ public final class Literal implements Term {
         } else if ("bytes".equals(this.forma)) {
             out = String.format("Φ.bytes(α0 ↦ ⟦ Δ ⤍ %s ⟧)", this.hex);
         } else if ("bool".equals(this.forma)) {
-            if ("01-".equals(this.hex)) {
+            if ("FF-".equals(this.hex)) {
                 out = "Φ.true";
             } else {
                 out = "Φ.false";

--- a/eo-lowering/src/main/java/org/eolang/lowering/Operand.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Operand.java
@@ -68,7 +68,7 @@ public final class Operand {
 
     /**
      * The identity of the value.
-     * @return A key such as {@code sym:s1}, {@code number:40-14-...} or {@code bool:01-}
+     * @return A key such as {@code sym:s1}, {@code number:40-14-...} or {@code bool:FF-}
      */
     public String key() {
         final String out = this.guessed();
@@ -86,7 +86,7 @@ public final class Operand {
     private String guessed() {
         String out = "";
         if ("Φ.true".equals(this.text)) {
-            out = "bool:01-";
+            out = "bool:FF-";
         } else if ("Φ.false".equals(this.text)) {
             out = "bool:00-";
         } else {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
@@ -60,7 +60,7 @@ public final class Parsed {
         final String base = node.attribute("base").text().orElse("");
         final Term out;
         if ("Φ.true".equals(base)) {
-            out = new Literal("bool", "01-");
+            out = new Literal("bool", "FF-");
         } else if ("Φ.false".equals(base)) {
             out = new Literal("bool", "00-");
         } else if ("Φ.number".equals(base) || "Φ.string".equals(base)) {

--- a/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
@@ -24,6 +24,6 @@
     size ↦ ⟦ λ ⤍ L_bytes_size ⟧,
     slice ↦ ⟦ start ↦ ∅, len ↦ ∅, cant-slice ↦ ∅, λ ⤍ L_bytes_slice ⟧
   ⟧,
-  true ↦ ⟦ Δ ⤍ 01- ⟧,
+  true ↦ ⟦ Δ ⤍ FF- ⟧,
   false ↦ ⟦ Δ ⤍ 00- ⟧
 ⟧

--- a/eo-lowering/src/test/java/org/eolang/lowering/ConstantTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ConstantTest.java
@@ -143,7 +143,7 @@ final class ConstantTest {
                     )
                 ).element("o")
             ).value().bytes(),
-            Matchers.equalTo("01-")
+            Matchers.equalTo("FF-")
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/LiteralTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/LiteralTest.java
@@ -41,7 +41,7 @@ final class LiteralTest {
     void rendersTruthAsDispatch() {
         MatcherAssert.assertThat(
             "the byte of truth must render as Φ.true, but it didnt",
-            new Literal("bool", "01-").phi(),
+            new Literal("bool", "FF-").phi(),
             Matchers.equalTo("Φ.true")
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/OperandTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/OperandTest.java
@@ -89,7 +89,7 @@ final class OperandTest {
         MatcherAssert.assertThat(
             "a bare truth must anchor to its byte, but it didnt",
             new Operand("Φ.true").key(),
-            Matchers.equalTo("bool:01-")
+            Matchers.equalTo("bool:FF-")
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/ProtocolTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ProtocolTest.java
@@ -28,7 +28,7 @@ final class ProtocolTest {
     void namesCarrier() {
         MatcherAssert.assertThat(
             "the forma must come back as given, but it didnt",
-            new Protocol(Collections.emptyList(), "bool:01-", "bool").carrier(),
+            new Protocol(Collections.emptyList(), "bool:FF-", "bool").carrier(),
             Matchers.equalTo("bool")
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/UniverseTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/UniverseTest.java
@@ -45,7 +45,7 @@ final class UniverseTest {
         MatcherAssert.assertThat(
             "the universe must be a complete expression phino can merge with, but it isnt",
             phino.dataize(new Universe().text(), "⟦ φ ↦ Φ.true ⟧").bytes(),
-            Matchers.equalTo("01-")
+            Matchers.equalTo("FF-")
         );
     }
 }

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -4,6 +4,12 @@
 # and every other operation are derived from this single choice, so no
 # conditional primitive is needed and `true`/`false` are simply two
 # applications of `bool`.
+#
+# TRUE carries the byte `FF-` and FALSE the byte `00-`, so the two are
+# complementary masks: the bitwise `and`, `or` and `not` of `bytes`
+# answer over them exactly what `if` answers. `FF-` is also no character
+# at all, so a boolean no longer passes for the one-byte text U+0001,
+# the way it did when TRUE was `01-`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -13,17 +19,17 @@
 
 [if] > bool
   if > @
-    01-
+    FF-
     00-
   ^.if > [^ x] > and
-    01-.eq x
+    FF-.eq x
     false
   if > not
     false
     true
   ^.if > [^ x] > or
     true
-    01-.eq x
+    FF-.eq x
 
   eq. ++> can-answer-the-left-method-of-a-chosen-branch
     left.
@@ -60,17 +66,15 @@
       "yes"
       "no"
 
-  and. ++> can-compare-a-bool-to-a-string
-    true.eq "\u0001"
-    false.eq "\u0000"
-
   and. ++> can-compare-a-bool-to-bytes
-    true.eq 01-
+    true.eq FF-
     false.eq 00-
 
   and. ++> can-compare-bytes-to-a-bool
-    01-.as-bytes.eq true
+    FF-.as-bytes.eq true
     00-.as-bytes.eq false
+
+  false.eq "\u0000" ++> can-compare-false-to-a-null-character
 
   true.eq true ++> can-compare-two-bools
 
@@ -222,6 +226,9 @@
 
   not. ++> can-tell-false-does-not-disjoin-with-itself
     false.or false
+
+  not. ++> can-tell-true-is-not-a-control-character
+    true.eq "\u0001"
 
   not. ++> can-tell-true-is-not-false
     true.eq false

--- a/eo-runtime/src/main/eo/bytes.eo
+++ b/eo-runtime/src/main/eo/bytes.eo
@@ -81,7 +81,7 @@
 
   eq. ++> can-concat-bools-as-bytes
     true.as-bytes.concat false.as-bytes
-    01-00
+    FF-00
 
   eq. ++> can-concat-bytes-with-empty-ones
     05-5E-78.concat --

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -1,4 +1,4 @@
-# Bytes as a boolean: TRUE when the single byte equals `01-`, FALSE otherwise.
+# Bytes as a boolean: TRUE when the single byte equals `FF-`, FALSE otherwise.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,7 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-bool
-  ^.eq 01- > @
+  ^.eq FF- > @
 
   not. ++> can-convert-bytes-to-a-bool
-    01-.as-bool.eq 00-.as-bool
+    FF-.as-bool.eq 00-.as-bool

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -33,17 +33,18 @@
 # rather than in reading order, because the linter sorts them by name.
 #
 # The `%s` conversion refuses an argument whose bytes do not decode as UTF-8.
-# `false` and `true` dataize to the single bytes `00-` and `01-`, which are
-# also the valid one-character encodings of U+0000 and U+0001, so an object
-# knows its own bytes here and not its type: a boolean routed through `%s`
-# is printed as that control character instead of being rejected, and `%b`
-# remains the conversion to reach for a boolean.
+# `false` dataizes to the single byte `00-`, which is also the valid
+# one-character encoding of U+0000, so an object knows its own bytes here
+# and not its type: FALSE routed through `%s` is printed as that control
+# character instead of being rejected. TRUE dataizes to `FF-`, which no
+# text encodes, so it is rejected. `%b` remains the conversion to reach
+# for a boolean either way.
 #
 # The `%b` conversion refuses an argument whose bytes are neither `00-` nor
-# `01-`, so a text or a number reaching it terminates instead of being
+# `FF-`, so a text or a number reaching it terminates instead of being
 # printed as `false`. The coin lands the other way up as well: the
-# one-character texts of U+0000 and U+0001 are accepted as booleans, since
-# their bytes are the bytes of `false` and `true`.
+# one-character text of U+0000 is accepted as a boolean, since its byte is
+# the byte of `false`.
 #
 # The `%d` guard names the number it rejects through `as-scientific` and not
 # through `%f`, because every magnitude it rejects is past the range `as-fixed`
@@ -230,7 +231,7 @@
               62-.eq conv
               if.
                 or.
-                  01-.eq datum
+                  FF-.eq datum
                   00-.eq datum
                 capped
                   arg.as-bool.if "true" "false"
@@ -428,11 +429,6 @@
     "%25x".printf
       * 42.as-bytes
 
-  eq. ++> can-format-a-boolean-as-a-control-character
-    "\u0001"
-    "%s".printf
-      * true
-
   eq. ++> can-format-a-computed-string
     "abcd"
     "%s".printf
@@ -626,6 +622,10 @@
     "-9223372036854775808"
     "%d".printf
       * -9.223372036854776e18
+
+  printf. --> stops-on-a-boolean-as-a-string
+    "%s"
+    * true
 
   printf. --> stops-on-a-comma-flag-with-s
     "%,s"

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -1,6 +1,6 @@
 # TRUE boolean state.
 # It is the `bool` whose choice returns its first argument, so `if` picks
-# the `left` branch and the byte representation is `01-`.
+# the `left` branch and the byte representation is `FF-`.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -49,6 +49,6 @@
   not. ++> can-tell-true-is-not-its-own-negation
     true.eq true.not
 
-  true.as-bytes.eq 01- ++> can-turn-into-a-single-true-byte
+  true.as-bytes.eq FF- ++> can-turn-into-a-single-true-byte
 
   true.if --> stops-on-if-without-arguments

--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -117,13 +117,13 @@ public final class Dataized {
                 weak.length, Arrays.toString(weak)
             );
         }
-        if (weak[0] != 0 && weak[0] != 1) {
+        if (weak[0] != 0 && weak[0] != -1) {
             throw new ExFailure(
-                "Can't dataize the byte %s to boolean, only 00- and 01- are booleans",
+                "Can't dataize the byte %s to boolean, only 00- and FF- are booleans",
                 Arrays.toString(weak)
             );
         }
-        return weak[0] == 1;
+        return weak[0] == -1;
     }
 
     /**

--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -42,7 +42,7 @@ public final class VerboseBytesAsString implements Supplier<String> {
             result = String.format(
                 "[0x%02X] = %s",
                 this.data[0],
-                this.data[0] == 1
+                this.data[0] == -1
             );
         } else if (this.data.length == Double.BYTES) {
             result = String.format(

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -69,13 +69,13 @@ final class DataizedTest {
     @Test
     void refusesAByteThatIsNeitherTrueNorFalse() {
         MatcherAssert.assertThat(
-            "a one byte datum that is not 00- or 01- must be refused, not read as false",
+            "a one byte datum that is not 00- or FF- must be refused, not read as false",
             Assertions.assertThrows(
                 ExFailure.class,
-                () -> new Dataized(new PhDefault(new byte[] {(byte) 0xFF})).asBool(),
-                "dataizing FF- as boolean was expected to fail with ExFailure"
+                () -> new Dataized(new PhDefault(new byte[] {(byte) 0x01})).asBool(),
+                "dataizing 01- as boolean was expected to fail with ExFailure"
             ).getMessage(),
-            Matchers.containsString("only 00- and 01- are booleans")
+            Matchers.containsString("only 00- and FF- are booleans")
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -58,7 +58,7 @@ final class SyscallTest {
                     new String(actual, StandardCharsets.UTF_8)
                 ),
                 actual,
-                Matchers.equalTo(new byte[]{1})
+                Matchers.equalTo(new byte[]{(byte) 0xFF})
             );
         } finally {
             server.stop();
@@ -76,7 +76,7 @@ final class SyscallTest {
         MatcherAssert.assertThat(
             "connecting to a refused port should have yielded the cant-connect fallback instead of terminating, but it didnt",
             new Dataized(connect).take(),
-            Matchers.equalTo(new byte[]{1})
+            Matchers.equalTo(new byte[]{(byte) 0xFF})
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -70,8 +70,9 @@ final class VerboseBytesAsStringTest {
                 ByteBuffer.allocate(Double.BYTES).putDouble(12.345_67d).array(),
                 "12.34567"
             ),
-            Arguments.of(new byte[]{1}, "[0x01] = true"),
+            Arguments.of(new byte[]{-1}, "[0xFF] = true"),
             Arguments.of(new byte[]{0}, "[0x00] = false"),
+            Arguments.of(new byte[]{1}, "[0x01] = false"),
             Arguments.of(new byte[]{2}, "[0x02] = false"),
             Arguments.of(new byte[]{}, "[<no bytes>]"),
             Arguments.of(new byte[]{12}, "[0x0C] = false"),


### PR DESCRIPTION
TRUE now dataizes to `FF-`, while FALSE stays at `00-`. The change touches
`bool.eo`, `bytes/as-bool.eo`, `printf.eo`'s `%b` guard, `Dataized.asBool`,
`VerboseBytesAsString` and the `universe.phi` of `eo-lowering` — everything
else follows on its own, because `Data.ToPhi` routes a Java `boolean`
through `Φ.true`/`Φ.false` rather than through a byte.

The old byte collided with a real one-character text: `01-` is the UTF-8
encoding of U+0001, so a boolean and that text were the same thing once
dataized. That is why `%s` had to print a boolean as a control character,
and why #7243 could only be closed by accepting the collision. `FF-` is no
character at all, so it is gone. It also buys back a property worth having:
`FF-` and `00-` are complementary masks, so the bitwise `and`, `or` and
`not` of `bytes` now answer over the two exactly what `if` answers.

Two tests changed meaning rather than bytes, which is the honest part of the
diff to look at: comparing TRUE to the U+0001 text is now false, and `%s`
on a boolean refuses instead of printing. FALSE still shares its byte with
the U+0000 text — unavoidable while a boolean is one byte, so only the TRUE
half was fixable. Verified with the full reactor under
`-Deo.transpileTests=true` (eo-runtime 2754 tests) and with qulice.

Closes #8346