### PR TITLE
Answer a variable return with the void that carries it

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -61,17 +61,26 @@ import java.util.stream.Collectors;
  * {@code [] > div /Q.number} says that a {@code div} is a {@code Φ.number}
  * once it has run, and the parser carries that annotation into the XMIR, so
  * the row keeps it and whoever reads the table can ask a {@code number} what
- * the atom itself cannot answer. An annotation that names no object is
- * skipped: {@code [] > recovered /A} comes back with whatever the caller put
- * in, and that is a variable, which nothing here understands yet.</p>
+ * the atom itself cannot answer.</p>
  *
- * <p>What a void says it will hold is written down for the same reason, and
- * skipped for the same one. {@code ? > code /Q.number} is how a formation that
- * only Java ever copies says what goes into its voids, since it has no caller
- * in the program to say it for it, and {@code /A} names no object and is
- * passed over. {@link Provided} walks through such a void the way it walks
- * behind a delegation, so a name asked of it is answered once and for all
- * rather than left to a caller.</p>
+ * <p>An annotation may name a variable rather than an object, and then it
+ * names the void that carries the same letter. {@code [] > recovered /A} over
+ * {@code ? > value /A?} and {@code ? > alternative /A} says that what comes
+ * back is what was put in, so the row keeps the {@code value}, and a caller
+ * who put a {@code number} there is answered with a {@code number} rather
+ * than with nothing (#8348). The letter stands on both voids, which is the
+ * source saying the two are one type; where a caller makes them two, the
+ * first is what the table has to go on. A mark of termination is dropped as
+ * {@link Held} drops it, since a termination answers to every name.</p>
+ *
+ * <p>What a void says it will hold is written down for the same reason as an
+ * atom's annotation, and only when it names an object. {@code ? > code
+ * /Q.number} is how a formation that only Java ever copies says what goes into
+ * its voids, since it has no caller in the program to say it for it, while a
+ * letter says nothing about what goes in and is read only by the atom above
+ * it. {@link Provided} walks through a void that says what it holds the way it
+ * walks behind a delegation, so a name asked of it is answered once and for
+ * all rather than left to a caller.</p>
  *
  * <p>Not every attribute is written inside the formation it belongs to:
  * {@code minus} in the package {@code number} is {@code Φ.number.minus} and
@@ -159,10 +168,33 @@ final class Provides implements Clue {
         for (final Xnav kid : kids) {
             final Noted attr = new Noted(kid);
             if ("λ".equals(attr.says("name"))) {
-                final String back = attr.says("atom");
-                if (back.startsWith("Φ.")) {
+                final String back = Provides.locator(attr.says("atom"), kids);
+                if (!back.isEmpty()) {
                     found.add(back);
                 }
+            }
+        }
+        return found;
+    }
+
+    private static String locator(final String annotation, final Collection<Xnav> kids) {
+        String found = "";
+        if (annotation.startsWith("Φ.")) {
+            found = annotation;
+        } else if (!annotation.isEmpty()) {
+            found = Provides.carrying(kids, annotation);
+        }
+        return found;
+    }
+
+    private static String carrying(final Collection<Xnav> kids, final String letter) {
+        String found = "";
+        for (final Xnav kid : kids) {
+            final Noted attr = new Noted(kid);
+            if ("∅".equals(attr.says("base"))
+                && letter.equals(attr.says("type").replace("?", ""))) {
+                found = attr.says("loc");
+                break;
             }
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Returned.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Returned.java
@@ -24,10 +24,11 @@ import java.util.Map;
  * file, where the body of an atom is the {@code λ} nobody types. Both are
  * answering the same question and must not answer it apart.</p>
  *
- * <p>An annotation that names no object never reaches the column, {@code
- * Provides} having passed over it: {@code [] > recovered /A} comes back with
- * whatever the caller put in, which is a variable, and nothing in these tables
- * understands one yet.</p>
+ * <p>An annotation that names a variable rather than an object reaches the
+ * column as the void that carries the same letter, {@code Provides} having put
+ * it there: {@code [] > recovered /A} comes back with whatever the caller put
+ * in, so the column holds the void it was put in, and a caller who filled it
+ * with a {@code number} is answered with a {@code number} (#8348).</p>
  *
  * @since 0.71.0
  */

--- a/eo-inference/src/test/java/org/eolang/inference/AnsweredTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnsweredTest.java
@@ -43,4 +43,58 @@ final class AnsweredTest {
             Matchers.equalTo("Φ.mug")
         );
     }
+
+    @Test
+    void answersTheBodyOfAnAtomWithTheVoidItComesBackWith(@Mktmp final Path temp)
+        throws IOException {
+        final Path world = Files.createDirectories(temp.resolve("xmirs"));
+        Files.writeString(
+            world.resolve("pick.xmir"),
+            String.join(
+                "",
+                "<object><o line='1' loc='Φ.pick' name='pick' pos='0'>",
+                "<o base='∅' line='2' loc='Φ.pick.left' name='left' pos='2' type='A?'/>",
+                "<o base='∅' line='3' loc='Φ.pick.right' name='right' pos='2' type='A'/>",
+                "<o atom='A' line='1' loc='Φ.pick.λ' name='λ' pos='0'/></o></object>"
+            )
+        );
+        final Path tables = temp.resolve("tables");
+        new Resolved(new Clues()).follow(world, tables);
+        MatcherAssert.assertThat(
+            "an atom that comes back with a variable must answer with its void, but it didnt",
+            new Answered(world, tables).all().get("Φ.pick.λ").where(),
+            Matchers.equalTo("Φ.pick.left")
+        );
+    }
+
+    @Test
+    void answersACallerOfSuchAnAtomWithWhatItPutIn(@Mktmp final Path temp)
+        throws IOException {
+        final Path world = Files.createDirectories(temp.resolve("xmirs"));
+        Files.writeString(
+            world.resolve("cup.xmir"),
+            String.join(
+                "",
+                "<object><o line='1' loc='Φ.pick' name='pick' pos='0'>",
+                "<o base='∅' line='2' loc='Φ.pick.left' name='left' pos='2' type='A?'/>",
+                "<o base='∅' line='3' loc='Φ.pick.right' name='right' pos='2' type='A'/>",
+                "<o atom='A' line='1' loc='Φ.pick.λ' name='λ' pos='0'/></o>",
+                "<o line='4' loc='Φ.mug' name='mug' pos='0'>",
+                "<o line='5' loc='Φ.mug.hot' name='hot' pos='2'/></o>",
+                "<o line='6' loc='Φ.cup' name='cup' pos='0'>",
+                "<o base='.hot' line='7' loc='Φ.cup.φ' name='φ' pos='2'>",
+                "<o base='Φ.pick' line='7' loc='Φ.cup.φ.ρ' pos='2'>",
+                "<o as='α0' base='Φ.mug' line='7' loc='Φ.cup.φ.ρ.α0' pos='2'/>",
+                "<o as='α1' base='Φ.mug' line='7' loc='Φ.cup.φ.ρ.α1' pos='2'/>",
+                "</o></o></o></object>"
+            )
+        );
+        final Path tables = temp.resolve("tables");
+        new Resolved(new Clues()).follow(world, tables);
+        MatcherAssert.assertThat(
+            "a name taken from such an atom must answer with what the caller put in, but it didnt",
+            new Answered(world, tables).all().get("Φ.cup.φ").where(),
+            Matchers.equalTo("Φ.mug.hot")
+        );
+    }
 }


### PR DESCRIPTION
Every object eo-runtime counted as nothing known — all fourteen of them — came
from one atom and from an annotation that already said enough to answer them:

```
[] > recovered /A
  ? > value /A?
  ? > alternative /A
```

`Provides` kept a `returns` cell only when the annotation was a locator, so the
letter was thrown away, `Φ.recovered` got no cell at all, and every dispatch on
a copy of `recovered` ended nowhere. It now resolves to the void carrying the
same letter:

```java
private static String locator(final String annotation, final Collection<Xnav> kids) {
    String found = "";
    if (annotation.startsWith("Φ.")) {
        found = annotation;
    } else if (!annotation.isEmpty()) {
        found = Provides.carrying(kids, annotation);
    }
    return found;
}
```

The letter stands on both voids, which is the source saying the two are one
type, and `value` is what comes back unless it terminates, so the first void
carrying the letter is what the table goes on. A termination mark is dropped
the way `Held` drops it. Nothing downstream changed: the cell still holds a
locator, so `Returned`, `Provided` and the walk read it as they always did.

The report on eo-runtime goes from `81.5% named, 18.4% rooted at a void, 14
nothing known` to `43262 named, 9794 rooted at a void, 0 nothing known`, and
`links.xml` has no `<unknown/>` row left. The fourteen come out amber rather
than green — `Φ.recovered.value.length`, `.head`, `.tail` in
`directory/deleted.eo`, `Φ.recovered.value.if` in `file.eo`,
`Φ.recovered.value.eq` in the six tests of `recovered.eo` — each carrying the
six formations the program puts into that void. They reach `value` through a
promoted void or through a delegation, where the fills of the call site are not
gathered; a caller that copies the atom with its arguments right there is
answered with what it put in, which is the second of the two new tests.

Closes #8348
