### PR TITLE
feat(lowering): #8408 apply a helper formation where it is named

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -27,7 +27,8 @@ import org.w3c.dom.Element;
  * carrier can stand for it. A helper is an attribute the source
  * privatized with {@code >>}, or a const the parser wrapped, and it
  * shows up under a synthetic {@code a🌵} name: the body reads it in
- * place, so it is folded into the atom and leaves with the body. A
+ * place, applying it to its arguments when it is a formation of its
+ * own, so it is folded into the atom and leaves with the body. A
  * public attribute keeps the formation as written, since deleting the
  * body must not change the object's interface, and a helper that stays
  * reachable would be dispatchable with nothing behind it. The formation

--- a/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
@@ -9,7 +9,6 @@ import com.github.lombrozo.xnav.Xnav;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -27,10 +26,13 @@ import java.util.stream.Collectors;
  * leaks into a marker, and a {@code ξ.ρ} reference to the formation
  * being lowered, with arguments, becomes the {@link Again} of its own
  * body. A {@code ξ} reference to a helper the formation binds next to
- * its body becomes the helper's own body, read in place: the helper is
- * an application over the same voids, so it stands wherever it is
- * named, twice when named twice, and identical sites collapse into one
- * step anyway. A helper that reads itself, directly or through another
+ * its body becomes the helper's own body, read in place: an application
+ * over the same voids stands wherever it is named, and a formation of
+ * its own is applied where it is named, its voids bound to the argument
+ * terms in a {@link Scope} of its own, the way phino would bind them,
+ * so its body stands there with every void spelled out. A helper named
+ * twice stands twice, and identical sites collapse into one step
+ * anyway. A helper that reads itself, directly or through another
  * helper, is a cycle and is refused. The parser rolls a dispatch chain
  * rooted in a reference into the base itself, so {@code ξ.b.size.plus}
  * unrolls here into nested sites, with the arguments of the element
@@ -47,21 +49,9 @@ public final class Parsed {
     private final Xnav fragment;
 
     /**
-     * The voids of the fragment: names to formas, in declaration order.
+     * What the names of the fragment mean.
      */
-    private final Map<String, String> voids;
-
-    /**
-     * The name of the formation being lowered, or empty when the
-     * fragment is not the body of one.
-     */
-    private final String self;
-
-    /**
-     * The helpers the formation binds next to its body: names to their
-     * {@code <o/>} elements.
-     */
-    private final Map<String, Xnav> helpers;
+    private final Scope scope;
 
     /**
      * The helpers being read at the moment, outermost first, so that a
@@ -97,18 +87,22 @@ public final class Parsed {
      *  whose calls to itself through {@code ξ.ρ} become repeats
      * @param bound The helpers the formation binds next to its body:
      *  names to their {@code <o/>} elements, read in place when named
+     * @checkstyle ParameterNumberCheck (5 lines)
      */
     public Parsed(final Xnav xmir, final Map<String, String> inputs,
         final String name, final Map<String, Xnav> bound) {
-        this(xmir, inputs, name, bound, Collections.emptyList());
+        this(xmir, new Scope(inputs, name, bound), Collections.emptyList());
     }
 
-    private Parsed(final Xnav xmir, final Map<String, String> inputs,
-        final String name, final Map<String, Xnav> bound, final Collection<String> above) {
+    /**
+     * Ctor.
+     * @param xmir The XMIR fragment to read, an {@code <o/>} element
+     * @param where What the names of the fragment mean
+     * @param above The helpers being read at the moment, outermost first
+     */
+    Parsed(final Xnav xmir, final Scope where, final Collection<String> above) {
         this.fragment = xmir;
-        this.voids = inputs;
-        this.self = name;
-        this.helpers = bound;
+        this.scope = where;
         this.trail = above;
     }
 
@@ -127,12 +121,6 @@ public final class Parsed {
             out = new Forced(this.parsed(Parsed.target(node)));
         } else if (base.startsWith("Φ.")) {
             out = new Carrier(node).literal();
-        } else if (this.recursive(base)) {
-            out = new Again(
-                this.bound(Parsed.kids(node)).stream()
-                    .map(Binding::value)
-                    .collect(Collectors.toList())
-            );
         } else if (base.startsWith("ξ.")) {
             out = this.chained(node, base.substring(2));
         } else if (base.length() > 1 && base.charAt(0) == '.') {
@@ -145,59 +133,51 @@ public final class Parsed {
         return out;
     }
 
-    private boolean recursive(final String base) {
-        return !this.self.isEmpty() && base.equals(String.format("ξ.ρ.%s", this.self));
-    }
-
-    private Term referenced(final String name) {
-        final List<String> names = new ArrayList<>(this.voids.keySet());
-        final int idx = names.indexOf(name);
-        final Term out;
-        if (idx >= 0) {
-            out = new Symbol(String.format("v%d", idx), this.voids.get(name));
-        } else if (this.helpers.containsKey(name)) {
-            out = this.expanded(name);
-        } else {
-            throw new IllegalStateException(
-                String.format(
-                    "The reference 'ξ.%s' names no void or helper of the fragment", name
-                )
-            );
-        }
-        return out;
-    }
-
-    private Term expanded(final String name) {
-        if (this.trail.contains(name)) {
-            throw new IllegalStateException(
-                String.format(
-                    "The helper 'ξ.%s' reads itself, so the fragment never settles", name
-                )
-            );
-        }
-        final Collection<String> deeper = new LinkedHashSet<>(this.trail);
-        deeper.add(name);
-        return new Parsed(
-            this.helpers.get(name), this.voids, this.self, this.helpers, deeper
-        ).term();
-    }
-
     private Term chained(final Xnav node, final String path) {
         final String[] parts = path.split("\\.", -1);
-        Term out = this.referenced(parts[0]);
-        final int last = parts.length - 1;
-        if (last == 0 && !Parsed.kids(node).isEmpty()) {
+        final List<Binding> args = this.bound(Parsed.kids(node));
+        Scope where = this.scope;
+        int hops = 0;
+        while (hops < parts.length && "ρ".equals(parts[hops]) && !where.root()) {
+            where = where.above();
+            ++hops;
+        }
+        if (hops == parts.length) {
             throw new IllegalStateException(
-                String.format("The reference 'ξ.%s' cannot take arguments", path)
+                String.format("The reference 'ξ.%s' names a formation, not a value", path)
             );
         }
-        for (int idx = 1; idx < last; ++idx) {
+        final int last = parts.length - 1;
+        Term out;
+        int next = hops + 1;
+        if ("ρ".equals(parts[hops])) {
+            out = Parsed.again(where, path, parts, args);
+            next = parts.length;
+        } else if (hops == last) {
+            out = new Reference(where, this.trail, parts[hops], args).term();
+        } else {
+            out = new Reference(where, this.trail, parts[hops], new ArrayList<>(0)).term();
+        }
+        for (int idx = next; idx < last; ++idx) {
             out = Parsed.site(parts[idx], out, new ArrayList<>(0));
         }
-        if (last > 0) {
-            out = Parsed.site(parts[last], out, this.bound(Parsed.kids(node)));
+        if (next <= last) {
+            out = Parsed.site(parts[last], out, args);
         }
         return out;
+    }
+
+    private static Term again(final Scope where, final String path,
+        final String[] parts, final List<Binding> args) {
+        if (where.name().isEmpty() || parts.length != 2 || !parts[1].equals(where.name())) {
+            throw new IllegalStateException(
+                String.format(
+                    "The reference 'ξ.%s' reaches through ρ beyond the formation being lowered",
+                    path
+                )
+            );
+        }
+        return new Again(args.stream().map(Binding::value).collect(Collectors.toList()));
     }
 
     private Term dispatched(final Xnav node, final String base) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
@@ -51,7 +51,8 @@ import java.util.Optional;
  * in its place.</p>
  *
  * <p>A helper the formation binds next to its body is read in place
- * wherever the body names it, by {@link Parsed}, so the tree phino sees
+ * wherever the body names it, by {@link Parsed}, applied to its
+ * arguments when it has voids of its own, so the tree phino sees
  * is the one the body would be with every helper written out, and the
  * protocol is the one that body would give: a helper named twice
  * stands twice and costs one step, since identical sites collapse, and

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reference.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reference.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * One name a fragment reaches in a scope, with the arguments handed to it.
+ *
+ * <p>The name is a void of the scope, which stands as its symbol and
+ * takes no arguments, or a helper of the scope, which is read where it
+ * is named: an application over the voids of the scope stands as its
+ * own body, and a formation of its own is applied, its body read in the
+ * {@link Scope} that binds its voids to the arguments. A helper that
+ * names itself, directly or through another helper, is a cycle and is
+ * refused, since reading it would never end.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Reference {
+
+    /**
+     * The scope the name is reached in.
+     */
+    private final Scope scope;
+
+    /**
+     * The helpers being read at the moment, outermost first.
+     */
+    private final Collection<String> trail;
+
+    /**
+     * The name.
+     */
+    private final String name;
+
+    /**
+     * The arguments handed to the name.
+     */
+    private final List<Binding> args;
+
+    /**
+     * Ctor.
+     * @param where The scope the name is reached in
+     * @param above The helpers being read at the moment, outermost first
+     * @param label The name
+     * @param arguments The arguments handed to the name
+     */
+    public Reference(final Scope where, final Collection<String> above,
+        final String label, final List<Binding> arguments) {
+        this.scope = where;
+        this.trail = above;
+        this.name = label;
+        this.args = arguments;
+    }
+
+    /**
+     * The term the name stands for.
+     * @return The term
+     */
+    public Term term() {
+        final Optional<Term> term = this.scope.term(this.name);
+        final Optional<Xnav> helper = this.scope.helper(this.name);
+        final Term out;
+        if (term.isPresent()) {
+            if (!this.args.isEmpty()) {
+                throw new IllegalStateException(
+                    String.format("The reference 'ξ.%s' cannot take arguments", this.name)
+                );
+            }
+            out = term.get();
+        } else if (helper.isPresent()) {
+            out = this.applied(helper.get());
+        } else {
+            throw new IllegalStateException(
+                String.format(
+                    "The reference 'ξ.%s' names no void or helper of the fragment", this.name
+                )
+            );
+        }
+        return out;
+    }
+
+    private Term applied(final Xnav helper) {
+        if (this.trail.contains(this.name)) {
+            throw new IllegalStateException(
+                String.format(
+                    "The helper 'ξ.%s' reads itself, so the fragment never settles", this.name
+                )
+            );
+        }
+        final Collection<String> deeper = new LinkedHashSet<>(this.trail);
+        deeper.add(this.name);
+        final Term out;
+        if (helper.attribute("base").text().isPresent()) {
+            if (!this.args.isEmpty()) {
+                throw new IllegalStateException(
+                    String.format(
+                        "The helper 'ξ.%s' is an application and cannot take arguments",
+                        this.name
+                    )
+                );
+            }
+            out = new Parsed(helper, this.scope, deeper).term();
+        } else {
+            out = new Parsed(
+                this.body(helper), this.scope.inside(helper, this.args), deeper
+            ).term();
+        }
+        return out;
+    }
+
+    private Xnav body(final Xnav helper) {
+        final Optional<Xnav> found = helper.elements(Filter.withName("o"))
+            .filter(kid -> "φ".equals(kid.attribute("name").text().orElse("")))
+            .filter(kid -> kid.attribute("base").text().isPresent())
+            .findFirst();
+        if (!found.isPresent()) {
+            throw new IllegalStateException(
+                String.format("The helper 'ξ.%s' has no body to apply", this.name)
+            );
+        }
+        return found.get();
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Scope.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Scope.java
@@ -1,0 +1,191 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * What the names of one formation mean while its body is read.
+ *
+ * <p>The formation being lowered is the root scope: its voids are the
+ * symbols {@code v0, v1, ...} in declaration order, and the helpers
+ * bound next to its body are reachable by name. A helper that is a
+ * formation of its own opens a scope inside the one it is named from
+ * when it is applied: its voids are bound to the argument terms, by
+ * position or by name, and its own attributes become its helpers, while
+ * {@code ρ} leads back to the scope it was opened from. The parser
+ * writes exactly as many {@code ρ} hops as the author did, so a name
+ * from an enclosing formation is read through them and never guessed.
+ * At the root, {@code ρ} leads to the object that owns the formation,
+ * where only the formation itself may be named, as the call that
+ * becomes a repeat.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Scope {
+
+    /**
+     * The names bound to terms: the voids of the formation.
+     */
+    private final Map<String, Term> terms;
+
+    /**
+     * The helpers reachable by name: their {@code <o/>} elements.
+     */
+    private final Map<String, Xnav> helpers;
+
+    /**
+     * The name of the formation at the root, empty elsewhere.
+     */
+    private final String self;
+
+    /**
+     * The scope this one was opened from, none at the root.
+     */
+    private final List<Scope> outer;
+
+    /**
+     * Ctor, for the root.
+     * @param voids The voids of the formation: names to formas, in order
+     * @param name The name of the formation, or empty when the fragment
+     *  is not the body of one
+     * @param bound The helpers the formation binds next to its body
+     */
+    public Scope(final Map<String, String> voids, final String name,
+        final Map<String, Xnav> bound) {
+        this(Scope.symbols(voids), bound, name, Collections.emptyList());
+    }
+
+    private Scope(final Map<String, Term> values, final Map<String, Xnav> bound,
+        final String name, final List<Scope> above) {
+        this.terms = values;
+        this.helpers = bound;
+        this.self = name;
+        this.outer = above;
+    }
+
+    /**
+     * The term a name is bound to here.
+     * @param name The name
+     * @return The term, or empty when the name is not a bound void here
+     */
+    public Optional<Term> term(final String name) {
+        return Optional.ofNullable(this.terms.get(name));
+    }
+
+    /**
+     * The helper a name reaches here.
+     * @param name The name
+     * @return Its element, or empty when the name is not a helper here
+     */
+    public Optional<Xnav> helper(final String name) {
+        return Optional.ofNullable(this.helpers.get(name));
+    }
+
+    /**
+     * Whether this is the root, the scope of the formation being lowered.
+     * @return True at the root
+     */
+    public boolean root() {
+        return this.outer.isEmpty();
+    }
+
+    /**
+     * The name of the formation being lowered.
+     * @return The name, empty when the fragment is not the body of one
+     */
+    public String name() {
+        return this.self;
+    }
+
+    /**
+     * The scope this one was opened from.
+     * @return The scope {@code ρ} leads to
+     */
+    public Scope above() {
+        if (this.root()) {
+            throw new IllegalStateException(
+                "The reference reaches through ρ beyond the formation being lowered"
+            );
+        }
+        return this.outer.get(0);
+    }
+
+    /**
+     * The scope of a helper formation applied to arguments, inside this one.
+     * @param formation The helper, an {@code <o/>} with no base
+     * @param args The arguments of the application
+     * @return The scope its body is read in
+     */
+    public Scope inside(final Xnav formation, final List<Binding> args) {
+        final List<String> voids = new ArrayList<>(0);
+        final Map<String, Xnav> bound = new LinkedHashMap<>();
+        for (final Xnav kid : formation.elements(Filter.withName("o"))
+            .collect(Collectors.toList())) {
+            final String name = kid.attribute("name").text().orElse("");
+            if ("∅".equals(kid.attribute("base").text().orElse(""))) {
+                if (!"ρ".equals(name)) {
+                    voids.add(name);
+                }
+            } else if (!name.isEmpty() && !"φ".equals(name)) {
+                bound.put(name, kid);
+            }
+        }
+        final Map<String, Term> values = new LinkedHashMap<>();
+        for (final Binding arg : args) {
+            values.put(Scope.named(voids, arg.label()), arg.value());
+        }
+        if (values.size() != voids.size()) {
+            throw new IllegalStateException(
+                String.format(
+                    "The helper declares %d voids, but the application binds %d of them",
+                    voids.size(), values.size()
+                )
+            );
+        }
+        return new Scope(values, bound, "", Collections.singletonList(this));
+    }
+
+    private static String named(final List<String> voids, final String label) {
+        final String out;
+        if (label.startsWith("α")) {
+            final int idx = Integer.parseInt(label.substring(1));
+            if (idx >= voids.size()) {
+                throw new IllegalStateException(
+                    String.format(
+                        "The helper declares %d voids, but is handed an argument '%s'",
+                        voids.size(), label
+                    )
+                );
+            }
+            out = voids.get(idx);
+        } else if (voids.contains(label)) {
+            out = label;
+        } else {
+            throw new IllegalStateException(
+                String.format("The helper declares no void '%s' to bind", label)
+            );
+        }
+        return out;
+    }
+
+    private static Map<String, Term> symbols(final Map<String, String> voids) {
+        final Map<String, Term> out = new LinkedHashMap<>();
+        int idx = 0;
+        for (final Map.Entry<String, String> entry : voids.entrySet()) {
+            out.put(entry.getKey(), new Symbol(String.format("v%d", idx), entry.getValue()));
+            ++idx;
+        }
+        return out;
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
@@ -6,6 +6,8 @@ package org.eolang.lowering;
 
 import com.github.lombrozo.xnav.Xnav;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -154,6 +156,74 @@ final class ParsedTest {
     }
 
     @Test
+    void appliesHelperFormationToArguments() {
+        MatcherAssert.assertThat(
+            "a helper with voids must be applied where it is named, but it isnt",
+            new Parsed(
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='ξ.a🌵3-4'>",
+                        "<o as='α0' base='Φ.number'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>40-00-00-00-00-00-00-00</o></o>",
+                        "</o>",
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("x", "number"),
+                "",
+                Collections.singletonMap("a🌵3-4", ParsedTest.scaled())
+            ).term().phi(),
+            Matchers.stringContainsInOrder(
+                "Sym_v0", ".times(", "Δ ⤍ 40-00-00-00-00-00-00-00"
+            )
+        );
+    }
+
+    @Test
+    void appliesHelperNamedFromAnotherHelper() {
+        final Map<String, Xnav> helpers = new LinkedHashMap<>();
+        helpers.put("a🌵3-4", ParsedTest.scaled());
+        helpers.put(
+            "a🌵7-4",
+            new Xnav(
+                String.join(
+                    "",
+                    "<o name='a🌵7-4'><o base='∅' name='ρ'/><o base='∅' name='j'/>",
+                    "<o base='ξ.ρ.a🌵3-4' name='φ'><o as='α0' base='ξ.j'/></o></o>"
+                )
+            ).element("o")
+        );
+        MatcherAssert.assertThat(
+            "a helper naming its sibling through ρ must apply it, but it doesnt",
+            new Parsed(
+                new Xnav("<o base='ξ.a🌵7-4'><o as='α0' base='ξ.x'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                "",
+                helpers
+            ).term().phi(),
+            Matchers.stringContainsInOrder("Sym_v0", ".times(", "Sym_v0")
+        );
+    }
+
+    @Test
+    void refusesReachBeyondTheFormation() {
+        MatcherAssert.assertThat(
+            "a reference past the root through ρ depends on a context the fragment lacks",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Parsed(
+                    new Xnav("<o base='ξ.ρ.ρ.x'/>").element("o"),
+                    Collections.singletonMap("x", "number"),
+                    "f"
+                )::term,
+                "a reference through two ρ from the root parsed, but it must not"
+            ).getMessage(),
+            Matchers.containsString("beyond the formation")
+        );
+    }
+
+    @Test
     void readsHelperInPlace() {
         MatcherAssert.assertThat(
             "a reference to a helper must stand as the helper's own body, but it doesnt",
@@ -226,6 +296,16 @@ final class ParsedTest {
             )::term,
             "a void applied to arguments cannot be reduced, but it was"
         );
+    }
+
+    private static Xnav scaled() {
+        return new Xnav(
+            String.join(
+                "",
+                "<o name='a🌵3-4'><o base='∅' name='ρ'/><o base='∅' name='i'/>",
+                "<o base='ξ.ρ.x.times' name='φ'><o as='α0' base='ξ.i'/></o></o>"
+            )
+        ).element("o");
     }
 
     private static Xnav square() {

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
@@ -194,6 +194,45 @@ final class ReductionTest {
     }
 
     @Test
+    void appliesHelperFormationTwice(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a helper with a void must be applied to each argument it is handed, but it isnt",
+            new Reduction(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='.plus'>",
+                        "<o base='ξ.a🌵3-4'>",
+                        ReductionTest.number("α0", "40-00-00-00-00-00-00-00"),
+                        "</o>",
+                        "<o as='α0' base='ξ.a🌵3-4'>",
+                        ReductionTest.number("α0", "40-08-00-00-00-00-00-00"),
+                        "</o>",
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("x", "number"),
+                8,
+                "",
+                Collections.singletonMap(
+                    "a🌵3-4",
+                    new Xnav(
+                        String.join(
+                            "",
+                            "<o name='a🌵3-4'><o base='∅' name='ρ'/><o base='∅' name='i'/>",
+                            "<o base='ξ.ρ.x.times' name='φ'><o as='α0' base='ξ.i'/></o></o>"
+                        )
+                    ).element("o")
+                )
+            ).protocol().moves(),
+            Matchers.hasSize(3)
+        );
+    }
+
+    @Test
     void foldsHelperNamedTwiceIntoOneStep(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());

--- a/eo-lowering/src/test/java/org/eolang/lowering/ScopeTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ScopeTest.java
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Scope}.
+ * @since 0.76.0
+ */
+final class ScopeTest {
+
+    @Test
+    void bindsRootVoidsPositionally() {
+        MatcherAssert.assertThat(
+            "a void of the formation must be its positional symbol, but it isnt",
+            ScopeTest.root().term("x").get().key(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void bindsArgumentByPosition() {
+        MatcherAssert.assertThat(
+            "the first argument must bind the first void after ρ, but it doesnt",
+            ScopeTest.root().inside(
+                ScopeTest.helper(),
+                Collections.singletonList(
+                    new Binding("α0", new Literal("number", "40-00-00-00-00-00-00-00"))
+                )
+            ).term("i").get().key(),
+            Matchers.equalTo("number:40-00-00-00-00-00-00-00")
+        );
+    }
+
+    @Test
+    void bindsArgumentByName() {
+        MatcherAssert.assertThat(
+            "an argument named after a void must bind that void, but it doesnt",
+            ScopeTest.root().inside(
+                ScopeTest.helper(),
+                Collections.singletonList(new Binding("i", new Symbol("v0", "number")))
+            ).term("i").get().key(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void leadsBackThroughRho() {
+        MatcherAssert.assertThat(
+            "ρ inside a helper must lead to the scope it was applied from, but it doesnt",
+            ScopeTest.root().inside(
+                ScopeTest.helper(),
+                Collections.singletonList(new Binding("α0", new Symbol("v0", "number")))
+            ).above().term("x").get().key(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void refusesRhoAtTheRoot() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            ScopeTest.root()::above,
+            "the root has nothing above it to read, but it answered"
+        );
+    }
+
+    @Test
+    void refusesPartialApplication() {
+        MatcherAssert.assertThat(
+            "a helper applied to fewer arguments than voids must refuse, but it didnt",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> ScopeTest.root().inside(ScopeTest.helper(), Collections.emptyList()),
+                "a helper with an unbound void was applied, but it must not be"
+            ).getMessage(),
+            Matchers.containsString("binds 0 of them")
+        );
+    }
+
+    @Test
+    void refusesArgumentBeyondVoids() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> ScopeTest.root().inside(
+                ScopeTest.helper(),
+                Arrays.asList(
+                    new Binding("α0", new Symbol("v0", "number")),
+                    new Binding("α1", new Symbol("v0", "number"))
+                )
+            ),
+            "a helper handed more arguments than it has voids was applied, but it must not be"
+        );
+    }
+
+    @Test
+    void refusesArgumentOfUnknownName() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> ScopeTest.root().inside(
+                ScopeTest.helper(),
+                Collections.singletonList(new Binding("k", new Symbol("v0", "number")))
+            ),
+            "an argument naming no void of the helper was bound, but it must not be"
+        );
+    }
+
+    private static Scope root() {
+        return new Scope(Collections.singletonMap("x", "number"), "f", Collections.emptyMap());
+    }
+
+    private static Xnav helper() {
+        return new Xnav(
+            String.join(
+                "",
+                "<o name='a🌵3-4'><o base='∅' name='ρ'/><o base='∅' name='i'/>",
+                "<o base='ξ.ρ.x.times' name='φ'><o as='α0' base='ξ.i'/></o></o>"
+            )
+        ).element("o");
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/applied-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/applied-helper.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A privatized helper may be a formation of its own, taking arguments,
+# the way the helpers of the runtime's `printf` do. It is applied where
+# it is named: its voids are bound to the arguments, the outer void is
+# read through the `^` the author wrote, and a helper of the helper is
+# applied the same way one level down. The body stands with every void
+# spelled out, so the protocol is the one the inline expression gives,
+# and both helpers leave with the body.
+input: |
+  [] > foo
+    [x] > bump
+      [^ i] >> scaled
+        [^ k] >> shifted
+          k.plus ^.^.x > @
+        shifted (^.x.times i) > @
+      (scaled 2).plus (scaled 3) > @
+    bump 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bump
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bump 5 > @
+    [] > bump /Q.number
+      ? > x /Q.number
+protocol: |
+  s1 ← L_number_times sym:v0 number:40-00-00-00-00-00-00-00
+  s2 ← L_number_plus sym:s1 sym:v0
+  s3 ← L_number_times sym:v0 number:40-08-00-00-00-00-00-00
+  s4 ← L_number_plus sym:s3 sym:v0
+  s5 ← L_number_plus sym:s2 sym:s4
+  answer sym:s5 number
+java: |
+  final double v0 = new Dataized(this.take("x")).asNumber();
+  final double s1 = v0 * Double.longBitsToDouble(0x4000000000000000L);
+  final double s2 = s1 + v0;
+  final double s3 = v0 * Double.longBitsToDouble(0x4008000000000000L);
+  final double s4 = s3 + v0;
+  final double s5 = s2 + s4;
+  return new Data.ToPhi(s5);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Two helpers applying each other never settle by application alone:
+# reading either where it is named reads the other, and then the first
+# again, so the reduction refuses the cycle before phino is asked and the
+# formation stays as written. Such a pair needs the loop, not the
+# application, the way `walk` and `spec` of `printf` do.
+input: |
+  [] > foo
+    [x] > bounce
+      [^ i] >> ping
+        pong (i.plus 1) > @
+      [^ j] >> pong
+        ping (j.times 2) > @
+      ping x > @
+    bounce 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bounce
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bounce 5 > @
+    [x] > bounce
+      ping x > @
+      pong > [^ i] >> ping
+        i.plus 1
+      ping > [^ j] >> pong
+        j.times 2
+stuck: "reads itself, so the fragment never settles"


### PR DESCRIPTION
Closes #8408.

A privatized helper was read in place only when it was an application over the voids of the formation. A helper that is a formation of its own, taking arguments, refused at both ends — at the call site, since a reference could not take arguments, and at the helper, since a formation has no base — and in the runtime that is the common case: seven of the ten helpers of `printf` are such formations, named 27 times with arguments.

## What changed

**Scope.** What the names of one formation mean while its body is read. The root scope binds the voids of the formation being lowered to their symbols `v0, v1, …` and reaches its helpers by name. Applying a helper formation opens a scope inside the one it is named from: its voids are bound to the argument terms, by position (`α0` is the first void after `ρ`) or by name, its own attributes become its helpers, and `ρ` leads back to the scope it was opened from. The parser writes exactly as many `ρ` hops as the author did, so a name from an enclosing formation is read through them and never guessed; at the root, `ρ` leads to the owner of the formation, where only the formation itself may be named, as the call that becomes a repeat.

**Reference.** One name a fragment reaches in a scope, with the arguments handed to it: a void, which stands as its symbol and takes no arguments, or a helper, which is read where it is named. A helper that is an application is still read in place; a helper that is a formation has its body read in the scope of the application. Partial application refuses, since a void left unbound would be ⊥ in the body, and so does an argument the helper has no void for. The cycle guard of #8402 stays: two helpers applying each other refuse before phino is asked.

**Parsed.** A `ξ` reference walks its `ρ` hops first, then hands the name and the arguments to a `Reference`, and dispatches the rest of a rolled chain on what comes back.

## Where the application happens

The issue proposes binding the helpers alongside `φ` in the term `Reduction.grown` hands phino and letting phino β-apply them. That is what happens semantically, but on this side of the pipe: the records phino returns are matched against the tree by shape, so the sites a helper's body contributes must stand in the tree, with the helper's voids already bound to the argument terms — which is exactly the β-application, done once, where the helper is named. The phino text is then the inline expression, phino parks on the same atoms an inline copy would park on, and a helper applied twice stands twice, its identical sites collapsing into one step as before. Binding the helpers in the phino text alone would leave nothing for the records to anchor to.

## Packs

- `applied-helper`: a helper formation with a void, applied twice, whose body applies a helper of its own and reads the outer void through `^.^`; both helpers leave with the body and the protocol is the inline one.
- `mutual-helpers`: two helpers applying each other refuse as a cycle and the formation stays as written — the shape of `walk` and `spec` in `printf`, which needs the loop of #8409, not the application.

## Verified

- `eo-lowering`: 230 tests pass, qulice clean, simian clean; `eo-maven-plugin`: all 160 lowering pack checks pass, two of them new.
- `eo-runtime` re-lowered end to end with phino 0.0.115 and compiled: still 144 fragments. The application reaches into real runtime code now: `directory.walk`, `tuple.without` and `tuple.withouti` used to refuse at the helper formation itself, and now read through it and stop one gate later, at the global `tuple.empty`, which no carrier stands for. The other 51 of the 54 formations with privatized helpers stop where #8403 found them: 46 declare a void the inference tables never witness as data — `printf` among them, whose `args` is a tuple — and 5 apply `Φ.number` to a computed value.

## Notes

- **pr-size** is over the cap, as the previous lowering PRs were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_