### PR TITLE
#8332: cite the rule that restricts a reversed-dispatch head

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -260,7 +260,7 @@ final class Value {
 
     /**
      * May this value open a reversed dispatch as the line's head — a
-     * bare identifier or a root glyph, the only kinds R-9.0.3 allows in
+     * bare identifier or a root glyph, the only kinds R-3.8.1 allows in
      * that position?
      * @return True for {@link Kind#IDENTIFIER} or {@link Kind#ROOT}
      */


### PR DESCRIPTION
`Value.reversible()` named `R-9.0.3` as the rule deciding which values may
open a reversed dispatch. `R-9.0.3` is an emission rule about how
method-dispatch chains are written into XMIR, in §9, which describes what
the parser writes, not what it accepts.

The rule the method implements is `R-3.8.1`, the reversed-dispatch line
shape, and it is the one `LnReversed` already cites for the same
restriction.

Closes #8332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_