### PR TITLE
Read what an atom hands into a void it is given

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Handed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Handed.java
@@ -1,0 +1,145 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * What an atom puts into the voids of what it is handed.
+ *
+ * <p>{@link Fillings} reads the applications of a program, and an atom is not
+ * one of them. Its body is Java, so a formation given to it is called where no
+ * source can be read, and the voids of that formation are filled by nobody as
+ * far as the tables can see. The source says so instead:</p>
+ *
+ * <pre> [] &gt; of /Q.bytes
+ *   ? &gt; size /Q.number
+ *   ? &gt; scope /{Q.chunk}</pre>
+ *
+ * <p>The braces are the list of what the atom hands in, one member to a place,
+ * which is exactly what {@code EOmalloc$EOof} does with a
+ * {@code scope.put(0, chunk)}. So whatever fills {@code scope} has its own
+ * first void filled with a {@code Φ.chunk}, and {@link Provided} names that
+ * void the way a positional argument finds one.</p>
+ *
+ * <p>A member that names no object is passed over. A letter stands for a type
+ * the atom carries from one void to another and says nothing about what is put
+ * in, which is a question for whoever fills the void the letter came from.</p>
+ *
+ * @since 0.69.0
+ */
+final class Handed {
+
+    /**
+     * What stands between two members of a list.
+     */
+    private static final Pattern SPACE = Pattern.compile(" ");
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * The rows of the provides table, asked what void a place lands in.
+     */
+    private final Provided provided;
+
+    /**
+     * What the applications of the program put into every void.
+     */
+    private final Map<String, Collection<Type>> filled;
+
+    /**
+     * Ctor.
+     * @param links The links table, as {@link Resolved} left it
+     * @param provides The provides table, which says what an atom hands in
+     * @param found What is put into every void, from {@link Fillings}
+     */
+    Handed(final XML links, final XML provides, final Map<String, Collection<Type>> found) {
+        this(
+            provides,
+            new Provided(
+                provides,
+                new Ends(new Pairs(links).all()).names(),
+                provides.xpath("//attr[@void='true']/@type")
+            ),
+            found
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param provides The provides table, which says what an atom hands in
+     * @param rows The provides table, asked what void a place lands in
+     * @param found What is put into every void, from {@link Fillings}
+     */
+    Handed(final XML provides, final Provided rows, final Map<String, Collection<Type>> found) {
+        this.given = provides;
+        this.provided = rows;
+        this.filled = found;
+    }
+
+    /**
+     * What is ever put into every void, by the program and by the atoms alike.
+     * @return The types put in, by the locator of the void
+     */
+    Map<String, Collection<Type>> all() {
+        final Map<String, Collection<Type>> found = new LinkedHashMap<>(this.filled);
+        for (final Map.Entry<String, Collection<String>> hole : this.holes().entrySet()) {
+            final Collection<Type> members = new ArrayList<>(
+                found.getOrDefault(hole.getKey(), Collections.emptyList())
+            );
+            final Collection<String> seen = new HashSet<>(0);
+            for (final Type member : members) {
+                seen.add(member.names());
+            }
+            for (final String handed : hole.getValue()) {
+                if (seen.add(handed)) {
+                    members.add(new Ref(handed));
+                }
+            }
+            found.put(hole.getKey(), members);
+        }
+        return found;
+    }
+
+    private Map<String, Collection<String>> holes() {
+        final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
+        for (final XML attr : this.given.nodes("//attr[@void='true' and @args]")) {
+            final Noted row = new Noted(attr);
+            for (final Type filler
+                : this.filled.getOrDefault(row.says("type"), Collections.emptyList())) {
+                this.landed(filler.names(), row.says("args")).forEach(
+                    (hollow, member) -> found
+                        .computeIfAbsent(hollow, key -> new ArrayList<>(0))
+                        .add(member)
+                );
+            }
+        }
+        return found;
+    }
+
+    private Map<String, String> landed(final String filler, final String args) {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        final String[] members = Handed.SPACE.split(args, -1);
+        for (int place = 0; place < members.length; place = place + 1) {
+            final String hollow = this.provided.vacant(
+                filler, Collections.emptyList(), place
+            );
+            if (!hollow.isEmpty() && members[place].startsWith("Φ.")) {
+                found.put(hollow, members[place]);
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -82,6 +82,14 @@ import java.util.stream.Collectors;
  * walks behind a delegation, so a name asked of it is answered once and for
  * all rather than left to a caller.</p>
  *
+ * <p>A void may also say what will be handed to whatever goes into it.
+ * {@code ? > scope /{Q.chunk}} in {@code malloc.of} says that the atom calls
+ * its {@code scope} with a chunk, which is what {@code EOmalloc$EOof} then
+ * does, and the row keeps that list as it stands. Nobody else in the program
+ * says it: the formation {@code malloc.for} hands in is copied by Java alone,
+ * so without the annotation its void is filled by nobody and looks empty to
+ * every reader (#8380). {@link Handed} is where the list is spent.</p>
+ *
  * <p>Not every attribute is written inside the formation it belongs to:
  * {@code minus} in the package {@code number} is {@code Φ.number.minus} and
  * belongs to {@code Φ.number} without ever appearing among its children,
@@ -135,6 +143,10 @@ final class Provides implements Clue {
                 final String held = attr.says("type");
                 if (held.startsWith("Φ.")) {
                     row.set("holds", held);
+                }
+                final String args = attr.says("args");
+                if (!args.isEmpty()) {
+                    row.set("args", args);
                 }
             }
         }

--- a/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
@@ -45,6 +45,11 @@ import org.xembly.Xembler;
  * {@code Φ.true}, with a {@code Φ.false} and with five other things, and
  * naming any one of them would be picking a favourite among facts.</p>
  *
+ * <p>Not every filling is an application. An atom calls what it is handed, and
+ * a formation only Java ever copies is filled where no source can be read, so
+ * the voids of one are answered by the annotation the atom carries and by
+ * {@link Handed}, which reads it (#8380).</p>
+ *
  * <p>A choice longer than the cap is written as {@code unknown} instead of its
  * members. {@code Φ.tuple.head} is filled with 56 different types, and a
  * choice of 56 tells a reader nothing except that nobody has thought about
@@ -91,8 +96,9 @@ public final class Witnessed implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
-        final Map<String, Collection<Type>> filled = new Fillings(
-            new XMLDocument(tables.resolve("links.xml")), given
+        final XML links = new XMLDocument(tables.resolve("links.xml"));
+        final Map<String, Collection<Type>> filled = new Handed(
+            links, given, new Fillings(links, given).all()
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
             final Collection<Type> members = filled.getOrDefault(

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/what-an-atom-hands-in-fills-the-void-it-lands-in.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/what-an-atom-hands-in-fills-the-void-it-lands-in.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An atom calls what it is handed, and the brace list says with what. Nobody in
+# the program fills the void that argument lands in, so the annotation is the
+# only thing that can answer for it, and without it the void looks unfilled
+# while Java fills it on every run.
+eo:
+  oak.eo: |
+    [] > oak
+  grip.eo: |
+    [] > grip /Q.bytes
+      ? > scope /{Q.oak}
+  app.eo: |
+    [] > app
+      grip hold > @
+      [m] > hold
+provides:
+  - "//attr[@name='m']/witnessed/ref[@loc='Φ.oak']"


### PR DESCRIPTION
A void can say two things about itself and the checker was reading one.
`? > size /Q.number` says what goes in; `? > scope /{Q.chunk}` says what
will be handed to whatever goes in. The parser carries the second as
`@args`, nothing in `eo-inference` ever mentioned it, and so the
formation `malloc.for` builds at `malloc.eo:71` came out filled by
nobody — while `EOmalloc$EOof` fills it on every run.

`Provides` keeps the list now, beside the `holds` it already kept, and
`Handed` spends it: whatever fills the annotated void has its own void
at that place filled with the member, which `Provided.vacant` names the
same way a positional argument finds one.

```java
Map<String, Collection<Type>> filled = new Handed(
    links, given, new Fillings(links, given).all()
).all();
```

A member that names no object is passed over — a letter is a type the
atom carries from one void to another and says nothing about what is
put in.

On eo-runtime the `m` of that formation reads
`<witnessed><ref loc="Φ.chunk"/></witnessed>` where it had nothing. The
voids of `chunk.copy` stay grey: they are filled by `m.copy 3 9 1`,
which is an application of a void and leaves no row anywhere until
#8158 lands. Joining the two is a follow-up.

Closes #8380
