### PR TITLE
fix(#8328): run the concurrency tests where the budget is generous

### DIFF
--- a/.github/workflows/fast.yml
+++ b/.github/workflows/fast.yml
@@ -68,17 +68,26 @@ jobs:
                 done \
               | paste -sd, -
           ) || true
-          # The `|| true` is what lets the guard below run at all. A step
+          # The `|| true` is what lets the lines below run at all. A step
           # script runs under `-e -o pipefail`, so a branch that touches no
           # `.eo` file leaves `grep` with nothing to match, `grep` exits 1,
           # the pipeline inherits it and the assignment dies before anything
           # reads `classes`. On the left of `||` the status is nobody's
           # business and `classes` simply comes out empty.
+          # The concurrency tests are hand-written Java, so no .eo file names
+          # them and the loop above never picks them up. They lose every race
+          # against the one-second `eo.deadline` and the 256M `eo.maxmem` of
+          # the ordinary build, which report an over-budget test as skipped:
+          # `EOdirectoryEOmadeRaceTest` is skipped in all ten repetitions of
+          # every job that completes. They are added here unconditionally, so
+          # the branch they guard is executed rather than reported as covered.
+          always='EOdirectoryEOmadeRaceTest,EOfileEOtouchedTest'
           if [ -z "${classes}" ]; then
-            echo 'This branch touches no .eo file that owns tests, nothing to run'
+            classes="${always}"
           else
-            echo "Test classes to run: ${classes}"
+            classes="${always},${classes}"
           fi
+          echo "Test classes to run: ${classes}"
           echo "classes=${classes}" >> "${GITHUB_OUTPUT}"
       - uses: actions/setup-java@v6
         with:


### PR DESCRIPTION
Fixes #8328.

`EOdirectoryEOmadeRaceTest` is skipped in all ten of its repetitions in every job that completes, on both platforms. It exists precisely because the `EEXIST` branch of `directory.made` cannot be reached from a single-threaded `++>` test, so that branch has no test that actually runs, while the guard for #7080 reports as present in every build.

Four threads each building an object graph do not fit in the one-second `eo.deadline` or the 256M `eo.maxmem` of the ordinary build, and both guards report an over-budget test as skipped rather than as a failure. Nothing compensates: the long-deadline step in `fast.yml` runs only the tests of the `.eo` files a branch touches, and this is hand-written Java that no `.eo` file names.

So the two concurrency tests are named in that step unconditionally. It already runs at `-Deo.deadline=3600 -Deo.maxmem=2G`, which is room enough for both — `Maxmem` measures `EOfileEOtouchedTest` at 419M — and a regression in the `EEXIST` branch is reported as a failure instead of being swallowed as a skip.

The run of this pull request is the check: the step should report both classes as run rather than skipped.
