### PR TITLE
Ask for a filling by the name it goes by

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Passed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Passed.java
@@ -7,6 +7,7 @@ package org.eolang.inference;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.xembly.Directives;
 
 /**
@@ -21,6 +22,13 @@ import org.xembly.Directives;
  * <p>Every formation the void is seen to hold is asked in turn, since neither
  * of two callers is more the answer than the other.</p>
  *
+ * <p>A filling is a locator written at a call site and rarely the formation
+ * itself: {@code malloc.for 0 x} puts an argument of its own into the void, and
+ * that argument is a copy of the {@code x} beside it. The voids are declared by
+ * the end of that chain of copies, so the filling is asked for by the name it
+ * goes by rather than by the name it is written under, and only a formation
+ * written out at the call site answers to both (#8389).</p>
+ *
  * @since 0.70.0
  */
 final class Passed {
@@ -29,6 +37,11 @@ final class Passed {
      * What the types certainly have.
      */
     private final Provided owned;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
 
     /**
      * The locators of what the void is seen to hold.
@@ -43,12 +56,19 @@ final class Passed {
     /**
      * Ctor.
      * @param provided What the types certainly have
+     * @param aliases The name every type goes by, from {@link Ends}
      * @param holds The locators of what the void is seen to hold
      * @param arguments The locators of the arguments, in the order they are
      *  written
      */
-    Passed(final Provided provided, final Collection<String> holds, final List<String> arguments) {
+    Passed(
+        final Provided provided,
+        final Map<String, String> aliases,
+        final Collection<String> holds,
+        final List<String> arguments
+    ) {
         this.owned = provided;
+        this.names = aliases;
         this.fillers = holds;
         this.args = arguments;
     }
@@ -60,8 +80,9 @@ final class Passed {
     Directives directives() {
         final Directives dirs = new Directives();
         for (final String filler : this.fillers) {
+            final String held = this.names.getOrDefault(filler, filler);
             for (int place = 0; place < this.args.size(); place += 1) {
-                final String slot = this.owned.vacant(filler, Collections.emptyList(), place);
+                final String slot = this.owned.vacant(held, Collections.emptyList(), place);
                 if (!slot.isEmpty() && !this.args.get(place).isEmpty()) {
                     dirs.add("bind")
                         .attr("void", slot)

--- a/eo-inference/src/main/java/org/eolang/inference/Relayed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Relayed.java
@@ -40,6 +40,12 @@ import org.xembly.Xembler;
  * is: the caller written tomorrow may put a formation of another shape
  * there.</p>
  *
+ * <p>What a caller puts in is a locator of its own, so what fills the void is
+ * looked up by the name it goes by. Only a formation written out at the call
+ * site is its own name, and {@code malloc.for 0 x} is the common case: the
+ * argument is a copy of an {@code x} written beside it, and the voids belong
+ * to that (#8389).</p>
+ *
  * @since 0.70.0
  */
 public final class Relayed implements Clue {
@@ -66,7 +72,8 @@ public final class Relayed implements Clue {
         final Pairs written = new Pairs(links);
         final Map<String, String> pairs = written.all();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
-        final Provided owned = new Provided(given, new Ends(pairs).names(), voids);
+        final Map<String, String> names = new Ends(pairs).names();
+        final Provided owned = new Provided(given, names, voids);
         final Collection<String> hollows = new HashSet<>(voids);
         final Map<String, Collection<String>> fillers = written.puts();
         final Map<String, Node> rows = written.refs();
@@ -77,6 +84,7 @@ public final class Relayed implements Clue {
                 new Xembler(
                     new Passed(
                         owned,
+                        names,
                         fillers.getOrDefault(hollow, Collections.emptyList()),
                         application.getValue()
                     ).directives()

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-fills-a-void-of-whatever-fills-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-fills-a-void-of-whatever-fills-it.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A call made on a void is a call on whatever fills it, so the argument lands
+# in a void of that, and of every one of them where the callers disagree. The
+# two halves are written down apart, the call on the row of the void and the
+# filling on the row of the formation, and nobody puts them together until
+# they are read as one.
+eo:
+  oak.eo: |
+    [] > oak
+  grip.eo: |
+    [scope] > grip
+      scope oak > @
+  app.eo: |
+    [] > app
+      grip hold > @
+      grip pick > twin
+      [k] > hold
+      [j] > pick
+provides:
+  - "//attr[@name='k']/witnessed/ref[@loc='Φ.oak']"
+  - "//attr[@name='j']/witnessed/ref[@loc='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-passes-on-what-fills-its-argument.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-passes-on-what-fills-its-argument.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What a void is called with is often another void, and it has no type of its
+# own to hand on. What fills it reaches one hop further, so a call made with a
+# void passes on whatever was put into that void rather than nothing at all.
+eo:
+  oak.eo: |
+    [] > oak
+  grip.eo: |
+    [scope] > grip
+      arm oak > @
+      [^ m] > arm
+        ^.scope m > @
+  app.eo: |
+    [] > app
+      grip hold > @
+      grip pick > twin
+      [k] > hold
+      [j] > pick
+provides:
+  - "//attr[@name='k']/witnessed/ref[@loc='Φ.oak']"
+  - "//attr[@name='j']/witnessed/ref[@loc='Φ.oak']"


### PR DESCRIPTION
`Relayed` is the rule that gives an argument somewhere to go when the
thing being applied is a void: a caller says what the void holds, and
the argument lands in a void of that. It asked for the filling by the
locator written at the call site, which is a name the table hardly ever
knows. `malloc.for 0 x` passes a copy of the `x` written beside it, the
copy has no row of its own, and the argument was dropped. Only a
formation written out at the call site answered — which is why the rule
looked right on `as-ascii ("bar" > [message])` and did nothing on the
whole of `malloc`.

`Ends` walks a chain of copies to its end and `Relayed` builds that map
already, for `Provided`. It now hands it to `Passed` too:

```java
final String held = this.names.getOrDefault(filler, filler);
for (int place = 0; place < this.args.size(); place += 1) {
    final String slot = this.owned.vacant(held, Collections.emptyList(), place);
```

On eo-runtime 66 voids gain a witness, 380 unfilled becoming 314. The
`m` of `[m] > x` at `malloc.eo:101` and the `acc` of `[^ acc] >>` at
`while.eo:67` are among them, both filled by Java on every run and by
nobody as far as the tables could see.

Neither reads `Φ.chunk` yet. Both are witnessed as the `m` of the
formation `malloc.for` builds, and that `m` is known to be a chunk only
through the `/{Q.chunk}` annotation `Handed` reads — which runs after
`Carried` has walked the hops, so the fact arrives too late to travel
one step further. That is a separate ticket.

Closes #8389
