### PR TITLE
#8335: report a control character in a meta part

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1380,6 +1380,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Plain child without name in formation | `object inside formation must have a name` |
 | Root identifier glued to a letter or a digit (e.g. the legacy `QQ.io.stdout`) | `<token> is not a valid object name, root <root> must be followed by a dot` (token and root substituted) |
 | Control character inside an identifier or a name suffix | `control character is not allowed in an identifier` |
+| Control character inside a meta part (R-3.2.4) | `control character is not allowed in a meta` |
 | Atom containing non-test child | `atom may contain only test attributes` |
 | `+>` outside indent 2 of top level | `test attribute legal only as direct child of top-level object` |
 | Bare reversed dispatch missing receiver | `reversed dispatch missing receiver` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -182,7 +182,15 @@ final class LnMeta implements Line {
                     "meta parts must be separated by exactly one space"
                 );
             }
-            out.add(LnMeta.promoteQ(tail.substring(idx, end)));
+            final String part = tail.substring(idx, end);
+            final int control = new Scrubbed(part).found();
+            if (control >= 0) {
+                throw new ParseError(
+                    this.span.line(), this.span.indent() + base + idx + control,
+                    "control character is not allowed in a meta"
+                );
+            }
+            out.add(LnMeta.promoteQ(part));
             idx = end;
             if (idx < tail.length()) {
                 idx = idx + 1;

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-meta-part-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-meta-part-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'control character is not allowed in a meta')]
+input: "+package a\x01b\n\n# c\n\n[] > app\n  1 > @\n"


### PR DESCRIPTION
A control character inside a meta part killed the parser: the part reached
xembly's `SET` directive, which refused it with an `IllegalArgumentException`
naming neither the file nor the line, and no `<error>` element was produced
at all. `+package`, `+alias` and `+home` values are the parts of a `.eo` file
most often generated or pasted from elsewhere, so this is where a stray
control character is most likely to be met.

`LnMeta.split` now reads each part as it cuts it and reports the character at
the column it sits in. A meta part is not an identifier, so the diagnostic
gets a text of its own — `control character is not allowed in a meta` — and a
row in the §9.9 canonical-text table, as R-9.9.3 requires.

A new `eo-syntax` pack reproduces the crash and now asserts the parse error.

Closes #8335

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_