### PR TITLE
Give a void nobody fills a band of its own

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answer.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answer.java
@@ -28,8 +28,9 @@ import java.util.Collections;
  * once, or a single one naming nothing a reader could go and look at. A reader
  * told that their object is whatever {@code Φ.bool.and.x} turns out to be has
  * nowhere to go next, and a reader told that {@code Φ.true} and
- * {@code Φ.false} have both been put there has. The rung is untouched by
- * it.</p>
+ * {@code Φ.false} have both been put there has. Nothing carried at all is an
+ * answer of its own rather than the want of one: nobody fills that void, so
+ * there is no caller to be sent to (#8355). The rung is untouched by it.</p>
  *
  * <p>Such an object also says whether the void it is rooted at is one that
  * only an atom fills. {@code Φ.posix.return.code} is filled in Java, by the

--- a/eo-inference/src/main/java/org/eolang/inference/Band.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Band.java
@@ -12,19 +12,22 @@ import java.util.List;
  *
  * <p>A rung is a number and a band is a colour, and the two are not the same
  * thing. The ladder has five rungs because a walk can end in five places, and
- * a page has four colours because a reader wants four different things done
+ * a page has five colours because a reader wants five different things done
  * about what they are looking at: a name they can go and read, a name that
- * waits on whoever calls them, a name that waits on Java, and nothing at
- * all.</p>
+ * waits on whoever calls them, a name that waits on Java, a name that waits on
+ * a caller who never came, and nothing at all.</p>
  *
  * <p>Two rungs share the green band, since a formation with voids still free
  * and a formation with none are both a place a reader can go and look at, and
- * one rung splits in two: a name rooted at a void is amber when the callers of
- * the program fill that void and violet when only an atom does. A void an atom
+ * one rung splits in three. A name rooted at a void is amber when the callers
+ * of the program fill that void with several different things, violet when
+ * only an atom fills it, and slate when nobody fills it at all. A void an atom
  * fills is not a gap in what we know — it is filled, in Java, where no caller
  * of the program can be looked at to find out with what, and telling a reader
  * to go and find the caller would send them looking for something that is not
- * there (#8352).</p>
+ * there (#8352). A void nobody fills sends them looking for the same missing
+ * thing, and each colour is worth having only while it asks for one thing
+ * (#8355).</p>
  *
  * <p>The band is worked out here and nowhere else. A page that colours a word
  * and a tally that counts it are two readers of the same answer, and the one
@@ -39,7 +42,7 @@ final class Band {
      * The bands, from the least known to the most.
      */
     private static final List<String> NAMES = Arrays.asList(
-        "blank", "rooted", "atom", "named"
+        "blank", "unfilled", "rooted", "atom", "named"
     );
 
     /**
@@ -71,12 +74,30 @@ final class Band {
         final int found;
         if (this.told.rung() == 0) {
             found = 0;
-        } else if (this.told.rung() > 1) {
-            found = Band.NAMES.size() - 1;
-        } else if (this.told.forged()) {
-            found = 2;
+        } else if (this.hollow()) {
+            found = this.shade();
         } else {
+            found = Band.NAMES.size() - 1;
+        }
+        return found;
+    }
+
+    /**
+     * Whether the walk ended at somebody else's void.
+     * @return TRUE when the answer is a void rather than a formation
+     */
+    boolean hollow() {
+        return this.told.rung() == 1;
+    }
+
+    private int shade() {
+        final int found;
+        if (this.told.forged()) {
+            found = 3;
+        } else if (this.told.seen().isEmpty()) {
             found = 1;
+        } else {
+            found = 2;
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Page.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Page.java
@@ -73,6 +73,7 @@ final class Page {
             .attr("named", Integer.toString(counted.getOrDefault("named", 0)))
             .attr("rooted", Integer.toString(counted.getOrDefault("rooted", 0)))
             .attr("atom", Integer.toString(counted.getOrDefault("atom", 0)))
+            .attr("unfilled", Integer.toString(counted.getOrDefault("unfilled", 0)))
             .attr("blank", Integer.toString(counted.getOrDefault("blank", 0)));
         for (int index = 0; index < lines.size(); index = index + 1) {
             dirs.add("line").attr("n", Integer.toString(index + 1));
@@ -121,7 +122,7 @@ final class Page {
     }
 
     private Map<String, Integer> counted() {
-        final Map<String, Integer> found = new HashMap<>(4);
+        final Map<String, Integer> found = new HashMap<>(5);
         for (final String loc : this.xmir.xpath("//o[@loc]/@loc")) {
             final Answer answer = this.answers.get(loc);
             if (answer != null) {

--- a/eo-inference/src/main/java/org/eolang/inference/Pieces.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Pieces.java
@@ -188,13 +188,13 @@ final class Pieces {
             .add("bit")
             .attr("band", Pieces.worst(said));
         for (final Written object : said) {
-            final String band = new Band(object.answer()).name();
+            final Band band = new Band(object.answer());
             dirs.add("told")
                 .attr("label", object.label())
-                .attr("band", band)
+                .attr("band", band.name())
                 .attr("where", object.answer().where())
                 .attr("loc", object.loc());
-            if (object.loc().equals(object.answer().where()) && "rooted".equals(band)) {
+            if (object.loc().equals(object.answer().where()) && band.hollow()) {
                 dirs.attr("void", "true");
             }
             Pieces.witnessed(dirs, object.answer().seen());

--- a/eo-inference/src/main/java/org/eolang/inference/Report.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Report.java
@@ -34,9 +34,10 @@ import org.xembly.Xembler;
  * machine.</p>
  *
  * <p>Green is a formation we can name, amber is a name rooted in a void the
- * callers of the program fill, violet is a name rooted in a void only an atom
- * fills, and red is nothing. The colours are {@link Band}'s, worked out from
- * the same {@link Answered} the goal counts, so a page and a number cannot
+ * callers of the program fill several ways, violet is a name rooted in a void
+ * only an atom fills, slate is a name rooted in a void nobody fills, and red
+ * is nothing. The colours are {@link Band}'s, worked out from the same
+ * {@link Answered} the goal counts, so a page and a number cannot
  * disagree.</p>
  *
  * @since 0.70.0
@@ -184,6 +185,7 @@ public final class Report {
                 .attr("named", made.xpath("/page/@named").get(0))
                 .attr("rooted", made.xpath("/page/@rooted").get(0))
                 .attr("atom", made.xpath("/page/@atom").get(0))
+                .attr("unfilled", made.xpath("/page/@unfilled").get(0))
                 .attr("blank", made.xpath("/page/@blank").get(0))
                 .up();
         }
@@ -193,16 +195,19 @@ public final class Report {
         int named = 0;
         int rooted = 0;
         int atom = 0;
+        int unfilled = 0;
         int blank = 0;
         for (final XML made : pages) {
             named = named + Integer.parseInt(made.xpath("/page/@named").get(0));
             rooted = rooted + Integer.parseInt(made.xpath("/page/@rooted").get(0));
             atom = atom + Integer.parseInt(made.xpath("/page/@atom").get(0));
+            unfilled = unfilled + Integer.parseInt(made.xpath("/page/@unfilled").get(0));
             blank = blank + Integer.parseInt(made.xpath("/page/@blank").get(0));
         }
         dirs.attr("named", Integer.toString(named))
             .attr("rooted", Integer.toString(rooted))
             .attr("atom", Integer.toString(atom))
+            .attr("unfilled", Integer.toString(unfilled))
             .attr("blank", Integer.toString(blank));
     }
 }

--- a/eo-inference/src/main/resources/org/eolang/inference/report/index.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/index.xsl
@@ -27,12 +27,16 @@ SPDX-License-Identifier: MIT
             <xsl:value-of select="@atom"/>
             <xsl:text> filled by an atom</xsl:text>
           </span>
+          <span class="unfilled">
+            <xsl:value-of select="@unfilled"/>
+            <xsl:text> filled by nobody</xsl:text>
+          </span>
           <span class="blank">
             <xsl:value-of select="@blank"/>
             <xsl:text> nothing known</xsl:text>
           </span>
         </p>
-        <p class="note">A mark is green where we can name the formation an object was copied from, amber where all we have is a name rooted in a void the callers fill, violet where the void is one only an atom fills and no caller can be looked at, and red where we have nothing. Hover a mark to see what we found.</p>
+        <p class="note">A mark is green where we can name the formation an object was copied from, amber where all we have is a name rooted in a void the callers fill several ways, violet where the void is one only an atom fills and no caller can be looked at, slate where nobody fills the void at all, and red where we have nothing. Hover a mark to see what we found.</p>
         <xsl:apply-templates select="dir|file"/>
       </body>
     </html>
@@ -57,10 +61,11 @@ SPDX-License-Identifier: MIT
     </div>
   </xsl:template>
   <xsl:template name="bar">
-    <span class="bar" title="{@named} named, {@rooted} rooted at a void, {@atom} filled by an atom, {@blank} nothing known">
+    <span class="bar" title="{@named} named, {@rooted} rooted at a void, {@atom} filled by an atom, {@unfilled} filled by nobody, {@blank} nothing known">
       <span class="named" style="flex: {@named}"/>
       <span class="rooted" style="flex: {@rooted}"/>
       <span class="atom" style="flex: {@atom}"/>
+      <span class="unfilled" style="flex: {@unfilled}"/>
       <span class="blank" style="flex: {@blank}"/>
     </span>
   </xsl:template>
@@ -75,6 +80,7 @@ SPDX-License-Identifier: MIT
       .tally .named { background: #d7f0d7; }
       .tally .rooted { background: #fbeecc; }
       .tally .atom { background: #e6dcf5; }
+      .tally .unfilled { background: #dfe6e9; }
       .tally .blank { background: #f7d4d4; }
       details { margin: 0; }
       summary { cursor: pointer; display: flex; align-items: center; gap: .8em; padding: .1em 0; font-weight: 600; }
@@ -85,6 +91,7 @@ SPDX-License-Identifier: MIT
       .bar .named { background: #6bbf6b; }
       .bar .rooted { background: #e8b64c; }
       .bar .atom { background: #9b7fd4; }
+      .bar .unfilled { background: #90a4ae; }
       .bar .blank { background: #d76b6b; }
     </style>
   </xsl:template>

--- a/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
+++ b/eo-inference/src/main/resources/org/eolang/inference/report/page.xsl
@@ -33,6 +33,10 @@ SPDX-License-Identifier: MIT
             <xsl:value-of select="@atom"/>
             <xsl:text> filled by an atom</xsl:text>
           </span>
+          <span class="unfilled">
+            <xsl:value-of select="@unfilled"/>
+            <xsl:text> filled by nobody</xsl:text>
+          </span>
           <span class="blank">
             <xsl:value-of select="@blank"/>
             <xsl:text> nothing known</xsl:text>
@@ -72,12 +76,6 @@ SPDX-License-Identifier: MIT
       </b>
       <xsl:text>: </xsl:text>
       <xsl:choose>
-        <xsl:when test="@band = 'atom'">
-          <code>
-            <xsl:value-of select="@where"/>
-          </code>
-          <xsl:text>, filled by an atom</xsl:text>
-        </xsl:when>
         <xsl:when test="@void = 'true'">
           <xsl:text>void</xsl:text>
         </xsl:when>
@@ -90,6 +88,12 @@ SPDX-License-Identifier: MIT
           </code>
         </xsl:otherwise>
       </xsl:choose>
+      <xsl:if test="@band = 'atom'">
+        <xsl:text>, filled by an atom</xsl:text>
+      </xsl:if>
+      <xsl:if test="@band = 'unfilled'">
+        <xsl:text>, filled by nobody</xsl:text>
+      </xsl:if>
       <xsl:apply-templates select="seen"/>
     </span>
   </xsl:template>
@@ -128,6 +132,7 @@ SPDX-License-Identifier: MIT
       .tally .named { background: #d7f0d7; }
       .tally .rooted { background: #fbeecc; }
       .tally .atom { background: #e6dcf5; }
+      .tally .unfilled { background: #dfe6e9; }
       .tally .blank { background: #f7d4d4; }
       table.src { border-collapse: collapse; }
       td.no { text-align: right; padding-right: 1em; color: #999; user-select: none; vertical-align: top; }
@@ -136,6 +141,7 @@ SPDX-License-Identifier: MIT
       .mark.named { color: #2e7d32; }
       .mark.rooted { color: #b26a00; }
       .mark.atom { color: #6a3fb5; }
+      .mark.unfilled { color: #546e7a; }
       .mark.blank { color: #c62828; }
       .pop { display: none; position: absolute; left: 0; top: 1.6em; z-index: 9; white-space: normal; width: 26em; padding: .6em .8em; background: #fffdf5; color: #1a1a1a; border: 1px solid #ccc; box-shadow: 0 2px 6px rgba(0,0,0,.15); }
       .mark:hover .pop { display: block; }

--- a/eo-inference/src/test/java/org/eolang/inference/BandTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BandTest.java
@@ -30,10 +30,34 @@ final class BandTest {
     void ranksAVoidTheCallersFillWorseThanOneAnAtomFills() {
         MatcherAssert.assertThat(
             "a void whose callers disagree is less known than one an atom fills, but it ranked above",
-            new Band(new Answer("Φ.bool.if", 1)).rank(),
+            new Band(
+                new Answer("Φ.bool.if", 1, Collections.singletonList(new Ref("Φ.true")))
+            ).rank(),
             Matchers.lessThan(
                 new Band(
                     new Answer("Φ.reply.code", 1, Collections.emptyList(), true)
+                ).rank()
+            )
+        );
+    }
+
+    @Test
+    void namesTheBandOfAVoidNobodyFills() {
+        MatcherAssert.assertThat(
+            "a void nobody fills must have a band of its own, but it took another",
+            new Band(new Answer("Φ.bytes.as-i16.cant-convert", 1)).name(),
+            Matchers.equalTo("unfilled")
+        );
+    }
+
+    @Test
+    void ranksAVoidNobodyFillsWorseThanOneTheCallersFill() {
+        MatcherAssert.assertThat(
+            "a void nobody fills is less known than one the callers fill, but it ranked above",
+            new Band(new Answer("Φ.chunk.copy.source", 1)).rank(),
+            Matchers.lessThan(
+                new Band(
+                    new Answer("Φ.bool.if", 1, Collections.singletonList(new Ref("Φ.true")))
                 ).rank()
             )
         );

--- a/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/PiecesTest.java
@@ -105,7 +105,7 @@ final class PiecesTest {
             ),
             XhtmlMatchers.hasXPaths(
                 "/line/bit[.='[']",
-                "/line/bit[text='if'][@band='rooted']",
+                "/line/bit[text='if'][@band='unfilled']",
                 "/line/bit[.='] > bool']"
             )
         );
@@ -213,6 +213,40 @@ final class PiecesTest {
                 )
             ),
             XhtmlMatchers.hasXPath("/line/bit[text='size'][@band='atom']")
+        );
+    }
+
+    @Test
+    void marksAVoidNobodyFillsApartFromTheRest() {
+        MatcherAssert.assertThat(
+            "a void nothing was ever put into must get a band of its own, but it took the amber one",
+            PiecesTest.drawn(
+                "  cant-convert",
+                Collections.singletonList(
+                    new Written(
+                        "Φ.bytes.as-i16.@.α2", 2, "",
+                        new Answer("Φ.bytes.as-i16.cant-convert", 1)
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath("/line/bit[text='cant-convert'][@band='unfilled']")
+        );
+    }
+
+    @Test
+    void saysAVoidNobodyFillsIsStillAVoid() {
+        MatcherAssert.assertThat(
+            "a void nobody fills is still a void and must be said to be one, but it wasnt",
+            PiecesTest.drawn(
+                "[cant-convert] > as-i16",
+                Collections.singletonList(
+                    new Written(
+                        "Φ.bytes.as-i16.cant-convert", 1, "cant-convert",
+                        new Answer("Φ.bytes.as-i16.cant-convert", 1)
+                    )
+                )
+            ),
+            XhtmlMatchers.hasXPath("/line/bit/told[@void='true']")
         );
     }
 

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -65,6 +65,17 @@ final class ReportTest {
     }
 
     @Test
+    void countsTheVoidsNobodyFillsApart(@Mktmp final Path temp) throws IOException {
+        new Report(ReportTest.program(temp), ReportTest.tables(temp))
+            .written(temp.resolve("out"));
+        MatcherAssert.assertThat(
+            "the tally must count the voids nobody fills apart from the rest, but it didnt",
+            Files.readString(temp.resolve("out").resolve("cup.eo.html")),
+            Matchers.containsString("filled by nobody")
+        );
+    }
+
+    @Test
     void listsEveryPageOnTheIndex(@Mktmp final Path temp) throws IOException {
         new Report(ReportTest.program(temp), ReportTest.tables(temp))
             .written(temp.resolve("out"));


### PR DESCRIPTION
Amber said two things at once. One was "the callers put several different
objects in here, go and look at them". The other was "nobody puts anything in
here at all", where there is nothing to go and look at, and a reader was sent
hunting for a call site that does not exist — the same complaint #8352 settled
one level over, for the voids only an atom fills. `bytes/as-i16.eo` declares
`cant-convert` for a caller to fill and no caller in eo-runtime ever does.

The fact was already in hand. `Seen` lists every void with an empty collection
where the tables say nothing, so the empty case picks out a band of its own and
nothing new has to be worked out:

```java
private int shade() {
    final int found;
    if (this.told.forged()) {
        found = 3;
    } else if (this.told.seen().isEmpty()) {
        found = 1;
    } else {
        found = 2;
    }
    return found;
}
```

Telling apart which of the three void colours an answer takes now lives in
`Band` beside the other two, so a word on a page and the tally above it still
cannot drift.

The mark that says a name is a void was hung on the amber band and had to come
off it, since all three void colours are voids. It hangs on the rung instead,
which is what it was always about. That also fixes the popup for a void an atom
fills, which used to read `code: Φ.posix.return.code, filled by an atom` and
now says `code: void, filled by an atom` rather than repeating the name back at
the reader. A name rooted in such a void still gets the locator it settled on.

The rungs are untouched. Every one of these walks ended at the same void, so
rung 1 stays one rung and the five colours are a reading of it for a human.

Across eo-runtime 2084 objects move out of amber, leaving 43259 named, 7563
rooted at a void, 147 filled by an atom and none unaccounted for. They come
from 62 files, most of them `socket.eo` (319), `file.eo` (197), `malloc.eo`
(135) and `path.eo` (87).

One thing worth a ticket rather than a fix here: `Report.rows` and
`Report.summed` copy the tally one named line per band, so a colour costs an
edit in four places. Children (`<band name="…" n="…"/>`) instead of attributes
would confine the next one to `Band` and the stylesheets.

Closes #8355
