### PR TITLE
Record on a void the calls made on it

### DIFF
--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -149,7 +149,7 @@ more question:
 | Pass | Answers |
 | --- | --- |
 | `Resolved` | What every dispatch turns out to be. `a.b.c` is walked one hop at a time, each hop asked of the type the last one arrived at, looking behind a delegation and into a package where it has to. |
-| `Demanded` | What a void will have to offer, gathered from everything ever asked of it. A contract: a caller that fills it owes these attributes. |
+| `Demanded` | What a void will have to offer, gathered from every name ever asked of it, and what it will have to take, gathered from every call ever made on it. A contract: a caller that fills it owes these attributes, and the voids of what it fills with have to take these arguments. |
 | `Witnessed` | What the program is actually seen to put into a void. Evidence, never a contract — the callers a program happens to have today do not oblige the one written tomorrow, and a void filled with a `Φ.number` everywhere is still a void. Nothing may work out a type from it. |
 
 `Depth` then walks the finished tables and puts every object on its rung.

--- a/eo-inference/src/main/java/org/eolang/inference/Applies.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Applies.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import org.xembly.Directives;
+
+/**
+ * What whatever fills a void will have to take.
+ *
+ * <p>{@link Demands} gathers the names a void is asked for, and a name is only
+ * half of what the program asks. A void is also applied: {@code while} writes
+ * {@code ^.body index}, {@code malloc} writes {@code ^.scope m}, and neither
+ * of those is a name taken off anything. Whatever fills such a void will have
+ * to keep a void of its own, in that place, that the argument fits (#8158).</p>
+ *
+ * <p>The two are checked in opposite directions, which is why they are written
+ * apart. A demand for a name is met when the filler offers that name, so the
+ * filler is asked what it has. A call is met when the filler's own void takes
+ * what was passed, so what is asked is the argument, of the filler — the
+ * question runs from the call site inwards rather than from the filler out.</p>
+ *
+ * <p>A call made on a name rooted at the void belongs here as much as one made
+ * on the void itself, since the object that name arrives at is handed over by
+ * whatever fills the void. {@link Rooted} is the one place that is worked
+ * out.</p>
+ *
+ * @since 0.72.0
+ */
+final class Applies {
+
+    /**
+     * Every call the program makes, from {@link Calls}.
+     */
+    private final Collection<Call> made;
+
+    /**
+     * The voids these calls are made on.
+     */
+    private final Rooted rooted;
+
+    /**
+     * Ctor.
+     * @param calls Every call the program makes, from {@link Calls}
+     * @param voids The voids these calls are made on: the void itself, and
+     *  every void it is handed into
+     */
+    Applies(final Collection<Call> calls, final Rooted voids) {
+        this.made = calls;
+        this.rooted = voids;
+    }
+
+    /**
+     * These calls, to be put inside the row of the void.
+     * @return The directives, empty when the void is never applied
+     */
+    Directives directives() {
+        final Directives dirs = new Directives();
+        for (final Call call : this.made) {
+            if (this.rooted.covers(call.of())) {
+                dirs.append(call.directives());
+            }
+        }
+        return dirs;
+    }
+
+    /**
+     * Whether the void is ever applied, or a name rooted at it is.
+     * @return True when at least one call is made on it
+     */
+    boolean any() {
+        boolean found = false;
+        for (final Call call : this.made) {
+            if (this.rooted.covers(call.of())) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Call.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Call.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import org.xembly.Directives;
+
+/**
+ * One argument of one call, against the object the call was made on.
+ *
+ * <p>A call made on a void says something no name taken off that void can
+ * say: that whatever fills it is applied at all, at which place, and with
+ * what. {@code while} writes {@code ^.body index} and {@code malloc} writes
+ * {@code ^.scope m}, and the arity of those calls and what they pass used to
+ * leave no row anywhere (#8158).</p>
+ *
+ * <p>What was passed is kept as a type rather than as a locator, because a
+ * locator is a place in one program and a type is something a reader can go
+ * and look at. An argument is written afresh at every call site, so the same
+ * object passed at eleven of them is eleven locators and one type, and
+ * counting the locators apart would make one call made eleven times look like
+ * eleven calls.</p>
+ *
+ * @since 0.72.0
+ */
+final class Call {
+
+    /**
+     * The object the call was made on.
+     */
+    private final String applied;
+
+    /**
+     * The place the argument fills.
+     */
+    private final int slot;
+
+    /**
+     * What was passed there.
+     */
+    private final Type carried;
+
+    /**
+     * Ctor.
+     * @param object The locator of the object the call was made on
+     * @param place The place the argument fills, counted from zero
+     * @param passed What was passed there
+     */
+    Call(final String object, final int place, final Type passed) {
+        this.applied = object;
+        this.slot = place;
+        this.carried = passed;
+    }
+
+    /**
+     * The object the call was made on.
+     * @return The locator
+     */
+    String of() {
+        return this.applied;
+    }
+
+    /**
+     * This call, to be put inside the row of a void.
+     * @return The directives
+     */
+    Directives directives() {
+        return new Directives()
+            .add("apply")
+            .attr("of", this.applied)
+            .attr("place", this.slot)
+            .append(this.carried.directives())
+            .up();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Calls.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Calls.java
@@ -1,0 +1,87 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Every call the program makes, against the object it was made on.
+ *
+ * <p>An application names no receiver of its own — it copies whatever its base
+ * settled on — so the links are what say who was called. A call written as
+ * {@code ^.body index} arrives at the {@code body} of a {@code while}, and it
+ * is only after the walk that the object called turns out to be a void.</p>
+ *
+ * <p>What was passed is settled the same way {@link Fillings} settles a
+ * filling, and for the same reason: an argument written at one call site is a
+ * locator nothing joins to the argument written at the next, and the two are
+ * one type. A walk that runs into a void has no type to give, so what is kept
+ * is the void it stopped at, which is a fact about another caller and still a
+ * fact.</p>
+ *
+ * @since 0.72.0
+ */
+final class Calls {
+
+    /**
+     * Every application of the program.
+     */
+    private final Collection<XML> sites;
+
+    /**
+     * What the links table says.
+     */
+    private final Pairs links;
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * Ctor.
+     * @param applications Every application of the program
+     * @param table What the links table says, as {@link Resolved} left it
+     * @param provides The provides table, which says where an argument can
+     *  land
+     */
+    Calls(final Collection<XML> applications, final Pairs table, final XML provides) {
+        this.sites = applications;
+        this.links = table;
+        this.given = provides;
+    }
+
+    /**
+     * Every call, one per argument.
+     * @return The calls, without the ones that pass the same type at the same
+     *  place of the same object twice
+     */
+    Collection<Call> all() {
+        final Map<String, String> names = new Ends(this.links.all()).names();
+        final Map<String, String> landings = new Landed(this.links, this.given).all();
+        final Forms forms = new Forms(this.links.forms());
+        final Map<String, Call> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, List<String>> made
+            : new Given(this.sites).arguments().entrySet()) {
+            final String applied = names.getOrDefault(made.getKey(), made.getKey());
+            final List<String> args = made.getValue();
+            for (int place = 0; place < args.size(); place += 1) {
+                final String arg = args.get(place);
+                if (!arg.isEmpty()) {
+                    final String end = landings.getOrDefault(arg, names.getOrDefault(arg, arg));
+                    found.putIfAbsent(
+                        String.join(" ", applied, String.valueOf(place), forms.name(end)),
+                        new Call(applied, place, forms.type(end))
+                    );
+                }
+            }
+        }
+        return found.values();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -36,6 +36,12 @@ import org.xembly.Xembler;
  * already in, because a demand is a fact about a void, and a second table
  * saying things about voids would only invite the two to disagree.</p>
  *
+ * <p>A name is one of two things the program asks of a void, and the other is
+ * a call: {@code ^.body index} applies whatever fills {@code body} rather than
+ * asking it for a name. {@link Needs} keeps no row for that, since it gathers
+ * dispatches, so the calls are read off the applications of the program here
+ * and written on the same rows by {@link Applies} (#8158).</p>
+ *
  * @since 0.69.0
  */
 public final class Demanded implements Clue {
@@ -67,13 +73,20 @@ public final class Demanded implements Clue {
             names,
             new Provided(given, names, voids)
         ).all();
+        final Collection<Call> calls = new Calls(
+            new Xmirs(xmirs).applications(), links, given
+        ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
-            final Demands demands = new Demands(
-                asked,
+            final Rooted rooted = new Rooted(
                 Demanded.roots(new Noted(hollow).says("type"), into)
             );
+            final Demands demands = new Demands(asked, rooted);
             if (demands.any()) {
                 new Xembler(demands.directives()).applyQuietly(hollow.inner());
+            }
+            final Applies applies = new Applies(calls, rooted);
+            if (applies.any()) {
+                new Xembler(applies.directives()).applyQuietly(hollow.inner());
             }
         }
         Files.write(table, given.toString().getBytes(StandardCharsets.UTF_8));

--- a/eo-inference/src/main/java/org/eolang/inference/Demands.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demands.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.inference;
 
-import java.util.Collection;
 import java.util.Map;
 import org.xembly.Directives;
 
@@ -34,6 +33,10 @@ import org.xembly.Directives;
  * asked for, 77 of the 2,303 in eo-runtime, and a fact that cannot be written
  * where it belongs is still a fact.</p>
  *
+ * <p>A name is not the only thing the program asks of a void. It also applies
+ * one, and that demand is {@link Applies}, written beside these on the same
+ * row and checked the other way round.</p>
+ *
  * @since 0.69.0
  */
 final class Demands {
@@ -44,10 +47,9 @@ final class Demands {
     private final Map<String, Map<String, String>> asked;
 
     /**
-     * The voids these demands are made of: this one, and every void it is
-     * handed into.
+     * The voids these demands are made of.
      */
-    private final Collection<String> roots;
+    private final Rooted rooted;
 
     /**
      * Ctor.
@@ -55,9 +57,9 @@ final class Demands {
      * @param objects The voids these demands are made of: the void itself,
      *  and every void it is handed into
      */
-    Demands(final Map<String, Map<String, String>> all, final Collection<String> objects) {
+    Demands(final Map<String, Map<String, String>> all, final Rooted objects) {
         this.asked = all;
-        this.roots = objects;
+        this.rooted = objects;
     }
 
     /**
@@ -67,7 +69,7 @@ final class Demands {
     Directives directives() {
         final Directives dirs = new Directives();
         for (final Map.Entry<String, Map<String, String>> bearer : this.asked.entrySet()) {
-            if (this.below(bearer.getKey())) {
+            if (this.rooted.covers(bearer.getKey())) {
                 for (final Map.Entry<String, String> demand : bearer.getValue().entrySet()) {
                     dirs.add("demand")
                         .attr("of", bearer.getKey())
@@ -87,18 +89,7 @@ final class Demands {
     boolean any() {
         boolean found = false;
         for (final String bearer : this.asked.keySet()) {
-            if (this.below(bearer)) {
-                found = true;
-                break;
-            }
-        }
-        return found;
-    }
-
-    private boolean below(final String object) {
-        boolean found = false;
-        for (final String root : this.roots) {
-            if (object.equals(root) || object.startsWith(root.concat("."))) {
+            if (this.rooted.covers(bearer)) {
                 found = true;
                 break;
             }

--- a/eo-inference/src/main/java/org/eolang/inference/Rooted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Rooted.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+
+/**
+ * The voids a fact may be about.
+ *
+ * <p>A void is not the only object that facts about it are written against.
+ * The program asks {@code x.next} for a {@code foo}, and that is a fact about
+ * the same void one step further out: whatever fills {@code x} will have to
+ * hand over a {@code next} that has a {@code foo}. So is anything said about a
+ * void this one is handed into, since what fills this one arrives there
+ * too.</p>
+ *
+ * <p>Which facts belong to a void is therefore a question about locators and
+ * not about the facts, and every kind of fact asks it the same way:
+ * {@link Demands} for a name taken off a void, {@link Applies} for a call made
+ * on one.</p>
+ *
+ * @since 0.72.0
+ */
+final class Rooted {
+
+    /**
+     * The voids: one of them, and every void it is handed into.
+     */
+    private final Collection<String> voids;
+
+    /**
+     * Ctor.
+     * @param objects The voids a fact may be about: the void itself, and every
+     *  void it is handed into
+     */
+    Rooted(final Collection<String> objects) {
+        this.voids = objects;
+    }
+
+    /**
+     * Whether a fact about this object is a fact about one of these voids.
+     * @param object The locator of the object the fact is written against
+     * @return True when it is one of the voids, or a name rooted at one
+     */
+    boolean covers(final String object) {
+        boolean found = false;
+        for (final String root : this.voids) {
+            if (object.equals(root) || object.startsWith(root.concat("."))) {
+                found = true;
+                break;
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/AppliesTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AppliesTest.java
@@ -1,0 +1,52 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link Applies}.
+ * @since 0.72.0
+ */
+final class AppliesTest {
+
+    @Test
+    void gathersACallMadeOnANameRootedAtTheVoid() {
+        MatcherAssert.assertThat(
+            "the call made a step out of the void must stand on its row, but it didnt",
+            new XMLDocument(
+                new Xembler(
+                    new Directives().add("attr").append(
+                        new Applies(
+                            Collections.singletonList(
+                                new Call("Φ.inc.x.plus", 0, new Ref("Φ.number"))
+                            ),
+                            new Rooted(Collections.singletonList("Φ.inc.x"))
+                        ).directives()
+                    )
+                ).xmlQuietly()
+            ).nodes("/attr/apply[@of='Φ.inc.x.plus' and @place='0']/ref[@loc='Φ.number']"),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void leavesAloneACallMadeOnAnotherVoid() {
+        MatcherAssert.assertThat(
+            "a call made on another void must stay there, but it came here",
+            new Applies(
+                Collections.singletonList(new Call("Φ.dec.y", 0, new Ref("Φ.number"))),
+                new Rooted(Collections.singletonList("Φ.inc.x"))
+            ).any(),
+            Matchers.is(false)
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/DemandedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandedTest.java
@@ -47,6 +47,55 @@ final class DemandedTest {
     }
 
     @Test
+    void putsACallMadeOnAVoidOnTheVoid(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("apply.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.apply' name='apply'>",
+                "<o base='∅' loc='Φ.apply.x' name='x'/>",
+                "<o base='ξ.x' loc='Φ.apply.φ' name='φ'>",
+                "<o as='α0' base='Φ.apply' loc='Φ.apply.φ.α0'/></o></o></object>"
+            )
+        );
+        new Demanded(new Resolved(new Clues())).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "the void must remember that it was applied, but it didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
+                "//attr[@name='x']/apply[@of='Φ.apply.x' and @place='0']/ref[@loc='Φ.apply']"
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void putsACallMadeOnANameRootedAtAVoidOnTheVoid(@Mktmp final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("inc.xmir"),
+            String.join(
+                "",
+                "<object><o loc='Φ.inc' name='inc'>",
+                "<o base='∅' loc='Φ.inc.x' name='x'/>",
+                "<o base='.plus' loc='Φ.inc.φ' name='φ'>",
+                "<o base='ξ.x' loc='Φ.inc.φ.ρ'/>",
+                "<o as='α0' base='Φ.inc' loc='Φ.inc.φ.α0'/></o></o></object>"
+            )
+        );
+        new Demanded(new Resolved(new Clues())).follow(
+            temp.resolve("xmirs"), temp.resolve("tables")
+        );
+        MatcherAssert.assertThat(
+            "the void must remember the call made a step out of it, but it didnt",
+            new XMLDocument(temp.resolve("tables").resolve("provides.xml")).nodes(
+                "//attr[@name='x']/apply[@of='Φ.inc.x.plus' and @place='0']"
+            ),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
     void leavesAVoidNobodyAsksOfAlone(@Mktmp final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("pipe.xmir"),

--- a/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/DemandsTest.java
@@ -30,7 +30,9 @@ final class DemandsTest {
             new XMLDocument(
                 new Xembler(
                     new Directives().add("attr").append(
-                        new Demands(asked, Collections.singletonList("Φ.inc.x")).directives()
+                        new Demands(
+                            asked, new Rooted(Collections.singletonList("Φ.inc.x"))
+                        ).directives()
                     )
                 ).xmlQuietly()
             ).nodes("/attr/demand[@of='Φ.inc.x.next' and @name='foo']"),
@@ -46,7 +48,7 @@ final class DemandsTest {
                 Collections.singletonMap(
                     "Φ.dec.y", Collections.singletonMap("prev", "Φ.dec.y.prev")
                 ),
-                Collections.singletonList("Φ.inc.x")
+                new Rooted(Collections.singletonList("Φ.inc.x"))
             ).any(),
             Matchers.is(false)
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-is-applied-remembers-the-call.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-is-applied-remembers-the-call.yaml
@@ -12,4 +12,4 @@ eo:
   oak.eo: |
     [] > oak
 provides:
-  - "//attr[@name='cant-read']/apply[@of='Φ.as-ascii.cant-read' and @place='0']/ref[@loc='Φ.oak']"
+  - "//attr[@name='cant-read']/apply[@of='Φ.as-ascii.cant-read'][@place='0']/ref[@loc='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-is-applied-remembers-the-call.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/void-that-is-applied-remembers-the-call.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Applying a void asks something of it that no name taken off it can say: that
+# whatever fills it takes an argument at all, and that an `oak` is what turns
+# up in the first place of it. The call goes on the void's own row, beside the
+# names the program asks of it, since both are demands upon the same void.
+eo:
+  as-ascii.eo: |
+    [^ cant-read] > as-ascii
+      cant-read oak > @
+  oak.eo: |
+    [] > oak
+provides:
+  - "//attr[@name='cant-read']/apply[@of='Φ.as-ascii.cant-read' and @place='0']/ref[@loc='Φ.oak']"


### PR DESCRIPTION
`Needs` walks the dispatches of a program and nothing else, so a name taken
off a void was written down and a call made on one was not. `^.body index`
in `while.eo` and `^.scope m` in `malloc.eo` left no row anywhere: not the
call, not its arity, not what was passed.

`Calls` reads those calls off the applications the program already has,
walking each argument to what it lands on the way `Relayed` does, and
`Applies` puts the ones rooted at a void onto that void's row, beside the
names the program asks of it. Both share the prefix rule with `Demands`,
which is now `Rooted`:

```xml
<attr name="cant-read" type="Φ.as-ascii.cant-read" void="true">
   <apply of="Φ.as-ascii.cant-read" place="0">
      <ref loc="Φ.oak"/>
   </apply>
</attr>
```

An `<apply>` records a type, not a locator, because the site is a fact
about the void and not about the caller that happened to make it. The two
kinds of demand are checked in opposite directions, and the docblock of
`Applies` says so: a demand for a name is met when the filler offers that
name, a call is met when the filler's own void takes what was passed.

Nothing checks either yet, so this moves no band on the report pages. It
closes a hole in the coverage of the tables instead: 29984 calls on 648 of
the 1588 voids of eo-runtime, which had no row at all before.

Closes #8158
