### PR TITLE
Spend what an atom hands in inside the walk

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -40,6 +40,15 @@ import java.util.Map;
  * seen to hold both, and a void whose every caller passes on a void of its own
  * is described by that rather than by silence.</p>
  *
+ * <p>An atom fills a void too, and says so in a brace list {@link Handed}
+ * reads. That is spent here and not later, because the two rules feed each
+ * other: a hop says which formation an atom is handed, the atom says what
+ * lands in that formation, and a hop carries it on from there. So the walk is
+ * made again for as long as the atoms have anything left to add, and what they
+ * add is put among the fillings a call site names rather than among the
+ * answers, so that a void left holding the far end of a hop gives that up as
+ * soon as a forma arrives for it (#8396).</p>
+ *
  * @since 0.69.0
  */
 final class Fillings {
@@ -89,9 +98,13 @@ final class Fillings {
                 }
             }
         }
+        final Handed atoms = new Handed(this.table, this.given);
+        Map<String, Map<String, Type>> walked = new Carried(placed, handed).all();
+        while (atoms.fills(placed, walked)) {
+            walked = new Carried(placed, handed).all();
+        }
         final Map<String, Collection<Type>> found = new LinkedHashMap<>(0);
-        for (final Map.Entry<String, Map<String, Type>> hollow
-            : new Carried(placed, handed).all().entrySet()) {
+        for (final Map.Entry<String, Map<String, Type>> hollow : walked.entrySet()) {
             found.put(hollow.getKey(), hollow.getValue().values());
         }
         return found;

--- a/eo-inference/src/main/java/org/eolang/inference/Handed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Handed.java
@@ -8,7 +8,6 @@ import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -35,6 +34,13 @@ import java.util.regex.Pattern;
  * the atom carries from one void to another and says nothing about what is put
  * in, which is a question for whoever fills the void the letter came from.</p>
  *
+ * <p>What the list says is a filling like any other and is spent among the
+ * others, in the walk {@link Carried} makes and not after it. Both ends of the
+ * walk need it there: which formation the atom is handed is itself carried in
+ * by a hop at {@code malloc.eo:64}, and what the atom puts into that formation
+ * is handed on again a line later, to the {@code m} of {@code [m] > x} that
+ * Java fills with a chunk on every run (#8396).</p>
+ *
  * @since 0.69.0
  */
 final class Handed {
@@ -45,9 +51,9 @@ final class Handed {
     private static final Pattern SPACE = Pattern.compile(" ");
 
     /**
-     * The provides table.
+     * The rows of the provides table that say what an atom hands in.
      */
-    private final XML given;
+    private final Collection<XML> annotated;
 
     /**
      * The rows of the provides table, asked what void a place lands in.
@@ -55,70 +61,63 @@ final class Handed {
     private final Provided provided;
 
     /**
-     * What the applications of the program put into every void.
-     */
-    private final Map<String, Collection<Type>> filled;
-
-    /**
      * Ctor.
      * @param links The links table, as {@link Resolved} left it
      * @param provides The provides table, which says what an atom hands in
-     * @param found What is put into every void, from {@link Fillings}
      */
-    Handed(final XML links, final XML provides, final Map<String, Collection<Type>> found) {
+    Handed(final XML links, final XML provides) {
         this(
-            provides,
+            provides.nodes("//attr[@void='true' and @args]"),
             new Provided(
                 provides,
                 new Ends(new Pairs(links).all()).names(),
                 provides.xpath("//attr[@void='true']/@type")
-            ),
-            found
+            )
         );
     }
 
     /**
      * Ctor.
-     * @param provides The provides table, which says what an atom hands in
+     * @param attrs The rows of the provides table that carry a brace list
      * @param rows The provides table, asked what void a place lands in
-     * @param found What is put into every void, from {@link Fillings}
      */
-    Handed(final XML provides, final Provided rows, final Map<String, Collection<Type>> found) {
-        this.given = provides;
+    Handed(final Collection<XML> attrs, final Provided rows) {
+        this.annotated = attrs;
         this.provided = rows;
-        this.filled = found;
     }
 
     /**
-     * What is ever put into every void, by the program and by the atoms alike.
-     * @return The types put in, by the locator of the void
+     * Put what the atoms hand in among the fillings the call sites name.
+     * @param named What every void is filled with where a call site says so,
+     *  which is what the atoms are added to
+     * @param filled What every void is filled with, the hops walked through,
+     *  which is where the formation an atom is handed is read from
+     * @return Whether any void learnt anything it did not know before
      */
-    Map<String, Collection<Type>> all() {
-        final Map<String, Collection<Type>> found = new LinkedHashMap<>(this.filled);
-        for (final Map.Entry<String, Collection<String>> hole : this.holes().entrySet()) {
-            final Collection<Type> members = new ArrayList<>(
-                found.getOrDefault(hole.getKey(), Collections.emptyList())
+    boolean fills(
+        final Map<String, Map<String, Type>> named,
+        final Map<String, Map<String, Type>> filled
+    ) {
+        boolean grown = false;
+        for (final Map.Entry<String, Collection<String>> hole : this.holes(filled).entrySet()) {
+            final Map<String, Type> members = named.computeIfAbsent(
+                hole.getKey(), key -> new LinkedHashMap<>(0)
             );
-            final Collection<String> seen = new HashSet<>(0);
-            for (final Type member : members) {
-                seen.add(member.names());
-            }
             for (final String handed : hole.getValue()) {
-                if (seen.add(handed)) {
-                    members.add(new Ref(handed));
+                if (members.putIfAbsent(handed, new Ref(handed)) == null) {
+                    grown = true;
                 }
             }
-            found.put(hole.getKey(), members);
         }
-        return found;
+        return grown;
     }
 
-    private Map<String, Collection<String>> holes() {
+    private Map<String, Collection<String>> holes(final Map<String, Map<String, Type>> filled) {
         final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
-        for (final XML attr : this.given.nodes("//attr[@void='true' and @args]")) {
+        for (final XML attr : this.annotated) {
             final Noted row = new Noted(attr);
             for (final Type filler
-                : this.filled.getOrDefault(row.says("type"), Collections.emptyList())) {
+                : filled.getOrDefault(row.says("type"), Collections.emptyMap()).values()) {
                 this.landed(filler.names(), row.says("args")).forEach(
                     (hollow, member) -> found
                         .computeIfAbsent(hollow, key -> new ArrayList<>(0))

--- a/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Witnessed.java
@@ -96,9 +96,8 @@ public final class Witnessed implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
-        final XML links = new XMLDocument(tables.resolve("links.xml"));
-        final Map<String, Collection<Type>> filled = new Handed(
-            links, given, new Fillings(links, given).all()
+        final Map<String, Collection<Type>> filled = new Fillings(
+            new XMLDocument(tables.resolve("links.xml")), given
         ).all();
         for (final XML hollow : given.nodes("//attr[@void='true']")) {
             final Collection<Type> members = filled.getOrDefault(

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/what-an-atom-hands-in-travels-one-hop-further.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/what-an-atom-hands-in-travels-one-hop-further.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The brace list is the only thing that says what lands in the void of the
+# formation an atom is handed, and that void is handed on again. What the atom
+# puts in has to walk the hop like any other filling, or the far end of it is
+# left holding a variable while Java fills it on every run.
+eo:
+  oak.eo: |
+    [] > oak
+  keep.eo: |
+    [k] > keep
+  grip.eo: |
+    [] > grip /Q.bytes
+      ? > scope /{Q.oak}
+  app.eo: |
+    [] > app
+      grip hold > @
+      [m] > hold
+        keep m > @
+provides:
+  - "//attr[@name='k']/witnessed/ref[@loc='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/what-an-atom-hands-in-waits-for-the-hop-to-arrive.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/what-an-atom-hands-in-waits-for-the-hop-to-arrive.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Which formation an atom is handed is itself a question the hops answer: the
+# void the atom reads is filled by a void of somebody else. So the brace list
+# cannot be spent before the hops are walked, any more than after.
+eo:
+  oak.eo: |
+    [] > oak
+  hold.eo: |
+    [m] > hold
+  grip.eo: |
+    [] > grip /Q.bytes
+      ? > scope /{Q.oak}
+  relay.eo: |
+    [s] > relay
+      grip s > @
+  app.eo: |
+    [] > app
+      relay hold > @
+provides:
+  - "//attr[@name='m']/witnessed/ref[@loc='Φ.oak']"


### PR DESCRIPTION
A void filled only from Java is described by the `/{Q.chunk}` brace list
and by nothing else. `Handed` read that list after `Carried` had walked
every hop, so the fact was in the tables with nowhere left to go: the
`m` of `[m] > x` at `malloc.eo:101` sat one hop away from a chunk and
came out as a variable.

Moving the list earlier is no good either, because `malloc.eo:64` fills
the annotated void through a hop of its own. The two rules answer each
other — a hop says which formation an atom is handed, the atom says what
lands in it, and a hop carries that on — so the walk is made again for as
long as the atoms have anything left to add:

```java
final Handed atoms = new Handed(this.table, this.given);
Map<String, Map<String, Type>> walked = new Carried(placed, handed).all();
while (atoms.fills(placed, walked)) {
    walked = new Carried(placed, handed).all();
}
```

What the atoms add goes among the fillings a call site names rather than
among the answers, so a void left holding the far end of a hop gives that
up as soon as a forma arrives for it. On eo-runtime 51 voids stop saying
"whatever that other void is" and name an object instead, 63 such answers
becoming 12; eleven more voids are answered at all, and 575 more
dispatches carry, including the first chain to run through a `Φ.chunk`.

One void loses its witness, `Φ.output.dead.write.a🌵14-4.write.ρ`: two
voids upstream of it turn out to be filled several ways rather than one,
which is a fact gained, and `Sole` rightly declines to name them.

The voids of `chunk.copy` are still unfilled. `m.copy` at `malloc.eo:127`
is a dispatch on a void whose filling `Relayed` writes, and `Relayed` runs
after `Resolved`, so no pass can promote it. That is a separate ticket.

Closes #8396
