### PR TITLE
feat(lowering): #8402 fold privatized helpers into the lowered atom

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Carrier.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Carrier.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * One data carrier of an XMIR fragment, read into the literal it carries.
+ *
+ * <p>A number and a string wrap exactly one bytes carrier, which wraps
+ * exactly one plain datum; bytes wrap the datum directly; the two bools
+ * carry nothing, since each is its own datum. Any element based on
+ * {@code Φ} that is shaped otherwise is refused, since it is no datum
+ * and its meaning depends on a context the reduction does not
+ * carry.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Carrier {
+
+    /**
+     * The XMIR element to read, an {@code <o/>} based on {@code Φ}.
+     */
+    private final Xnav node;
+
+    /**
+     * Ctor.
+     * @param xmir The XMIR element to read, an {@code <o/>} based on {@code Φ}
+     */
+    public Carrier(final Xnav xmir) {
+        this.node = xmir;
+    }
+
+    /**
+     * The literal the element carries.
+     * @return The literal, with its forma and its bytes
+     */
+    public Term literal() {
+        final String base = this.node.attribute("base").text().orElse("");
+        final Term out;
+        if ("Φ.true".equals(base)) {
+            out = new Literal("bool", "FF-");
+        } else if ("Φ.false".equals(base)) {
+            out = new Literal("bool", "00-");
+        } else if ("Φ.number".equals(base) || "Φ.string".equals(base)) {
+            out = new Literal(base.substring(2), this.datum(base));
+        } else if ("Φ.bytes".equals(base)) {
+            out = new Literal("bytes", this.datum(base));
+        } else {
+            throw new IllegalStateException(
+                String.format(
+                    "The base '%s' carries no datum, so it cannot stand in a lowered fragment",
+                    base
+                )
+            );
+        }
+        return out;
+    }
+
+    private String datum(final String base) {
+        List<Xnav> inner = Carrier.kids(this.node);
+        if (!"Φ.bytes".equals(base)) {
+            if (inner.size() != 1
+                || !"Φ.bytes".equals(inner.get(0).attribute("base").text().orElse(""))) {
+                throw new IllegalStateException(
+                    String.format(
+                        "The literal '%s' must wrap exactly one bytes carrier", base
+                    )
+                );
+            }
+            inner = Carrier.kids(inner.get(0));
+        }
+        if (inner.size() != 1
+            || inner.get(0).attribute("base").text().isPresent()
+            || !Carrier.kids(inner.get(0)).isEmpty()) {
+            throw new IllegalStateException(
+                String.format("The carrier '%s' does not wrap a plain datum", base)
+            );
+        }
+        return inner.get(0).text().orElse("").replaceAll("\\s+", "");
+    }
+
+    private static List<Xnav> kids(final Xnav node) {
+        return node.elements(Filter.withName("o")).collect(Collectors.toList());
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -21,10 +21,16 @@ import org.w3c.dom.Element;
  * Rewrite the pure formations of one XMIR into synthetic atoms.
  *
  * <p>A formation qualifies when it is a named direct attribute of a
- * top-level object, its body is voids plus one {@code φ} and nothing
- * else — deleting the body must not change the object's interface — and
- * every void is witnessed in the tables of {@code eo:inference} as a
- * number, a string or bytes, so a symbolic carrier can stand for it. It
+ * top-level object, its body is voids plus one {@code φ} plus helpers
+ * nothing outside can name, and every void is witnessed in the tables
+ * of {@code eo:inference} as a number, a string or bytes, so a symbolic
+ * carrier can stand for it. A helper is an attribute the source
+ * privatized with {@code >>}, or a const the parser wrapped, and it
+ * shows up under a synthetic {@code a🌵} name: the body reads it in
+ * place, so it is folded into the atom and leaves with the body. A
+ * public attribute keeps the formation as written, since deleting the
+ * body must not change the object's interface, and a helper that stays
+ * reachable would be dispatchable with nothing behind it. The formation
  * may declare {@code ρ}, but its body may reach through it only to call
  * the formation itself again, which the reduction turns into a repeat;
  * any other use of {@code ρ} depends on a context the atom does not
@@ -92,9 +98,10 @@ public final class Lowered implements Rewrite {
         final List<Xnav> bodies = Lowered.bodies(node);
         final List<Xnav> kids = Lowered.kids(node);
         final long rhos = kids.stream().filter(Lowered::rho).count();
+        final long hidden = kids.stream().filter(Lowered::hidden).count();
         boolean done = false;
         if (!inputs.isEmpty() && bodies.size() == 1
-            && kids.size() == inputs.size() + 1 + (int) rhos) {
+            && kids.size() == inputs.size() + 1 + (int) rhos + (int) hidden) {
             done = this.spliced(node, bodies.get(0), inputs);
         }
         return done;
@@ -106,7 +113,9 @@ public final class Lowered implements Rewrite {
         String carrier = "";
         try {
             final Protocol protocol = new Reduction(
-                this.phino, body, inputs, 8, node.attribute("name").text().orElse("")
+                this.phino, body, inputs, 8,
+                node.attribute("name").text().orElse(""),
+                Lowered.helpers(node)
             ).protocol();
             if (!protocol.moves().isEmpty()) {
                 text = new JavaAtom(protocol, inputs).text();
@@ -131,7 +140,7 @@ public final class Lowered implements Rewrite {
         element.setAttribute("lowered", digest);
         element.removeChild(body.node());
         for (final Xnav kid : Lowered.kids(new Xnav(element))) {
-            if (Lowered.rho(kid)) {
+            if (Lowered.rho(kid) || Lowered.hidden(kid)) {
                 element.removeChild(kid.node());
             }
         }
@@ -173,6 +182,20 @@ public final class Lowered implements Rewrite {
     private static boolean rho(final Xnav kid) {
         return "∅".equals(kid.attribute("base").text().orElse(""))
             && "ρ".equals(kid.attribute("name").text().orElse(""));
+    }
+
+    private static boolean hidden(final Xnav kid) {
+        return kid.attribute("name").text().orElse("").startsWith("a🌵");
+    }
+
+    private static Map<String, Xnav> helpers(final Xnav node) {
+        final Map<String, Xnav> out = new LinkedHashMap<>();
+        for (final Xnav kid : Lowered.kids(node)) {
+            if (Lowered.hidden(kid)) {
+                out.put(kid.attribute("name").text().get(), kid);
+            }
+        }
+        return out;
     }
 
     private static Collection<Xnav> candidates(final Xnav doc) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
@@ -7,6 +7,9 @@ package org.eolang.lowering;
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -14,17 +17,22 @@ import java.util.stream.Collectors;
 /**
  * One XMIR fragment, read into a reduction tree.
  *
- * <p>Dispatches become sites, literal carriers become literals — a
- * number and a string alike wrap their datum in a bytes carrier — and a
+ * <p>Dispatches become sites, the data carriers become literals, by
+ * {@link Carrier}, and a
  * {@code ξ} reference to a declared void becomes the symbol of that
  * void, named positionally so that no spelling of a void name ever
  * leaks into a marker, and a {@code ξ.ρ} reference to the formation
  * being lowered, with arguments, becomes the {@link Again} of its own
- * body. The parser rolls a dispatch chain rooted in a
- * reference into the base itself, so {@code ξ.b.size.plus} unrolls here
- * into nested sites, with the arguments of the element attached to the
- * last link. Anything else is refused, since its meaning depends on a
- * context the reduction does not carry.</p>
+ * body. A {@code ξ} reference to a helper the formation binds next to
+ * its body becomes the helper's own body, read in place: the helper is
+ * an application over the same voids, so it stands wherever it is
+ * named, twice when named twice, and identical sites collapse into one
+ * step anyway. A helper that reads itself, directly or through another
+ * helper, is a cycle and is refused. The parser rolls a dispatch chain
+ * rooted in a reference into the base itself, so {@code ξ.b.size.plus}
+ * unrolls here into nested sites, with the arguments of the element
+ * attached to the last link. Anything else is refused, since its
+ * meaning depends on a context the reduction does not carry.</p>
  *
  * @since 0.76.0
  */
@@ -47,6 +55,18 @@ public final class Parsed {
     private final String self;
 
     /**
+     * The helpers the formation binds next to its body: names to their
+     * {@code <o/>} elements.
+     */
+    private final Map<String, Xnav> helpers;
+
+    /**
+     * The helpers being read at the moment, outermost first, so that a
+     * helper reading itself is caught.
+     */
+    private final Collection<String> trail;
+
+    /**
      * Ctor.
      * @param xmir The XMIR fragment to read, an {@code <o/>} element
      * @param inputs The voids of the fragment: names to formas, in order
@@ -63,9 +83,30 @@ public final class Parsed {
      *  whose calls to itself through {@code ξ.ρ} become repeats
      */
     public Parsed(final Xnav xmir, final Map<String, String> inputs, final String name) {
+        this(xmir, inputs, name, Collections.emptyMap());
+    }
+
+    /**
+     * Ctor.
+     * @param xmir The XMIR fragment to read, an {@code <o/>} element
+     * @param inputs The voids of the fragment: names to formas, in order
+     * @param name The name of the formation the fragment is the body of,
+     *  whose calls to itself through {@code ξ.ρ} become repeats
+     * @param bound The helpers the formation binds next to its body:
+     *  names to their {@code <o/>} elements, read in place when named
+     */
+    public Parsed(final Xnav xmir, final Map<String, String> inputs,
+        final String name, final Map<String, Xnav> bound) {
+        this(xmir, inputs, name, bound, Collections.emptyList());
+    }
+
+    private Parsed(final Xnav xmir, final Map<String, String> inputs,
+        final String name, final Map<String, Xnav> bound, final Collection<String> above) {
         this.fragment = xmir;
         this.voids = inputs;
         this.self = name;
+        this.helpers = bound;
+        this.trail = above;
     }
 
     /**
@@ -79,14 +120,8 @@ public final class Parsed {
     private Term parsed(final Xnav node) {
         final String base = node.attribute("base").text().orElse("");
         final Term out;
-        if ("Φ.true".equals(base)) {
-            out = new Literal("bool", "FF-");
-        } else if ("Φ.false".equals(base)) {
-            out = new Literal("bool", "00-");
-        } else if ("Φ.number".equals(base) || "Φ.string".equals(base)) {
-            out = new Literal(base.substring(2), Parsed.datum(Parsed.kids(node), base));
-        } else if ("Φ.bytes".equals(base)) {
-            out = new Literal("bytes", Parsed.datum(Parsed.kids(node), base));
+        if (base.startsWith("Φ.")) {
+            out = new Carrier(node).literal();
         } else if (this.recursive(base)) {
             out = new Again(
                 this.bound(Parsed.kids(node)).stream()
@@ -112,12 +147,34 @@ public final class Parsed {
     private Term referenced(final String name) {
         final List<String> names = new ArrayList<>(this.voids.keySet());
         final int idx = names.indexOf(name);
-        if (idx < 0) {
+        final Term out;
+        if (idx >= 0) {
+            out = new Symbol(String.format("v%d", idx), this.voids.get(name));
+        } else if (this.helpers.containsKey(name)) {
+            out = this.expanded(name);
+        } else {
             throw new IllegalStateException(
-                String.format("The reference 'ξ.%s' names no void of the fragment", name)
+                String.format(
+                    "The reference 'ξ.%s' names no void or helper of the fragment", name
+                )
             );
         }
-        return new Symbol(String.format("v%d", idx), this.voids.get(name));
+        return out;
+    }
+
+    private Term expanded(final String name) {
+        if (this.trail.contains(name)) {
+            throw new IllegalStateException(
+                String.format(
+                    "The helper 'ξ.%s' reads itself, so the fragment never settles", name
+                )
+            );
+        }
+        final Collection<String> deeper = new LinkedHashSet<>(this.trail);
+        deeper.add(name);
+        return new Parsed(
+            this.helpers.get(name), this.voids, this.self, this.helpers, deeper
+        ).term();
     }
 
     private Term chained(final Xnav node, final String path) {
@@ -126,7 +183,7 @@ public final class Parsed {
         final int last = parts.length - 1;
         if (last == 0 && !Parsed.kids(node).isEmpty()) {
             throw new IllegalStateException(
-                String.format("The void 'ξ.%s' cannot take arguments", path)
+                String.format("The reference 'ξ.%s' cannot take arguments", path)
             );
         }
         for (int idx = 1; idx < last; ++idx) {
@@ -164,29 +221,6 @@ public final class Parsed {
             args.add(new Binding(name, this.parsed(kid)));
         }
         return args;
-    }
-
-    private static String datum(final List<Xnav> kids, final String base) {
-        List<Xnav> inner = kids;
-        if (!"Φ.bytes".equals(base)) {
-            if (inner.size() != 1
-                || !"Φ.bytes".equals(inner.get(0).attribute("base").text().orElse(""))) {
-                throw new IllegalStateException(
-                    String.format(
-                        "The literal '%s' must wrap exactly one bytes carrier", base
-                    )
-                );
-            }
-            inner = Parsed.kids(inner.get(0));
-        }
-        if (inner.size() != 1
-            || inner.get(0).attribute("base").text().isPresent()
-            || !Parsed.kids(inner.get(0)).isEmpty()) {
-            throw new IllegalStateException(
-                String.format("The carrier '%s' does not wrap a plain datum", base)
-            );
-        }
-        return inner.get(0).text().orElse("").replaceAll("\\s+", "");
     }
 
     private static List<Xnav> kids(final Xnav node) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
@@ -50,6 +50,14 @@ import java.util.Optional;
  * an operation that still awaits the value would rerun the whole body
  * in its place.</p>
  *
+ * <p>A helper the formation binds next to its body is read in place
+ * wherever the body names it, by {@link Parsed}, so the tree phino sees
+ * is the one the body would be with every helper written out, and the
+ * protocol is the one that body would give: a helper named twice
+ * stands twice and costs one step, since identical sites collapse, and
+ * a helper named in one arm of a fork alone is computed in that arm
+ * alone.</p>
+ *
  * <p>Whatever does not settle is refused with an exception, never
  * repaired: a foreign atom, a site the records cannot anchor, a value of
  * a forma no carrier stands for, an exhausted budget, an arm of a fork
@@ -97,6 +105,12 @@ public final class Reduction {
     private final String formation;
 
     /**
+     * The helpers the formation binds next to the fragment: names to
+     * their {@code <o/>} elements.
+     */
+    private final Map<String, Xnav> helpers;
+
+    /**
      * Ctor.
      * @param exe The binary that dataizes
      * @param xmir The XMIR fragment to reduce, an {@code <o/>} element
@@ -119,11 +133,29 @@ public final class Reduction {
      */
     public Reduction(final Phino exe, final Xnav xmir,
         final Map<String, String> inputs, final int budget, final String name) {
+        this(exe, xmir, inputs, budget, name, Collections.emptyMap());
+    }
+
+    /**
+     * Ctor.
+     * @param exe The binary that dataizes
+     * @param xmir The XMIR fragment to reduce, an {@code <o/>} element
+     * @param inputs The voids of the fragment: names to formas, in order
+     * @param budget The most partial runs one reduction may take
+     * @param name The name of the formation the fragment is the body of,
+     *  whose calls to itself become repeats; empty when there is none
+     * @param bound The helpers the formation binds next to the fragment:
+     *  names to their {@code <o/>} elements, read in place when named
+     */
+    public Reduction(final Phino exe, final Xnav xmir,
+        final Map<String, String> inputs, final int budget, final String name,
+        final Map<String, Xnav> bound) {
         this.phino = exe;
         this.fragment = xmir;
         this.voids = inputs;
         this.rounds = budget;
         this.formation = name;
+        this.helpers = bound;
     }
 
     /**
@@ -133,7 +165,7 @@ public final class Reduction {
      */
     public Protocol protocol() throws IOException {
         return this.settled(
-            new Parsed(this.fragment, this.voids, this.formation).term(),
+            new Parsed(this.fragment, this.voids, this.formation, this.helpers).term(),
             new Minted(this.voids)
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/CarrierTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/CarrierTest.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Carrier}.
+ * @since 0.76.0
+ */
+final class CarrierTest {
+
+    @Test
+    void readsNumberThroughItsBytes() {
+        MatcherAssert.assertThat(
+            "a number must be read as its forma and the bytes it wraps, but it isnt",
+            new Carrier(
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='Φ.number'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>40-00-00-00-00-00-00-00</o></o>",
+                        "</o>"
+                    )
+                ).element("o")
+            ).literal().key(),
+            Matchers.equalTo("number:40-00-00-00-00-00-00-00")
+        );
+    }
+
+    @Test
+    void readsBoolWithoutDatum() {
+        MatcherAssert.assertThat(
+            "a bool must be its own datum, but it isnt",
+            new Carrier(new Xnav("<o base='Φ.false'/>").element("o")).literal().key(),
+            Matchers.equalTo("bool:00-")
+        );
+    }
+
+    @Test
+    void readsBytesDirectly() {
+        MatcherAssert.assertThat(
+            "bytes must wrap their datum directly, but they dont",
+            new Carrier(
+                new Xnav("<o base='Φ.bytes'><o as='α0'>01-02</o></o>").element("o")
+            ).literal().key(),
+            Matchers.equalTo("bytes:01-02")
+        );
+    }
+
+    @Test
+    void refusesNumberWithoutBytes() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Carrier(
+                new Xnav("<o base='Φ.number'><o as='α0'>40-00-00-00-00-00-00-00</o></o>")
+                    .element("o")
+            )::literal,
+            "a number wrapping no bytes carrier is malformed, but it was read"
+        );
+    }
+
+    @Test
+    void refusesObjectThatCarriesNoDatum() {
+        MatcherAssert.assertThat(
+            "an object of the universe that is no datum must be refused, but it wasnt",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Carrier(
+                    new Xnav("<o base='Φ.dataized'><o base='ξ.x'/></o>").element("o")
+                )::literal,
+                "a dataized object carries no datum, but it was read"
+            ).getMessage(),
+            Matchers.containsString("cannot stand in a lowered fragment")
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
@@ -116,6 +116,60 @@ final class ParsedTest {
     }
 
     @Test
+    void readsHelperInPlace() {
+        MatcherAssert.assertThat(
+            "a reference to a helper must stand as the helper's own body, but it doesnt",
+            new Parsed(
+                new Xnav("<o base='ξ.a🌵3-4.plus'><o as='α0' base='ξ.a🌵3-4'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                "",
+                Collections.singletonMap("a🌵3-4", ParsedTest.square())
+            ).term().phi(),
+            Matchers.stringContainsInOrder(".times(", ".plus(", ".times(")
+        );
+    }
+
+    @Test
+    void refusesHelperReadingItself() {
+        MatcherAssert.assertThat(
+            "a helper reading itself is a cycle and must be refused as one, but it wasnt",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Parsed(
+                    new Xnav("<o base='ξ.a🌵3-4.plus'><o as='α0' base='ξ.x'/></o>").element("o"),
+                    Collections.singletonMap("x", "number"),
+                    "",
+                    Collections.singletonMap(
+                        "a🌵3-4",
+                        new Xnav(
+                            "<o base='ξ.a🌵3-4.times'><o as='α0' base='ξ.x'/></o>"
+                        ).element("o")
+                    )
+                )::term,
+                "a helper reading itself never settles, but it parsed"
+            ).getMessage(),
+            Matchers.containsString("reads itself")
+        );
+    }
+
+    @Test
+    void refusesHelperReadingTheBody() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Parsed(
+                new Xnav("<o base='ξ.a🌵3-4.plus'><o as='α0' base='ξ.x'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                "",
+                Collections.singletonMap(
+                    "a🌵3-4",
+                    new Xnav("<o base='ξ.φ.times'><o as='α0' base='ξ.x'/></o>").element("o")
+                )
+            )::term,
+            "a helper reading the body it is read by is a cycle, but it parsed"
+        );
+    }
+
+    @Test
     void refusesArgumentsOnBareReference() {
         Assertions.assertThrows(
             IllegalStateException.class,
@@ -134,5 +188,9 @@ final class ParsedTest {
             )::term,
             "a void applied to arguments cannot be reduced, but it was"
         );
+    }
+
+    private static Xnav square() {
+        return new Xnav("<o base='ξ.x.times'><o as='α0' base='ξ.x'/></o>").element("o");
     }
 }

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
@@ -146,6 +146,27 @@ final class ReductionTest {
     }
 
     @Test
+    void foldsHelperNamedTwiceIntoOneStep(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a helper named twice must be read in place and cost one step, but it doesnt",
+            new Reduction(
+                phino,
+                new Xnav("<o base='ξ.a🌵3-4.plus'><o as='α0' base='ξ.a🌵3-4'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                8,
+                "",
+                Collections.singletonMap(
+                    "a🌵3-4",
+                    new Xnav("<o base='ξ.x.times'><o as='α0' base='ξ.x'/></o>").element("o")
+                )
+            ).protocol().moves(),
+            Matchers.hasSize(2)
+        );
+    }
+
+    @Test
     void reducesBytesOperation(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -89,7 +89,8 @@ final class LoweringTest {
                     LoweringTest.fragment(foo),
                     voids,
                     8,
-                    story.map().getOrDefault("unit", "").toString()
+                    story.map().getOrDefault("unit", "").toString(),
+                    LoweringTest.helpers(foo)
                 ).protocol(),
                 voids.size()
             ).trim(),
@@ -114,7 +115,8 @@ final class LoweringTest {
                     LoweringTest.fragment(foo),
                     LoweringTest.voids(foo, story),
                     8,
-                    story.map().getOrDefault("unit", "").toString()
+                    story.map().getOrDefault("unit", "").toString(),
+                    LoweringTest.helpers(foo)
                 )::protocol,
                 "a fragment the pack calls stuck cannot reduce, but it did"
             ).getMessage(),
@@ -200,6 +202,19 @@ final class LoweringTest {
                 if (!"ρ".equals(name)) {
                     out.put(name, ((Map<?, ?>) formas).get(name).toString());
                 }
+            }
+        }
+        return out;
+    }
+
+    private static Map<String, Xnav> helpers(final Xnav formation) {
+        final Map<String, Xnav> out = new LinkedHashMap<>();
+        for (final Xnav kid
+            : formation.elements(Filter.withName("o")).collect(Collectors.toList())) {
+            final String name = kid.attribute("name").text().orElse("");
+            if (!name.isEmpty() && !"φ".equals(name)
+                && !"∅".equals(kid.attribute("base").text().orElse(""))) {
+                out.put(name, kid);
             }
         }
         return out;

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/const-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/const-helper.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A const helper is privatized too, but the parser wraps it into a
+# dataized object, and the reduction has no atom for one, so the
+# formation stays as written; `shifted!` of `i64.scan` waits on this.
+input: |
+  [] > foo
+    [x] > bump
+      x.times x >> square!
+      square.plus 1 > @
+    bump 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bump
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bump 5 > @
+    [x] > bump
+      plus. > @
+        x.times x >> square!
+        1
+stuck: "The base 'Φ.dataized' carries no datum"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/cyclic-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/cyclic-helper.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A privatized helper that reads itself never settles, and reading it in
+# place would never end, so the reduction refuses before phino is asked
+# and the formation stays as written, helper and all.
+input: |
+  [] > foo
+    [x] > spin
+      more.plus x >> more
+      more.times 2 > @
+    spin 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: spin
+voids:
+  x: number
+lowered: |
+  [] > foo
+    spin 5 > @
+    [x] > spin
+      times. > @
+        v3_4.plus x >> more
+        2
+stuck: "reads itself, so the fragment never settles"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/helper-atom.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/helper-atom.yaml
@@ -1,9 +1,10 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# A helper attribute is part of the formation's interface, and deleting
-# the body would delete it too, so the formation stays as written even
-# though it is pure.
+# A public helper attribute is part of the formation's interface, and
+# deleting the body would delete it too, so the formation stays as
+# written even though it is pure. Compare hidden-helper.yaml, where the
+# same helper is privatized with `>>` and the formation lowers.
 input: |
   [] > foo
     [x] > bump

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/hidden-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/hidden-helper.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A helper the source privatized with `>>` is no part of the formation's
+# interface, so nothing outside can miss it once the body is gone: the
+# body reads it in place, the two reads are identical sites and collapse
+# into one step, and the helper leaves with the body. Compare
+# helper-atom.yaml, where the same helper is public and keeps the
+# formation as written.
+input: |
+  [] > foo
+    [x] > bump
+      x.times x >> square
+      square.plus square > @
+    bump 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bump
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bump 5 > @
+    [] > bump /Q.number
+      ? > x /Q.number
+protocol: |
+  s1 ← L_number_times sym:v0 sym:v0
+  s2 ← L_number_plus sym:s1 sym:s1
+  answer sym:s2 number
+java: |
+  final double v0 = new Dataized(this.take("x")).asNumber();
+  final double s1 = v0 * v0;
+  final double s2 = s1 + s1;
+  return new Data.ToPhi(s2);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-helper.yaml
@@ -1,0 +1,65 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The countdown of looped-countdown.yaml, with its guard moved into a
+# privatized helper, the way the recursive formations of the runtime
+# keep theirs. The helper is read in place where the `if` tests it, so
+# the protocol and the loop are exactly the ones the inline guard gives,
+# and the helper leaves with the body together with `^`.
+input: |
+  [] > foo
+    [^ n acc] > down
+      n.eq 0 >> stop
+      if. > @
+        stop
+        acc
+        ^.down
+          n.plus -1
+          acc.times n
+    down 5 1 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: down
+voids:
+  n: number
+  acc: number
+lowered: |
+  [] > foo
+    down > @
+      5
+      1
+    [] > down /Q.number
+      ? > n /Q.number
+      ? > acc /Q.number
+protocol: |
+  loop v0 v1
+    s1 ← L_bytes_eq sym:v0 number:00-00-00-00-00-00-00-00
+    s2 ← fork sym:s1 number
+      then
+        answer sym:v1 number
+      else
+        s3 ← L_number_plus sym:v0 number:BF-F0-00-00-00-00-00-00
+        s4 ← L_number_times sym:v1 sym:v0
+        repeat sym:s3 sym:s4
+    answer sym:s2 number
+java: |
+  double v0 = new Dataized(this.take("n")).asNumber();
+  double v1 = new Dataized(this.take("acc")).asNumber();
+  final double s2;
+  while (true) {
+      final boolean s1 = Double.doubleToRawLongBits(v0) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+      if (s1) {
+          s2 = v1;
+          break;
+      } else {
+          final double s3 = v0 + Double.longBitsToDouble(0xBFF0000000000000L);
+          final double s4 = v1 * v0;
+          v0 = s3;
+          v1 = s4;
+          continue;
+      }
+  }
+  return new Data.ToPhi(s2);


### PR DESCRIPTION
Closes #8402.

`Lowered` admitted a formation only when its body was voids plus one `φ`, so a single privatized helper — a `>>` attribute, or a const the parser wraps — kept the formation as written before phino ever saw it. Such a helper is no part of the interface, so folding it into the atom changes nothing outside; only a public attribute has to keep the formation as written.

## What changed

**Lowered.** A bound kid under a synthetic `a🌵` name — the name the parser gives a `>>` handle and a wrapped const — counts as a helper: `lowered` allows any number of them next to the voids, `ρ` and `φ`, and `marked` removes them together with the body, so nothing stays dispatchable with nothing behind it. A kid under any other name still keeps the formation as written.

**Parsed.** A `ξ` reference to a helper becomes the helper's own body, read in place, so the tree is the one the body would be with every helper written out. A helper named twice stands twice, and identical sites already collapse into one step, so it costs one; a helper named in one arm of a fork alone is computed in that arm alone; a helper that reads itself, directly or through another helper, refuses as a cycle before phino is asked; a helper reading `φ` refuses as a reference to nothing the fragment declares. `Reduction` takes the helpers and hands them on.

**Carrier.** PMD put `Parsed` at the God Class threshold once it learned helpers, so the reading of the data carriers (`Φ.number`, `Φ.string`, `Φ.bytes`, the two bools) moved out into `Carrier`, unchanged.

## Where the helpers are read

The issue proposes binding the helpers next to `φ` in the formation `Reduction.grown` hands phino. The records phino returns are matched against the tree by shape, so a helper bound in the phino text alone would still need a term on this side that resolves to whatever the helper has settled into so far, and every sub-reduction — an arm of a fork, an argument of a repeat — sends a `φ` of its own, so the helpers would have to be threaded into each of them and re-resolved as they settle. Reading the helper's body where it is named hands phino the same sites and gives the same protocol the issue's probe describes, with no new state: `doubled ↦ x.times 2, φ ↦ doubled.plus 1` reduces to `times` then `plus`.

## Packs

- `hidden-helper`: `x.times x >> square`, read twice in the body, lowers into two steps and the helper leaves with the body. `helper-atom` keeps its public helper and stays as written; its comment now points at the difference.
- `looped-helper`: the countdown with its guard moved into a privatized helper, the shape the runtime's recursive formations have; protocol, loop and Java are exactly `looped-countdown`'s.
- `cyclic-helper`: a helper reading itself refuses as a cycle.
- `const-helper`: a `>>` helper marked `!` stays as written, since the parser wraps it into `Φ.dataized` and the reduction has no atom for that. `shifted!` of `i64.scan` waits on this as well as on `L_number_lt`, `L_bytes_right` and a `>>` on `empty` in the source, as the issue notes.

## Verified

- `eo-lowering`: 204 tests pass, qulice clean; `eo-maven-plugin`: qulice clean, all 144 lowering pack checks pass.
- `eo-runtime` re-lowered end to end with phino 0.0.115 and compiled: still 144 fragments. Exactly the 54 formations the issue counts now pass the shape check, and none of them lowers yet, each for a reason the reduction already states: 46 declare a void the inference tables never witness as a number, a string or bytes (`x` of `i64.gt` is an `i64`, `func` of `tuple.mapped` is a formation), 5 apply `Φ.number` to a computed value rather than a bytes datum, which the reduction reads as a malformed literal (`number.power`, `string.starts-with` and its three siblings), 2 reach through `^` (`tuple.without`, `tuple.withouti`), and 1 nests a formation (`directory.walk`). So the shape gate is open now, and the next one is witnessing.

## Notes

- **pr-size** is over the cap, as the previous lowering PRs were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_