### PR TITLE
Give a void only an atom fills a band of its own

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answer.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answer.java
@@ -31,6 +31,15 @@ import java.util.Collections;
  * {@code Φ.false} have both been put there has. The rung is untouched by
  * it.</p>
  *
+ * <p>Such an object also says whether the void it is rooted at is one that
+ * only an atom fills. {@code Φ.posix.return.code} is filled in Java, by the
+ * syscall that hands the object back, and no caller of the program can be
+ * looked at to find out what goes in there — which is a different thing to
+ * say than that the callers disagree, and asks a different thing of whoever
+ * reads it (#8352). The rung is untouched by this as well: it is the same
+ * name rooted at the same void, and only the reason it stayed there
+ * differs.</p>
+ *
  * @since 0.70.0
  */
 final class Answer {
@@ -49,6 +58,11 @@ final class Answer {
      * What the program was seen putting into the void it is rooted at.
      */
     private final Collection<Type> witnesses;
+
+    /**
+     * Whether that void is one only an atom fills.
+     */
+    private final boolean hammered;
 
     /**
      * Ctor.
@@ -71,9 +85,25 @@ final class Answer {
      *  rooted at, empty when it is rooted at none or nobody fills it
      */
     Answer(final String where, final int rung, final Collection<Type> seen) {
+        this(where, rung, seen, false);
+    }
+
+    /**
+     * Ctor.
+     * @param where The object this one settled on, which is the object itself
+     *  when the walk went nowhere
+     * @param rung The rung it stands on, from nothing at all up to nothing
+     *  left to find out
+     * @param seen What the program was seen putting into the void it is
+     *  rooted at, empty when it is rooted at none or nobody fills it
+     * @param atom Whether that void is one only an atom fills
+     */
+    Answer(final String where, final int rung, final Collection<Type> seen,
+        final boolean atom) {
         this.settled = where;
         this.climbed = rung;
         this.witnesses = seen;
+        this.hammered = atom;
     }
 
     /**
@@ -98,5 +128,13 @@ final class Answer {
      */
     Collection<Type> seen() {
         return this.witnesses;
+    }
+
+    /**
+     * Whether the void it is rooted at is one only an atom fills.
+     * @return TRUE when no caller of the program can be looked at
+     */
+    boolean forged() {
+        return this.hammered;
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Answered.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answered.java
@@ -32,6 +32,12 @@ import java.util.Map;
  * The source said all along what running the body gives back, and now the body
  * answers with it.</p>
  *
+ * <p>Which voids an atom fills is stamped on afterwards, by {@link Forged},
+ * rather than worked out inside the walk. It is not something the walk found
+ * out — it is the same name rooted at the same void, and only the reason it
+ * stayed there differs — and the walk has no business carrying a fact it never
+ * uses (#8352).</p>
+ *
  * @since 0.70.0
  */
 final class Answered {
@@ -79,6 +85,6 @@ final class Answered {
                 locator, answers.of(locator, filled.getOrDefault(locator, Collections.emptyList()))
             );
         }
-        return found;
+        return new Forged(given).marked(found);
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Band.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Band.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Which band an answer belongs to.
+ *
+ * <p>A rung is a number and a band is a colour, and the two are not the same
+ * thing. The ladder has five rungs because a walk can end in five places, and
+ * a page has four colours because a reader wants four different things done
+ * about what they are looking at: a name they can go and read, a name that
+ * waits on whoever calls them, a name that waits on Java, and nothing at
+ * all.</p>
+ *
+ * <p>Two rungs share the green band, since a formation with voids still free
+ * and a formation with none are both a place a reader can go and look at, and
+ * one rung splits in two: a name rooted at a void is amber when the callers of
+ * the program fill that void and violet when only an atom does. A void an atom
+ * fills is not a gap in what we know — it is filled, in Java, where no caller
+ * of the program can be looked at to find out with what, and telling a reader
+ * to go and find the caller would send them looking for something that is not
+ * there (#8352).</p>
+ *
+ * <p>The band is worked out here and nowhere else. A page that colours a word
+ * and a tally that counts it are two readers of the same answer, and the one
+ * way to be sure they cannot disagree is for neither of them to know how a
+ * colour is arrived at.</p>
+ *
+ * @since 0.71.0
+ */
+final class Band {
+
+    /**
+     * The bands, from the least known to the most.
+     */
+    private static final List<String> NAMES = Arrays.asList(
+        "blank", "rooted", "atom", "named"
+    );
+
+    /**
+     * The answer.
+     */
+    private final Answer told;
+
+    /**
+     * Ctor.
+     * @param answer The answer, which says where a walk ended and how far up
+     */
+    Band(final Answer answer) {
+        this.told = answer;
+    }
+
+    /**
+     * The name of the band.
+     * @return The name, which a page puts on a span and a tally counts under
+     */
+    String name() {
+        return Band.NAMES.get(this.rank());
+    }
+
+    /**
+     * How much is known, on the bands rather than on the rungs.
+     * @return The rank, from nothing at all up to a formation we can name
+     */
+    int rank() {
+        final int found;
+        if (this.told.rung() == 0) {
+            found = 0;
+        } else if (this.told.rung() > 1) {
+            found = Band.NAMES.size() - 1;
+        } else if (this.told.forged()) {
+            found = 2;
+        } else {
+            found = 1;
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Forged.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Forged.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Which answers are rooted at a void only an atom fills.
+ *
+ * <p>An atom is written in Java and hands back an object the source names:
+ * {@code [] > @ /Q.posix.return} says that running it gives back a
+ * {@code Φ.posix.return}, and that formation has voids of its own. Java fills
+ * them, one {@code put} per void, as the syscall comes back with its answer.
+ * No caller of the program fills them, and there is nowhere a reader can be
+ * sent to find out what goes in there, because the thing that puts it there is
+ * not written in EO at all.</p>
+ *
+ * <p>Without this the answer for such an object reads the same as the answer
+ * for a void the callers disagree about, and the two ask opposite things of a
+ * reader. One says go and look at the call sites; the other says the call
+ * sites will never tell you, read the atom. So the answers rooted at a void of
+ * a formation some atom comes back with are stamped here, once the walk is
+ * over, and {@link Band} gives them a colour of their own (#8352).</p>
+ *
+ * <p>The receiver of such a formation is left alone: whoever writes
+ * {@code posix.return} fills the {@code ρ} themselves, in EO, and the callers
+ * are exactly who a reader should be sent to. So is the void an atom comes
+ * back with rather than fills — {@code [] > recovered /A} over {@code ? > value
+ * /A?} hands back whatever it was given, and {@code Φ.recovered.value} belongs
+ * to whoever copied the atom (#8348). Such a void is what a {@code returns}
+ * cell holds, not what the row it names declares, and falls out of the walk
+ * for nothing.</p>
+ *
+ * @since 0.71.0
+ */
+final class Forged {
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * Ctor.
+     * @param provides The provides table, which says what every atom comes
+     *  back with and which voids that formation declares
+     */
+    Forged(final XML provides) {
+        this.given = provides;
+    }
+
+    /**
+     * Stamp the answers rooted at a void only an atom fills.
+     * @param told The answers, by the locator of the object
+     * @return The same answers, with the ones an atom fills told apart
+     */
+    Map<String, Answer> marked(final Map<String, Answer> told) {
+        final Collection<String> hollows = this.hollows();
+        final Map<String, Answer> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, Answer> object : told.entrySet()) {
+            found.put(object.getKey(), Forged.stamped(object.getValue(), hollows));
+        }
+        return found;
+    }
+
+    private Collection<String> hollows() {
+        final Collection<String> backs = new HashSet<>(new Returned(this.given).all().values());
+        final Collection<String> found = new HashSet<>(0);
+        for (final Xnav type : new Rows(this.given).all()) {
+            if (backs.contains(new Noted(type).says("id"))) {
+                found.addAll(Forged.filled(type));
+            }
+        }
+        return found;
+    }
+
+    private static Collection<String> filled(final Xnav type) {
+        return type.elements(Filter.withName("attr"))
+            .filter(attr -> "true".equals(new Noted(attr).says("void")))
+            .filter(attr -> !"ρ".equals(new Noted(attr).says("name")))
+            .map(attr -> new Noted(attr).says("type"))
+            .collect(Collectors.toList());
+    }
+
+    private static Answer stamped(final Answer answer, final Collection<String> hollows) {
+        final Answer found;
+        if (answer.rung() == 1 && answer.seen().isEmpty()
+            && Forged.rooted(answer.where(), hollows)) {
+            found = new Answer(answer.where(), answer.rung(), answer.seen(), true);
+        } else {
+            found = answer;
+        }
+        return found;
+    }
+
+    private static boolean rooted(final String locator, final Collection<String> hollows) {
+        String walked = locator;
+        while (!hollows.contains(walked)) {
+            final int dot = walked.lastIndexOf('.');
+            if (dot < 0) {
+                break;
+            }
+            walked = walked.substring(0, dot);
+        }
+        return hollows.contains(walked);
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Page.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Page.java
@@ -66,13 +66,14 @@ final class Page {
     Directives directives(final String name) {
         final List<String> lines = this.lines();
         final Map<Integer, Collection<Written>> written = this.written();
-        final Map<Integer, Integer> counted = this.counted();
+        final Map<String, Integer> counted = this.counted();
         final Directives dirs = new Directives()
             .add("page")
             .attr("file", name)
-            .attr("named", Integer.toString(counted.getOrDefault(2, 0)))
-            .attr("rooted", Integer.toString(counted.getOrDefault(1, 0)))
-            .attr("blank", Integer.toString(counted.getOrDefault(0, 0)));
+            .attr("named", Integer.toString(counted.getOrDefault("named", 0)))
+            .attr("rooted", Integer.toString(counted.getOrDefault("rooted", 0)))
+            .attr("atom", Integer.toString(counted.getOrDefault("atom", 0)))
+            .attr("blank", Integer.toString(counted.getOrDefault("blank", 0)));
         for (int index = 0; index < lines.size(); index = index + 1) {
             dirs.add("line").attr("n", Integer.toString(index + 1));
             dirs.append(
@@ -119,12 +120,12 @@ final class Page {
         return found;
     }
 
-    private Map<Integer, Integer> counted() {
-        final Map<Integer, Integer> found = new HashMap<>(3);
+    private Map<String, Integer> counted() {
+        final Map<String, Integer> found = new HashMap<>(4);
         for (final String loc : this.xmir.xpath("//o[@loc]/@loc")) {
             final Answer answer = this.answers.get(loc);
             if (answer != null) {
-                found.merge(Math.min(answer.rung(), 2), 1, Integer::sum);
+                found.merge(new Band(answer).name(), 1, Integer::sum);
             }
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Pieces.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pieces.java
@@ -49,7 +49,9 @@ import org.xembly.Directives;
  * reason. The body of an atom sits under the bracket that opens it, so an
  * atom nobody can answer for used to be invisible on the page while being
  * counted at the top of it (#8318). Which object the warning is about the
- * reader finds in the popup, where all of them are listed.</p>
+ * reader finds in the popup, where all of them are listed. Which colour any of
+ * it comes out as is {@link Band}'s to say and not this one's, so that a word
+ * on the page and the tally above it cannot disagree.</p>
  *
  * @since 0.70.0
  */
@@ -184,15 +186,15 @@ final class Pieces {
     private static Directives marked(final String text, final Collection<Written> said) {
         final Directives dirs = new Directives()
             .add("bit")
-            .attr("band", Pieces.band(Pieces.worst(said)));
+            .attr("band", Pieces.worst(said));
         for (final Written object : said) {
+            final String band = new Band(object.answer()).name();
             dirs.add("told")
                 .attr("label", object.label())
-                .attr("band", Pieces.band(object.answer().rung()))
+                .attr("band", band)
                 .attr("where", object.answer().where())
                 .attr("loc", object.loc());
-            if (object.loc().equals(object.answer().where())
-                && "rooted".equals(Pieces.band(object.answer().rung()))) {
+            if (object.loc().equals(object.answer().where()) && "rooted".equals(band)) {
                 dirs.attr("void", "true");
             }
             Pieces.witnessed(dirs, object.answer().seen());
@@ -211,22 +213,15 @@ final class Pieces {
         }
     }
 
-    private static int worst(final Collection<Written> said) {
-        int found = Integer.MAX_VALUE;
+    private static String worst(final Collection<Written> said) {
+        String found = "named";
+        int rank = Integer.MAX_VALUE;
         for (final Written object : said) {
-            found = Math.min(found, object.answer().rung());
-        }
-        return found;
-    }
-
-    private static String band(final int rung) {
-        final String found;
-        if (rung == 0) {
-            found = "blank";
-        } else if (rung == 1) {
-            found = "rooted";
-        } else {
-            found = "named";
+            final Band band = new Band(object.answer());
+            if (band.rank() < rank) {
+                rank = band.rank();
+                found = band.name();
+            }
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Report.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Report.java
@@ -33,8 +33,9 @@ import org.xembly.Xembler;
  * name, says both at once, and says them to a reader rather than to a
  * machine.</p>
  *
- * <p>Green is a formation we can name, amber is a name rooted in somebody
- * else's void, red is nothing. The colours are the bands the goal prints, from
+ * <p>Green is a formation we can name, amber is a name rooted in a void the
+ * callers of the program fill, violet is a name rooted in a void only an atom
+ * fills, and red is nothing. The colours are {@link Band}'s, worked out from
  * the same {@link Answered} the goal counts, so a page and a number cannot
  * disagree.</p>
  *
@@ -182,6 +183,7 @@ public final class Report {
                 .attr("href", name.concat(".html"))
                 .attr("named", made.xpath("/page/@named").get(0))
                 .attr("rooted", made.xpath("/page/@rooted").get(0))
+                .attr("atom", made.xpath("/page/@atom").get(0))
                 .attr("blank", made.xpath("/page/@blank").get(0))
                 .up();
         }
@@ -190,14 +192,17 @@ public final class Report {
     private static void summed(final Directives dirs, final Iterable<XML> pages) {
         int named = 0;
         int rooted = 0;
+        int atom = 0;
         int blank = 0;
         for (final XML made : pages) {
             named = named + Integer.parseInt(made.xpath("/page/@named").get(0));
             rooted = rooted + Integer.parseInt(made.xpath("/page/@rooted").get(0));
+            atom = atom + Integer.parseInt(made.xpath("/page/@atom").get(0));
             blank = blank + Integer.parseInt(made.xpath("/page/@blank").get(0));
         }
         dirs.attr("named", Integer.toString(named))
             .attr("rooted", Integer.toString(rooted))
+            .attr("atom", Integer.toString(atom))
             .attr("blank", Integer.toString(blank));
     }
 }

--- a/eo-inference/src/main/resources/org/eolang/inference/report/index.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/index.xsl
@@ -23,12 +23,16 @@ SPDX-License-Identifier: MIT
             <xsl:value-of select="@rooted"/>
             <xsl:text> rooted at a void</xsl:text>
           </span>
+          <span class="atom">
+            <xsl:value-of select="@atom"/>
+            <xsl:text> filled by an atom</xsl:text>
+          </span>
           <span class="blank">
             <xsl:value-of select="@blank"/>
             <xsl:text> nothing known</xsl:text>
           </span>
         </p>
-        <p class="note">A mark is green where we can name the formation an object was copied from, amber where all we have is a name rooted in somebody else's void, and red where we have nothing. Hover a mark to see what we found.</p>
+        <p class="note">A mark is green where we can name the formation an object was copied from, amber where all we have is a name rooted in a void the callers fill, violet where the void is one only an atom fills and no caller can be looked at, and red where we have nothing. Hover a mark to see what we found.</p>
         <xsl:apply-templates select="dir|file"/>
       </body>
     </html>
@@ -53,9 +57,10 @@ SPDX-License-Identifier: MIT
     </div>
   </xsl:template>
   <xsl:template name="bar">
-    <span class="bar" title="{@named} named, {@rooted} rooted at a void, {@blank} nothing known">
+    <span class="bar" title="{@named} named, {@rooted} rooted at a void, {@atom} filled by an atom, {@blank} nothing known">
       <span class="named" style="flex: {@named}"/>
       <span class="rooted" style="flex: {@rooted}"/>
+      <span class="atom" style="flex: {@atom}"/>
       <span class="blank" style="flex: {@blank}"/>
     </span>
   </xsl:template>
@@ -69,6 +74,7 @@ SPDX-License-Identifier: MIT
       .tally span { margin-right: 1.4em; padding: .1em .4em; border-radius: 3px; }
       .tally .named { background: #d7f0d7; }
       .tally .rooted { background: #fbeecc; }
+      .tally .atom { background: #e6dcf5; }
       .tally .blank { background: #f7d4d4; }
       details { margin: 0; }
       summary { cursor: pointer; display: flex; align-items: center; gap: .8em; padding: .1em 0; font-weight: 600; }
@@ -78,6 +84,7 @@ SPDX-License-Identifier: MIT
       .bar { display: flex; flex: 1; height: 8px; min-width: 8em; border-radius: 2px; overflow: hidden; background: #eee; }
       .bar .named { background: #6bbf6b; }
       .bar .rooted { background: #e8b64c; }
+      .bar .atom { background: #9b7fd4; }
       .bar .blank { background: #d76b6b; }
     </style>
   </xsl:template>

--- a/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
@@ -29,6 +29,10 @@ SPDX-License-Identifier: MIT
             <xsl:value-of select="@rooted"/>
             <xsl:text> rooted at a void</xsl:text>
           </span>
+          <span class="atom">
+            <xsl:value-of select="@atom"/>
+            <xsl:text> filled by an atom</xsl:text>
+          </span>
           <span class="blank">
             <xsl:value-of select="@blank"/>
             <xsl:text> nothing known</xsl:text>
@@ -68,6 +72,12 @@ SPDX-License-Identifier: MIT
       </b>
       <xsl:text>: </xsl:text>
       <xsl:choose>
+        <xsl:when test="@band = 'atom'">
+          <code>
+            <xsl:value-of select="@where"/>
+          </code>
+          <xsl:text>, filled by an atom</xsl:text>
+        </xsl:when>
         <xsl:when test="@void = 'true'">
           <xsl:text>void</xsl:text>
         </xsl:when>
@@ -117,6 +127,7 @@ SPDX-License-Identifier: MIT
       .tally span { margin-right: 1.4em; padding: .1em .4em; border-radius: 3px; }
       .tally .named { background: #d7f0d7; }
       .tally .rooted { background: #fbeecc; }
+      .tally .atom { background: #e6dcf5; }
       .tally .blank { background: #f7d4d4; }
       table.src { border-collapse: collapse; }
       td.no { text-align: right; padding-right: 1em; color: #999; user-select: none; vertical-align: top; }
@@ -124,6 +135,7 @@ SPDX-License-Identifier: MIT
       .mark { position: relative; box-shadow: inset 0 -2px 0 currentColor; cursor: help; }
       .mark.named { color: #2e7d32; }
       .mark.rooted { color: #b26a00; }
+      .mark.atom { color: #6a3fb5; }
       .mark.blank { color: #c62828; }
       .pop { display: none; position: absolute; left: 0; top: 1.6em; z-index: 9; white-space: normal; width: 26em; padding: .6em .8em; background: #fffdf5; color: #1a1a1a; border: 1px solid #ccc; box-shadow: 0 2px 6px rgba(0,0,0,.15); }
       .mark:hover .pop { display: block; }

--- a/eo-inference/src/test/java/org/eolang/inference/AnsweredTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnsweredTest.java
@@ -68,6 +68,30 @@ final class AnsweredTest {
     }
 
     @Test
+    void tellsApartTheVoidsOnlyAnAtomFills(@Mktmp final Path temp)
+        throws IOException {
+        final Path world = Files.createDirectories(temp.resolve("xmirs"));
+        Files.writeString(
+            world.resolve("reply.xmir"),
+            String.join(
+                "",
+                "<object><o line='1' loc='Φ.reply' name='reply' pos='0'>",
+                "<o base='∅' line='2' loc='Φ.reply.code' name='code' pos='2'/></o>",
+                "<o line='3' loc='Φ.syscall' name='syscall' pos='0'>",
+                "<o atom='Φ.reply' line='3' loc='Φ.syscall.λ' name='λ' pos='0'/>",
+                "</o></object>"
+            )
+        );
+        final Path tables = temp.resolve("tables");
+        new Resolved(new Clues()).follow(world, tables);
+        MatcherAssert.assertThat(
+            "a void nothing but an atom fills must be told apart, but it wasnt",
+            new Answered(world, tables).all().get("Φ.reply.code").forged(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
     void answersACallerOfSuchAnAtomWithWhatItPutIn(@Mktmp final Path temp)
         throws IOException {
         final Path world = Files.createDirectories(temp.resolve("xmirs"));

--- a/eo-inference/src/test/java/org/eolang/inference/BandTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BandTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Band}.
+ * @since 0.71.0
+ */
+final class BandTest {
+
+    @Test
+    void namesTheBandOfAVoidAnAtomFills() {
+        MatcherAssert.assertThat(
+            "a void an atom fills must have a band of its own, but it took another",
+            new Band(
+                new Answer("Φ.reply.code.size", 1, Collections.emptyList(), true)
+            ).name(),
+            Matchers.equalTo("atom")
+        );
+    }
+
+    @Test
+    void ranksAVoidTheCallersFillWorseThanOneAnAtomFills() {
+        MatcherAssert.assertThat(
+            "a void whose callers disagree is less known than one an atom fills, but it ranked above",
+            new Band(new Answer("Φ.bool.if", 1)).rank(),
+            Matchers.lessThan(
+                new Band(
+                    new Answer("Φ.reply.code", 1, Collections.emptyList(), true)
+                ).rank()
+            )
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/ForgedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ForgedTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Forged}.
+ * @since 0.71.0
+ */
+final class ForgedTest {
+
+    @Test
+    void marksAnAnswerRootedAtAVoidOnlyAnAtomFills() {
+        MatcherAssert.assertThat(
+            "a name taken through a void an atom fills must be told apart, but it wasnt",
+            new Forged(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.syscall' returns='Φ.reply'/>",
+                        "<type id='Φ.reply'><attr name='code' type='Φ.reply.code'",
+                        " void='true'/></type></provides>"
+                    )
+                )
+            ).marked(
+                Collections.singletonMap("Φ.app.size", new Answer("Φ.reply.code.size", 1))
+            ).get("Φ.app.size").forged(),
+            Matchers.equalTo(true)
+        );
+    }
+
+    @Test
+    void leavesAVoidTheCallersFillAlone() {
+        MatcherAssert.assertThat(
+            "a void the program fills itself must keep the band it had, but it moved",
+            new Forged(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.syscall' returns='Φ.reply'/>",
+                        "<type id='Φ.reply'><attr name='code' type='Φ.reply.code'",
+                        " void='true'/></type></provides>"
+                    )
+                )
+            ).marked(
+                Collections.singletonMap(
+                    "Φ.app.size",
+                    new Answer(
+                        "Φ.reply.code.size", 1,
+                        Arrays.asList(new Ref("Φ.number"), new Ref("Φ.string"))
+                    )
+                )
+            ).get("Φ.app.size").forged(),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void leavesTheReceiverOfSuchAFormationAlone() {
+        MatcherAssert.assertThat(
+            "whoever dispatches fills the receiver, so it must keep its band, but it moved",
+            new Forged(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.syscall' returns='Φ.reply'/>",
+                        "<type id='Φ.reply'><attr name='ρ' type='Φ.reply.ρ'",
+                        " void='true'/></type></provides>"
+                    )
+                )
+            ).marked(
+                Collections.singletonMap("Φ.app.name", new Answer("Φ.reply.ρ.name", 1))
+            ).get("Φ.app.name").forged(),
+            Matchers.equalTo(false)
+        );
+    }
+
+    @Test
+    void leavesTheVoidAnAtomComesBackWithAlone() {
+        MatcherAssert.assertThat(
+            "an atom that hands back what it was given fills nothing, but its void was marked",
+            new Forged(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.recovered' returns='Φ.recovered.value'>",
+                        "<attr name='value' type='Φ.recovered.value' void='true'/>",
+                        "</type></provides>"
+                    )
+                )
+            ).marked(
+                Collections.singletonMap("Φ.app.eq", new Answer("Φ.recovered.value.eq", 1))
+            ).get("Φ.app.eq").forged(),
+            Matchers.equalTo(false)
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
@@ -197,6 +197,25 @@ final class PiecesTest {
         );
     }
 
+    @Test
+    void marksAVoidAnAtomFillsApartFromTheRest() {
+        MatcherAssert.assertThat(
+            "a void filled inside an atom must get a band of its own, but it took the amber one",
+            PiecesTest.drawn(
+                "  size",
+                Collections.singletonList(
+                    new Written(
+                        "Φ.info.size", 2, "size",
+                        new Answer(
+                            "Φ.posix.return.output.size", 1, Collections.emptyList(), true
+                        )
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath("/line/bit[text='size'][@band='atom']")
+        );
+    }
+
     private static String drawn(final String line, final Collection<Written> written) {
         return new Xembler(
             new Directives()

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -54,6 +54,17 @@ final class ReportTest {
     }
 
     @Test
+    void countsTheVoidsAnAtomFillsApart(@Mktmp final Path temp) throws IOException {
+        new Report(ReportTest.program(temp), ReportTest.tables(temp))
+            .written(temp.resolve("out"));
+        MatcherAssert.assertThat(
+            "the tally must count the voids an atom fills apart from the rest, but it didnt",
+            Files.readString(temp.resolve("out").resolve("cup.eo.html")),
+            Matchers.containsString("filled by an atom")
+        );
+    }
+
+    @Test
     void listsEveryPageOnTheIndex(@Mktmp final Path temp) throws IOException {
         new Report(ReportTest.program(temp), ReportTest.tables(temp))
             .written(temp.resolve("out"));


### PR DESCRIPTION
A void that only Java fills was drawn in the same amber as a void the callers
of the program disagree about, and the two ask opposite things of a reader.
`Φ.posix.return.code` is filled by the syscall that hands the object back, one
`put` per void, and amber sent a reader off to find the call site that fills
it. There is no such call site and there never will be. So it gets a colour of
its own — violet, "filled by an atom" — and amber goes back to meaning what it
says.

The fact is stamped on after the walk rather than worked out inside it. It is
not something the walk found out: it is the same name rooted at the same void,
and only the reason it stayed there differs.

```java
private static Answer stamped(final Answer answer, final Collection<String> hollows) {
    final Answer found;
    if (answer.rung() == 1 && answer.seen().isEmpty()
        && Forged.rooted(answer.where(), hollows)) {
        found = new Answer(answer.where(), answer.rung(), answer.seen(), true);
    } else {
        found = answer;
    }
    return found;
}
```

The receiver of such a formation is left alone, since whoever writes
`posix.return` fills the `^` themselves and the callers are exactly who a
reader should be sent to. So is the void an atom comes back with rather than
fills: `[] > recovered /A` over `? > value /A?` hands back what it was given,
and that void belongs to whoever copied the atom (#8348).

Naming a colour and ranking it now live in one place, `Band`, so that a word on
the page and the tally above it cannot drift apart. The rung ladder is
untouched — it counts where a walk ended, and both of these ended in the same
place, so rung 1 stays one rung and the four colours are a reading of it for a
human.

Across eo-runtime 147 objects move out of amber: 52 in `posix.eo`, 47 in
`win32.eo`, 17 in `clock.eo`, 14 in `file.eo`, 7 in `socket.eo`, and a few
elsewhere. Every one of them is a syscall reply.

Closes #8352
