### PR TITLE
#8345: do not call a body skipped while it still runs

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/Watched.java
+++ b/eo-runtime/src/test/java/org/eolang/Watched.java
@@ -44,15 +44,15 @@ import org.opentest4j.TestAbortedException;
  * a box with more memory would never have reached says nothing about the
  * code under test.</p>
  *
+ * <p>That skip is reported only once the group is empty. A body that
+ * outlasts its grace keeps whatever it opened, and JUnit deletes the
+ * {@code @TempDir} of the test right behind it — which on Windows cannot be
+ * done while a file in it is open, so the skip comes out as a failure that
+ * names neither the memory nor the test. So a group that still holds
+ * threads when the grace runs out fails the test with a sentence saying how
+ * many of them are left, instead of a skip that is not true yet.</p>
+ *
  * @since 0.75.0
- * @todo #8336:30min Let a body that will not stop be waited for. A terminated
- *  body gets half a second to die and the skip is reported whether it died or
- *  not, so its threads outlive the test that owns them, holding whatever they
- *  opened. JUnit closes the context right behind them and deletes the
- *  {@code @TempDir} of that test, which on windows cannot be deleted while a
- *  file in it is open, so the skip comes out as a failure that names neither
- *  the memory nor the test. Either wait for the group to empty, or say
- *  plainly that the body outlived its test.
  */
 @SuppressWarnings({"PMD.AvoidThreadGroup", "PMD.AvoidCatchingGenericException"})
 final class Watched {
@@ -65,6 +65,21 @@ final class Watched {
         "The test allocated %d bytes, which is over the %d bytes",
         "of eo.maxmem it was given, so it was terminated"
     );
+
+    /**
+     * What is said about a body that would not stop.
+     */
+    private static final String LINGERED = String.join(
+        " ",
+        "The test allocated %d bytes, which is over the %d bytes of eo.maxmem",
+        "it was given, and %d of its threads were still running %d ms after the",
+        "group was interrupted, so the body outlived the test that owns it"
+    );
+
+    /**
+     * How many milliseconds a terminated body is given to actually stop.
+     */
+    private static final long GRACE = 500L;
 
     /**
      * How many tests have been watched, to give every group its own name.
@@ -131,7 +146,11 @@ final class Watched {
         }
         if (over) {
             group.interrupt();
-            Watched.settle(done);
+            Watched.settle(group, done);
+            final int alive = group.activeCount();
+            if (alive > 0) {
+                throw this.outlived(consumed.bytes(), alive);
+            }
             throw this.aborted(consumed.bytes());
         }
         final Throwable error = failure.get();
@@ -143,9 +162,13 @@ final class Watched {
         }
     }
 
-    private static void settle(final CountDownLatch done) {
+    private static void settle(final ThreadGroup group, final CountDownLatch done) {
+        final long deadline = System.currentTimeMillis() + Watched.GRACE;
         try {
-            done.await(500L, TimeUnit.MILLISECONDS);
+            while (System.currentTimeMillis() < deadline
+                && (done.getCount() > 0L || group.activeCount() > 0)) {
+                Thread.sleep(10L);
+            }
         } catch (final InterruptedException ex) {
             Thread.currentThread().interrupt();
         }
@@ -154,6 +177,12 @@ final class Watched {
     private TestAbortedException aborted(final long taken) {
         return new TestAbortedException(
             String.format(Watched.MESSAGE, taken, this.limit)
+        );
+    }
+
+    private IllegalStateException outlived(final long taken, final int alive) {
+        return new IllegalStateException(
+            String.format(Watched.LINGERED, taken, this.limit, alive, Watched.GRACE)
         );
     }
 

--- a/eo-runtime/src/test/java/org/eolang/WatchedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/WatchedTest.java
@@ -4,12 +4,14 @@
  */
 package org.eolang;
 
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 import org.opentest4j.TestAbortedException;
 
 /**
@@ -80,6 +82,16 @@ final class WatchedTest {
     }
 
     @Test
+    @Timeout(value = 10L, unit = TimeUnit.SECONDS)
+    void refusesToSkipBodyThatWillNotStop() {
+        MatcherAssert.assertThat(
+            "A body that will not stop must be said to outlive its test, but it wasnt",
+            WatchedTest.lingering(),
+            Matchers.containsString("outlived the test")
+        );
+    }
+
+    @Test
     void letsFrugalBodyThrough() {
         MatcherAssert.assertThat(
             "A body that eats almost nothing must run to its end, but it didnt",
@@ -128,6 +140,30 @@ final class WatchedTest {
             "A body that never stops allocating must be terminated, but it wasnt"
         );
         return WatchedTest.awaited(stopped);
+    }
+
+    private static String lingering() {
+        final AtomicBoolean release = new AtomicBoolean(false);
+        try {
+            return Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> new Watched(1024L * 1024L).through(
+                    () -> {
+                        final byte[][] junk = new byte[1][];
+                        for (int idx = 0; idx < 16; ++idx) {
+                            junk[0] = new byte[256 * 1024];
+                        }
+                        while (!release.get()) {
+                            WatchedTest.rest(1L);
+                        }
+                        return null;
+                    }
+                ),
+                "A body that ignores its interrupt must fail the test, but it didnt"
+            ).getMessage();
+        } finally {
+            release.set(true);
+        }
     }
 
     private static boolean interrupted() {


### PR DESCRIPTION
Resolves the `8336-be89e19c` puzzle in `Watched`.

A terminated body was given half a second to die, and the skip was reported
whether it died or not. Its threads outlived the test that owns them, holding
whatever they opened; JUnit then deleted that test's `@TempDir` right behind
them, which on Windows cannot be done while a file in it is open, so the skip
came out as a failure naming neither the memory nor the test.

The grace now waits for the group to empty rather than only for the body to
count down, and a group that still holds threads when the grace runs out fails
the test with a sentence saying how many are left — the puzzle's second
option, taken where the first cannot be honoured.

`WatchedTest.refusesToSkipBodyThatWillNotStop` runs a body that ignores its
interrupt; before the change it came back as a `TestAbortedException` while
the body was still running.

Closes #8345

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_