### PR TITLE
fix(lowering): #8376 read a void in the innermost block that reaches its uses

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
@@ -14,9 +14,11 @@ import java.util.List;
  * <p>It is what an {@code if} parked on a symbolic bool turns into: the
  * key of that bool, and one protocol per arm, each reduced on its own
  * from the argument the site held. The steps of an arm are computed only
- * when the arm is taken, which is what keeps a guard guarding: an
- * operation that is partial stays behind the bool that protects it. The
- * value of the fork is whatever the taken arm answers, so the two arms
+ * when the arm is taken, and so are the reads of the voids that arm
+ * alone touches, which is what keeps a guard guarding: an operation that
+ * is partial, and an argument whose dataization may never end, both
+ * stay behind the bool that protects them. The value of the fork is
+ * whatever the taken arm answers, so the two arms
  * must answer the same forma, and a fork whose arms disagree refuses to
  * name one.</p>
  *

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -5,11 +5,13 @@
 package org.eolang.lowering;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -18,12 +20,16 @@ import java.util.stream.Stream;
  *
  * <p>A protocol is a program of steps, so its Java is one statement per
  * step: one local per void any step reads, dataized through the public
- * runtime API and hoisted to the top of the body, one local per
- * application, rendered by the format the {@link Op} table holds for its
- * atom, one blank final per fork, assigned at the end of each of its two
- * arms, whose own steps sit inside the arm's block and so compute only
- * when the arm is taken, and one return handing the answer to
- * {@code Data.ToPhi}. A string is bytes here: its Δ is the very UTF-8
+ * runtime API, one local per application, rendered by the format the
+ * {@link Op} table holds for its atom, one blank final per fork,
+ * assigned at the end of each of its two arms, whose own steps sit
+ * inside the arm's block and so compute only when the arm is taken, and
+ * one return handing the answer to {@code Data.ToPhi}. A void is read
+ * at the top of the innermost block that reaches every use of it: at the
+ * top of the body when a step outside every fork reads it, or both arms
+ * of one fork do, and at the top of an arm when that arm alone does, so
+ * that an argument a guard protects is never forced while the guard
+ * holds it back. A string is bytes here: its Δ is the very UTF-8
  * sequence the byte atoms it reaches through {@code φ} operate on, so a
  * string void is read as a {@code byte[]} and meets a bytes carrier as
  * one. The text is exactly what the {@code lambda()} of the generated
@@ -68,18 +74,9 @@ public final class JavaAtom {
                 "A string answer cannot be handed over, since Data.ToPhi makes bytes of a byte array"
             );
         }
-        final List<String> names = new ArrayList<>(this.voids.keySet());
-        final List<String> lines = new ArrayList<>(names.size());
-        for (final Integer index : this.used()) {
-            if (index >= names.size()) {
-                throw new IllegalStateException(
-                    String.format("The protocol reads void #%d, which the fragment lacks", index)
-                );
-            }
-            final String name = names.get(index);
-            lines.add(JavaAtom.reading(index, name, this.voids.get(name)));
-        }
-        lines.addAll(this.computed(this.protocol, ""));
+        final List<String> lines = this.computed(
+            this.protocol, "", Collections.emptySet()
+        );
         lines.add(
             String.format(
                 "return new Data.ToPhi(%s);",
@@ -91,19 +88,6 @@ public final class JavaAtom {
             .collect(Collectors.joining(System.lineSeparator()));
     }
 
-    private SortedSet<Integer> used() {
-        final SortedSet<Integer> out = new TreeSet<>();
-        final Stream<String> keys = JavaAtom.unfolded(this.protocol).flatMap(
-            proto -> Stream.concat(
-                proto.moves().stream().flatMap(step -> step.keys().stream()),
-                Stream.of(proto.answer())
-            )
-        );
-        keys.filter(key -> key.startsWith("sym:v"))
-            .forEach(key -> out.add(Integer.parseInt(key.substring(5))));
-        return out;
-    }
-
     private static Stream<Protocol> unfolded(final Protocol proto) {
         return Stream.concat(
             Stream.of(proto),
@@ -111,6 +95,17 @@ public final class JavaAtom {
                 .flatMap(step -> step.branches().stream())
                 .flatMap(JavaAtom::unfolded)
         );
+    }
+
+    private String dataized(final int index) {
+        final List<String> names = new ArrayList<>(this.voids.keySet());
+        if (index >= names.size()) {
+            throw new IllegalStateException(
+                String.format("The protocol reads void #%d, which the fragment lacks", index)
+            );
+        }
+        final String name = names.get(index);
+        return JavaAtom.reading(index, name, this.voids.get(name));
     }
 
     private static String reading(final int index, final String name, final String forma) {
@@ -138,8 +133,15 @@ public final class JavaAtom {
         return out;
     }
 
-    private List<String> computed(final Protocol proto, final String pad) {
+    private List<String> computed(final Protocol proto, final String pad,
+        final Set<Integer> above) {
         final List<String> out = new ArrayList<>(proto.moves().size());
+        final SortedSet<Integer> here = new Reads(proto).own(above);
+        for (final Integer index : here) {
+            out.add(String.format("%s%s", pad, this.dataized(index)));
+        }
+        final Set<Integer> known = new HashSet<>(above);
+        known.addAll(here);
         for (final Step step : proto.moves()) {
             if (step.branches().isEmpty()) {
                 out.add(
@@ -149,13 +151,13 @@ public final class JavaAtom {
                     )
                 );
             } else {
-                out.addAll(this.forked(step, pad));
+                out.addAll(this.forked(step, pad, known));
             }
         }
         return out;
     }
 
-    private List<String> forked(final Step step, final String pad) {
+    private List<String> forked(final Step step, final String pad, final Set<Integer> known) {
         final String test = step.keys().get(0);
         if (!"bool".equals(this.forma(test))) {
             throw new IllegalStateException(
@@ -173,15 +175,16 @@ public final class JavaAtom {
             )
         );
         out.add(String.format("%sif (%s) {", pad, JavaAtom.expression(test)));
-        out.addAll(this.assigned(step.label(), step.branches().get(0), inner));
+        out.addAll(this.assigned(step.label(), step.branches().get(0), inner, known));
         out.add(String.format("%s} else {", pad));
-        out.addAll(this.assigned(step.label(), step.branches().get(1), inner));
+        out.addAll(this.assigned(step.label(), step.branches().get(1), inner, known));
         out.add(String.format("%s}", pad));
         return out;
     }
 
-    private List<String> assigned(final String label, final Protocol arm, final String pad) {
-        final List<String> out = this.computed(arm, pad);
+    private List<String> assigned(final String label, final Protocol arm,
+        final String pad, final Set<Integer> known) {
+        final List<String> out = this.computed(arm, pad, known);
         out.add(String.format("%s%s = %s;", pad, label, JavaAtom.expression(arm.answer())));
         return out;
     }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
@@ -1,0 +1,88 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+/**
+ * The voids one protocol reads, and which of them its own block declares.
+ *
+ * <p>A void is dataized at the top of the innermost block that reaches
+ * every use of it, so that an argument only one arm of a fork touches is
+ * never forced when the other arm is taken. The block of a protocol
+ * therefore declares the voids a step of its own reads or its answer
+ * names, and the voids two or more arms of its forks read, since no
+ * single arm dominates such a void; a void exactly one arm reads is
+ * left to the protocol of that arm, which decides the same way. Whatever
+ * an enclosing block declared already is in scope and is not declared
+ * again.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Reads {
+
+    /**
+     * The protocol.
+     */
+    private final Protocol protocol;
+
+    /**
+     * Ctor.
+     * @param proto The protocol
+     */
+    public Reads(final Protocol proto) {
+        this.protocol = proto;
+    }
+
+    /**
+     * Every void the protocol reads, nested arms included.
+     * @return The indices of the voids, ascending
+     */
+    public SortedSet<Integer> all() {
+        final SortedSet<Integer> out = this.direct();
+        this.protocol.moves().stream()
+            .flatMap(step -> step.branches().stream())
+            .forEach(arm -> out.addAll(new Reads(arm).all()));
+        return out;
+    }
+
+    /**
+     * The voids the block of this protocol declares.
+     * @param above The indices of the voids the enclosing blocks declared
+     * @return The indices of the voids, ascending
+     */
+    public SortedSet<Integer> own(final Set<Integer> above) {
+        final Map<Integer, Integer> count = new HashMap<>(0);
+        final Stream<Protocol> arms = this.protocol.moves().stream()
+            .flatMap(step -> step.branches().stream());
+        arms.forEach(
+            arm -> new Reads(arm).all().forEach(index -> count.merge(index, 1, Integer::sum))
+        );
+        final SortedSet<Integer> out = this.direct();
+        for (final Map.Entry<Integer, Integer> entry : count.entrySet()) {
+            if (entry.getValue() > 1) {
+                out.add(entry.getKey());
+            }
+        }
+        out.removeAll(above);
+        return out;
+    }
+
+    private SortedSet<Integer> direct() {
+        final SortedSet<Integer> out = new TreeSet<>();
+        final Stream<String> keys = Stream.concat(
+            this.protocol.moves().stream().flatMap(step -> step.keys().stream()),
+            Stream.of(this.protocol.answer())
+        );
+        keys.filter(key -> key.startsWith("sym:v"))
+            .forEach(key -> out.add(Integer.parseInt(key.substring(5))));
+        return out;
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -336,12 +336,12 @@ final class JavaAtomTest {
     }
 
     @Test
-    void hoistsVoidReadOutOfArm() {
+    void readsVoidInsideTheArmThatAloneUsesIt() {
         final Map<String, String> voids = new LinkedHashMap<>();
         voids.put("f", "bool");
         voids.put("y", "number");
         MatcherAssert.assertThat(
-            "a void read inside an arm alone must be dataized at the top, but it isnt",
+            "a void one arm alone reads must be dataized inside that arm, but it isnt",
             new JavaAtom(
                 new Protocol(
                     Collections.singletonList(
@@ -358,13 +358,60 @@ final class JavaAtomTest {
                 ),
                 voids
             ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final boolean v0 = new Dataized(this.take(\"f\")).asBool();",
+                    "        final double s1;",
+                    "        if (v0) {",
+                    "            final double v1 = new Dataized(this.take(\"y\")).asNumber();",
+                    "            s1 = v1;",
+                    "        } else {",
+                    "            s1 = Double.longBitsToDouble(0x0000000000000000L);",
+                    "        }",
+                    "        return new Data.ToPhi(s1);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void readsVoidBothArmsUseAboveTheFork() {
+        final Map<String, String> voids = new LinkedHashMap<>();
+        voids.put("f", "bool");
+        voids.put("y", "number");
+        MatcherAssert.assertThat(
+            "a void both arms read must be dataized once, above the fork, but it isnt",
+            new JavaAtom(
+                new Protocol(
+                    Collections.singletonList(
+                        new Fork(
+                            "s1", "L_bool_if", "sym:v0",
+                            new Protocol(Collections.emptyList(), "sym:v1", "number"),
+                            new Protocol(
+                                Collections.singletonList(
+                                    new Application(
+                                        "s2", "L_number_times", Arrays.asList("sym:v1", "sym:v1")
+                                    )
+                                ),
+                                "sym:s2",
+                                "number"
+                            )
+                        )
+                    ),
+                    "sym:s1",
+                    "number"
+                ),
+                voids
+            ).text(),
             Matchers.startsWith(
                 String.join(
                     System.lineSeparator(),
                     "        final boolean v0 = new Dataized(this.take(\"f\")).asBool();",
                     "        final double v1 = new Dataized(this.take(\"y\")).asNumber();",
                     "        final double s1;",
-                    "        if (v0) {"
+                    "        if (v0) {",
+                    "            s1 = v1;"
                 )
             )
         );

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReadsTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReadsTest.java
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Reads}.
+ * @since 0.76.0
+ */
+final class ReadsTest {
+
+    @Test
+    void listsVoidsOfNestedArms() {
+        MatcherAssert.assertThat(
+            "a void read deep inside an arm must count among all the reads, but it doesnt",
+            new Reads(ReadsTest.forked("sym:v1", "number:11-")).all(),
+            Matchers.contains(0, 1)
+        );
+    }
+
+    @Test
+    void leavesVoidOfOneArmToThatArm() {
+        MatcherAssert.assertThat(
+            "a void one arm alone reads must not be declared above the fork, but it is",
+            new Reads(ReadsTest.forked("sym:v1", "number:11-")).own(Collections.emptySet()),
+            Matchers.contains(0)
+        );
+    }
+
+    @Test
+    void claimsVoidBothArmsRead() {
+        MatcherAssert.assertThat(
+            "a void both arms read must be declared above the fork, but it isnt",
+            new Reads(ReadsTest.forked("sym:v1", "sym:v1")).own(Collections.emptySet()),
+            Matchers.contains(0, 1)
+        );
+    }
+
+    @Test
+    void skipsVoidDeclaredAbove() {
+        MatcherAssert.assertThat(
+            "a void an enclosing block declared must not be declared again, but it is",
+            new Reads(ReadsTest.forked("sym:v1", "sym:v1")).own(Collections.singleton(0)),
+            Matchers.contains(1)
+        );
+    }
+
+    @Test
+    void claimsVoidOfArmsOfTwoForks() {
+        MatcherAssert.assertThat(
+            "a void two forks read, one arm each, must be declared above both, but it isnt",
+            new Reads(
+                new Protocol(
+                    Arrays.asList(
+                        new Fork(
+                            "s1", "L_bool_if", "sym:v0",
+                            new Protocol(Collections.emptyList(), "sym:v1", "number"),
+                            new Protocol(Collections.emptyList(), "number:11-", "number")
+                        ),
+                        new Fork(
+                            "s2", "L_bool_if", "sym:v0",
+                            new Protocol(Collections.emptyList(), "number:22-", "number"),
+                            new Protocol(Collections.emptyList(), "sym:v1", "number")
+                        )
+                    ),
+                    "sym:s2",
+                    "number"
+                )
+            ).own(Collections.emptySet()),
+            Matchers.contains(0, 1)
+        );
+    }
+
+    private static Protocol forked(final String yes, final String not) {
+        return new Protocol(
+            Collections.singletonList(
+                new Fork(
+                    "s1", "L_bool_if", "sym:v0",
+                    new Protocol(Collections.emptyList(), yes, "number"),
+                    new Protocol(Collections.emptyList(), not, "number")
+                )
+            ),
+            "sym:s1",
+            "number"
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-branches.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-branches.yaml
@@ -8,8 +8,10 @@
 # a fork, whose arms are reduced on their own and nest the next guard,
 # so the whole formation leaves the EO as one atom. Every step of an
 # arm sits inside the block of that arm in the Java, so a polynomial is
-# computed only when its guards let it through, and the void `k`, read
-# by the innermost guard alone, is still dataized at the top with `t`.
+# computed only when its guards let it through, and so is every read of
+# a void that arm alone touches: `t` is read at the top, since the first
+# guard needs it, while `k`, read by the innermost guard alone, is
+# dataized inside the arm that reaches that guard and nowhere else.
 input: |
   [] > foo
     [t k] > ease
@@ -95,7 +97,6 @@ protocol: |
   answer sym:s2 number
 java: |
   final double v0 = new Dataized(this.take("t")).asNumber();
-  final double v1 = new Dataized(this.take("k")).asNumber();
   final boolean s1 = Double.longBitsToDouble(0x0000000000000000L) > v0;
   final double s2;
   if (s1) {
@@ -106,6 +107,7 @@ java: |
       if (s3) {
           s4 = Double.longBitsToDouble(0x3FF0000000000000L);
       } else {
+          final double v1 = new Dataized(this.take("k")).asNumber();
           final boolean s5 = v1 > Double.longBitsToDouble(0x0000000000000000L);
           final double s6;
           if (s5) {


### PR DESCRIPTION
Closes #8376.

A fork kept the *steps* of an arm inside that arm, but every void read was still hoisted to the top of the body, so an argument only one arm ever touched was dataized before the guard was tested. For the clamp in `tuple.withi` that meant walking the whole tuple for `^.length` even when a negative index answers `0` at once; for an argument whose dataization terminates or diverges, it meant doing so in an arm that was never taken.

## What changed

**`Reads`** (new) answers, for one protocol, which voids its own block declares: those a step of its own reads or its answer names, plus those read by two or more arms of its forks, since no single arm dominates such a void, minus whatever an enclosing block declared already. A void exactly one arm reads is left to that arm's protocol, which decides the same way, recursively.

**`JavaAtom`** emits the reads of each block at the top of that block instead of collecting every nested void at the top of the body. The dominance logic moved out of it into `Reads`, which also keeps PMD's God Class rule quiet.

**`Fork`**'s Javadoc now states the guarantee for reads as well as steps, and it is true.

**Packs and tests.** `guarded-branches.yaml` moves the read of `k` into the arm of the innermost guard and its comment says why. `JavaAtomTest` pins an arm-private read staying inside the arm and a read shared by both arms staying above the fork; `ReadsTest` covers the dominance rules, including a void read by one arm each of two sibling forks.

## Verified

- `eo-lowering`: 164 tests pass, qulice clean.
- `eo-maven-plugin`: all lowering packs pass, the `guarded-branches` sidecar digest included.
- `eo-runtime` re-lowered with phino 0.0.115: the generated `if/else` atoms compile; the three bodies the issue names now read their arm-private void inside the arm.

## Notes

- **pr-size** is over the 200-line cap by about 130 lines, mostly the new class, its test and Javadoc; the previous lowering PRs merged with the same check red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_