### PR TITLE
#8334: report a control character in a void parameter

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -233,6 +233,11 @@ final class Emissions {
 
     /**
      * Reject a void parameter name the grammar does not accept — §4.5.
+     *
+     * <p>The shape check leaves a control character through, since §2.3
+     * does not count one among the NAME terminators, so the glyph check
+     * every other identifier position runs happens here too.</p>
+     *
      * @param raw The parameter text, as written
      * @param line Source line (for error reporting)
      * @param pos Source column of the parameter's first character
@@ -244,6 +249,7 @@ final class Emissions {
                 "parameter names in voids must be NAME, @ or ^"
             );
         }
+        Suffix.checkGlyphs(raw, line, pos);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -306,7 +306,7 @@ final class Suffix {
      * @return Emitted token — variable verbatim, forma promoted
      */
     static String typeAtom(final String raw, final Span span, final int pos) {
-        Suffix.checkGlyphs(raw, span, pos);
+        Suffix.checkGlyphs(raw, span.line(), pos);
         final char first = raw.charAt(0);
         if (first >= 'A' && first <= 'Z'
             && !Suffix.VARIABLE.matcher(raw).matches() && !raw.startsWith("Q.")) {
@@ -331,6 +331,36 @@ final class Suffix {
             promoted = raw;
         }
         return promoted;
+    }
+
+    /**
+     * Reject an identifier carrying a glyph no identifier may hold.
+     *
+     * <p>The cactus emoji is reserved for auto-names (§2.3). A control
+     * character is worse than reserved: an XML attribute cannot hold it,
+     * so a name that keeps one reaches xembly and breaks the parse with
+     * an exception that names neither the file nor the line. Every
+     * position that reads an identifier runs this, and reports the
+     * character at the column it sits in.</p>
+     *
+     * @param name The identifier, as written
+     * @param line Source line
+     * @param pos Source column of the identifier's first character
+     */
+    static void checkGlyphs(final String name, final int line, final int pos) {
+        if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
+            throw new ParseError(
+                line, pos,
+                "cactus emoji is reserved for auto-names; not allowed in identifiers"
+            );
+        }
+        final int control = new Scrubbed(name).found();
+        if (control >= 0) {
+            throw new ParseError(
+                line, pos + control,
+                "control character is not allowed in an identifier"
+            );
+        }
     }
 
     private static int clamped(final int pos, final Span span) {
@@ -399,7 +429,7 @@ final class Suffix {
             );
         }
         final String name = tail.substring(start, idx);
-        Suffix.checkGlyphs(name, span, home + start);
+        Suffix.checkGlyphs(name, span.line(), home + start);
         Suffix.checkLowercaseStart(name, span, home, start);
         Suffix.endsClean(tail, idx, span, home);
         return new Suffix(form, name, "", false);
@@ -422,22 +452,6 @@ final class Suffix {
                 );
             }
             from = end + 1;
-        }
-    }
-
-    private static void checkGlyphs(final String name, final Span span, final int pos) {
-        if (name.codePoints().anyMatch(cp -> cp == 0x1F335)) {
-            throw new ParseError(
-                span.line(), pos,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
-        final int control = new Scrubbed(name).found();
-        if (control >= 0) {
-            throw new ParseError(
-                span.line(), pos + control,
-                "control character is not allowed in an identifier"
-            );
         }
     }
 
@@ -484,7 +498,7 @@ final class Suffix {
                 )
             );
         }
-        Suffix.checkGlyphs(handle, span, home + begin);
+        Suffix.checkGlyphs(handle, span.line(), home + begin);
         Suffix.checkLowercaseStart(handle, span, home, begin);
         if (!cnst && tail.startsWith("!", rest)) {
             cnst = true;
@@ -514,7 +528,7 @@ final class Suffix {
         int idx = Suffix.skipName(tail, begin);
         Suffix.checkNamePresent(tail, begin, idx, span, home);
         final String name = tail.substring(begin, idx);
-        Suffix.checkGlyphs(name, span, home + begin);
+        Suffix.checkGlyphs(name, span.line(), home + begin);
         Suffix.checkLowercaseStart(name, span, home, begin);
         boolean cnst = false;
         if (idx < tail.length() && tail.charAt(idx) == '!') {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-void-parameter-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-void-parameter-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'control character is not allowed in an identifier')]
+input: "[a\fb] > app\n  1 > @\n"


### PR DESCRIPTION
A control character inside a formation's bracket parameter list killed the
parser: `[a␁b] > app` came out of `EoSyntax.parsed()` as an
`IllegalArgumentException` from xembly, with no `<error>`, no line and no
position, while the same character in the five other identifier positions is
reported as `control character is not allowed in an identifier`.

The shape check (`Emissions.validParam`) lets it through, because §2.3's NAME
excludes a fixed set of token boundaries and control characters are not among
them. The name then reaches `Directives.attr`, which refuses it.

`Suffix.checkGlyphs` — the check the working positions already run — is now
package-private and called from `Emissions.validParam`, the one validator all
three void-parameter paths (`LnFormation`, `LnOnlyPhi`, `Emissions.onlyPhi`)
go through. It takes the source line rather than the whole `Span`, since that
is all it reads.

A new `eo-syntax` pack reproduces the crash and now asserts the parse error.

Closes #8334

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_