### PR TITLE
#8327: let the scanf diagnostic actually be checked

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -115,7 +115,18 @@ jobs:
       # here from a clean target with them. An hour per test leaves `Deadline`
       # nothing to swallow, so a test that fails is reported as a failure and
       # not as a skip.
-      - if: steps.eo.outputs.classes != ''
-        env:
+      #
+      # `EOscanfDiagnosticTest` is hand-written and no `.eo` file names it, so
+      # the walk above never picks it up, while both guards abort it in an
+      # ordinary run: one dataization of a twenty-digit `%d` takes longer than
+      # `eo.deadline` and passes about 800M through the allocator. It is named
+      # here so that a regression in the message is a failure and not a skip
+      # (#8327).
+      - env:
           CLASSES: ${{ steps.eo.outputs.classes }}
-        run: mvn clean test -ntp -pl :eo-runtime '-Deo.deadline=3600' '-Deo.maxmem=2G' "-Dtest=${CLASSES}"
+        run: |
+          tests='EOscanfDiagnosticTest'
+          if [ -n "${CLASSES}" ]; then
+            tests="${tests},${CLASSES}"
+          fi
+          mvn clean test -ntp -pl :eo-runtime '-Deo.deadline=3600' '-Deo.maxmem=2G' "-Dtest=${tests}"

--- a/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EO_string/EOscanfDiagnosticTest.java
@@ -8,6 +8,7 @@
  */
 package org.eolang.EO_string; // NOPMD
 
+import java.util.concurrent.TimeUnit;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.ExAbstract;
@@ -17,12 +18,22 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 /**
  * Test case for {@link EOscanf} diagnostics.
+ *
+ * <p>One dataization of a twenty-digit {@code %d} walks the recursive digit
+ * fold and costs seconds, well over the {@code eo.deadline} an ordinary run
+ * grants, so the cost is declared here instead of being discovered as a
+ * skip. The memory it passes through the allocator is over
+ * {@code eo.maxmem} too, and only the step of {@code fast.yml} that names
+ * this class runs it with room for both.</p>
+ *
  * @since 0.61.0
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
+@Timeout(value = 30L, unit = TimeUnit.SECONDS)
 final class EOscanfDiagnosticTest {
 
     @Test


### PR DESCRIPTION
`EOscanfDiagnosticTest` has one test and it was skipped in every job that
completes, on both platforms, so nothing has ever stopped the doubled percent
from coming back.

One correction to the issue: it is not only the deadline. Measured on
`52d947a`, each guard aborts the test on its own —

| budgets | result |
| --- | --- |
| defaults | skipped |
| `-Deo.deadline=3600` | skipped, terminated at 280,504,968 bytes |
| `-Deo.maxmem=2G` | skipped |
| `-Deo.deadline=3600 -Deo.maxmem=2G` | **passes** |

Bisecting the memory alone puts the whole run between 737M and 900M, so
raising `eo.maxmem` to `1G` (#8341) would leave it green but with little
room; the class needs a run where both budgets are generous.

Shortening the input does not help: a nineteen-digit value that overflows a
long costs the same (554,712,168 bytes at the same reading), because the cost
is the `scanf` machinery, not the fold length.

So the class declares its own timeout, and the `fast.yml` step that already
runs with an hour and 2G names it. That step is filled by walking the `.eo`
files a branch touches, which can never reach a hand-written Java test, so it
now always runs with this class and adds the touched ones to it. The cost is
that a branch touching no `.eo` file gets one `eo-runtime` rerun it did not
have before.

Closes #8327

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe

---
_Generated by [Claude Code](https://claude.ai/code/session_01K7Rz8qnTzgvrWMMHzubBNe)_