### PR TITLE
#8331: cite the rule that enforces the indent step

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Stack.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Stack.java
@@ -12,7 +12,7 @@ import java.util.List;
  *
  * <p>The stack carries one {@link Level} per occupied indent level. Indents
  * grow strictly bottom-to-top in steps of exactly two (R-5.1.1, R-5.1.2);
- * the caller enforces the step (R-5.1.3) before calling
+ * the caller enforces the step (R-5.2.7) before calling
  * {@link #push(int, int, Kind, Openness)}. The bottom entry's
  * {@code parent} is always {@link Kind#TOP_LEVEL}; higher entries carry the
  * kind of the entry directly below them as their parent.</p>

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -11,7 +11,7 @@ package org.eolang.parser;
  * <p>Every line-shape parser (application, reversed, compact-tuple,
  * inline-phi, …) replays the same prologue when it owns the cursor:
  * if the new line is deeper-indent it pushes a fresh {@link Level}
- * after checking the indent step (R-5.1.3) and the parent's openness
+ * after checking the indent step (R-5.2.7) and the parent's openness
  * (R-5.2.4); otherwise it replaces the level on top at the same
  * indent. Either way, if the new line carries a naming suffix the
  * level is flagged as named (R-5.3.1). This class is the single


### PR DESCRIPTION
`Stack` and `Transition` named `R-5.1.3` as the rule behind the indent-step
check. `R-5.1.3` is about atoms and says nothing about indents.

`R-5.1.1` and `R-5.1.2` are invariants of the stack, not checks. The rule
that enforces the step at push time is `R-5.2.7`, which `Stack.push` already
cites correctly where it does the work.

Closes #8331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_