### PR TITLE
feat(lowering): #8365 let a protocol fork, so `.if` lowers to `if/else`

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Application.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Application.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * One atom applied to values, as a step of a protocol.
+ *
+ * <p>It is what a parked record turns into: the λ name of the atom, and
+ * the keys of its operands — the receiver first, then the arguments in
+ * their positional order. The forma of its value is the one the
+ * {@link Op} table binds to the atom, and it nests nothing.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Application implements Step {
+
+    /**
+     * The name of the step, such as {@code s1}.
+     */
+    private final String name;
+
+    /**
+     * The λ name of the atom, such as {@code L_number_plus}.
+     */
+    private final String lambda;
+
+    /**
+     * The keys of the operands: the receiver first, then the arguments.
+     */
+    private final List<String> operands;
+
+    /**
+     * Ctor.
+     * @param label The name of the step, such as {@code s1}
+     * @param atom The λ name of the atom, such as {@code L_number_plus}
+     * @param keys The keys of the operands, the receiver first
+     */
+    public Application(final String label, final String atom, final List<String> keys) {
+        this.name = label;
+        this.lambda = atom;
+        this.operands = keys;
+    }
+
+    @Override
+    public String label() {
+        return this.name;
+    }
+
+    @Override
+    public String atom() {
+        return this.lambda;
+    }
+
+    @Override
+    public String forma() {
+        return new Op(this.lambda).forma();
+    }
+
+    @Override
+    public List<String> keys() {
+        return Collections.unmodifiableList(this.operands);
+    }
+
+    @Override
+    public List<Protocol> branches() {
+        return Collections.emptyList();
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A choice between two nested protocols, as a step of a protocol.
+ *
+ * <p>It is what an {@code if} parked on a symbolic bool turns into: the
+ * key of that bool, and one protocol per arm, each reduced on its own
+ * from the argument the site held. The steps of an arm are computed only
+ * when the arm is taken, which is what keeps a guard guarding: an
+ * operation that is partial stays behind the bool that protects it. The
+ * value of the fork is whatever the taken arm answers, so the two arms
+ * must answer the same forma, and a fork whose arms disagree refuses to
+ * name one.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Fork implements Step {
+
+    /**
+     * The name of the step, such as {@code s2}.
+     */
+    private final String name;
+
+    /**
+     * The λ name of the atom that parked, such as {@code L_bool_if}.
+     */
+    private final String lambda;
+
+    /**
+     * The key of the bool that decides.
+     */
+    private final String condition;
+
+    /**
+     * The arm taken when the bool holds.
+     */
+    private final Protocol taken;
+
+    /**
+     * The arm taken otherwise.
+     */
+    private final Protocol other;
+
+    /**
+     * Ctor.
+     * @param label The name of the step, such as {@code s2}
+     * @param atom The λ name of the atom that parked
+     * @param test The key of the bool that decides
+     * @param yes The arm taken when the bool holds
+     * @param not The arm taken otherwise
+     */
+    public Fork(final String label, final String atom, final String test,
+        final Protocol yes, final Protocol not) {
+        this.name = label;
+        this.lambda = atom;
+        this.condition = test;
+        this.taken = yes;
+        this.other = not;
+    }
+
+    @Override
+    public String label() {
+        return this.name;
+    }
+
+    @Override
+    public String atom() {
+        return this.lambda;
+    }
+
+    @Override
+    public String forma() {
+        final String out = this.taken.carrier();
+        if (!out.equals(this.other.carrier())) {
+            throw new IllegalStateException(
+                String.format(
+                    "The fork '%s' answers a %s in one arm and a %s in the other",
+                    this.name, out, this.other.carrier()
+                )
+            );
+        }
+        return out;
+    }
+
+    @Override
+    public List<String> keys() {
+        return Collections.singletonList(this.condition);
+    }
+
+    @Override
+    public List<Protocol> branches() {
+        return Arrays.asList(this.taken, this.other);
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Formas.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Formas.java
@@ -34,6 +34,16 @@ import org.w3c.dom.Node;
  * literal — answers with the empty string, and the caller refuses.</p>
  *
  * @since 0.76.0
+ * @todo #8365:30min Witness a bool void filled with {@code true} or
+ *  {@code false}. The provides table records such an argument by the
+ *  locator of the argument itself, {@code Φ.foo.φ.α0} say, with no
+ *  links row behind it, where a number literal is recorded as
+ *  {@code Φ.number} outright. So {@code admitted} finds no carrier, and
+ *  the {@code pick} formation of the {@code fork-on-flag} pack stays as
+ *  written, though its reduction forks on the void fine. Find out how
+ *  {@code eo:inference} names the fillings of a void, teach it to name
+ *  {@code Φ.true} and {@code Φ.false} the way it names {@code Φ.number},
+ *  and let that pack lower into Java.
  */
 public final class Formas {
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -7,17 +7,22 @@ package org.eolang.lowering;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * The Java body of one lowered fragment.
  *
- * <p>A protocol is a straight-line program, so its Java is a straight
- * line too: one local per void a step reads, dataized through the public
- * runtime API, one local per step, rendered by the format the {@link Op}
- * table holds for its atom, and one return handing the answer to
+ * <p>A protocol is a program of steps, so its Java is one statement per
+ * step: one local per void any step reads, dataized through the public
+ * runtime API and hoisted to the top of the body, one local per
+ * application, rendered by the format the {@link Op} table holds for its
+ * atom, one blank final per fork, assigned at the end of each of its two
+ * arms, whose own steps sit inside the arm's block and so compute only
+ * when the arm is taken, and one return handing the answer to
  * {@code Data.ToPhi}. A string is bytes here: its Δ is the very UTF-8
  * sequence the byte atoms it reaches through {@code φ} operate on, so a
  * string void is read as a {@code byte[]} and meets a bytes carrier as
@@ -74,9 +79,7 @@ public final class JavaAtom {
             final String name = names.get(index);
             lines.add(JavaAtom.reading(index, name, this.voids.get(name)));
         }
-        for (final Step step : this.protocol.moves()) {
-            lines.add(this.computed(step));
-        }
+        lines.addAll(this.computed(this.protocol, ""));
         lines.add(
             String.format(
                 "return new Data.ToPhi(%s);",
@@ -89,18 +92,25 @@ public final class JavaAtom {
     }
 
     private SortedSet<Integer> used() {
-        final List<String> keys = new ArrayList<>(0);
-        for (final Step step : this.protocol.moves()) {
-            keys.addAll(step.keys());
-        }
-        keys.add(this.protocol.answer());
         final SortedSet<Integer> out = new TreeSet<>();
-        for (final String key : keys) {
-            if (key.startsWith("sym:v")) {
-                out.add(Integer.parseInt(key.substring(5)));
-            }
-        }
+        final Stream<String> keys = JavaAtom.unfolded(this.protocol).flatMap(
+            proto -> Stream.concat(
+                proto.moves().stream().flatMap(step -> step.keys().stream()),
+                Stream.of(proto.answer())
+            )
+        );
+        keys.filter(key -> key.startsWith("sym:v"))
+            .forEach(key -> out.add(Integer.parseInt(key.substring(5))));
         return out;
+    }
+
+    private static Stream<Protocol> unfolded(final Protocol proto) {
+        return Stream.concat(
+            Stream.of(proto),
+            proto.moves().stream()
+                .flatMap(step -> step.branches().stream())
+                .flatMap(JavaAtom::unfolded)
+        );
     }
 
     private static String reading(final int index, final String name, final String forma) {
@@ -128,17 +138,56 @@ public final class JavaAtom {
         return out;
     }
 
-    private String computed(final Step step) {
-        final Op operation = new Op(step.atom());
-        return String.format(
-            "final %s %s = %s;",
-            JavaAtom.typed(operation.forma()),
-            step.label(),
-            this.applied(step, operation)
-        );
+    private List<String> computed(final Protocol proto, final String pad) {
+        final List<String> out = new ArrayList<>(proto.moves().size());
+        for (final Step step : proto.moves()) {
+            if (step.branches().isEmpty()) {
+                out.add(
+                    String.format(
+                        "%sfinal %s %s = %s;",
+                        pad, JavaAtom.typed(step.forma()), step.label(), this.applied(step)
+                    )
+                );
+            } else {
+                out.addAll(this.forked(step, pad));
+            }
+        }
+        return out;
     }
 
-    private String applied(final Step step, final Op operation) {
+    private List<String> forked(final Step step, final String pad) {
+        final String test = step.keys().get(0);
+        if (!"bool".equals(this.forma(test))) {
+            throw new IllegalStateException(
+                String.format(
+                    "The condition '%s' of the fork '%s' does not carry a bool",
+                    test, step.label()
+                )
+            );
+        }
+        final String inner = String.format("%s    ", pad);
+        final List<String> out = new ArrayList<>(8);
+        out.add(
+            String.format(
+                "%sfinal %s %s;", pad, JavaAtom.typed(JavaAtom.carried(step.forma())), step.label()
+            )
+        );
+        out.add(String.format("%sif (%s) {", pad, JavaAtom.expression(test)));
+        out.addAll(this.assigned(step.label(), step.branches().get(0), inner));
+        out.add(String.format("%s} else {", pad));
+        out.addAll(this.assigned(step.label(), step.branches().get(1), inner));
+        out.add(String.format("%s}", pad));
+        return out;
+    }
+
+    private List<String> assigned(final String label, final Protocol arm, final String pad) {
+        final List<String> out = this.computed(arm, pad);
+        out.add(String.format("%s%s = %s;", pad, label, JavaAtom.expression(arm.answer())));
+        return out;
+    }
+
+    private String applied(final Step step) {
+        final Op operation = new Op(step.atom());
         final String out;
         if ("eq".equals(operation.method())) {
             out = this.compared(step);
@@ -204,7 +253,7 @@ public final class JavaAtom {
                         .get(Integer.parseInt(parts[1].substring(1)))
                 );
             } else {
-                out = new Op(this.move(parts[1]).atom()).forma();
+                out = this.move(parts[1]).forma();
             }
         } else {
             out = parts[0];
@@ -223,19 +272,16 @@ public final class JavaAtom {
     }
 
     private Step move(final String label) {
-        Step found = null;
-        for (final Step step : this.protocol.moves()) {
-            if (step.label().equals(label)) {
-                found = step;
-                break;
-            }
-        }
-        if (found == null) {
+        final Optional<Step> found = JavaAtom.unfolded(this.protocol)
+            .flatMap(proto -> proto.moves().stream())
+            .filter(step -> step.label().equals(label))
+            .findFirst();
+        if (!found.isPresent()) {
             throw new IllegalStateException(
                 String.format("The protocol has no step '%s'", label)
             );
         }
-        return found;
+        return found.get();
     }
 
     private static String typed(final String forma) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.lowering;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * A value known at build time, standing in the reduction tree.
  *
@@ -70,6 +73,11 @@ public final class Literal implements Term {
     @Override
     public boolean matches(final Shape shape) {
         return false;
+    }
+
+    @Override
+    public Optional<List<Binding>> arguments(final Shape shape) {
+        return Optional.empty();
     }
 
     @Override

--- a/eo-lowering/src/main/java/org/eolang/lowering/Op.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Op.java
@@ -66,8 +66,10 @@ public final class Op {
     }
 
     /**
-     * The forma of the value.
-     * @return One of {@code number}, {@code bool}, {@code bytes}
+     * The forma of the value. An operation may have none: {@code if}
+     * answers whatever the arm it picks answers, so its row leaves the
+     * column empty, and {@link Reduction} reads that as the sign to fork.
+     * @return One of {@code number}, {@code bool}, {@code bytes}, or empty
      */
     public String forma() {
         return this.row()[3];

--- a/eo-lowering/src/main/java/org/eolang/lowering/Protocol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Protocol.java
@@ -8,14 +8,18 @@ import java.util.Collections;
 import java.util.List;
 
 /**
- * What a fragment computes, as a straight-line program.
+ * What a fragment computes, as a program of steps.
  *
  * <p>A reduction settles into this: the steps in their dependency order,
  * the key of the value the fragment answers with — the last step,
  * usually, though a fragment may also collapse into a literal or answer
- * one of its voids unchanged — and the forma of that value. This is the
- * whole input of code generation: rendering each step as one Java
- * expression, in order, is a faithful compilation of the fragment.</p>
+ * one of its voids unchanged — and the forma of that value. A step is an
+ * application or a {@link Fork}, and a fork holds one protocol of this
+ * very kind per arm, so a program with choices in it is a tree of
+ * protocols whose every path is straight. This is the whole input of
+ * code generation: rendering each step as one Java statement, in order,
+ * with a block under each arm, is a faithful compilation of the
+ * fragment.</p>
  *
  * @since 0.76.0
  */

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
@@ -7,6 +7,8 @@ package org.eolang.lowering;
 import com.github.lombrozo.xnav.Xnav;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -26,12 +28,25 @@ import java.util.Optional;
  * only matches records to sites, by the shapes {@link Operand} anchors
  * and the one {@link Op} table of lowerable operations.</p>
  *
+ * <p>An {@code if} is the one operation whose arguments must not be
+ * reduced in place: they are the arms of a choice, and a step minted
+ * from either would compute regardless of the bool that guards it. So
+ * when the {@code if} atom parks on a symbolic bool, the two arguments
+ * are taken out of the site as they stand in the tree, each is reduced
+ * by a loop of its own, and the site becomes a {@link Fork} holding one
+ * protocol per arm. Every loop of one reduction shares the voids and one
+ * ledger of the steps minted so far, by label, so that a label never
+ * repeats across the arms and the forma of any step can be looked up
+ * wherever its symbol ends up. When the bool is data instead, the site
+ * simply gives way to the arm it picks.</p>
+ *
  * <p>Whatever does not settle is refused with an exception, never
  * repaired: a foreign atom, a site the records cannot anchor, a value of
- * a forma no carrier stands for, an exhausted budget. The caller treats
- * every refusal as one fragment staying unlowered, the way {@link Constant}
- * refusals are treated, so a refusal here is a filter, not a
- * failure.</p>
+ * a forma no carrier stands for, an exhausted budget, an arm of a fork
+ * that refuses or answers a forma the other arm does not. The caller
+ * treats every refusal as one fragment staying unlowered, the way
+ * {@link Constant} refusals are treated, so a refusal here is a filter,
+ * not a failure.</p>
  *
  * @since 0.76.0
  * @todo #8308:30min Let a string literal stand as the receiver of a step.
@@ -87,8 +102,16 @@ public final class Reduction {
      * @throws IOException If the binary cannot be run
      */
     public Protocol protocol() throws IOException {
+        return this.settled(
+            new Parsed(this.fragment, this.voids).term(),
+            new LinkedHashMap<>(0)
+        );
+    }
+
+    private Protocol settled(final Term start, final Map<String, String> minted)
+        throws IOException {
         final List<Step> steps = new ArrayList<>(0);
-        Term tree = new Parsed(this.fragment, this.voids).term();
+        Term tree = start;
         int round = 0;
         while (tree.key().isEmpty()) {
             if (round >= this.rounds) {
@@ -97,12 +120,13 @@ public final class Reduction {
                 );
             }
             ++round;
-            tree = this.grown(tree, steps);
+            tree = this.grown(tree, steps, minted);
         }
-        return new Protocol(steps, tree.key(), this.carrier(tree.key(), steps));
+        return new Protocol(steps, tree.key(), this.carrier(tree.key(), minted));
     }
 
-    private Term grown(final Term tree, final List<Step> steps) throws IOException {
+    private Term grown(final Term tree, final List<Step> steps,
+        final Map<String, String> minted) throws IOException {
         final Trace trace = this.phino.partial(
             new Universe().text(),
             String.format("⟦%n  φ ↦ %s%n⟧%n", tree.phi())
@@ -121,29 +145,79 @@ public final class Reduction {
                 );
                 continue;
             }
-            final Optional<Shape> shape = Reduction.shaped(operation, record);
-            if (!shape.isPresent() || !out.matches(shape.get())) {
-                continue;
-            }
-            final Term swap;
-            if (record.parked()) {
-                final String label = String.format("s%d", steps.size() + 1);
-                final List<String> keys = new ArrayList<>(1);
-                keys.add(Reduction.self(operation, record));
-                keys.addAll(Reduction.arguments(operation, record).get());
-                steps.add(new Step(label, record.name(), keys));
-                swap = new Symbol(label, operation.forma());
+            final Optional<Term> next;
+            if (record.parked() && operation.forma().isEmpty()) {
+                next = this.forked(out, operation, record, steps, minted);
             } else {
-                final String[] parts = new Operand(record.result()).key().split(":", 2);
-                swap = new Literal(parts[0], parts[1]);
+                next = Reduction.applied(out, operation, record, steps, minted);
             }
-            out = out.swapped(shape.get(), swap);
-            ++done;
+            if (next.isPresent()) {
+                out = next.get();
+                ++done;
+            }
         }
         if (done == 0) {
             throw new IllegalStateException(
                 String.format("The reduction is stuck: %s", excuse)
             );
+        }
+        return out;
+    }
+
+    private static Optional<Term> applied(final Term tree, final Op operation,
+        final Evaluation record, final List<Step> steps, final Map<String, String> minted) {
+        Optional<Term> out = Optional.empty();
+        final Optional<Shape> shape = Reduction.shaped(operation, record);
+        if (shape.isPresent() && tree.matches(shape.get())) {
+            final Term swap;
+            if (record.parked()) {
+                final String label = String.format("s%d", minted.size() + 1);
+                minted.put(label, operation.forma());
+                final List<String> keys = new ArrayList<>(1);
+                keys.add(Reduction.self(operation, record));
+                keys.addAll(Reduction.arguments(operation, record).get());
+                steps.add(new Application(label, record.name(), keys));
+                swap = new Symbol(label, operation.forma());
+            } else {
+                final String[] parts = new Operand(record.result()).key().split(":", 2);
+                swap = new Literal(parts[0], parts[1]);
+            }
+            out = Optional.of(tree.swapped(shape.get(), swap));
+        }
+        return out;
+    }
+
+    private Optional<Term> forked(final Term tree, final Op operation,
+        final Evaluation record, final List<Step> steps, final Map<String, String> minted)
+        throws IOException {
+        final String self = Reduction.self(operation, record);
+        final Optional<List<Binding>> found = tree.arguments(
+            new Shape(
+                operation.method(), self, operation.args(),
+                Collections.nCopies(operation.args().size(), "")
+            )
+        );
+        Optional<Term> out = Optional.empty();
+        if (found.isPresent()) {
+            final List<Binding> args = found.get();
+            final Term swap;
+            if ("bool:FF-".equals(self)) {
+                swap = args.get(0).value();
+            } else if ("bool:00-".equals(self)) {
+                swap = args.get(1).value();
+            } else {
+                final String label = String.format("s%d", minted.size() + 1);
+                minted.put(label, "");
+                final Step fork = new Fork(
+                    label, record.name(), self,
+                    this.settled(args.get(0).value(), minted),
+                    this.settled(args.get(1).value(), minted)
+                );
+                minted.put(label, fork.forma());
+                steps.add(fork);
+                swap = new Symbol(label, fork.forma());
+            }
+            out = Optional.of(tree.swapped(new Shape(operation.method(), self, args), swap));
         }
         return out;
     }
@@ -204,23 +278,15 @@ public final class Reduction {
         return out;
     }
 
-    private String carrier(final String key, final List<Step> steps) {
+    private String carrier(final String key, final Map<String, String> minted) {
         final String out;
         if (key.startsWith("sym:s")) {
-            final String label = key.substring(4);
-            String atom = "";
-            for (final Step step : steps) {
-                if (step.label().equals(label)) {
-                    atom = step.atom();
-                    break;
-                }
-            }
-            if (atom.isEmpty()) {
+            out = minted.getOrDefault(key.substring(4), "");
+            if (out.isEmpty()) {
                 throw new IllegalStateException(
                     String.format("The answer '%s' names no step", key)
                 );
             }
-            out = new Op(atom).forma();
         } else if (key.startsWith("sym:v")) {
             out = new ArrayList<>(this.voids.values())
                 .get(Integer.parseInt(key.substring(5)));

--- a/eo-lowering/src/main/java/org/eolang/lowering/Shape.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Shape.java
@@ -5,16 +5,19 @@
 package org.eolang.lowering;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * The shape of one recorded evaluation, ready to meet the tree.
  *
  * <p>It is the identity of the site an atom fired or parked at: the
- * method that dispatched it, the key of its receiver, and the keys of
- * its arguments under their positional names. A site of the tree matches
- * when all three agree, with the argument names read either way — the
- * resolved name the record shows, or the {@code α}-positional name the
- * XMIR wrote.</p>
+ * method that dispatched it, the key of its receiver, and the identities
+ * of its arguments under their positional names — the key of an argument
+ * that is a value, the phi text of one that is still a site, or nothing
+ * at all where any argument will do. A site of the tree matches when all
+ * three agree, with the argument names read either way — the resolved
+ * name the record shows, or the {@code α}-positional name the XMIR
+ * wrote.</p>
  *
  * @since 0.76.0
  */
@@ -36,16 +39,32 @@ public final class Shape {
     private final List<String> names;
 
     /**
-     * The keys of the arguments, in the same order.
+     * The identities of the arguments, in the same order.
      */
     private final List<String> keys;
+
+    /**
+     * Ctor, for the shape of exactly one site as it stands in the tree.
+     * @param verb The method the site dispatches
+     * @param self The key of its receiver
+     * @param args The bindings of the site
+     */
+    public Shape(final String verb, final String self, final List<Binding> args) {
+        this(
+            verb,
+            self,
+            args.stream().map(Binding::label).collect(Collectors.toList()),
+            args.stream().map(arg -> Shape.identity(arg.value())).collect(Collectors.toList())
+        );
+    }
 
     /**
      * Ctor.
      * @param verb The method that dispatched the atom
      * @param self The key of the receiver
      * @param labels The names of the arguments, in their positional order
-     * @param values The keys of the arguments, in the same order
+     * @param values The identities of the arguments, in the same order,
+     *  an empty one standing for any argument at all
      */
     public Shape(final String verb, final String self,
         final List<String> labels, final List<String> values) {
@@ -71,8 +90,18 @@ public final class Shape {
             final Binding arg = args.get(idx);
             good = arg.label().equals(this.names.get(idx))
                 || arg.label().equals(String.format("α%d", idx));
-            good = good && this.keys.get(idx).equals(arg.value().key());
+            final String expected = this.keys.get(idx);
+            good = good
+                && (expected.isEmpty() || expected.equals(Shape.identity(arg.value())));
         }
         return good;
+    }
+
+    private static String identity(final Term term) {
+        String out = term.key();
+        if (out.isEmpty()) {
+            out = term.phi();
+        }
+        return out;
     }
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Site.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Site.java
@@ -6,7 +6,9 @@ package org.eolang.lowering;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * One application of the fragment, standing in the reduction tree.
@@ -76,6 +78,20 @@ public final class Site implements Term {
             found = this.args.get(idx).value().matches(shape);
         }
         return found;
+    }
+
+    @Override
+    public Optional<List<Binding>> arguments(final Shape shape) {
+        Optional<List<Binding>> out;
+        if (shape.covers(this.method, this.receiver.key(), this.args)) {
+            out = Optional.of(Collections.unmodifiableList(this.args));
+        } else {
+            out = this.receiver.arguments(shape);
+            for (int idx = 0; !out.isPresent() && idx < this.args.size(); ++idx) {
+                out = this.args.get(idx).value().arguments(shape);
+            }
+        }
+        return out;
     }
 
     @Override

--- a/eo-lowering/src/main/java/org/eolang/lowering/Step.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Step.java
@@ -4,71 +4,53 @@
  */
 package org.eolang.lowering;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
  * One step of a protocol.
  *
- * <p>It is a single application whose value run time must compute: the λ
- * name of the atom, and the keys of its operands — the receiver first,
- * then the arguments in their positional order. An operand key names a
- * void of the fragment, an earlier step, or a literal with its forma and
- * bytes, so the whole protocol is a static single-assignment program
- * over the values the fragment starts from.</p>
+ * <p>It is one value run time must compute, named so that the steps
+ * after it and the answer can refer to it by the key {@code sym:<label>}.
+ * An {@link Application} is one atom applied to operands that are
+ * already values; a {@link Fork} picks between two nested protocols by a
+ * bool that is already a value. Either way a step reads only keys minted
+ * before it — a void of the fragment, an earlier step, or a literal with
+ * its forma and bytes — so a protocol is a static single-assignment
+ * program over the values the fragment starts from, with a block of its
+ * own under every arm of every fork.</p>
  *
  * @since 0.76.0
  */
-public final class Step {
-
-    /**
-     * The name of the step, such as {@code s1}.
-     */
-    private final String name;
-
-    /**
-     * The λ name of the atom, such as {@code L_number_plus}.
-     */
-    private final String lambda;
-
-    /**
-     * The keys of the operands: the receiver first, then the arguments.
-     */
-    private final List<String> operands;
-
-    /**
-     * Ctor.
-     * @param label The name of the step, such as {@code s1}
-     * @param atom The λ name of the atom, such as {@code L_number_plus}
-     * @param keys The keys of the operands, the receiver first
-     */
-    public Step(final String label, final String atom, final List<String> keys) {
-        this.name = label;
-        this.lambda = atom;
-        this.operands = keys;
-    }
+public interface Step {
 
     /**
      * The name of the step.
      * @return The name, such as {@code s1}
      */
-    public String label() {
-        return this.name;
-    }
+    String label();
 
     /**
-     * The λ name of the atom.
-     * @return The name, such as {@code L_number_plus}
+     * The λ name of the atom that parked into this step.
+     * @return The name, such as {@code L_number_plus} or {@code L_bool_if}
      */
-    public String atom() {
-        return this.lambda;
-    }
+    String atom();
 
     /**
-     * The keys of the operands.
-     * @return The receiver first, then the arguments in positional order
+     * The forma of the value this step computes.
+     * @return One of {@code number}, {@code bool}, {@code bytes}, {@code string}
      */
-    public List<String> keys() {
-        return Collections.unmodifiableList(this.operands);
-    }
+    String forma();
+
+    /**
+     * The keys of the values this step reads directly.
+     * @return The receiver first and then the arguments, or the one
+     *  condition of a fork
+     */
+    List<String> keys();
+
+    /**
+     * The protocols nested in this step.
+     * @return The two arms of a fork, the taken one first; none for an application
+     */
+    List<Protocol> branches();
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.lowering;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * A value not known until run time, standing in the reduction tree.
  *
@@ -69,6 +72,11 @@ public final class Symbol implements Term {
     @Override
     public boolean matches(final Shape shape) {
         return false;
+    }
+
+    @Override
+    public Optional<List<Binding>> arguments(final Shape shape) {
+        return Optional.empty();
     }
 
     @Override

--- a/eo-lowering/src/main/java/org/eolang/lowering/Term.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Term.java
@@ -4,6 +4,9 @@
  */
 package org.eolang.lowering;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * One node of the tree a reduction works on.
  *
@@ -39,6 +42,13 @@ public interface Term {
      * @return True if {@link #swapped(Shape, Term)} would rewrite something
      */
     boolean matches(Shape shape);
+
+    /**
+     * The arguments of the first site of this tree matching the shape.
+     * @param shape The shape of a recorded evaluation
+     * @return The bindings of that site, or empty when no site matches
+     */
+    Optional<List<Binding>> arguments(Shape shape);
 
     /**
      * This tree with every site matching the shape replaced.

--- a/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
@@ -16,7 +16,9 @@ import org.cactoos.text.UncheckedText;
  * root formation of the document it evaluates. This is that root, read
  * from the {@code universe.phi} resource: {@code number} and {@code bytes}
  * with their twelve λ methods, {@code string} which owns none and reaches
- * every one of them through its {@code φ}, and {@code true}/{@code false}
+ * every one of them through its {@code φ}, {@code bool} with the one
+ * {@code if} that phino never fires but always parks, so that the
+ * reduction learns where a choice stands, and {@code true}/{@code false}
  * as data, since the comparing atoms answer with a reference to them. It is
  * a complete expression of its own, merged with an {@link Expression} by
  * {@code phino merge} before dataization; a dispatch into anything it

--- a/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
@@ -2,6 +2,7 @@ L_number_plus	plus	number	number	x	%1$s + %2$s
 L_number_times	times	number	number	x	%1$s * %2$s
 L_number_div	div	number	number	x	%1$s / %2$s
 L_number_gt	gt	number	bool	x	%1$s > %2$s
+L_bool_if	if	bool		t,f
 L_bytes_and	and	bytes	bytes	b	new BytesOf(%1$s).and(new BytesOf(%2$s)).take()
 L_bytes_or	or	bytes	bytes	b	new BytesOf(%1$s).or(new BytesOf(%2$s)).take()
 L_bytes_not	not	bytes	bytes		new BytesOf(%1$s).not().take()

--- a/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
@@ -26,7 +26,8 @@
   ⟧,
   bool ↦ ⟦
     as-bytes ↦ ∅,
-    φ ↦ ξ.as-bytes
+    φ ↦ ξ.as-bytes,
+    if ↦ ⟦ t ↦ ∅, f ↦ ∅, λ ⤍ L_bool_if ⟧
   ⟧,
   true ↦ Φ.bool(α0 ↦ Φ.bytes(α0 ↦ ⟦ Δ ⤍ FF- ⟧)),
   false ↦ Φ.bool(α0 ↦ Φ.bytes(α0 ↦ ⟦ Δ ⤍ 00- ⟧))

--- a/eo-lowering/src/test/java/org/eolang/lowering/ApplicationTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ApplicationTest.java
@@ -5,21 +5,22 @@
 package org.eolang.lowering;
 
 import java.util.Arrays;
+import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link Step}.
+ * Test case for {@link Application}.
  * @since 0.76.0
  */
-final class StepTest {
+final class ApplicationTest {
 
     @Test
     void keepsReceiverFirst() {
         MatcherAssert.assertThat(
             "the keys must start with the receiver, but they dont",
-            new Step(
+            new Application(
                 "s2",
                 "L_bytes_slice",
                 Arrays.asList("sym:v0", "number:11-", "sym:s1")
@@ -32,10 +33,30 @@ final class StepTest {
     void namesAtom() {
         MatcherAssert.assertThat(
             "the λ name must come back as given, but it didnt",
-            new Step(
+            new Application(
                 "s1", "L_number_div", Arrays.asList("sym:v0", "number:40-00-")
             ).atom(),
             Matchers.equalTo("L_number_div")
+        );
+    }
+
+    @Test
+    void answersFormaOfAtom() {
+        MatcherAssert.assertThat(
+            "a comparison must compute a bool, but it doesnt",
+            new Application(
+                "s1", "L_number_gt", Arrays.asList("sym:v0", "number:40-00-")
+            ).forma(),
+            Matchers.equalTo("bool")
+        );
+    }
+
+    @Test
+    void nestsNothing() {
+        MatcherAssert.assertThat(
+            "an application must hold no arms, but it does",
+            new Application("s1", "L_bytes_not", Collections.singletonList("sym:v0")).branches(),
+            Matchers.empty()
         );
     }
 }

--- a/eo-lowering/src/test/java/org/eolang/lowering/ForkTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ForkTest.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Fork}.
+ * @since 0.76.0
+ */
+final class ForkTest {
+
+    @Test
+    void answersFormaOfArms() {
+        MatcherAssert.assertThat(
+            "a fork must compute what its arms compute, but it doesnt",
+            new Fork(
+                "s2", "L_bool_if", "sym:s1",
+                new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                new Protocol(Collections.emptyList(), "number:40-00-", "number")
+            ).forma(),
+            Matchers.equalTo("number")
+        );
+    }
+
+    @Test
+    void refusesDisagreeingArms() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Fork(
+                "s2", "L_bool_if", "sym:s1",
+                new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                new Protocol(Collections.emptyList(), "bool:FF-", "bool")
+            )::forma,
+            "arms of two formas cannot share one value, but they did"
+        );
+    }
+
+    @Test
+    void readsOnlyItsCondition() {
+        MatcherAssert.assertThat(
+            "the one key a fork reads directly must be its condition, but it isnt",
+            new Fork(
+                "s2", "L_bool_if", "sym:v1",
+                new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                new Protocol(Collections.emptyList(), "sym:v0", "number")
+            ).keys(),
+            Matchers.contains("sym:v1")
+        );
+    }
+
+    @Test
+    void holdsTakenArmFirst() {
+        MatcherAssert.assertThat(
+            "the arm taken when the bool holds must come first, but it doesnt",
+            new Fork(
+                "s2", "L_bool_if", "sym:s1",
+                new Protocol(Collections.emptyList(), "number:11-", "number"),
+                new Protocol(Collections.emptyList(), "number:22-", "number")
+            ).branches().get(0).answer(),
+            Matchers.equalTo("number:11-")
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -32,11 +32,11 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Arrays.asList(
-                        new Step(
+                        new Application(
                             "s1", "L_number_plus",
                             Arrays.asList("sym:v0", "number:40-00-00-00-00-00-00-00")
                         ),
-                        new Step("s2", "L_number_times", Arrays.asList("sym:s1", "sym:v0"))
+                        new Application("s2", "L_number_times", Arrays.asList("sym:s1", "sym:v0"))
                     ),
                     "sym:s2",
                     "number"
@@ -62,12 +62,12 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Arrays.asList(
-                        new Step(
+                        new Application(
                             "s1", "L_bytes_and",
                             Arrays.asList("sym:v0", "bytes:1F-")
                         ),
-                        new Step("s2", "L_bytes_size", Collections.singletonList("sym:s1")),
-                        new Step(
+                        new Application("s2", "L_bytes_size", Collections.singletonList("sym:s1")),
+                        new Application(
                             "s3", "L_number_gt",
                             Arrays.asList("sym:s2", "number:40-00-00-00-00-00-00-00")
                         )
@@ -100,7 +100,7 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step("s1", "L_bytes_eq", Arrays.asList("sym:v0", "bool:FF-"))
+                        new Application("s1", "L_bytes_eq", Arrays.asList("sym:v0", "bool:FF-"))
                     ),
                     "sym:s1",
                     "bool"
@@ -164,7 +164,7 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step(
+                        new Application(
                             "s1", "L_number_plus",
                             Arrays.asList("sym:v1", "number:3F-F0-00-00-00-00-00-00")
                         )
@@ -195,8 +195,8 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Arrays.asList(
-                        new Step("s1", "L_number_div", Arrays.asList("sym:v0", "sym:v1")),
-                        new Step("s2", "L_bytes_eq", Arrays.asList("sym:s1", "sym:v0"))
+                        new Application("s1", "L_number_div", Arrays.asList("sym:v0", "sym:v1")),
+                        new Application("s2", "L_bytes_eq", Arrays.asList("sym:s1", "sym:v0"))
                     ),
                     "sym:s2",
                     "bool"
@@ -220,11 +220,11 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Arrays.asList(
-                        new Step(
+                        new Application(
                             "s1", "L_bytes_concat",
                             Arrays.asList("sym:v0", "string:21-")
                         ),
-                        new Step("s2", "L_bytes_size", Collections.singletonList("sym:s1"))
+                        new Application("s2", "L_bytes_size", Collections.singletonList("sym:s1"))
                     ),
                     "sym:s2",
                     "number"
@@ -244,7 +244,9 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step("s1", "L_bytes_eq", Arrays.asList("sym:v0", "string:61-62-63"))
+                        new Application(
+                            "s1", "L_bytes_eq", Arrays.asList("sym:v0", "string:61-62-63")
+                        )
                     ),
                     "sym:s1",
                     "bool"
@@ -267,7 +269,7 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step("s1", "L_bytes_eq", Arrays.asList("sym:v0", "bytes:1F-2E-"))
+                        new Application("s1", "L_bytes_eq", Arrays.asList("sym:v0", "bytes:1F-2E-"))
                     ),
                     "sym:s1",
                     "bool"
@@ -284,13 +286,120 @@ final class JavaAtomTest {
     }
 
     @Test
+    void rendersForkAsIfElse() {
+        MatcherAssert.assertThat(
+            "a fork must declare a blank final and assign it in both arms, but it doesnt",
+            new JavaAtom(
+                new Protocol(
+                    Arrays.asList(
+                        new Application(
+                            "s1", "L_number_gt",
+                            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+                        ),
+                        new Fork(
+                            "s2", "L_bool_if", "sym:s1",
+                            new Protocol(
+                                Collections.emptyList(), "number:3F-F0-00-00-00-00-00-00", "number"
+                            ),
+                            new Protocol(
+                                Collections.singletonList(
+                                    new Application(
+                                        "s3", "L_number_times", Arrays.asList("sym:v0", "sym:v0")
+                                    )
+                                ),
+                                "sym:s3",
+                                "number"
+                            )
+                        )
+                    ),
+                    "sym:s2",
+                    "number"
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final double v0 = new Dataized(this.take(\"x\")).asNumber();",
+                    "        final boolean s1 = v0 > Double.longBitsToDouble(0x3FF0000000000000L);",
+                    "        final double s2;",
+                    "        if (s1) {",
+                    "            s2 = Double.longBitsToDouble(0x3FF0000000000000L);",
+                    "        } else {",
+                    "            final double s3 = v0 * v0;",
+                    "            s2 = s3;",
+                    "        }",
+                    "        return new Data.ToPhi(s2);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void hoistsVoidReadOutOfArm() {
+        final Map<String, String> voids = new LinkedHashMap<>();
+        voids.put("f", "bool");
+        voids.put("y", "number");
+        MatcherAssert.assertThat(
+            "a void read inside an arm alone must be dataized at the top, but it isnt",
+            new JavaAtom(
+                new Protocol(
+                    Collections.singletonList(
+                        new Fork(
+                            "s1", "L_bool_if", "sym:v0",
+                            new Protocol(Collections.emptyList(), "sym:v1", "number"),
+                            new Protocol(
+                                Collections.emptyList(), "number:00-00-00-00-00-00-00-00", "number"
+                            )
+                        )
+                    ),
+                    "sym:s1",
+                    "number"
+                ),
+                voids
+            ).text(),
+            Matchers.startsWith(
+                String.join(
+                    System.lineSeparator(),
+                    "        final boolean v0 = new Dataized(this.take(\"f\")).asBool();",
+                    "        final double v1 = new Dataized(this.take(\"y\")).asNumber();",
+                    "        final double s1;",
+                    "        if (v0) {"
+                )
+            )
+        );
+    }
+
+    @Test
+    void refusesForkOnNumberCondition() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new JavaAtom(
+                new Protocol(
+                    Collections.singletonList(
+                        new Fork(
+                            "s1", "L_bool_if", "sym:v0",
+                            new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                            new Protocol(Collections.emptyList(), "sym:v0", "number")
+                        )
+                    ),
+                    "sym:s1",
+                    "number"
+                ),
+                Collections.singletonMap("x", "number")
+            )::text,
+            "a number cannot decide a fork, but one rendered"
+        );
+    }
+
+    @Test
     void refusesEqualityOverMixedFormas() {
         Assertions.assertThrows(
             IllegalStateException.class,
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step("s1", "L_bytes_eq", Arrays.asList("sym:v0", "bytes:01-02-"))
+                        new Application("s1", "L_bytes_eq", Arrays.asList("sym:v0", "bytes:01-02-"))
                     ),
                     "sym:s1",
                     "bool"
@@ -308,7 +417,7 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step(
+                        new Application(
                             "s1", "L_number_plus",
                             Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
                         )
@@ -329,7 +438,7 @@ final class JavaAtomTest {
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
-                        new Step(
+                        new Application(
                             "s1", "L_bytes_right",
                             Arrays.asList("sym:v0", "number:40-00-00-00-00-00-00-00")
                         )

--- a/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
@@ -52,6 +52,24 @@ final class OpTest {
     }
 
     @Test
+    void namesNoFormaOfChoice() {
+        MatcherAssert.assertThat(
+            "a choice answers whatever its arms answer, so it must name no forma, but it does",
+            new Op("L_bool_if").forma(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void listsArmsOfChoice() {
+        MatcherAssert.assertThat(
+            "a choice must take its two arms in positional order, but it doesnt",
+            new Op("L_bool_if").args(),
+            Matchers.contains("t", "f")
+        );
+    }
+
+    @Test
     void listsNoArgumentsOfSize() {
         MatcherAssert.assertThat(
             "the size of bytes must take no arguments, but it does",

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
@@ -293,6 +293,132 @@ final class ReductionTest {
     }
 
     @Test
+    void forksOnSymbolicBool(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a choice on a parked comparison must fork on its symbol, but it doesnt",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    ReductionTest.guard(),
+                    ReductionTest.number("α0", "40-00-00-00-00-00-00-00"),
+                    "<o as='α1' base='ξ.x'/>"
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            ).protocol().moves().get(1).keys(),
+            Matchers.contains("sym:s1")
+        );
+    }
+
+    @Test
+    void numbersArmStepsAfterFork(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "the steps of the second arm must count on from the first arm, but they dont",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    ReductionTest.guard(),
+                    String.format(
+                        "<o as='α0' base='.plus'><o base='ξ.x'/>%s</o>",
+                        ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00")
+                    ),
+                    "<o as='α1' base='.times'><o base='ξ.x'/><o as='α0' base='ξ.x'/></o>"
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            ).protocol().moves().get(1).branches().get(1).moves().get(0).label(),
+            Matchers.equalTo("s4")
+        );
+    }
+
+    @Test
+    void picksArmOfLiteralCondition(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a choice decided by data must keep only the arm it picks, but it didnt",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    "<o base='Φ.false'/>",
+                    "<o as='α0' base='ξ.x'/>",
+                    "<o as='α1' base='.times'><o base='ξ.x'/><o as='α0' base='ξ.x'/></o>"
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            ).protocol().moves().get(0).atom(),
+            Matchers.equalTo("L_number_times")
+        );
+    }
+
+    @Test
+    void forksOnBoolVoid(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a choice on a bool void must fork on that void, but it doesnt",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    "<o base='ξ.f'/>",
+                    ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00"),
+                    ReductionTest.number("α1", "40-00-00-00-00-00-00-00")
+                ),
+                Collections.singletonMap("f", "bool"),
+                8
+            ).protocol().moves().get(0).keys(),
+            Matchers.contains("sym:v0")
+        );
+    }
+
+    @Test
+    void refusesForkOfDisagreeingArms(@Mktmp final Path temp) {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    ReductionTest.guard(),
+                    "<o as='α0' base='ξ.x'/>",
+                    "<o as='α1' base='Φ.true'/>"
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            )::protocol,
+            "arms of a number and a bool cannot share one carrier, but they reduced"
+        );
+    }
+
+    @Test
+    void refusesForkWithStuckArm(@Mktmp final Path temp) {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    ReductionTest.guard(),
+                    "<o as='α0' base='ξ.x'/>",
+                    String.format(
+                        "<o as='α1' base='.minus'><o base='ξ.x'/>%s</o>",
+                        ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00")
+                    )
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            )::protocol,
+            "an arm the universe cannot reduce must refuse the whole fork, but it didnt"
+        );
+    }
+
+    @Test
     void refusesNumberMethodOnBool(@Mktmp final Path temp) {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());
@@ -418,6 +544,26 @@ final class ReductionTest {
                 8
             ).protocol().answer(),
             Matchers.equalTo("number:40-14-00-00-00-00-00-00")
+        );
+    }
+
+    private static Xnav choice(final String test, final String yes, final String not) {
+        return new Xnav(
+            String.format("<o base='.if'>%s%s%s</o>", test, yes, not)
+        ).element("o");
+    }
+
+    private static String guard() {
+        return String.format(
+            "<o base='.gt'><o base='ξ.x'/>%s</o>",
+            ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00")
+        );
+    }
+
+    private static String number(final String name, final String hex) {
+        return String.format(
+            "<o as='%s' base='Φ.number'><o as='α0' base='Φ.bytes'><o as='α0'>%s</o></o></o>",
+            name, hex
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/ShapeTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ShapeTest.java
@@ -6,6 +6,7 @@ package org.eolang.lowering;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -48,6 +49,69 @@ final class ShapeTest {
                 Collections.emptyList(),
                 Collections.emptyList()
             ).covers("size", "sym:v1", Collections.emptyList()),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void coversAnyArgumentWhereBlank() {
+        MatcherAssert.assertThat(
+            "a blank identity must let any argument through, but it doesnt",
+            new Shape(
+                "if", "sym:s1", Arrays.asList("t", "f"), Arrays.asList("", "")
+            ).covers(
+                "if",
+                "sym:s1",
+                Arrays.asList(
+                    new Binding("α0", new Literal("number", "11-")),
+                    new Binding(
+                        "α1",
+                        new Site("size", new Symbol("v0", "bytes"), Collections.emptyList())
+                    )
+                )
+            ),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void coversSiteByItsOwnBindings() {
+        final List<Binding> args = Arrays.asList(
+            new Binding("α0", new Literal("number", "11-")),
+            new Binding(
+                "α1",
+                new Site("size", new Symbol("v0", "bytes"), Collections.emptyList())
+            )
+        );
+        MatcherAssert.assertThat(
+            "a shape taken off a site must cover that very site, but it doesnt",
+            new Shape("if", "sym:s1", args).covers("if", "sym:s1", args),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void tellsSitesApartByTheirText() {
+        MatcherAssert.assertThat(
+            "an argument still a site must match only its own text, but it matched another",
+            new Shape(
+                "if", "sym:s1",
+                Collections.singletonList(
+                    new Binding(
+                        "α0",
+                        new Site("size", new Symbol("v0", "bytes"), Collections.emptyList())
+                    )
+                )
+            ).covers(
+                "if",
+                "sym:s1",
+                Collections.singletonList(
+                    new Binding(
+                        "α0",
+                        new Site("size", new Symbol("v1", "bytes"), Collections.emptyList())
+                    )
+                )
+            ),
             Matchers.is(false)
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/SiteTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/SiteTest.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lowering;
 
+import java.util.Arrays;
 import java.util.Collections;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -98,6 +99,43 @@ final class SiteTest {
                     ".plus(α0 ↦ Φ.number(α0 ↦ Φ.bytes(α0 ↦ ⟦ λ ⤍ Sym_s1 ⟧)))"
                 )
             )
+        );
+    }
+
+    @Test
+    void handsOutArgumentsOfMatchingSite() {
+        MatcherAssert.assertThat(
+            "the arguments of the site below the root must come back, but they didnt",
+            new Site(
+                "plus",
+                new Site(
+                    "if",
+                    new Symbol("s1", "bool"),
+                    Arrays.asList(
+                        new Binding("α0", new Literal("number", "11-")),
+                        new Binding("α1", new Symbol("v0", "number"))
+                    )
+                ),
+                Collections.singletonList(
+                    new Binding("α0", new Literal("number", "22-"))
+                )
+            ).arguments(
+                new Shape("if", "sym:s1", Arrays.asList("t", "f"), Arrays.asList("", ""))
+            ).get().get(1).value().key(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void handsOutNothingForForeignShape() {
+        MatcherAssert.assertThat(
+            "a shape no site matches must find no arguments, but it did",
+            new Site(
+                "size", new Symbol("v0", "bytes"), Collections.emptyList()
+            ).arguments(
+                new Shape("if", "sym:v0", Arrays.asList("t", "f"), Arrays.asList("", ""))
+            ).isPresent(),
+            Matchers.is(false)
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/UniverseTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/UniverseTest.java
@@ -39,6 +39,20 @@ final class UniverseTest {
     }
 
     @Test
+    void parksTheChoiceOfABool(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 100, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "the choice of a bool must park instead of firing, but it didnt",
+            phino.partial(
+                new Universe().text(),
+                "⟦ φ ↦ Φ.true.if(α0 ↦ Φ.true, α1 ↦ Φ.false) ⟧"
+            ).records().get(0).name(),
+            Matchers.equalTo("L_bool_if")
+        );
+    }
+
+    @Test
     void carriesTheMethodsOfABool(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 100, temp);
         Assumptions.assumeTrue(phino.suitable());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -88,7 +88,8 @@ final class LoweringTest {
                     LoweringTest.fragment(foo),
                     LoweringTest.voids(foo, story),
                     8
-                ).protocol()
+                ).protocol(),
+                ""
             ).trim(),
             Matchers.equalTo(story.map().get("protocol").toString().trim())
         );
@@ -196,16 +197,38 @@ final class LoweringTest {
         return out;
     }
 
-    private static String rendered(final Protocol protocol) {
+    /**
+     * Render a protocol as the packs spell it: one line per step, and
+     * under a fork an indented block per arm, each a protocol of its own.
+     * @param protocol The protocol
+     * @param pad The indentation of this protocol
+     * @return The text, ending with a line break
+     */
+    private static String rendered(final Protocol protocol, final String pad) {
         final StringBuilder out = new StringBuilder(64);
         for (final Step step : protocol.moves()) {
-            out.append(step.label()).append(" ← ").append(step.atom());
-            for (final String key : step.keys()) {
-                out.append(' ').append(key);
+            out.append(pad).append(step.label()).append(" ← ");
+            if (step.branches().isEmpty()) {
+                out.append(step.atom());
+                for (final String key : step.keys()) {
+                    out.append(' ').append(key);
+                }
+                out.append(System.lineSeparator());
+            } else {
+                out.append("fork ").append(step.keys().get(0)).append(' ')
+                    .append(step.forma()).append(System.lineSeparator());
+                final String[] arms = {"then", "else"};
+                for (int idx = 0; idx < arms.length; ++idx) {
+                    out.append(pad).append("  ").append(arms[idx]).append(System.lineSeparator())
+                        .append(
+                            LoweringTest.rendered(
+                                step.branches().get(idx), String.format("%s    ", pad)
+                            )
+                        );
+                }
             }
-            out.append(System.lineSeparator());
         }
-        return out.append("answer ").append(protocol.answer())
-            .append(' ').append(protocol.carrier()).toString();
+        return out.append(pad).append("answer ").append(protocol.answer())
+            .append(' ').append(protocol.carrier()).append(System.lineSeparator()).toString();
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -197,13 +197,6 @@ final class LoweringTest {
         return out;
     }
 
-    /**
-     * Render a protocol as the packs spell it: one line per step, and
-     * under a fork an indented block per arm, each a protocol of its own.
-     * @param protocol The protocol
-     * @param pad The indentation of this protocol
-     * @return The text, ending with a line break
-     */
     private static String rendered(final Protocol protocol, final String pad) {
         final StringBuilder out = new StringBuilder(64);
         for (final Step step : protocol.moves()) {
@@ -219,12 +212,11 @@ final class LoweringTest {
                     .append(step.forma()).append(System.lineSeparator());
                 final String[] arms = {"then", "else"};
                 for (int idx = 0; idx < arms.length; ++idx) {
-                    out.append(pad).append("  ").append(arms[idx]).append(System.lineSeparator())
-                        .append(
-                            LoweringTest.rendered(
-                                step.branches().get(idx), String.format("%s    ", pad)
-                            )
-                        );
+                    final String arm = LoweringTest.rendered(
+                        step.branches().get(idx), String.format("%s    ", pad)
+                    );
+                    out.append(pad).append("  ").append(arms[idx])
+                        .append(System.lineSeparator()).append(arm);
                 }
             }
         }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/fork-on-flag.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/fork-on-flag.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A bool void decides between two computations. The `.if` parks on the
+# symbolic bool at once, with no guard to reduce first, so the fork is
+# the first and only step at the top, each arm holds one step of its
+# own, and the label of the else arm counts on from the then arm. The
+# formation stays as written all the same: the tables witness the
+# `true` filling `flag` by the locator of the argument, not as a bool
+# carrier, so the lowering never learns the forma of that void.
+input: |
+  [] > foo
+    [flag x] > pick
+      if. > @
+        flag
+        x.plus 1
+        x.times 2
+    pick true 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: pick
+voids:
+  flag: bool
+  x: number
+lowered: |
+  [] > foo
+    pick > @
+      true
+      5
+    flag.if > [flag x] > pick
+      x.plus 1
+      x.times 2
+protocol: |
+  s1 ← fork sym:v0 number
+    then
+      s2 ← L_number_plus sym:v1 number:3F-F0-00-00-00-00-00-00
+      answer sym:s2 number
+    else
+      s3 ← L_number_times sym:v1 number:40-00-00-00-00-00-00-00
+      answer sym:s3 number
+  answer sym:s1 number

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-branches.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-branches.yaml
@@ -2,16 +2,13 @@
 # SPDX-License-Identifier: MIT
 ---
 # Two clamps and a degree selector guard the easing polynomials of
-# Perlin: smootherstep for the then, smoothstep for the else. The
-# `.if` is void selection and the universe holds no `if` at all, so
-# no fragment reaching one ever reduces: the first guard parks into
-# a symbolic bool, and the `.if` reading that bool then dispatches
-# on a method nothing models, which is why `ease` keeps its body.
-# The guards are the only part that refuses, though. Each branch is
-# a pure application of its own, so both polynomials leave for
-# synthetic atoms and the `.if` spine stays behind to pick between
-# them at run time. Neither guard is outlined, since a lone
-# comparison is a Java atom already.
+# Perlin: smootherstep for the then, smoothstep for the else. Each
+# `.if` parks on the symbolic bool its guard leaves behind and becomes
+# a fork, whose arms are reduced on their own and nest the next guard,
+# so the whole formation leaves the EO as one atom. Every step of an
+# arm sits inside the block of that arm in the Java, so a polynomial is
+# computed only when its guards let it through, and the void `k`, read
+# by the innermost guard alone, is still dataized at the top with `t`.
 input: |
   [] > foo
     [t k] > ease
@@ -61,29 +58,73 @@ lowered: |
     ease > @
       0.3
       1
-    [t k] > ease
-      if. > @
-        0.gt t
-        0
-        if.
-          t.gt 1
-          1
-          if.
-            k.gt 0
-            l🌵01dcbdee24f2 t
-            l🌵14de55c7653e t
-      [] > l🌵01dcbdee24f2 /Q.number
-        ? > v0 /Q.number
-      [] > l🌵14de55c7653e /Q.number
-        ? > v0 /Q.number
-stuck: "no atom parked at any known operation"
+    [] > ease /Q.number
+      ? > t /Q.number
+      ? > k /Q.number
+protocol: |
+  s1 ← L_number_gt number:00-00-00-00-00-00-00-00 sym:v0
+  s2 ← fork sym:s1 number
+    then
+      answer number:00-00-00-00-00-00-00-00 number
+    else
+      s3 ← L_number_gt sym:v0 number:3F-F0-00-00-00-00-00-00
+      s4 ← fork sym:s3 number
+        then
+          answer number:3F-F0-00-00-00-00-00-00 number
+        else
+          s5 ← L_number_gt sym:v1 number:00-00-00-00-00-00-00-00
+          s6 ← fork sym:s5 number
+            then
+              s7 ← L_number_times sym:v0 number:40-18-00-00-00-00-00-00
+              s8 ← L_number_plus sym:s7 number:C0-2E-00-00-00-00-00-00
+              s9 ← L_number_times sym:s8 sym:v0
+              s10 ← L_number_plus sym:s9 number:40-24-00-00-00-00-00-00
+              s11 ← L_number_times sym:s10 sym:v0
+              s12 ← L_number_times sym:s11 sym:v0
+              s13 ← L_number_times sym:s12 sym:v0
+              answer sym:s13 number
+            else
+              s14 ← L_number_times sym:v0 sym:v0
+              s15 ← L_number_times sym:v0 number:C0-00-00-00-00-00-00-00
+              s16 ← L_number_plus sym:s15 number:40-08-00-00-00-00-00-00
+              s17 ← L_number_times sym:s14 sym:s16
+              answer sym:s17 number
+          answer sym:s6 number
+      answer sym:s4 number
+  answer sym:s2 number
 java: |
-  final double v0 = new Dataized(this.take("v0")).asNumber();
-  final double s1 = v0 * Double.longBitsToDouble(0x4018000000000000L);
-  final double s2 = s1 + Double.longBitsToDouble(0xC02E000000000000L);
-  final double s3 = s2 * v0;
-  final double s4 = s3 + Double.longBitsToDouble(0x4024000000000000L);
-  final double s5 = s4 * v0;
-  final double s6 = s5 * v0;
-  final double s7 = s6 * v0;
-  return new Data.ToPhi(s7);
+  final double v0 = new Dataized(this.take("t")).asNumber();
+  final double v1 = new Dataized(this.take("k")).asNumber();
+  final boolean s1 = Double.longBitsToDouble(0x0000000000000000L) > v0;
+  final double s2;
+  if (s1) {
+      s2 = Double.longBitsToDouble(0x0000000000000000L);
+  } else {
+      final boolean s3 = v0 > Double.longBitsToDouble(0x3FF0000000000000L);
+      final double s4;
+      if (s3) {
+          s4 = Double.longBitsToDouble(0x3FF0000000000000L);
+      } else {
+          final boolean s5 = v1 > Double.longBitsToDouble(0x0000000000000000L);
+          final double s6;
+          if (s5) {
+              final double s7 = v0 * Double.longBitsToDouble(0x4018000000000000L);
+              final double s8 = s7 + Double.longBitsToDouble(0xC02E000000000000L);
+              final double s9 = s8 * v0;
+              final double s10 = s9 + Double.longBitsToDouble(0x4024000000000000L);
+              final double s11 = s10 * v0;
+              final double s12 = s11 * v0;
+              final double s13 = s12 * v0;
+              s6 = s13;
+          } else {
+              final double s14 = v0 * v0;
+              final double s15 = v0 * Double.longBitsToDouble(0xC000000000000000L);
+              final double s16 = s15 + Double.longBitsToDouble(0x4008000000000000L);
+              final double s17 = s14 * s16;
+              s6 = s17;
+          }
+          s4 = s6;
+      }
+      s2 = s4;
+  }
+  return new Data.ToPhi(s2);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-branches.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-branches.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 # Two clamps and a degree selector guard the easing polynomials of
 # Perlin: smootherstep for the then, smoothstep for the else. Each
 # `.if` parks on the symbolic bool its guard leaves behind and becomes

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/outlined-fork.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/outlined-fork.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A clamp is a guard and a choice, two operations over one witnessed
+# void, so the whole application is outlined into a synthetic atom: the
+# comparison is its first step and the fork its second, and the else
+# arm answers the void itself with no step at all. The one-step
+# neighbour stays as written, since its op is a Java atom already.
+input: |
+  [] > foo
+    [x] > clamp
+      if. > @
+        x.gt 1
+        1
+        x
+      x.plus 1 > incr
+    clamp 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+lowered: |
+  [] > foo
+    clamp 5 > @
+    [x] > clamp
+      l🌵99796751a821 x > @
+      x.plus 1 > incr
+      [] > l🌵99796751a821 /Q.number
+        ? > v0 /Q.number
+java: |
+  final double v0 = new Dataized(this.take("v0")).asNumber();
+  final boolean s1 = v0 > Double.longBitsToDouble(0x3FF0000000000000L);
+  final double s2;
+  if (s1) {
+      s2 = Double.longBitsToDouble(0x3FF0000000000000L);
+  } else {
+      s2 = v0;
+  }
+  return new Data.ToPhi(s2);


### PR DESCRIPTION
Closes #8365.

A lowered protocol was a straight line, so any fragment reaching an `.if` refused at the reduction. This lets a protocol fork: `.if` on a symbolic bool becomes a Java `if/else`, with the steps of each arm inside that arm's block, so a guard keeps guarding the partial operation behind it.

## What changed

**Universe and table.** `bool` gains `if ↦ ⟦ t ↦ ∅, f ↦ ∅, λ ⤍ L_bool_if ⟧`, a λ phino never fires but always parks. Its `ops.tsv` row has an empty forma column and no Java format; `Reduction` reads the empty forma as the sign to fork.

**Step.** `Step` is an interface now. `Application` is the old class (one atom over values). `Fork` holds the key of the bool plus one `Protocol` per arm, so nesting is free. `Fork.forma()` refuses when the arms disagree.

**Reduction.** When `L_bool_if` parks, the two arguments are taken out of the matched site as they stand in the tree and each is reduced by a nested loop sharing the voids and one ledger of labels, so numbering continues across arms (`s2 ← fork`, then `s3…` inside). A refusing arm refuses the whole fork. A choice whose bool is already data gives way to the arm it picks, with no fork.

**Shape and Term.** `Shape` matches arguments by identity (the key of a value, the phi text of a site still unreduced), and a blank identity covers any argument, which is how the parked `if` finds its site before the arms are known. `Term.arguments(Shape)` hands back the bindings of that site.

**JavaAtom.** A fork renders as a blank final assigned at the end of each arm's block. Void reads from every nested protocol are hoisted to the top of the body.

**Tests and packs.** `LoweringTest.rendered()` prints an indented block per arm. `guarded-branches.yaml` now lowers `ease` whole into three nested forks, exactly the body the issue sketched. Two new packs: `outlined-fork.yaml` (an outlined clamp whose else arm answers the void itself) and `fork-on-flag.yaml` (a fork on a bool void; reduction only, see below).

## Verified

- `eo-lowering`: 158 tests pass, qulice clean.
- `eo-maven-plugin`: `LoweringTest` packs pass (108 run), `MjLowerTest` passes.
- `eo-runtime` lowered and compiled end to end with the real phino 0.0.115: 144 fragments where master finds 139, five of them forks, and the generated `if/else` atoms compile. The runtime test suite was still running when this PR was opened; I will report its result in a comment.

## Notes

- **pr-size**: this exceeds the 200-line cap, as the earlier lowering PRs for #8137 and #8308 did. The issue asks for an interface change across `Step`, `Reduction`, `JavaAtom` and the packs, and I did not find a smaller cut that leaves every intermediate state green.
- **Bool voids are not witnessed end to end yet.** For `pick true 5`, the provides table records the `true` argument by its own locator with no links row behind it, so `Lowered` never learns `flag` is a bool and `pick` stays as written, though its reduction forks fine. The `fork-on-flag` pack pins that state, and a pdd puzzle on `Formas` points at `eo:inference`.
- `Outlined` still requires two top-level steps, so a fork on a bare bool void with computation only inside its arms is not outlined; left as is to keep this change to what the issue asks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_