### PR TITLE
Read every step of a chain back off the source

### DIFF
--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/inference/unroll-bases.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/inference/unroll-bases.xsl
@@ -3,7 +3,7 @@
 * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 * SPDX-License-Identifier: MIT
 -->
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" id="unroll-bases" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:eo="https://www.eolang.org" exclude-result-prefixes="eo xs" id="unroll-bases" version="2.0">
   <!--
   Here we split every composite @base into one object per dispatch step,
   which is exactly what "roll-bases.xsl" of the parser glued together:
@@ -24,13 +24,84 @@
   5 to "foo", not to "x"), so they stay where they were. The receiver of
   a base that already starts with a dot is its first child, so that child
   moves down into the shorter base together with it.
+  A rolled base carries one line and one column, the ones of the name the
+  chain ends with, and the others were dropped when it was glued. Here
+  they are read back off the source, which the <listing> of the same
+  document holds in full, so that every step comes out where its own name
+  is written: a dot at the column means the step before it ends on the
+  same line just to the left of that dot, and a name standing alone on
+  its line with a dot after it means the receiver is the block below, at
+  its indent. A step whose receiver the source never wrote, such as the
+  package an aliased object is taken from, keeps what it was given and
+  shares the word before it, since a reader has nothing else to hang it
+  on.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
+  <xsl:variable name="eo:lines" as="xs:string*" select="tokenize(string(/object/listing), '\r?\n')"/>
+  <!--
+  How far the leading spaces of a line reach.
+  -->
+  <xsl:function name="eo:indent" as="xs:integer">
+    <xsl:param name="text" as="xs:string"/>
+    <xsl:sequence select="string-length($text) - string-length(replace($text, '^ +', ''))"/>
+  </xsl:function>
+  <!--
+  The names and dots a line begins with, once its indent is passed.
+  -->
+  <xsl:function name="eo:run" as="xs:string">
+    <xsl:param name="text" as="xs:string"/>
+    <xsl:sequence select="replace(substring($text, eo:indent($text) + 1), '[^A-Za-z0-9_.^-].*$', '')"/>
+  </xsl:function>
+  <!--
+  The column just past the last name of what a line begins with.
+  -->
+  <xsl:function name="eo:edge" as="xs:integer">
+    <xsl:param name="text" as="xs:string"/>
+    <xsl:sequence select="eo:indent($text) + string-length(replace(eo:run($text), '\.+$', ''))"/>
+  </xsl:function>
+  <!--
+  The column the thing ending just before this one starts at, or -1
+  when there is nothing readable to the left.
+  -->
+  <xsl:function name="eo:spot" as="xs:integer">
+    <xsl:param name="text" as="xs:string"/>
+    <xsl:param name="edge" as="xs:integer"/>
+    <xsl:variable name="head" as="xs:string" select="substring($text, 1, $edge)"/>
+    <xsl:variable name="word" as="xs:string" select="replace($head, '.*[^A-Za-z0-9_-]', '')"/>
+    <xsl:variable name="start" as="xs:integer" select="if ($edge &lt;= 0 or $edge &gt; string-length($text)) then -1 else if ($word != '') then $edge - string-length($word) else if (substring($head, $edge, 1) = '^') then $edge - 1 else -1"/>
+    <xsl:sequence select="if ($start &gt; 0 and substring($text, $start, 1) = '.') then $start - 1 else $start"/>
+  </xsl:function>
+  <!--
+  The line and the column of the receiver of this dispatch, or nothing
+  when the source never wrote it.
+  -->
+  <xsl:function name="eo:place" as="xs:integer*">
+    <xsl:param name="o" as="element(o)"/>
+    <xsl:variable name="line" as="xs:integer" select="xs:integer(($o/@line, 0)[1])"/>
+    <xsl:variable name="pos" as="xs:integer" select="xs:integer(($o/@pos, -1)[1])"/>
+    <xsl:variable name="text" as="xs:string" select="($eo:lines[$line], '')[1]"/>
+    <xsl:variable name="below" as="xs:string" select="($eo:lines[$line + 1], '')[1]"/>
+    <xsl:variable name="tail" as="xs:string" select="tokenize($o/@base, '\.')[last()]"/>
+    <xsl:variable name="along" as="xs:boolean" select="$pos &gt;= 0 and $pos &lt; string-length($text) and substring($text, $pos + 1, 1) = '.'"/>
+    <xsl:variable name="down" as="xs:boolean" select="$pos = eo:indent($text) and eo:run($text) = concat(if ($tail = 'ρ') then '^' else $tail, '.') and eo:indent($below) &gt; eo:indent($text)"/>
+    <xsl:variable name="found" as="xs:integer" select="if ($along) then $line else if ($down) then $line + 1 else -1"/>
+    <xsl:variable name="spot" as="xs:integer" select="eo:spot(($eo:lines[$found], '')[1], if ($along) then $pos else eo:edge($below))"/>
+    <xsl:sequence select="if ($spot &lt; 0) then () else ($found, $spot)"/>
+  </xsl:function>
   <xsl:template match="o[contains(replace(@base, '\.[^.]*$', ''), '.')]">
     <xsl:variable name="dotted" select="starts-with(@base, '.')"/>
+    <xsl:variable name="place" as="xs:integer*" select="eo:place(.)"/>
     <xsl:variable name="receiver" as="element()">
       <o base="{replace(@base, '\.[^.]*$', '')}">
-        <xsl:copy-of select="@line|@pos"/>
+        <xsl:choose>
+          <xsl:when test="count($place) = 2">
+            <xsl:attribute name="line" select="$place[1]"/>
+            <xsl:attribute name="pos" select="$place[2]"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="@line|@pos"/>
+          </xsl:otherwise>
+        </xsl:choose>
         <xsl:if test="$dotted">
           <xsl:copy-of select="o[1]"/>
         </xsl:if>

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-chain-is-followed-through-a-turn.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-chain-is-followed-through-a-turn.yaml
@@ -11,4 +11,4 @@ eo:
         ^.seconds
 xmir:
   gauge.eo:
-    - "//o[@base='.times' and @line=2 and @pos=2]/o[@base='.seconds' and @line=3 and @pos=5]/o[@base='ξ.ρ' and @line=3 and @pos=4]"
+    - "//o[@base='.times'][@line=2][@pos=2]/o[@base='.seconds'][@line=3][@pos=5]/o[@base='ξ.ρ'][@line=3][@pos=4]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-chain-is-followed-through-a-turn.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-chain-is-followed-through-a-turn.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A chain can turn from down the page to along a line in the middle of itself,
+# and the caret it stands on is a word like any other, so the block below a
+# reversed dispatch is read from its right end leftwards.
+eo:
+  gauge.eo: |
+    [] > gauge
+      times. > @
+        ^.seconds
+xmir:
+  gauge.eo:
+    - "//o[@base='.times' and @line=2 and @pos=2]/o[@base='.seconds' and @line=3 and @pos=5]/o[@base='ξ.ρ' and @line=3 and @pos=4]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-step-nobody-wrote-shares-the-word-before-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-step-nobody-wrote-shares-the-word-before-it.yaml
@@ -13,4 +13,4 @@ eo:
         "hello"
 xmir:
   app.eo:
-    - "//o[@base='.stdout' and @line=4 and @pos=2]/o[@base='.io' and @line=4 and @pos=2]"
+    - "//o[@base='.stdout'][@line=4][@pos=2]/o[@base='.io'][@line=4][@pos=2]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-step-nobody-wrote-shares-the-word-before-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-step-nobody-wrote-shares-the-word-before-it.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The package an aliased object is taken from is a step of the chain that the
+# source never wrote, so it keeps the place it was given and stands under the
+# same word, there being nothing else to hang it on.
+eo:
+  app.eo: |
+    +alias org.eolang.io.stdout
+
+    [] > app
+      stdout.write > @
+        "hello"
+xmir:
+  app.eo:
+    - "//o[@base='.stdout' and @line=4 and @pos=2]/o[@base='.io' and @line=4 and @pos=2]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-along-a-line-takes-its-dot.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-along-a-line-takes-its-dot.yaml
@@ -9,4 +9,4 @@ eo:
       x.seconds.times > @
 xmir:
   clock.eo:
-    - "//o[@base='.times' and @line=2 and @pos=11]/o[@base='.seconds' and @line=2 and @pos=3]/o[@base='ξ.x' and @line=2 and @pos=2]"
+    - "//o[@base='.times'][@line=2][@pos=11]/o[@base='.seconds'][@line=2][@pos=3]/o[@base='ξ.x'][@line=2][@pos=2]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-along-a-line-takes-its-dot.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-along-a-line-takes-its-dot.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A dispatch begins at its dot, so a chain written along one line is read back
+# dot by dot, and the name the chain stands on keeps the column it starts at.
+eo:
+  clock.eo: |
+    [x] > clock
+      x.seconds.times > @
+xmir:
+  clock.eo:
+    - "//o[@base='.times' and @line=2 and @pos=11]/o[@base='.seconds' and @line=2 and @pos=3]/o[@base='ξ.x' and @line=2 and @pos=2]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-down-the-page-keeps-its-line.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-down-the-page-keeps-its-line.yaml
@@ -12,4 +12,4 @@ eo:
           x
 xmir:
   clock.eo:
-    - "//o[@base='.times' and @line=2 and @pos=2]/o[@base='.seconds' and @line=3 and @pos=4]/o[@base='ξ.x' and @line=4 and @pos=6]"
+    - "//o[@base='.times'][@line=2][@pos=2]/o[@base='.seconds'][@line=3][@pos=4]/o[@base='ξ.x'][@line=4][@pos=6]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-down-the-page-keeps-its-line.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/every-step-of-a-chain-down-the-page-keeps-its-line.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A rolled base carries one line and one column, the ones of the name the
+# chain ends with, so the steps of a chain written down the page all came out
+# on the top line of it and the lines below were left with nothing on them.
+eo:
+  clock.eo: |
+    [x] > clock
+      times. > @
+        seconds.
+          x
+xmir:
+  clock.eo:
+    - "//o[@base='.times' and @line=2 and @pos=2]/o[@base='.seconds' and @line=3 and @pos=4]/o[@base='ξ.x' and @line=4 and @pos=6]"


### PR DESCRIPTION
`roll-bases.xsl` glues a dotted chain into one `<o>` and keeps the place of
the last name only. That is fine for the parser, but `unroll-bases.xsl` then
handed that one line and column to every step it split out, so a chain
written down the page put all of its marks on its top line. On the inference
report `clock.eo:23` and `i64.eo:121` were left with nothing on them at all.

Nothing is really lost, though: the whole source sits in the `<listing>` of
the same document, so each step can be read back off it.

```xml
<xsl:variable name="along" as="xs:boolean" select="$pos &gt;= 0 and $pos &lt; string-length($text) and substring($text, $pos + 1, 1) = '.'"/>
<xsl:variable name="down" as="xs:boolean" select="$pos = eo:indent($text) and eo:run($text) = concat(if ($tail = 'ρ') then '^' else $tail, '.') and eo:indent($below) &gt; eo:indent($text)"/>
```

A dot at the column means the step before it ends on the same line just to
the left of that dot; a name standing alone with a dot after it means the
receiver is the block below, at its indent. A step the source never wrote,
such as the package an aliased object is taken from, keeps what it was given
and shares the word before it, since a reader has nothing else to hang it on.

Four packs cover it: a chain down the page, a chain along a line, a chain
that turns from one into the other, and a package step nobody wrote. All 172
XMIRs of `eo-runtime` were run through the new stylesheet as a check: 5594
nodes move, none of them onto a space and none of them off its own line.

One case stays as it is, no worse than before: in `nan.@.as-bytes` the `@`
is not read as a word, so the step before it keeps the outer place.

Closes #8363
