### PR TITLE
fix(#8330): say that the receiver parameter may stand anywhere

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -13,9 +13,9 @@ import java.util.List;
  * <p>Form: {@code [params] [> name [/sig]]}. Each parameter becomes a
  * void child (R-3.4.1). The standalone {@code @} parameter maps to
  * {@code φ} in XMIR (R-3.4.2 / R-9.3). The standalone {@code ^} maps to
- * {@code ρ} and declares the formation's receiver, which only the first
- * parameter may be (R-3.4.3 / R-3.4.11). No leading/trailing space inside the
- * brackets (R-3.4.4); exactly one space between parameter names
+ * {@code ρ} and declares the formation's receiver, and may stand in any
+ * position among the parameters (R-3.4.3 / R-3.4.11). No leading/trailing
+ * space inside the brackets (R-3.4.4); exactly one space between parameter names
  * (R-3.4.5). The line may carry an optional name suffix per §3.10,
  * including the atom-signature form {@code > name /sig}. The shorthand
  * {@code ++> name} is accepted as sugar for {@code [] +> name} — a


### PR DESCRIPTION
Fixes #8330.

The class comment said the `^` receiver may only be the first parameter and cited R-3.4.3 and R-3.4.11 for it. Both rules say the opposite: `^` may stand in any position, and `LnVoid`, the vertical half of the same feature, states it correctly.

The parser already behaves that way, and `LnFormationTest` already pins it — `[x ^] > foo` is asserted to emit `ρ` "wherever it stands". Only the comment was wrong, so only the comment changes.
