### PR TITLE
#8341: raise the allocation ceiling above ordinary tests

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -27,10 +27,13 @@
     How much memory a single test may allocate before Maxmem terminates it
     and reports it as skipped. The suffixes of -Xmx are understood: "2G",
     "512M", "65536K", or plain bytes. Empty, or zero, means no limit at all
-    and no watching either, which is the default: a box with memory to
-    spare should run every test to its end.
+    and no watching either: a box with memory to spare should run every
+    test to its end. The value here sits above the band an ordinary test
+    occupies — a directory walk passes about 300M through the allocator
+    without ever holding much — so that the guard fires on a runaway test
+    rather than on the population (#8341).
     -->
-    <eo.maxmem>256M</eo.maxmem>
+    <eo.maxmem>1G</eo.maxmem>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
`eo.maxmem` defaulted to `256M`, which is below the band an ordinary `.eo`
test occupies. `EOdirectoryTest` allocates between 256M and 306M across its
60 tests, so the guard aborted 59 of them — the smallest offender by 133 KB,
0.05% of the budget — and the build went green with the tests thrown away.
The `mvn` workflow reports 72 to 84 such skips per build.

`Maxmem` exists to stop one greedy test taking the heap down with it. A limit
that fires on the population instead of the outlier does not do that. `1G`
sits above the 306M worst case and still catches the runaway case from #8046,
which exhausts whatever it is given.

The property comment also claimed no-limit was the default while the value
said `256M`; it now describes what the value is for.

Closes #8341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_