### PR TITLE
#8361: say ASCII where R-3.2.4 turns on it

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1366,7 +1366,6 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Bracket-parameter name that is neither NAME, `@` nor `^` (§4.5) | `parameter names in voids must be NAME, @ or ^` |
 | `@` among the bracket parameters of an only-phi formation, which binds its φ from the left-hand side | `an only-phi formation binds φ from its left-hand side, so @ is not allowed among its voids` |
 | Bracket parameters on an atom head (R-3.4.10) | `an atom must declare its void attributes vertically, as ? > name lines` |
-| More than one space between meta parts (R-3.2.4) | `meta parts must be separated by exactly one space` |
 | Test attribute name is `@` (PHI) instead of NAME (R-6.3.5) | `test attribute name must be an identifier, not @` |
 | Leading-zero in integer literal (R-9.8.1, e.g., `007`) | `integer literal must not have leading zeros` |
 | Decimal `INT`/`FLOAT` literal whose exact decimal value differs from the IEEE-754 double it parses to (dead digits; e.g., `2.7182818284590452354`). Alternate spellings of the same value (`+42`, `1.50`) are accepted. | `<literal> is over-precise, write <canonical> instead` (literal and canonical substituted) |
@@ -1432,7 +1431,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | File-local handle after `>>` that is a scope token rather than an identifier (R-3.10.12) | `file-local handle must be an identifier, not <token>` (token substituted) |
 | `+` with no meta name after it (§3.2) | `meta directive requires a name` |
 | Meta name that is not lowercase letters and digits opening with a letter (§3.2) | `meta name must be lowercase letters and digits, starting with a letter` |
-| Whitespace other than a plain space between meta parts (R-3.2.4) | `meta parts must be separated by a single ASCII space` |
+| Anything but a single plain space between meta parts — a second space, a tab, an ideographic space (R-3.2.4) | `meta parts must be separated by a single ASCII space` |
 | `+package` carrying a number of parts other than one (§3.2) | `'+package' directive requires exactly one argument` |
 | `+package` path with an empty dotted segment (§3.2) | `'+package' path must not have an empty segment` |
 | `+alias` carrying no part (R-3.2.3) | `'+alias' directive requires at least one argument` |

--- a/eo-parser/README.md
+++ b/eo-parser/README.md
@@ -99,7 +99,7 @@ input: |
 ```yaml
 line: 1
 message: |-
-  [1:5] error: 'meta parts must be separated by exactly one space'
+  [1:5] error: 'meta parts must be separated by a single ASCII space'
 input: |
   +meta with  spaces
 ```

--- a/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMeta.java
@@ -179,7 +179,7 @@ final class LnMeta implements Line {
             if (end == idx || end < tail.length() && tail.charAt(end) != ' ') {
                 throw new ParseError(
                     this.span.line(), this.span.indent() + base + end,
-                    "meta parts must be separated by exactly one space"
+                    "meta parts must be separated by a single ASCII space"
                 );
             }
             out.add(LnMeta.promoteQ(tail.substring(idx, end)));

--- a/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnMetaTest.java
@@ -221,7 +221,7 @@ final class LnMetaTest {
                     .into(new Stack(), new Globals(), new Emit()),
                 "a tab between meta parts must be rejected per R-3.2.4"
             ).getMessage(),
-            Matchers.equalTo("meta parts must be separated by exactly one space")
+            Matchers.equalTo("meta parts must be separated by a single ASCII space")
         );
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/meta-parts-separated-by-a-tab-are-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/meta-parts-separated-by-a-tab-are-rejected.yaml
@@ -4,5 +4,5 @@
 sheets: []
 asserts:
   - /object/errors[count(error)=1]
-  - /object/errors/error[contains(text(),'separated by exactly one space')]
+  - /object/errors/error[contains(text(),'separated by a single ASCII space')]
 input: "+rt jvm\torg.eolang:eo-runtime:0.0.0\n\n[] > app\n  42 > x\n"

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/double-space-in-meta.yaml
@@ -4,7 +4,7 @@
 # yamllint disable rule:line-length
 line: 1
 message: |-
-  [1:11] error: 'meta parts must be separated by exactly one space'
+  [1:11] error: 'meta parts must be separated by a single ASCII space'
   +meta with  spaces
              ^
 input: |


### PR DESCRIPTION
§9.9 exists so that one text is *the* text, and for R-3.2.4 it carried two —
`meta parts must be separated by exactly one space` and `meta parts must be
separated by a single ASCII space` — while `LnMeta` printed the first. A
reader matching the parser's diagnostic against the table found the row that
omits the substantive half of the rule: a tab or an ideographic space between
meta parts is rejected too, and the message did not say that a space-looking
character was the problem.

The parser now prints the ASCII wording. One literal covers both conditions,
so the two table rows collapse into one that names them. The packs, the unit
test and the README example follow the literal.

Closes #8361

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_