### PR TITLE
fix(runtime): hold the memoized attributes on a monitor, not on a lock

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/AtOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/AtOnce.java
@@ -4,17 +4,21 @@
  */
 package org.eolang;
 
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 /**
  * Attribute that retrieves object only once.
  *
  * <p>It's highly recommended to use it with {@link AtComposite}.</p>
  *
+ * <p>The first retrieval happens under the monitor of this very attribute,
+ * and not under a lock of its own, because an object of the language is made
+ * of these attributes and there are millions of them in the heap of a program
+ * that runs for a while: a lock costs two objects each, while a monitor
+ * costs nothing until two threads want it at the same time.</p>
+ *
  * @since 0.1
+ * @checkstyle RegexpSinglelineCheck (60 lines)
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 public final class AtOnce implements Attribute {
 
     /**
@@ -23,14 +27,9 @@ public final class AtOnce implements Attribute {
     private final Attribute origin;
 
     /**
-     * Cache.
+     * Cache, {@code null} until the origin is retrieved.
      */
-    private final AtomicReference<Phi> cached;
-
-    /**
-     * Lock guarding the first retrieval of the origin attribute.
-     */
-    private final Lock lock;
+    private volatile Phi cached;
 
     /**
      * Ctor.
@@ -38,8 +37,6 @@ public final class AtOnce implements Attribute {
      */
     public AtOnce(final Attribute attr) {
         this.origin = attr;
-        this.cached = new AtomicReference<>(null);
-        this.lock = new ReentrantLock();
     }
 
     @Override
@@ -49,17 +46,16 @@ public final class AtOnce implements Attribute {
 
     @Override
     public Phi get() {
-        if (this.cached.get() == null) {
-            this.lock.lock();
-            try {
-                if (this.cached.get() == null) {
-                    this.cached.set(this.origin.get());
+        Phi ret = this.cached;
+        if (ret == null) {
+            synchronized (this) {
+                if (this.cached == null) {
+                    this.cached = this.origin.get();
                 }
-            } finally {
-                this.lock.unlock();
+                ret = this.cached;
             }
         }
-        return this.cached.get();
+        return ret;
     }
 
     @Override

--- a/eo-runtime/src/main/java/org/eolang/AtWithRho.java
+++ b/eo-runtime/src/main/java/org/eolang/AtWithRho.java
@@ -5,19 +5,22 @@
 
 package org.eolang;
 
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
-
 /**
  * The attribute that copies the object and binds itself as its \rho, but
  * only when the object declares a \rho and has not been bound to one yet.
  * The terminator ({@link PhTerminator}) silently ignores this \rho itself, so no container
  * leaks into it and its cause is not masked as it propagates.
  * Every caller takes a copy of its own, since that copy is where the caller puts its
- * own arguments, and the copying happens under a lock, so that no thread reads the
- * object being bound while another one is still copying it.
+ * own arguments, and the copying happens under the monitor of this attribute, so that
+ * no thread reads the object being bound while another one is still copying it. The
+ * monitor is the attribute itself and not a lock of its own, because an object of the
+ * language is made of these attributes and there are millions of them in the heap of a
+ * program that runs for a while: a lock costs two objects each, while a monitor costs
+ * nothing until two threads want it at the same time.
  * @since 0.36.0
+ * @checkstyle RegexpSinglelineCheck (60 lines)
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 final class AtWithRho implements Attribute {
 
     /**
@@ -31,11 +34,6 @@ final class AtWithRho implements Attribute {
     private final Phi rho;
 
     /**
-     * Lock guarding the copying of the object being bound.
-     */
-    private final Lock lock;
-
-    /**
      * Ctor.
      * @param attr Attribute
      * @param rho Rho
@@ -43,7 +41,6 @@ final class AtWithRho implements Attribute {
     AtWithRho(final Attribute attr, final Phi rho) {
         this.original = attr;
         this.rho = rho;
-        this.lock = new ReentrantLock();
     }
 
     @Override
@@ -58,12 +55,9 @@ final class AtWithRho implements Attribute {
     public Phi get() {
         Phi ret = this.original.get();
         if (ret.needsRho()) {
-            this.lock.lock();
-            try {
+            synchronized (this) {
                 ret = ret.copy();
                 ret.put(Phi.RHO, this.rho);
-            } finally {
-                this.lock.unlock();
             }
         }
         return ret;

--- a/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
+++ b/eo-runtime/src/main/java/org/eolang/CopiedAttrs.java
@@ -7,7 +7,6 @@ package org.eolang;
 import java.util.AbstractMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 
 /**
@@ -30,7 +29,9 @@ import java.util.function.BiConsumer;
  * decided and reads the same whenever it is copied out.</p>
  *
  * @since 0.63
+ * @checkstyle RegexpSinglelineCheck (120 lines)
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 final class CopiedAttrs extends AbstractMap<String, Attribute> implements Walkable {
 
     /**
@@ -44,14 +45,14 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> implements Walkab
     private final Phi owner;
 
     /**
-     * The ones taken out of the origin so far.
+     * The ones taken out of the origin so far, guarded by the monitor of this
+     * map. The monitor is the map itself and not a lock of its own, because
+     * every copy of an object makes one of these and there are millions of
+     * them in the heap of a program that runs for a while: a lock costs two
+     * objects each, while a monitor costs nothing until two threads want it
+     * at the same time.
      */
     private final Bindings taken;
-
-    /**
-     * Guards {@link #taken} against concurrent readers.
-     */
-    private final ReentrantLock lock;
 
     /**
      * Ctor.
@@ -63,23 +64,18 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> implements Walkab
         this.origin = from;
         this.owner = phi;
         this.taken = new Bindings();
-        this.lock = new ReentrantLock();
     }
 
     @Override
     public boolean containsKey(final Object key) {
-        this.lock.lock();
-        try {
+        synchronized (this) {
             return this.taken.containsKey(key) || this.origin.containsKey(key);
-        } finally {
-            this.lock.unlock();
         }
     }
 
     @Override
     public Attribute get(final Object key) {
-        this.lock.lock();
-        try {
+        synchronized (this) {
             final Attribute ready = this.taken.get(key);
             final Attribute attr;
             if (ready == null) {
@@ -88,41 +84,30 @@ final class CopiedAttrs extends AbstractMap<String, Attribute> implements Walkab
                 attr = ready;
             }
             return attr;
-        } finally {
-            this.lock.unlock();
         }
     }
 
     @Override
     public Attribute put(final String key, final Attribute value) {
-        this.lock.lock();
-        try {
+        synchronized (this) {
             return this.taken.put(key, value);
-        } finally {
-            this.lock.unlock();
         }
     }
 
     @Override
     public Set<Map.Entry<String, Attribute>> entrySet() {
-        this.lock.lock();
-        try {
+        synchronized (this) {
             for (final String key : this.origin.keySet()) {
                 this.taken.put(key, this.get(key));
             }
             return this.taken.entrySet();
-        } finally {
-            this.lock.unlock();
         }
     }
 
     @Override
     public void each(final BiConsumer<String, Attribute> action) {
-        this.lock.lock();
-        try {
+        synchronized (this) {
             this.taken.each(action);
-        } finally {
-            this.lock.unlock();
         }
     }
 

--- a/eo-runtime/src/main/java/org/eolang/PhOnce.java
+++ b/eo-runtime/src/main/java/org/eolang/PhOnce.java
@@ -5,9 +5,6 @@
 
 package org.eolang;
 
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 /**
@@ -27,7 +24,9 @@ import java.util.function.Supplier;
  *
  * @since 0.1
  * @checkstyle DesignForExtensionCheck (200 lines)
+ * @checkstyle RegexpSinglelineCheck (200 lines)
  */
+@SuppressWarnings("PMD.AvoidSynchronizedStatement")
 public class PhOnce implements Phi {
 
     /**
@@ -36,19 +35,18 @@ public class PhOnce implements Phi {
     private final Supplier<Phi> object;
 
     /**
-     * Reference.
+     * Reference, {@code null} until the object is fetched. The first fetch
+     * happens under the monitor of this very object, and not under a lock of
+     * its own, because there are millions of these in the heap of a program
+     * that runs for a while: a lock costs two objects each, while a monitor
+     * costs nothing until two threads want it at the same time.
      */
-    private final AtomicReference<Phi> ref;
+    private volatile Phi ref;
 
     /**
      * Supplier of the φ-term, or {@code null} to delegate to the wrapped object.
      */
     private final Supplier<String> term;
-
-    /**
-     * Lock guarding the first load of the reference.
-     */
-    private final Lock lock;
 
     /**
      * Ctor.
@@ -64,9 +62,7 @@ public class PhOnce implements Phi {
      * @param term Supplier of the φ-term
      */
     public PhOnce(final Supplier<Phi> obj, final Supplier<String> term) {
-        this.ref = new AtomicReference<>(null);
         this.term = term;
-        this.lock = new ReentrantLock();
         this.object = () -> this.loaded(obj);
     }
 
@@ -147,16 +143,15 @@ public class PhOnce implements Phi {
     }
 
     private Phi loaded(final Supplier<Phi> obj) {
-        if (this.ref.get() == null) {
-            this.lock.lock();
-            try {
-                if (this.ref.get() == null) {
-                    this.ref.set(obj.get());
+        Phi ret = this.ref;
+        if (ret == null) {
+            synchronized (this) {
+                if (this.ref == null) {
+                    this.ref = obj.get();
                 }
-            } finally {
-                this.lock.unlock();
+                ret = this.ref;
             }
         }
-        return this.ref.get();
+        return ret;
     }
 }


### PR DESCRIPTION
**This no longer fixes a red build.** It was opened for the [`snippets` failure on `d944474d`](https://github.com/objectionary/eo/actions/runs/33894204754/job/101092869441), where `ReadmeSnippetsIT.validatesReadmeSnippets[5]` -- the `while` loop of the `README` -- printed three of its five lines and filled a heap of 7.6Gb. #8337 landed half an hour earlier than this branch and turned that build green again by taking the regex out of `os.is-windows`. What is left here is the headroom the snippet has, which the measurement below puts at one step of `-Xmx`.

## Where the heap goes

An object of the language is made of attributes, and a program that runs for a while has millions of them alive at once. Four of the classes they are made of carry a `ReentrantLock` apiece, and a lock is two objects, 48 bytes, none of which is the state it guards. A class histogram taken while the snippet ran:

```
 num     #instances         #bytes  class name
   1:      19549294      625577408  java.util.concurrent.locks.ReentrantLock$NonfairSync
   2:       9797156      382088744  [Ljava.lang.Object;
   3:      19549190      312787040  java.util.concurrent.locks.ReentrantLock
   4:      11055350      265328400  java.util.ArrayList
   5:      12138162      194210592  java.util.concurrent.atomic.AtomicReference
   6:       6143386      147441264  org.eolang.AtWithRho
   7:       3638822      116442304  org.eolang.Bindings
   8:       2637551      105502040  org.eolang.CopiedAttrs
```

19.5M locks, 940Mb, against 2.4Gb of everything else: the locks alone were more than a third of what the program held.

## What changed

They are gone. The three that guard a memoization -- `AtOnce`, `PhOnce`, `CopiedAttrs` -- and `AtWithRho`, which guards the copying of the object it binds, now take the monitor of the very object they belong to. A monitor is a bit in the header of an object that already exists, costs nothing until two threads want it at the same time, and is reentrant the same way a `ReentrantLock` is, so `CopiedAttrs.entrySet` still reads through `get` while it holds it. The two `AtomicReference` fields that the double-checked reads went through are plain `volatile` fields now, since nothing compares and sets them.

Qulice asks for a lock instead of a synchronized block and refuses `this` as a monitor. Both are set aside in these four classes, where the count of instances is the point, and nowhere else. That is the `+4 suppressions, +4 checkstyles` the counts bot reports, and it is the whole of the cost.

## What it buys

The sandbox of the integration test, compiling every runtime `.eo` and running the README snippet in one JVM, on `fb5f30b2` with #8337 in it, from a clean `target` every time:

| `-Xmx` | `master` | with this branch |
|:--|:--|:--|
| 2g | -- | out of memory |
| 3g | out of memory | 13.2s |
| 4g | 15.8s | 13.2s |

The snippet needs one step less of heap and runs 16% faster.

## What was checked

- `mvn -Psnippets verify -pl eo-integration-tests -Dit.test=ReadmeSnippetsIT`: 5 of 5, no failures, 76s.
- `mvn test -pl eo-runtime`: 2767 tests, the same result as before the change. The only red ones need a free TCP port or a version in the manifest, and are red on `master` in this sandbox too.
- `mvn -Pqulice -Deo.skip clean process-classes qulice:check -pl eo-runtime`, the command the qulice job runs: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QM7TZMWnc8yDY5R2BXhSw
