### PR TITLE
feat(lowering): #8409 loop over helpers that apply one another

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Again.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Again.java
@@ -12,23 +12,28 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
- * A call of the formation being lowered to itself, standing in the
- * reduction tree.
+ * A call of the formation being lowered to itself, or of one of its
+ * recursive helpers, standing in the reduction tree.
  *
- * <p>It holds the arguments of the call, in their positional order, and
- * nothing else: the formation is the fragment itself, so calling it
- * again means computing the same body over the values the arguments
- * settle into. It renders as a formation binding the arguments to
- * {@code a0}, {@code a1} and so on, next to the marker λ
- * {@code L_self}, so that phino parks on it wherever it stands and never
- * looks inside; the arity is whatever the call has, and the universe
- * needs no row for it. It has no key, since
- * it is not a value, and a reduction that finds it at the root of a
- * tree settles that tree into a repeat instead of an answer.</p>
+ * <p>It holds the name of the body it resumes, empty for the formation
+ * itself, and the arguments of the call in their positional order, and
+ * nothing else: resuming a body means computing that body again over
+ * the values the arguments settle into. It renders as a formation
+ * binding the arguments to {@code a0}, {@code a1} and so on, next to
+ * the marker λ {@code L_self}, so that phino parks on it wherever it
+ * stands and never looks inside; the arity is whatever the call has,
+ * and the universe needs no row for it. It has no key, since it is not
+ * a value, and a reduction that finds it at the root of a tree settles
+ * that tree into a repeat instead of an answer.</p>
  *
  * @since 0.76.0
  */
 public final class Again implements Term {
+
+    /**
+     * The name of the body the call resumes, empty for the formation.
+     */
+    private final String target;
 
     /**
      * The arguments of the call, in their positional order.
@@ -36,11 +41,38 @@ public final class Again implements Term {
     private final List<Term> args;
 
     /**
-     * Ctor.
+     * Ctor, for the call of the formation to itself.
      * @param arguments The arguments of the call, in their positional order
      */
     public Again(final List<Term> arguments) {
+        this("", arguments);
+    }
+
+    /**
+     * Ctor.
+     * @param name The name of the body the call resumes, empty for the
+     *  formation itself
+     * @param arguments The arguments of the call, in their positional order
+     */
+    public Again(final String name, final List<Term> arguments) {
+        this.target = name;
         this.args = arguments;
+    }
+
+    /**
+     * The name of the body the call resumes.
+     * @return The name of the helper, empty for the formation itself
+     */
+    public String name() {
+        return this.target;
+    }
+
+    /**
+     * The arguments of the call.
+     * @return The arguments, in their positional order
+     */
+    public List<Term> arguments() {
+        return Collections.unmodifiableList(this.args);
     }
 
     @Override
@@ -78,13 +110,14 @@ public final class Again implements Term {
     }
 
     @Override
-    public Optional<List<Term>> again() {
-        return Optional.of(Collections.unmodifiableList(this.args));
+    public Optional<Again> again() {
+        return Optional.of(this);
     }
 
     @Override
     public Term swapped(final Shape shape, final Term swap) {
         return new Again(
+            this.target,
             this.args.stream()
                 .map(arg -> arg.swapped(shape, swap))
                 .collect(Collectors.toList())

--- a/eo-lowering/src/main/java/org/eolang/lowering/Bodies.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Bodies.java
@@ -1,0 +1,141 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * The bodies of one formation, reduced as the repeats between them are
+ * found.
+ *
+ * <p>The formation's own body goes first, over the symbols of its
+ * voids, with the recursive helpers the {@link Cycles} name marked in
+ * its {@link Scope} as bodies to resume rather than read. Every repeat
+ * that settles a tree into a helper declares that helper's voids in the
+ * {@link Minted} ledger, with the formas the repeat hands over, and the
+ * helper's body is then reduced over the symbols of those voids, in a
+ * scope of its own inside the root, which may declare further bodies,
+ * until every declared body is reduced. A program whose bodies only
+ * resume one another never answers and is refused here, so that the
+ * caller treats it like any other fragment that stays as written.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Bodies {
+
+    /**
+     * The reduction settling each tree.
+     */
+    private final Reduction core;
+
+    /**
+     * The XMIR fragment that is the formation's own body.
+     */
+    private final Xnav fragment;
+
+    /**
+     * The voids of the formation: names to formas, in declaration order.
+     */
+    private final Map<String, String> voids;
+
+    /**
+     * The name of the formation, or empty.
+     */
+    private final String formation;
+
+    /**
+     * The helpers the formation binds next to its body.
+     */
+    private final Map<String, Xnav> helpers;
+
+    /**
+     * Ctor.
+     * @param reduction The reduction settling each tree
+     * @param xmir The XMIR fragment that is the formation's own body
+     * @param inputs The voids of the formation: names to formas, in order
+     * @param name The name of the formation, or empty
+     * @param bound The helpers the formation binds next to its body
+     */
+    public Bodies(final Reduction reduction, final Xnav xmir,
+        final Map<String, String> inputs, final String name, final Map<String, Xnav> bound) {
+        this.core = reduction;
+        this.fragment = xmir;
+        this.voids = inputs;
+        this.formation = name;
+        this.helpers = bound;
+    }
+
+    /**
+     * The program.
+     * @return The bodies, the formation's own first
+     * @throws IOException If the binary cannot be run
+     */
+    public Program program() throws IOException {
+        final Minted minted = new Minted(this.voids);
+        final Scope root = new Scope(
+            this.voids, this.formation, this.helpers, new Cycles(this.helpers).names()
+        );
+        final List<Body> out = new ArrayList<>(1);
+        out.add(
+            new Body(
+                "", 0, new ArrayList<>(this.voids.values()),
+                this.core.settled(
+                    new Parsed(this.fragment, root, Collections.emptyList()).term(), minted
+                )
+            )
+        );
+        final Set<String> done = new HashSet<>();
+        done.add("");
+        Optional<String> next = Bodies.pending(minted, done);
+        while (next.isPresent()) {
+            final String name = next.get();
+            done.add(name);
+            final Xnav helper = this.helpers.get(name);
+            out.add(
+                new Body(
+                    name, minted.offset(name), minted.voids(name),
+                    this.core.settled(
+                        new Parsed(
+                            Bodies.body(name, helper),
+                            root.body(helper, minted.offset(name), minted.voids(name)),
+                            Collections.singletonList(name)
+                        ).term(),
+                        minted
+                    )
+                )
+            );
+            next = Bodies.pending(minted, done);
+        }
+        final Program program = new Program(out, this.voids);
+        program.carrier();
+        return program;
+    }
+
+    private static Optional<String> pending(final Minted minted, final Set<String> done) {
+        return minted.names().stream().filter(name -> !done.contains(name)).findFirst();
+    }
+
+    private static Xnav body(final String name, final Xnav helper) {
+        final Optional<Xnav> found = helper.elements(Filter.withName("o"))
+            .filter(kid -> "φ".equals(kid.attribute("name").text().orElse("")))
+            .filter(kid -> kid.attribute("base").text().isPresent())
+            .findFirst();
+        if (!found.isPresent()) {
+            throw new IllegalStateException(
+                String.format("The helper 'ξ.%s' has no body to resume", name)
+            );
+        }
+        return found.get();
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Body.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Body.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * One body of a program: the formation being lowered, or a recursive
+ * helper of it, reduced over voids of its own.
+ *
+ * <p>The voids of every body are locals of one Java method, so they
+ * stand in one list: the voids of the formation first, then those of
+ * each helper body in the order the bodies were reached, and a body
+ * knows the offset of its own. Its protocol is reduced once, over the
+ * symbols of those voids, and each path of it either answers or resumes
+ * a body, this one or another, with the values the voids of that body
+ * take next.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Body {
+
+    /**
+     * The name of the helper, empty for the formation itself.
+     */
+    private final String label;
+
+    /**
+     * The position of the first void of this body among all voids.
+     */
+    private final int start;
+
+    /**
+     * The formas of the voids of this body, in declaration order.
+     */
+    private final List<String> voids;
+
+    /**
+     * The protocol of the body.
+     */
+    private final Protocol steps;
+
+    /**
+     * Ctor.
+     * @param name The name of the helper, empty for the formation itself
+     * @param offset The position of the first void among all voids
+     * @param formas The formas of the voids, in declaration order
+     * @param protocol The protocol of the body
+     */
+    public Body(final String name, final int offset, final List<String> formas,
+        final Protocol protocol) {
+        this.label = name;
+        this.start = offset;
+        this.voids = formas;
+        this.steps = protocol;
+    }
+
+    /**
+     * The name of the helper this is the body of.
+     * @return The name, empty for the formation itself
+     */
+    public String name() {
+        return this.label;
+    }
+
+    /**
+     * The position of the first void of this body among all voids.
+     * @return The offset
+     */
+    public int offset() {
+        return this.start;
+    }
+
+    /**
+     * The formas of the voids of this body.
+     * @return The formas, in declaration order
+     */
+    public List<String> formas() {
+        return Collections.unmodifiableList(this.voids);
+    }
+
+    /**
+     * The protocol of the body.
+     * @return The protocol
+     */
+    public Protocol protocol() {
+        return this.steps;
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Cycles.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Cycles.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * The helpers of a formation that apply themselves, directly or through
+ * one another.
+ *
+ * <p>Such a helper cannot be read in place where it is named, since the
+ * reading would never end; it is a body of its own instead, resumed
+ * where it is named. Which helpers those are is a question of the
+ * names: every synthetic {@code a🌵} name standing anywhere under a
+ * helper is a helper it may reach, and a helper that reaches itself
+ * along such names takes part in a cycle. A name a nested helper spells
+ * counts for the helper it is nested in, since nothing outside that
+ * helper can reach the nested one, so the answer may name a helper
+ * whose cycle runs through a nested body; it then resumes rather than
+ * reads, which is as sound, and only costs the lowering of a call of it
+ * outside a tail position. Only a formation can be a body, since only a
+ * formation has voids to carry across; an application in a cycle is
+ * left to the reading, which refuses it as the cycle it is.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Cycles {
+
+    /**
+     * What a synthetic name looks like.
+     */
+    private static final Pattern NAME = Pattern.compile("a🌵[0-9]+-[0-9]+");
+
+    /**
+     * The helpers: names to their {@code <o/>} elements.
+     */
+    private final Map<String, Xnav> helpers;
+
+    /**
+     * Ctor.
+     * @param bound The helpers: names to their {@code <o/>} elements
+     */
+    public Cycles(final Map<String, Xnav> bound) {
+        this.helpers = bound;
+    }
+
+    /**
+     * The names of the helpers in a cycle.
+     * @return The names, in the order the helpers are bound
+     */
+    public Collection<String> names() {
+        final Map<String, Set<String>> edges = new LinkedHashMap<>();
+        for (final Map.Entry<String, Xnav> entry : this.helpers.entrySet()) {
+            final Set<String> named = new LinkedHashSet<>();
+            Cycles.named(entry.getValue(), named);
+            named.retainAll(this.helpers.keySet());
+            edges.put(entry.getKey(), named);
+        }
+        final Collection<String> out = new LinkedHashSet<>();
+        for (final String name : edges.keySet()) {
+            if (!this.helpers.get(name).attribute("base").text().isPresent()
+                && Cycles.reaches(name, name, edges, new HashSet<>())) {
+                out.add(name);
+            }
+        }
+        return out;
+    }
+
+    private static boolean reaches(final String from, final String target,
+        final Map<String, Set<String>> edges, final Set<String> seen) {
+        boolean out = false;
+        for (final String next : edges.getOrDefault(from, Collections.emptySet())) {
+            if (next.equals(target)) {
+                out = true;
+            } else if (seen.add(next)) {
+                out = Cycles.reaches(next, target, edges, seen);
+            }
+            if (out) {
+                break;
+            }
+        }
+        return out;
+    }
+
+    private static void named(final Xnav node, final Set<String> into) {
+        final Matcher found = Cycles.NAME.matcher(node.attribute("base").text().orElse(""));
+        while (found.find()) {
+            into.add(found.group());
+        }
+        node.elements(Filter.withName("o")).forEach(kid -> Cycles.named(kid, into));
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
@@ -92,7 +92,7 @@ public final class Forced implements Term {
     }
 
     @Override
-    public Optional<List<Term>> again() {
+    public Optional<Again> again() {
         return Optional.empty();
     }
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
@@ -20,9 +20,9 @@ import java.util.List;
  * stay behind the bool that protects them. The value of the fork is
  * whatever the taken arm answers, so the two arms must answer the same
  * forma, and a fork whose arms disagree refuses to name one. An arm may
- * also repeat the whole fragment instead of answering, and then the
- * fork answers what the other arm does; a fork repeating in both arms
- * answers nothing and refuses too.</p>
+ * also resume a body instead of answering, and then the fork answers
+ * what the other arm does; a fork resuming in both arms has no value
+ * and names no forma, since nothing after it ever runs.</p>
  *
  * @since 0.76.0
  */
@@ -84,13 +84,6 @@ public final class Fork implements Step {
     public String forma() {
         final String yes = this.taken.carrier();
         final String not = this.other.carrier();
-        if (yes.isEmpty() && not.isEmpty()) {
-            throw new IllegalStateException(
-                String.format(
-                    "The fork '%s' repeats in both arms, so it answers nothing", this.name
-                )
-            );
-        }
         if (!yes.isEmpty() && !not.isEmpty() && !yes.equals(not)) {
             throw new IllegalStateException(
                 String.format(

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -31,7 +31,14 @@ import java.util.stream.Collectors;
  * finals, so every one of them is read before the loop, the answer of
  * the fork that ends the program is assigned and followed by
  * {@code break}, and a repeat assigns the voids their next values,
- * through temporaries wherever a value names a void, and continues. The
+ * through temporaries wherever a value names a void the same repeat
+ * rebinds, and continues. A
+ * program of several bodies runs the same loop over a state naming the
+ * body that runs next: the voids of every body are locals, the
+ * formation's read before the loop and the helpers' blank until a repeat
+ * hands them values, each body is one branch on the state, a body that
+ * answers assigns the one answer and breaks, and a repeat assigns the
+ * voids of the body it resumes, then the state, and continues. The
  * text is exactly what the {@code lambda()} of the generated atom class
  * holds, indented for that spot, and it is the content the sidecar file
  * is named after. A protocol the rendering refuses, or one whose answer
@@ -43,14 +50,9 @@ import java.util.stream.Collectors;
 public final class JavaAtom {
 
     /**
-     * The protocol to render.
+     * The program to render.
      */
-    private final Protocol protocol;
-
-    /**
-     * The voids of the fragment: names to formas, in declaration order.
-     */
-    private final Map<String, String> voids;
+    private final Program program;
 
     /**
      * The spelling of the values.
@@ -58,14 +60,28 @@ public final class JavaAtom {
     private final Rendering values;
 
     /**
-     * Ctor.
+     * Ctor, for a program of one body.
      * @param proto The protocol to render
      * @param inputs The voids of the fragment: names to formas, in order
      */
     public JavaAtom(final Protocol proto, final Map<String, String> inputs) {
-        this.protocol = proto;
-        this.voids = inputs;
-        this.values = new Rendering(proto, inputs);
+        this(
+            new Program(
+                Collections.singletonList(
+                    new Body("", 0, new ArrayList<>(inputs.values()), proto)
+                ),
+                inputs
+            )
+        );
+    }
+
+    /**
+     * Ctor.
+     * @param plan The program to render
+     */
+    public JavaAtom(final Program plan) {
+        this.program = plan;
+        this.values = new Rendering(plan);
     }
 
     /**
@@ -73,31 +89,40 @@ public final class JavaAtom {
      * @return Java statements, one per line, without a trailing newline
      */
     public String text() {
-        if ("string".equals(this.protocol.carrier())) {
+        if ("string".equals(this.program.carrier())) {
             throw new IllegalStateException(
                 "A string answer cannot be handed over, since Data.ToPhi makes bytes of a byte array"
             );
         }
+        final Protocol first = this.program.bodies().get(0).protocol();
         final List<String> lines;
-        if (this.protocol.repeats()) {
+        if (this.program.bodies().size() > 1) {
+            lines = this.resumed();
+        } else if (first.repeats()) {
             lines = this.looped();
+            lines.add(
+                String.format(
+                    "return new Data.ToPhi(%s);", this.values.expression(first.answer())
+                )
+            );
         } else {
-            lines = this.computed(this.protocol, "", Collections.emptySet(), "");
+            lines = this.computed(first, "", Collections.emptySet(), "");
+            lines.add(
+                String.format(
+                    "return new Data.ToPhi(%s);", this.values.expression(first.answer())
+                )
+            );
         }
-        lines.add(
-            String.format(
-                "return new Data.ToPhi(%s);",
-                this.values.expression(this.protocol.answer())
-            )
-        );
         return lines.stream()
             .map(line -> String.format("        %s", line))
             .collect(Collectors.joining(System.lineSeparator()));
     }
 
     private List<String> looped() {
-        final String exit = this.protocol.answer();
-        if (!exit.startsWith("sym:s") || this.values.step(exit.substring(4)).branches().isEmpty()) {
+        final Protocol first = this.program.bodies().get(0).protocol();
+        final String exit = first.answer();
+        if (!exit.startsWith("sym:s") || this.values.step(exit.substring(4)).branches().isEmpty()
+            || this.values.forma(exit).isEmpty()) {
             throw new IllegalStateException(
                 String.format(
                     "A program that repeats must answer through a fork, but it answers '%s'",
@@ -106,17 +131,81 @@ public final class JavaAtom {
             );
         }
         final Step last = this.values.step(exit.substring(4));
-        final List<String> out = new ArrayList<>(this.voids.size() + 4);
-        final Set<Integer> all = new HashSet<>(this.voids.size());
-        for (int idx = 0; idx < this.voids.size(); ++idx) {
+        final int inputs = this.program.inputs().size();
+        final List<String> out = new ArrayList<>(inputs + 4);
+        final Set<Integer> all = new HashSet<>(inputs);
+        for (int idx = 0; idx < inputs; ++idx) {
             out.add(this.values.reading(idx));
             all.add(idx);
         }
         out.add(String.format("final %s %s;", this.values.type(exit), last.label()));
         out.add("while (true) {");
-        out.addAll(this.computed(this.protocol, "    ", all, last.label()));
+        out.addAll(this.computed(first, "    ", all, last.label()));
         out.add("}");
         return out;
+    }
+
+    private List<String> resumed() {
+        final int inputs = this.program.inputs().size();
+        final int total = this.program.formas().size();
+        final List<String> out = new ArrayList<>(total + 8);
+        final Set<Integer> all = new HashSet<>(total);
+        for (int idx = 0; idx < total; ++idx) {
+            if (idx < inputs) {
+                out.add(this.values.reading(idx));
+            } else {
+                out.add(this.values.blank(idx));
+            }
+            all.add(idx);
+        }
+        out.add("int body = 0;");
+        out.add(String.format("final %s out;", this.values.type(this.answer())));
+        out.add("while (true) {");
+        final List<Body> bodies = this.program.bodies();
+        for (int idx = 0; idx < bodies.size(); ++idx) {
+            out.add(JavaAtom.branch(idx, bodies.size()));
+            out.addAll(this.ran(bodies.get(idx).protocol(), all));
+        }
+        out.add("    }");
+        out.add("}");
+        out.add("return new Data.ToPhi(out);");
+        return out;
+    }
+
+    private static String branch(final int idx, final int count) {
+        final String out;
+        if (idx == 0) {
+            out = "    if (body == 0) {";
+        } else if (idx == count - 1) {
+            out = "    } else {";
+        } else {
+            out = String.format("    } else if (body == %d) {", idx);
+        }
+        return out;
+    }
+
+    private List<String> ran(final Protocol proto, final Set<Integer> all) {
+        final String pad = "        ";
+        final List<String> out = this.computed(proto, pad, all, "");
+        if (proto.again().isEmpty()) {
+            if (!proto.carrier().isEmpty()) {
+                out.add(
+                    String.format("%sout = %s;", pad, this.values.expression(proto.answer()))
+                );
+                out.add(String.format("%sbreak;", pad));
+            }
+        } else {
+            out.addAll(this.rebound(proto.target(), proto.again(), pad));
+        }
+        return out;
+    }
+
+    private String answer() {
+        this.program.carrier();
+        return this.program.bodies().stream()
+            .map(Body::protocol)
+            .filter(proto -> !proto.carrier().isEmpty())
+            .findFirst().get().answer();
     }
 
     private List<String> computed(final Protocol proto, final String pad,
@@ -157,7 +246,7 @@ public final class JavaAtom {
         }
         final String inner = String.format("%s    ", pad);
         final List<String> out = new ArrayList<>(8);
-        if (!step.label().equals(exit)) {
+        if (!step.label().equals(exit) && !step.forma().isEmpty()) {
             out.add(
                 String.format(
                     "%sfinal %s %s;",
@@ -184,49 +273,64 @@ public final class JavaAtom {
                 out.add(String.format("%sbreak;", pad));
             }
         } else {
-            out.addAll(this.rebound(arm.again(), pad));
+            out.addAll(this.rebound(arm.target(), arm.again(), pad));
         }
         return out;
     }
 
-    private List<String> rebound(final List<String> keys, final String pad) {
-        final List<String> names = new ArrayList<>(this.voids.keySet());
-        if (keys.size() != names.size()) {
+    private List<String> rebound(final String target, final List<String> keys,
+        final String pad) {
+        final Body body = this.program.body(target);
+        if (keys.size() != body.formas().size()) {
             throw new IllegalStateException(
                 String.format(
-                    "The repeat hands %d values to %d voids", keys.size(), names.size()
+                    "The repeat hands %d values to %d voids", keys.size(), body.formas().size()
                 )
             );
         }
-        final List<String> out = new ArrayList<>(keys.size() * 2 + 1);
-        final List<String> later = new ArrayList<>(keys.size());
+        final List<String> out = new ArrayList<>(keys.size() * 2 + 2);
+        final List<String> later = new ArrayList<>(keys.size() + 1);
         for (int idx = 0; idx < keys.size(); ++idx) {
             final String key = keys.get(idx);
-            final String type = this.values.type(String.format("sym:v%d", idx));
+            final String local = String.format("v%d", body.offset() + idx);
+            final String type = this.values.type(String.format("sym:%s", local));
             if (!type.equals(this.values.type(key))) {
                 throw new IllegalStateException(
                     String.format(
                         "The repeat hands '%s' to the void '%s', which is a %s",
-                        key, names.get(idx), type
+                        key, local, type
                     )
                 );
             }
-            if (key.equals(String.format("sym:v%d", idx))) {
+            if (key.equals(String.format("sym:%s", local))) {
                 continue;
             }
-            if (key.startsWith("sym:v")) {
+            if (JavaAtom.inside(key, body)) {
                 out.add(
                     String.format(
-                        "%sfinal %s r%d = %s;", pad, type, idx, this.values.expression(key)
+                        "%sfinal %s r%d = %s;", pad, type, body.offset() + idx,
+                        this.values.expression(key)
                     )
                 );
-                later.add(String.format("%sv%d = r%d;", pad, idx, idx));
+                later.add(String.format("%s%s = r%d;", pad, local, body.offset() + idx));
             } else {
-                later.add(String.format("%sv%d = %s;", pad, idx, this.values.expression(key)));
+                later.add(String.format("%s%s = %s;", pad, local, this.values.expression(key)));
             }
         }
         out.addAll(later);
+        if (this.program.bodies().size() > 1) {
+            out.add(String.format("%sbody = %d;", pad, this.program.index(target)));
+        }
         out.add(String.format("%scontinue;", pad));
+        return out;
+    }
+
+    private static boolean inside(final String key, final Body body) {
+        boolean out = false;
+        if (key.startsWith("sym:v")) {
+            final int idx = Integer.parseInt(key.substring(5));
+            out = idx >= body.offset() && idx < body.offset() + body.formas().size();
+        }
         return out;
     }
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
@@ -86,7 +86,7 @@ public final class Literal implements Term {
     }
 
     @Override
-    public Optional<List<Term>> again() {
+    public Optional<Again> again() {
         return Optional.empty();
     }
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -32,9 +32,12 @@ import org.w3c.dom.Element;
  * public attribute keeps the formation as written, since deleting the
  * body must not change the object's interface, and a helper that stays
  * reachable would be dispatchable with nothing behind it. The formation
- * may declare {@code ρ}, but its body may reach through it only to call
+ * may declare {@code ρ}, and its body may reach through it only to call
  * the formation itself again, which the reduction turns into a repeat;
- * any other use of {@code ρ} depends on a context the atom does not
+ * a helper reaches through {@code ρ} to the voids and the other helpers
+ * of the formation, which the atom carries, and helpers that apply one
+ * another in tail positions become one loop with them; any other use of
+ * {@code ρ} depends on a context the atom does not
  * carry and refuses. Purity needs no separate analysis:
  * the reduction itself is constructive proof, since it settles only a
  * body made of literals, void references, and the lowerable operations,
@@ -113,14 +116,15 @@ public final class Lowered implements Rewrite {
         String text = "";
         String carrier = "";
         try {
-            final Protocol protocol = new Reduction(
+            final Program program = new Reduction(
                 this.phino, body, inputs, 8,
                 node.attribute("name").text().orElse(""),
                 Lowered.helpers(node)
-            ).protocol();
-            if (!protocol.moves().isEmpty()) {
-                text = new JavaAtom(protocol, inputs).text();
-                carrier = protocol.carrier();
+            ).program();
+            if (program.bodies().size() > 1
+                || !program.bodies().get(0).protocol().moves().isEmpty()) {
+                text = new JavaAtom(program).text();
+                carrier = program.carrier();
             }
         } catch (final IllegalStateException | IOException ex) {
             carrier = "";

--- a/eo-lowering/src/main/java/org/eolang/lowering/Minted.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Minted.java
@@ -5,30 +5,35 @@
 package org.eolang.lowering;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
- * The ledger of the steps one reduction has minted so far.
+ * The ledger of the labels and formas one reduction shares.
  *
  * <p>Every loop of one reduction — the top of it, the arms of its forks,
- * the arguments of its repeats — shares one ledger, so that a label
- * never repeats across the arms and the forma of any step can be looked
- * up wherever its symbol ends up. A label is taken before the step is
- * finished, since the arms of a fork mint their own steps before the
- * fork knows what forma it answers, and it is bound to a forma once
- * that is known. The ledger also knows the voids of the fragment, so it
- * names the carrier of any key: a step by its binding, a void by its
- * declaration, a literal by its own prefix.</p>
+ * the arguments of its repeats, the bodies of its recursive helpers —
+ * shares one ledger, so that a label never repeats across the arms and
+ * the forma of any step can be looked up wherever its symbol ends up. A
+ * label is taken before the step is finished, since the arms of a fork
+ * mint their own steps before the fork knows what forma it answers, and
+ * it is bound to a forma once that is known. The ledger also knows the
+ * voids: those of the formation first, and those of every body a repeat
+ * resumes after them, declared with the formas of the values the first
+ * repeat hands over, so it names the carrier of any key — a step by its
+ * binding, a void by its position, a literal by its own prefix.</p>
  *
  * @since 0.76.0
  */
 public final class Minted {
 
     /**
-     * The voids of the fragment: names to formas, in declaration order.
+     * The formas of all the voids, by position.
      */
-    private final Map<String, String> voids;
+    private final List<String> voids;
 
     /**
      * The formas of the steps, by label, in the order they were taken.
@@ -36,12 +41,35 @@ public final class Minted {
     private final Map<String, String> formas;
 
     /**
+     * The voids of every body: names to the formas of their voids, the
+     * formation itself under the empty name.
+     */
+    private final Map<String, List<String>> bodies;
+
+    /**
+     * The position of the first void of every body, by name.
+     */
+    private final Map<String, Integer> offsets;
+
+    /**
      * Ctor.
      * @param inputs The voids of the fragment: names to formas, in order
      */
     public Minted(final Map<String, String> inputs) {
-        this.voids = inputs;
-        this.formas = new LinkedHashMap<>(0);
+        this(
+            new ArrayList<>(inputs.values()),
+            new LinkedHashMap<>(0),
+            Minted.first(new ArrayList<>(inputs.values())),
+            Minted.first(0)
+        );
+    }
+
+    private Minted(final List<String> kinds, final Map<String, String> labels,
+        final Map<String, List<String>> parts, final Map<String, Integer> starts) {
+        this.voids = kinds;
+        this.formas = labels;
+        this.bodies = parts;
+        this.offsets = starts;
     }
 
     /**
@@ -64,6 +92,63 @@ public final class Minted {
     }
 
     /**
+     * Declare the voids of a body a repeat resumes.
+     * @param name The name of the helper
+     * @param kinds The formas of its voids, in declaration order
+     */
+    public void declare(final String name, final List<String> kinds) {
+        if (this.bodies.containsKey(name)) {
+            throw new IllegalStateException(
+                String.format("The body '%s' is declared already", name)
+            );
+        }
+        this.offsets.put(name, this.voids.size());
+        this.bodies.put(name, new ArrayList<>(kinds));
+        this.voids.addAll(kinds);
+    }
+
+    /**
+     * Whether the voids of a body are declared.
+     * @param name The name of the helper, empty for the formation itself
+     * @return True if declared
+     */
+    public boolean declared(final String name) {
+        return this.bodies.containsKey(name);
+    }
+
+    /**
+     * The names of the bodies declared, the formation itself first.
+     * @return The names, in the order they were declared
+     */
+    public Collection<String> names() {
+        return Collections.unmodifiableCollection(this.bodies.keySet());
+    }
+
+    /**
+     * The formas of the voids of a body.
+     * @param name The name of the helper, empty for the formation itself
+     * @return The formas, in declaration order
+     */
+    public List<String> voids(final String name) {
+        if (!this.bodies.containsKey(name)) {
+            throw new IllegalStateException(
+                String.format("The body '%s' is not declared", name)
+            );
+        }
+        return Collections.unmodifiableList(this.bodies.get(name));
+    }
+
+    /**
+     * The position of the first void of a body among all voids.
+     * @param name The name of the helper, empty for the formation itself
+     * @return The position
+     */
+    public int offset(final String name) {
+        this.voids(name);
+        return this.offsets.get(name);
+    }
+
+    /**
      * The carrier of a key.
      * @param key The key, such as {@code sym:s2}, {@code sym:v0} or {@code bool:FF-}
      * @return The forma, such as {@code number}
@@ -78,8 +163,13 @@ public final class Minted {
                 );
             }
         } else if (key.startsWith("sym:v")) {
-            out = new ArrayList<>(this.voids.values())
-                .get(Integer.parseInt(key.substring(5)));
+            final int idx = Integer.parseInt(key.substring(5));
+            if (idx >= this.voids.size()) {
+                throw new IllegalStateException(
+                    String.format("The key '%s' names no declared void", key)
+                );
+            }
+            out = this.voids.get(idx);
         } else {
             out = key.split(":", 2)[0];
         }
@@ -113,5 +203,11 @@ public final class Minted {
             );
         }
         return carrier;
+    }
+
+    private static <T> Map<String, T> first(final T value) {
+        final Map<String, T> out = new LinkedHashMap<>(1);
+        out.put("", value);
+        return out;
     }
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Program.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Program.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * The bodies one formation reduces to, the formation's own first.
+ *
+ * <p>A formation whose helpers apply themselves or each other in tail
+ * positions is one loop with a state: which body runs next. Every body
+ * is reduced once, over the symbols of its own voids, and every path of
+ * it answers or resumes a body with the values that body's voids take
+ * next, so the whole program is a state machine over the union of the
+ * voids, and the Java of it is one {@code while (true)} that runs the
+ * body the state names. A formation that never resumes anything is a
+ * program of one body, the plain case. The program answers one forma,
+ * whatever body the answer comes from, and a program whose bodies only
+ * resume one another answers nothing and is refused.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Program {
+
+    /**
+     * The bodies, the formation's own first.
+     */
+    private final List<Body> parts;
+
+    /**
+     * The voids of the formation: names to formas, in declaration order.
+     */
+    private final Map<String, String> voids;
+
+    /**
+     * Ctor.
+     * @param bodies The bodies, the formation's own first
+     * @param inputs The voids of the formation: names to formas, in order
+     */
+    public Program(final List<Body> bodies, final Map<String, String> inputs) {
+        this.parts = bodies;
+        this.voids = inputs;
+    }
+
+    /**
+     * The bodies.
+     * @return The bodies, the formation's own first
+     */
+    public List<Body> bodies() {
+        return Collections.unmodifiableList(this.parts);
+    }
+
+    /**
+     * The voids of the formation.
+     * @return Names to formas, in declaration order
+     */
+    public Map<String, String> inputs() {
+        return Collections.unmodifiableMap(this.voids);
+    }
+
+    /**
+     * The formas of all the voids of all the bodies.
+     * @return The formas, by the positions the bodies know
+     */
+    public List<String> formas() {
+        final List<String> out = new ArrayList<>(
+            Collections.nCopies(
+                this.parts.stream()
+                    .mapToInt(body -> body.offset() + body.formas().size())
+                    .max().orElse(0),
+                ""
+            )
+        );
+        for (final Body body : this.parts) {
+            for (int idx = 0; idx < body.formas().size(); ++idx) {
+                out.set(body.offset() + idx, body.formas().get(idx));
+            }
+        }
+        return out;
+    }
+
+    /**
+     * The body of a name.
+     * @param name The name of the helper, empty for the formation itself
+     * @return The body
+     */
+    public Body body(final String name) {
+        return this.parts.get(this.index(name));
+    }
+
+    /**
+     * The position of the body of a name, which is the state that runs it.
+     * @param name The name of the helper, empty for the formation itself
+     * @return The position, zero for the formation itself
+     */
+    public int index(final String name) {
+        for (int idx = 0; idx < this.parts.size(); ++idx) {
+            if (this.parts.get(idx).name().equals(name)) {
+                return idx;
+            }
+        }
+        throw new IllegalStateException(
+            String.format("The program has no body named '%s'", name)
+        );
+    }
+
+    /**
+     * The forma the program answers.
+     * @return The forma, the same from every body that answers
+     */
+    public String carrier() {
+        final List<String> formas = this.parts.stream()
+            .map(body -> body.protocol().carrier())
+            .filter(forma -> !forma.isEmpty())
+            .distinct()
+            .collect(Collectors.toList());
+        if (formas.isEmpty()) {
+            throw new IllegalStateException(
+                "The program never answers, since every body of it resumes another"
+            );
+        }
+        if (formas.size() > 1) {
+            throw new IllegalStateException(
+                String.format(
+                    "The bodies of the program answer different formas: %s",
+                    String.join(", ", formas)
+                )
+            );
+        }
+        return formas.get(0);
+    }
+
+    /**
+     * Whether the Java of the program needs a loop.
+     * @return True if a body resumes any body
+     */
+    public boolean repeats() {
+        return this.parts.size() > 1 || this.parts.get(0).protocol().repeats();
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Protocol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Protocol.java
@@ -17,10 +17,11 @@ import java.util.List;
  * application or a {@link Fork}, and a fork holds one protocol of this
  * very kind per arm, so a program with choices in it is a tree of
  * protocols whose every path is straight. A path may also end by
- * repeating instead of answering: a fragment that calls itself in a
- * tail position settles into the keys its voids take next, one per
- * void in declaration order, and the whole program runs again over
- * them. This is the whole input of code generation: rendering each step
+ * repeating instead of answering: a fragment that calls itself, or a
+ * recursive helper of the formation, in a tail position settles into
+ * the name of the body it resumes and the keys the voids of that body
+ * take next, one per void in declaration order, and that body runs
+ * over them. This is the whole input of code generation: rendering each step
  * as one Java statement, in order, with a block under each arm and a
  * loop around a program that repeats, is a faithful compilation of the
  * fragment.</p>
@@ -45,6 +46,12 @@ public final class Protocol {
     private final String forma;
 
     /**
+     * The name of the body the fragment resumes, empty for the formation
+     * itself, when it repeats instead of answering.
+     */
+    private final String body;
+
+    /**
      * The keys of the values the voids take next, when the fragment
      * repeats instead of answering.
      */
@@ -57,17 +64,28 @@ public final class Protocol {
      * @param carrier The forma of that value
      */
     public Protocol(final List<Step> moves, final String answer, final String carrier) {
-        this(moves, answer, carrier, Collections.emptyList());
+        this(moves, answer, carrier, "", Collections.emptyList());
     }
 
     /**
-     * Ctor, for a program that repeats.
+     * Ctor, for a program that repeats the formation itself.
      * @param moves The steps, in their dependency order
      * @param again The keys of the values the voids take next, in
      *  declaration order
      */
     public Protocol(final List<Step> moves, final List<String> again) {
-        this(moves, "", "", again);
+        this(moves, "", again);
+    }
+
+    /**
+     * Ctor, for a program that resumes a body.
+     * @param moves The steps, in their dependency order
+     * @param target The name of the body resumed, empty for the formation
+     * @param again The keys of the values the voids of that body take
+     *  next, in declaration order
+     */
+    public Protocol(final List<Step> moves, final String target, final List<String> again) {
+        this(moves, "", "", target, again);
     }
 
     /**
@@ -75,13 +93,15 @@ public final class Protocol {
      * @param moves The steps, in their dependency order
      * @param answer The key of the value the fragment answers with
      * @param carrier The forma of that value
+     * @param target The name of the body resumed, empty for the formation
      * @param again The keys of the values the voids take next
      */
     private Protocol(final List<Step> moves, final String answer,
-        final String carrier, final List<String> again) {
+        final String carrier, final String target, final List<String> again) {
         this.steps = moves;
         this.root = answer;
         this.forma = carrier;
+        this.body = target;
         this.next = again;
     }
 
@@ -112,9 +132,18 @@ public final class Protocol {
     }
 
     /**
-     * The keys of the values the voids take next.
-     * @return One key per void, in declaration order, or none when the
-     *  program answers
+     * The name of the body the program resumes.
+     * @return The name of the helper, empty for the formation itself or
+     *  when the program answers
+     */
+    public String target() {
+        return this.body;
+    }
+
+    /**
+     * The keys of the values the voids of the resumed body take next.
+     * @return One key per void of that body, in declaration order, or
+     *  none when the program answers
      */
     public List<String> again() {
         return Collections.unmodifiableList(this.next);

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
@@ -38,17 +38,22 @@ import java.util.Optional;
  * wherever its symbol ends up. When the bool is data instead, the site
  * simply gives way to the arm it picks.</p>
  *
- * <p>A call of the formation to itself is the one term that never goes
- * to phino: it is a repeat, and φ has no expression for one. When such
- * a call is the root of the tree being settled, its arguments are
- * reduced in turn into the same list of steps — a repeat evaluates all
- * of them, there is nothing lazy about it — and the tree settles into
- * the keys they become, one per void, instead of an answer. When the
- * call stands anywhere else, phino parks on its marker and the
- * fragment is refused: the recursion is not in a tail position, and a
- * fork whose arm repeats is held to the same rule, since a repeat below
- * an operation that still awaits the value would rerun the whole body
- * in its place.</p>
+ * <p>A call of the formation to itself, or of a recursive helper of it,
+ * is the one term that never goes to phino: it is a repeat, and φ has
+ * no expression for one. When such a call is the root of the tree being
+ * settled, its arguments are reduced in turn into the same list of
+ * steps — a repeat evaluates all of them, there is nothing lazy about
+ * it — and the tree settles into the body it resumes and the keys its
+ * voids take, one per void, instead of an answer; the first repeat into
+ * a helper declares the formas of the helper's voids, and every later
+ * one must agree. When the call stands anywhere else, phino parks on
+ * its marker and the fragment is refused: the recursion is not in a
+ * tail position, and a fork whose arm repeats is held to the same rule,
+ * since a repeat below an operation that still awaits the value would
+ * rerun the whole body in its place. The keys a repeat hands over, and
+ * the formas it declares or checks, are the concern of {@link Repeat};
+ * the bodies a program is made of, and the order they are reduced in,
+ * of {@link Bodies}.</p>
  *
  * <p>A helper the formation binds next to its body is read in place
  * wherever the body names it, by {@link Parsed}, applied to its
@@ -160,31 +165,60 @@ public final class Reduction {
     }
 
     /**
-     * The protocol the fragment reduces to.
+     * The protocol the fragment reduces to, when it is one body.
      * @return The steps, the answer, and its forma
      * @throws IOException If the binary cannot be run
      */
     public Protocol protocol() throws IOException {
-        return this.settled(
-            new Parsed(this.fragment, this.voids, this.formation, this.helpers).term(),
-            new Minted(this.voids)
-        );
+        final Program program = this.program();
+        if (program.bodies().size() > 1) {
+            throw new IllegalStateException(
+                "The fragment resumes a helper of the formation, which one protocol cannot express"
+            );
+        }
+        return program.bodies().get(0).protocol();
     }
 
-    private Protocol settled(final Term start, final Minted minted) throws IOException {
+    /**
+     * The program the fragment reduces to: its own body, and the body of
+     * every recursive helper it resumes.
+     * @return The bodies, the fragment's own first
+     * @throws IOException If the binary cannot be run
+     */
+    public Program program() throws IOException {
+        return new Bodies(
+            this, this.fragment, this.voids, this.formation, this.helpers
+        ).program();
+    }
+
+    /**
+     * The protocol one tree settles into.
+     * @param start The tree
+     * @param minted The ledger this reduction shares
+     * @return The protocol
+     * @throws IOException If the binary cannot be run
+     */
+    Protocol settled(final Term start, final Minted minted) throws IOException {
         final List<Step> steps = new ArrayList<>(0);
         final Term tree = this.reduced(start, steps, minted);
-        final Optional<List<Term>> again = tree.again();
         final Protocol out;
-        if (again.isPresent()) {
-            out = new Protocol(steps, this.repeated(again.get(), steps, minted));
+        if (tree.again().isPresent()) {
+            out = new Repeat(this, minted).protocol(tree.again().get(), steps);
         } else {
             out = new Protocol(steps, tree.key(), minted.carried(tree));
         }
         return out;
     }
 
-    private Term reduced(final Term start, final List<Step> steps, final Minted minted)
+    /**
+     * The value one tree settles into, over the steps it adds.
+     * @param start The tree
+     * @param steps The steps of the protocol being built
+     * @param minted The ledger this reduction shares
+     * @return A term with a key, or the call the tree is
+     * @throws IOException If the binary cannot be run
+     */
+    Term reduced(final Term start, final List<Step> steps, final Minted minted)
         throws IOException {
         Term tree = start;
         int round = 0;
@@ -198,40 +232,6 @@ public final class Reduction {
             tree = this.grown(tree, steps, minted);
         }
         return tree;
-    }
-
-    private List<String> repeated(final List<Term> args, final List<Step> steps,
-        final Minted minted) throws IOException {
-        final List<String> formas = new ArrayList<>(this.voids.values());
-        if (args.size() != formas.size()) {
-            throw new IllegalStateException(
-                String.format(
-                    "The call to itself passes %d arguments to %d voids",
-                    args.size(), formas.size()
-                )
-            );
-        }
-        final List<String> keys = new ArrayList<>(args.size());
-        for (int idx = 0; idx < args.size(); ++idx) {
-            final Term arg = this.reduced(args.get(idx), steps, minted);
-            final String key = arg.key();
-            if (key.isEmpty()) {
-                throw new IllegalStateException(
-                    "A call to itself cannot be an argument of a call to itself"
-                );
-            }
-            final String forma = minted.carried(arg);
-            if (!formas.get(idx).equals(forma)) {
-                throw new IllegalStateException(
-                    String.format(
-                        "The call to itself passes a %s where void #%d carries a %s",
-                        forma, idx, formas.get(idx)
-                    )
-                );
-            }
-            keys.add(key);
-        }
-        return keys;
     }
 
     private Term grown(final Term tree, final List<Step> steps, final Minted minted)

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reference.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reference.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 /**
  * One name a fragment reaches in a scope, with the arguments handed to it.
@@ -18,9 +19,13 @@ import java.util.Optional;
  * takes no arguments, or a helper of the scope, which is read where it
  * is named: an application over the voids of the scope stands as its
  * own body, and a formation of its own is applied, its body read in the
- * {@link Scope} that binds its voids to the arguments. A helper that
- * names itself, directly or through another helper, is a cycle and is
- * refused, since reading it would never end.</p>
+ * {@link Scope} that binds its voids to the arguments. A helper the
+ * scope knows to be recursive is not read but resumed: naming it is the
+ * {@link Again} of that helper's body, over the arguments, and the
+ * reduction turns it into a repeat when it stands in a tail position.
+ * Any other helper that names itself, directly or through another
+ * helper, is a cycle and is refused, since reading it would never
+ * end.</p>
  *
  * @since 0.76.0
  */
@@ -89,6 +94,19 @@ public final class Reference {
     }
 
     private Term applied(final Xnav helper) {
+        final Term out;
+        if (this.scope.resumes(this.name)) {
+            out = new Again(
+                this.name,
+                this.args.stream().map(Binding::value).collect(Collectors.toList())
+            );
+        } else {
+            out = this.read(helper);
+        }
+        return out;
+    }
+
+    private Term read(final Xnav helper) {
         if (this.trail.contains(this.name)) {
             throw new IllegalStateException(
                 String.format(

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -5,6 +5,7 @@
 package org.eolang.lowering;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -23,7 +24,7 @@ import java.util.stream.Stream;
  * comes from the format the {@link Op} table holds for its atom, except
  * an equality, which compares by the forma of its operands; and a void
  * is read through the public runtime API. The forma of a key is looked
- * up in the voids of the fragment or in the steps of the protocol,
+ * up in the voids of the program or in the steps of its bodies,
  * nested arms included. Whatever the table cannot spell — an operation
  * with no Java column, a void of a forma the runtime cannot hand over,
  * an operand of a forma the atom does not take — is refused.</p>
@@ -33,39 +34,48 @@ import java.util.stream.Stream;
 public final class Rendering {
 
     /**
-     * The protocol.
+     * The program.
      */
-    private final Protocol protocol;
+    private final Program program;
 
     /**
-     * The voids of the fragment: names to formas, in declaration order.
-     */
-    private final Map<String, String> voids;
-
-    /**
-     * Ctor.
+     * Ctor, for a program of one body.
      * @param proto The protocol
      * @param inputs The voids of the fragment: names to formas, in order
      */
     public Rendering(final Protocol proto, final Map<String, String> inputs) {
-        this.protocol = proto;
-        this.voids = inputs;
+        this(
+            new Program(
+                Collections.singletonList(
+                    new Body("", 0, new ArrayList<>(inputs.values()), proto)
+                ),
+                inputs
+            )
+        );
     }
 
     /**
-     * The declaration reading one void, without {@code final}.
+     * Ctor.
+     * @param plan The program
+     */
+    public Rendering(final Program plan) {
+        this.program = plan;
+    }
+
+    /**
+     * The declaration reading one void of the formation, without {@code final}.
      * @param index The index of the void
      * @return A statement such as {@code double v0 = new Dataized(this.take("x")).asNumber();}
      */
     public String reading(final int index) {
-        final List<String> names = new ArrayList<>(this.voids.keySet());
+        final List<String> names = new ArrayList<>(this.program.inputs().keySet());
         if (index >= names.size()) {
             throw new IllegalStateException(
                 String.format("The protocol reads void #%d, which the fragment lacks", index)
             );
         }
         final String name = names.get(index);
-        final String forma = this.voids.get(name);
+        final String forma = this.program.inputs().get(name);
         final String out;
         if ("number".equals(forma)) {
             out = String.format(
@@ -83,6 +93,25 @@ public final class Rendering {
             throw new IllegalStateException(
                 String.format("The void '%s' of forma '%s' cannot be read in Java", name, forma)
             );
+        }
+        return out;
+    }
+
+    /**
+     * The declaration of one void of a resumed body, blank until a repeat
+     * hands it a value, without {@code final}.
+     * @param index The index of the void
+     * @return A statement such as {@code double v3 = 0.0;}
+     */
+    public String blank(final int index) {
+        final String type = this.type(String.format("sym:v%d", index));
+        final String out;
+        if ("double".equals(type)) {
+            out = String.format("double v%d = 0.0;", index);
+        } else if ("boolean".equals(type)) {
+            out = String.format("boolean v%d = false;", index);
+        } else {
+            out = String.format("byte[] v%d = new byte[0];", index);
         }
         return out;
     }
@@ -123,20 +152,7 @@ public final class Rendering {
      * @return The type, such as {@code double} or {@code byte[]}
      */
     public String type(final String key) {
-        final String carrier = this.forma(key);
-        final String out;
-        if ("number".equals(carrier)) {
-            out = "double";
-        } else if ("bool".equals(carrier)) {
-            out = "boolean";
-        } else if ("bytes".equals(carrier)) {
-            out = "byte[]";
-        } else {
-            throw new IllegalStateException(
-                String.format("The value '%s' has no Java type to carry it", key)
-            );
-        }
-        return out;
+        return Rendering.typed(this.forma(key), key);
     }
 
     /**
@@ -149,10 +165,7 @@ public final class Rendering {
         final String out;
         if ("sym".equals(parts[0])) {
             if (parts[1].charAt(0) == 'v') {
-                out = this.voids.get(
-                    new ArrayList<>(this.voids.keySet())
-                        .get(Integer.parseInt(parts[1].substring(1)))
-                );
+                out = this.program.formas().get(Integer.parseInt(parts[1].substring(1)));
             } else {
                 out = this.step(parts[1]).forma();
             }
@@ -168,7 +181,9 @@ public final class Rendering {
      * @return The step
      */
     public Step step(final String label) {
-        final Optional<Step> found = Rendering.unfolded(this.protocol)
+        final Optional<Step> found = this.program.bodies().stream()
+            .map(Body::protocol)
+            .flatMap(Rendering::unfolded)
             .flatMap(proto -> proto.moves().stream())
             .filter(step -> step.label().equals(label))
             .findFirst();
@@ -214,6 +229,22 @@ public final class Rendering {
         } else {
             throw new IllegalStateException(
                 String.format("The operand '%s' has no Java expression", key)
+            );
+        }
+        return out;
+    }
+
+    private static String typed(final String carrier, final String what) {
+        final String out;
+        if ("number".equals(carrier)) {
+            out = "double";
+        } else if ("bool".equals(carrier)) {
+            out = "boolean";
+        } else if ("bytes".equals(carrier)) {
+            out = "byte[]";
+        } else {
+            throw new IllegalStateException(
+                String.format("The value '%s' has no Java type to carry it", what)
             );
         }
         return out;

--- a/eo-lowering/src/main/java/org/eolang/lowering/Repeat.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Repeat.java
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * The protocol a tree settles into when it resumes a body.
+ *
+ * <p>The arguments of the call are reduced in turn into the same list of
+ * steps, since a repeat evaluates all of them, and the keys they become
+ * are what the voids of the resumed body take next. The first repeat
+ * into a helper declares the formas of the helper's voids in the ledger,
+ * with the formas of the values it hands over, and every repeat, into
+ * the formation itself or into a helper declared already, must hand over
+ * as many values as there are voids, each of the forma its void
+ * carries.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Repeat {
+
+    /**
+     * The reduction settling each argument.
+     */
+    private final Reduction core;
+
+    /**
+     * The ledger the reduction shares.
+     */
+    private final Minted minted;
+
+    /**
+     * Ctor.
+     * @param reduction The reduction settling each argument
+     * @param ledger The ledger the reduction shares
+     */
+    public Repeat(final Reduction reduction, final Minted ledger) {
+        this.core = reduction;
+        this.minted = ledger;
+    }
+
+    /**
+     * The protocol of the repeat.
+     * @param call The call that resumes a body
+     * @param steps The steps of the protocol so far, to add to
+     * @return The protocol, ending in the repeat
+     * @throws IOException If the binary cannot be run
+     */
+    public Protocol protocol(final Again call, final List<Step> steps) throws IOException {
+        final List<Term> args = call.arguments();
+        final List<String> keys = new ArrayList<>(args.size());
+        final List<String> handed = new ArrayList<>(args.size());
+        for (final Term arg : args) {
+            final Term value = this.core.reduced(arg, steps, this.minted);
+            if (value.key().isEmpty()) {
+                throw new IllegalStateException(
+                    "A call to itself cannot be an argument of a call to itself"
+                );
+            }
+            keys.add(value.key());
+            handed.add(this.minted.carried(value));
+        }
+        if (!this.minted.declared(call.name())) {
+            this.minted.declare(call.name(), handed);
+        }
+        final List<String> formas = this.minted.voids(call.name());
+        if (handed.size() != formas.size()) {
+            throw new IllegalStateException(
+                String.format(
+                    "The call to %s passes %d arguments to %d voids",
+                    Repeat.whom(call), handed.size(), formas.size()
+                )
+            );
+        }
+        for (int idx = 0; idx < handed.size(); ++idx) {
+            if (!formas.get(idx).equals(handed.get(idx))) {
+                throw new IllegalStateException(
+                    String.format(
+                        "The call to %s passes a %s where void #%d carries a %s",
+                        Repeat.whom(call), handed.get(idx), idx, formas.get(idx)
+                    )
+                );
+            }
+        }
+        return new Protocol(steps, call.name(), keys);
+    }
+
+    private static String whom(final Again call) {
+        final String out;
+        if (call.name().isEmpty()) {
+            out = "itself";
+        } else {
+            out = String.format("'ξ.%s'", call.name());
+        }
+        return out;
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Scope.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Scope.java
@@ -7,6 +7,7 @@ package org.eolang.lowering;
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -28,7 +29,10 @@ import java.util.stream.Collectors;
  * from an enclosing formation is read through them and never guessed.
  * At the root, {@code ρ} leads to the object that owns the formation,
  * where only the formation itself may be named, as the call that
- * becomes a repeat.</p>
+ * becomes a repeat. A helper the root knows to be recursive is not
+ * read where it is named but resumed, as a body of its own, and the
+ * scope of that body binds the helper's voids to symbols of their own
+ * instead of to arguments.</p>
  *
  * @since 0.76.0
  */
@@ -55,6 +59,12 @@ public final class Scope {
     private final List<Scope> outer;
 
     /**
+     * The names of the helpers that are bodies of their own, resumed
+     * rather than read where they are named; at the root only.
+     */
+    private final Collection<String> looped;
+
+    /**
      * Ctor, for the root.
      * @param voids The voids of the formation: names to formas, in order
      * @param name The name of the formation, or empty when the fragment
@@ -63,15 +73,29 @@ public final class Scope {
      */
     public Scope(final Map<String, String> voids, final String name,
         final Map<String, Xnav> bound) {
-        this(Scope.symbols(voids), bound, name, Collections.emptyList());
+        this(voids, name, bound, Collections.emptyList());
+    }
+
+    /**
+     * Ctor, for the root.
+     * @param voids The voids of the formation: names to formas, in order
+     * @param name The name of the formation, or empty when the fragment
+     *  is not the body of one
+     * @param bound The helpers the formation binds next to its body
+     * @param bodies The names of the helpers that are bodies of their own
+     */
+    public Scope(final Map<String, String> voids, final String name,
+        final Map<String, Xnav> bound, final Collection<String> bodies) {
+        this(Scope.symbols(voids), bound, name, Collections.emptyList(), bodies);
     }
 
     private Scope(final Map<String, Term> values, final Map<String, Xnav> bound,
-        final String name, final List<Scope> above) {
+        final String name, final List<Scope> above, final Collection<String> bodies) {
         this.terms = values;
         this.helpers = bound;
         this.self = name;
         this.outer = above;
+        this.looped = bodies;
     }
 
     /**
@@ -98,6 +122,16 @@ public final class Scope {
      */
     public boolean root() {
         return this.outer.isEmpty();
+    }
+
+    /**
+     * Whether a helper of this scope is a body of its own, to be resumed
+     * where it is named rather than read there.
+     * @param name The name of the helper
+     * @return True if naming it is a repeat
+     */
+    public boolean resumes(final String name) {
+        return this.looped.contains(name) && this.helpers.containsKey(name);
     }
 
     /**
@@ -128,16 +162,13 @@ public final class Scope {
      * @return The scope its body is read in
      */
     public Scope inside(final Xnav formation, final List<Binding> args) {
-        final List<String> voids = new ArrayList<>(0);
+        final List<String> voids = Scope.voids(formation);
         final Map<String, Xnav> bound = new LinkedHashMap<>();
         for (final Xnav kid : formation.elements(Filter.withName("o"))
             .collect(Collectors.toList())) {
             final String name = kid.attribute("name").text().orElse("");
-            if ("∅".equals(kid.attribute("base").text().orElse(""))) {
-                if (!"ρ".equals(name)) {
-                    voids.add(name);
-                }
-            } else if (!name.isEmpty() && !"φ".equals(name)) {
+            if (!"∅".equals(kid.attribute("base").text().orElse(""))
+                && !name.isEmpty() && !"φ".equals(name)) {
                 bound.put(name, kid);
             }
         }
@@ -153,7 +184,47 @@ public final class Scope {
                 )
             );
         }
-        return new Scope(values, bound, "", Collections.singletonList(this));
+        return new Scope(
+            values, bound, "", Collections.singletonList(this), Collections.emptyList()
+        );
+    }
+
+    /**
+     * The scope of a helper formation that is a body of its own, inside
+     * this one: its voids are the symbols at the given positions.
+     * @param formation The helper, an {@code <o/>} with no base
+     * @param offset The position of its first void among all voids
+     * @param formas The formas of its voids, in declaration order
+     * @return The scope its body is read in
+     */
+    public Scope body(final Xnav formation, final int offset, final List<String> formas) {
+        final List<String> voids = Scope.voids(formation);
+        if (voids.size() != formas.size()) {
+            throw new IllegalStateException(
+                String.format(
+                    "The helper declares %d voids, but is resumed with %d values",
+                    voids.size(), formas.size()
+                )
+            );
+        }
+        final List<Binding> args = new ArrayList<>(voids.size());
+        for (int idx = 0; idx < voids.size(); ++idx) {
+            args.add(
+                new Binding(
+                    voids.get(idx),
+                    new Symbol(String.format("v%d", offset + idx), formas.get(idx))
+                )
+            );
+        }
+        return this.inside(formation, args);
+    }
+
+    private static List<String> voids(final Xnav formation) {
+        return formation.elements(Filter.withName("o"))
+            .filter(kid -> "∅".equals(kid.attribute("base").text().orElse("")))
+            .map(kid -> kid.attribute("name").text().orElse(""))
+            .filter(name -> !"ρ".equals(name))
+            .collect(Collectors.toList());
     }
 
     private static String named(final List<String> voids, final String label) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Site.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Site.java
@@ -100,7 +100,7 @@ public final class Site implements Term {
     }
 
     @Override
-    public Optional<List<Term>> again() {
+    public Optional<Again> again() {
         return Optional.empty();
     }
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
@@ -85,7 +85,7 @@ public final class Symbol implements Term {
     }
 
     @Override
-    public Optional<List<Term>> again() {
+    public Optional<Again> again() {
         return Optional.empty();
     }
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/Term.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Term.java
@@ -61,12 +61,11 @@ public interface Term {
     Optional<List<Binding>> arguments(Shape shape);
 
     /**
-     * The arguments of the call of the fragment to itself that this term
-     * is, if it is one.
-     * @return The arguments in their positional order, or empty for any
-     *  other term
+     * The call this term is, of the formation to itself or of one of
+     * its recursive helpers, if it is one.
+     * @return The call, or empty for any other term
      */
-    Optional<List<Term>> again();
+    Optional<Again> again();
 
     /**
      * This tree with every site matching the shape replaced.

--- a/eo-lowering/src/test/java/org/eolang/lowering/AgainTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/AgainTest.java
@@ -48,7 +48,7 @@ final class AgainTest {
             "the arguments must come back in their order, but they dont",
             new Again(
                 Arrays.asList(new Symbol("v1", "number"), new Symbol("v0", "number"))
-            ).again().get().get(0).key(),
+            ).again().get().arguments().get(0).key(),
             Matchers.equalTo("sym:v1")
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/CyclesTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/CyclesTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Cycles}.
+ * @since 0.76.0
+ */
+final class CyclesTest {
+
+    @Test
+    void namesHelpersApplyingEachOther() {
+        final Map<String, Xnav> helpers = new LinkedHashMap<>();
+        helpers.put("a🌵3-4", CyclesTest.helper("a🌵3-4", "ξ.ρ.a🌵8-4"));
+        helpers.put("a🌵8-4", CyclesTest.helper("a🌵8-4", "ξ.ρ.a🌵3-4"));
+        MatcherAssert.assertThat(
+            "two helpers applying each other must both be in the cycle, but they arent",
+            new Cycles(helpers).names(),
+            Matchers.contains("a🌵3-4", "a🌵8-4")
+        );
+    }
+
+    @Test
+    void namesHelperApplyingItself() {
+        MatcherAssert.assertThat(
+            "a helper applying itself must be in the cycle, but it isnt",
+            new Cycles(
+                Collections.singletonMap("a🌵3-4", CyclesTest.helper("a🌵3-4", "ξ.ρ.a🌵3-4"))
+            ).names(),
+            Matchers.contains("a🌵3-4")
+        );
+    }
+
+    @Test
+    void leavesOutHelperAppliedOnce() {
+        final Map<String, Xnav> helpers = new LinkedHashMap<>();
+        helpers.put("a🌵3-4", CyclesTest.helper("a🌵3-4", "ξ.ρ.a🌵8-4"));
+        helpers.put("a🌵8-4", CyclesTest.helper("a🌵8-4", "ξ.ρ.x.plus"));
+        MatcherAssert.assertThat(
+            "a helper reaching only a helper that reaches nothing back is no cycle, but it was",
+            new Cycles(helpers).names(),
+            Matchers.empty()
+        );
+    }
+
+    private static Xnav helper(final String name, final String base) {
+        return new Xnav(
+            String.format(
+                "<o name='%s'><o base='∅' name='ρ'/><o base='∅' name='i'/><o base='%s' name='φ'><o as='α0' base='ξ.i'/></o></o>",
+                name, base
+            )
+        ).element("o");
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/ForkTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ForkTest.java
@@ -56,15 +56,15 @@ final class ForkTest {
     }
 
     @Test
-    void refusesRepeatingInBothArms() {
-        Assertions.assertThrows(
-            IllegalStateException.class,
+    void answersNothingWhenBothArmsRepeat() {
+        MatcherAssert.assertThat(
+            "a fork whose both arms repeat has no value and must name no forma, but it did",
             new Fork(
                 "s2", "L_bool_if", "sym:s1",
                 new Protocol(Collections.emptyList(), Collections.singletonList("sym:v0")),
                 new Protocol(Collections.emptyList(), Collections.singletonList("sym:v0"))
-            )::forma,
-            "a fork whose both arms repeat answers nothing, but it named a forma"
+            ).forma(),
+            Matchers.equalTo("")
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -26,6 +26,77 @@ import org.junit.jupiter.api.Test;
 final class JavaAtomTest {
 
     @Test
+    void rendersBodiesAsStateMachine() {
+        MatcherAssert.assertThat(
+            "bodies resuming one another must run as one loop over a state, but they dont",
+            new JavaAtom(
+                new Program(
+                    Arrays.asList(
+                        new Body(
+                            "", 0, Collections.singletonList("number"),
+                            new Protocol(
+                                Collections.emptyList(), "a🌵3-4",
+                                Collections.singletonList("sym:v0")
+                            )
+                        ),
+                        new Body(
+                            "a🌵3-4", 1, Collections.singletonList("number"),
+                            new Protocol(
+                                Arrays.asList(
+                                    new Application(
+                                        "s1", "L_bytes_eq",
+                                        Arrays.asList("sym:v1", "number:00-00-00-00-00-00-00-00")
+                                    ),
+                                    new Fork(
+                                        "s2", "L_bool_if", "sym:s1",
+                                        new Protocol(Collections.emptyList(), "sym:v1", "number"),
+                                        new Protocol(
+                                            Collections.singletonList(
+                                                new Application(
+                                                    "s3", "L_number_plus",
+                                                    Arrays.asList(
+                                                        "sym:v1", "number:BF-F0-00-00-00-00-00-00"
+                                                    )
+                                                )
+                                            ),
+                                            "a🌵3-4",
+                                            Collections.singletonList("sym:s3")
+                                        )
+                                    )
+                                ),
+                                "sym:s2", "number"
+                            )
+                        )
+                    ),
+                    Collections.singletonMap("n", "number")
+                )
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "double v0 = new Dataized(this.take(\"n\")).asNumber();",
+                "double v1 = 0.0;",
+                "int body = 0;",
+                "final double out;",
+                "while (true) {",
+                "if (body == 0) {",
+                "v1 = v0;",
+                "body = 1;",
+                "continue;",
+                "} else {",
+                "final double s2;",
+                "if (s1) {",
+                "s2 = v1;",
+                "} else {",
+                "v1 = s3;",
+                "body = 1;",
+                "continue;",
+                "out = s2;",
+                "break;",
+                "return new Data.ToPhi(out);"
+            )
+        );
+    }
+
+    @Test
     void rendersChainOfNumberSteps() {
         MatcherAssert.assertThat(
             "a chain of two steps must render one line each, but it doesnt",

--- a/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
@@ -99,7 +99,7 @@ final class ParsedTest {
                 new Xnav("<o base='ξ.ρ.f'><o as='α0' base='ξ.x'/></o>").element("o"),
                 Collections.singletonMap("x", "number"),
                 "f"
-            ).term().again().get(),
+            ).term().again().get().arguments(),
             Matchers.hasSize(1)
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/ProgramTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ProgramTest.java
@@ -1,0 +1,96 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Program}.
+ * @since 0.76.0
+ */
+final class ProgramTest {
+
+    @Test
+    void listsFormasOfAllBodiesByPosition() {
+        MatcherAssert.assertThat(
+            "the voids of every body must stand at the positions the bodies know, but they dont",
+            ProgramTest.bouncing().formas(),
+            Matchers.contains("number", "number", "bytes")
+        );
+    }
+
+    @Test
+    void numbersBodiesFromTheFormation() {
+        MatcherAssert.assertThat(
+            "a helper body must be numbered after the formation's own, but it isnt",
+            ProgramTest.bouncing().index("a🌵3-4"),
+            Matchers.equalTo(1)
+        );
+    }
+
+    @Test
+    void answersFormaOfTheBodyThatAnswers() {
+        MatcherAssert.assertThat(
+            "the program must answer what its answering body answers, but it doesnt",
+            ProgramTest.bouncing().carrier(),
+            Matchers.equalTo("number")
+        );
+    }
+
+    @Test
+    void refusesProgramThatNeverAnswers() {
+        MatcherAssert.assertThat(
+            "a program whose bodies only resume one another never answers and must refuse",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Program(
+                    Arrays.asList(
+                        new Body(
+                            "", 0, Collections.singletonList("number"),
+                            new Protocol(
+                                Collections.emptyList(), "a🌵3-4",
+                                Collections.singletonList("sym:v0")
+                            )
+                        ),
+                        new Body(
+                            "a🌵3-4", 1, Collections.singletonList("number"),
+                            new Protocol(
+                                Collections.emptyList(), "a🌵3-4",
+                                Collections.singletonList("sym:v1")
+                            )
+                        )
+                    ),
+                    Collections.singletonMap("x", "number")
+                )::carrier,
+                "a program that never answers was given a forma, but it must not be"
+            ).getMessage(),
+            Matchers.containsString("never answers")
+        );
+    }
+
+    private static Program bouncing() {
+        return new Program(
+            Arrays.asList(
+                new Body(
+                    "", 0, Collections.singletonList("number"),
+                    new Protocol(
+                        Collections.emptyList(), "a🌵3-4",
+                        Arrays.asList("sym:v0", "bytes:01-")
+                    )
+                ),
+                new Body(
+                    "a🌵3-4", 1, Arrays.asList("number", "bytes"),
+                    new Protocol(Collections.emptyList(), "sym:v1", "number")
+                )
+            ),
+            Collections.singletonMap("x", "number")
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
@@ -194,6 +194,70 @@ final class ReductionTest {
     }
 
     @Test
+    void resumesHelpersApplyingEachOther(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "two helpers applying each other in tail positions must become two more bodies",
+            new Reduction(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='ξ.a🌵3-4'><o as='α0' base='ξ.x'/>",
+                        ReductionTest.number("α1", "3F-F0-00-00-00-00-00-00"),
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("x", "number"),
+                8,
+                "bounce",
+                ReductionTest.bouncers()
+            ).program().bodies(),
+            Matchers.hasSize(3)
+        );
+    }
+
+    @Test
+    void refusesHelpersThatNeverAnswer(@Mktmp final Path temp) {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        final Map<String, Xnav> helpers = new LinkedHashMap<>();
+        helpers.put(
+            "a🌵3-4",
+            ReductionTest.bouncer(
+                "a🌵3-4",
+                "<o base='ξ.ρ.a🌵8-4'><o as='α0' base='ξ.n'/><o as='α1' base='ξ.acc'/></o>"
+            )
+        );
+        helpers.put(
+            "a🌵8-4",
+            ReductionTest.bouncer(
+                "a🌵8-4",
+                "<o base='ξ.ρ.a🌵3-4'><o as='α0' base='ξ.n'/><o as='α1' base='ξ.acc'/></o>"
+            )
+        );
+        MatcherAssert.assertThat(
+            "helpers that only resume each other never answer and must refuse, but they didnt",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Reduction(
+                    phino,
+                    new Xnav(
+                        "<o base='ξ.a🌵3-4'><o as='α0' base='ξ.x'/><o as='α1' base='ξ.x'/></o>"
+                    ).element("o"),
+                    Collections.singletonMap("x", "number"),
+                    8,
+                    "bounce",
+                    helpers
+                )::program,
+                "a program that never answers reduced, but it must not"
+            ).getMessage(),
+            Matchers.containsString("never answers")
+        );
+    }
+
+    @Test
     void appliesHelperFormationTwice(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());
@@ -781,6 +845,66 @@ final class ReductionTest {
                 "<o as='α0' base='Φ.bytes'><o as='α0'>3F-F0-00-00-00-00-00-00</o></o>",
                 "</o>",
                 "</o>"
+            )
+        ).element("o");
+    }
+
+    private static Map<String, Xnav> bouncers() {
+        final Map<String, Xnav> out = new LinkedHashMap<>();
+        out.put(
+            "a🌵3-4",
+            ReductionTest.bouncer(
+                "a🌵3-4",
+                String.join(
+                    "",
+                    "<o base='.if'>",
+                    "<o base='ξ.n.eq'>",
+                    ReductionTest.number("α0", "00-00-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α0' base='ξ.acc'/>",
+                    "<o as='α1' base='ξ.ρ.a🌵8-4'>",
+                    "<o as='α0' base='ξ.n.plus'>",
+                    ReductionTest.number("α0", "BF-F0-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α1' base='ξ.acc.plus'>",
+                    ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00"),
+                    "</o>",
+                    "</o>",
+                    "</o>"
+                )
+            )
+        );
+        out.put(
+            "a🌵8-4",
+            ReductionTest.bouncer(
+                "a🌵8-4",
+                String.join(
+                    "",
+                    "<o base='.if'>",
+                    "<o base='ξ.n.eq'>",
+                    ReductionTest.number("α0", "00-00-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α0' base='ξ.acc'/>",
+                    "<o as='α1' base='ξ.ρ.a🌵3-4'>",
+                    "<o as='α0' base='ξ.n.plus'>",
+                    ReductionTest.number("α0", "BF-F0-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α1' base='ξ.acc.times'>",
+                    ReductionTest.number("α0", "40-00-00-00-00-00-00-00"),
+                    "</o>",
+                    "</o>",
+                    "</o>"
+                )
+            )
+        );
+        return out;
+    }
+
+    private static Xnav bouncer(final String name, final String body) {
+        return new Xnav(
+            String.format(
+                "<o name='%s'><o base='∅' name='ρ'/><o base='∅' name='n'/><o base='∅' name='acc'/>%s</o>",
+                name, body.replaceFirst("<o base=", "<o name='φ' base=")
             )
         ).element("o");
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -82,14 +82,13 @@ final class LoweringTest {
         final Phino phino = new Phino("phino", 1000, this.temp);
         Assumptions.assumeTrue(phino.suitable());
         final Xnav foo = LoweringTest.formation(this.temp, story);
-        final Map<String, String> voids = LoweringTest.voids(foo, story);
         MatcherAssert.assertThat(
             "the fragment must reduce into the protocol the pack promises, but it doesnt",
             LoweringTest.printed(
                 new Reduction(
                     phino,
                     LoweringTest.fragment(foo),
-                    voids,
+                    LoweringTest.voids(foo, story),
                     8,
                     story.map().getOrDefault("unit", "").toString(),
                     LoweringTest.helpers(foo)

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -17,8 +17,10 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.eolang.jucs.ClasspathSource;
+import org.eolang.lowering.Body;
 import org.eolang.lowering.Digest;
 import org.eolang.lowering.Phino;
+import org.eolang.lowering.Program;
 import org.eolang.lowering.Protocol;
 import org.eolang.lowering.Reduction;
 import org.eolang.lowering.Step;
@@ -91,8 +93,7 @@ final class LoweringTest {
                     8,
                     story.map().getOrDefault("unit", "").toString(),
                     LoweringTest.helpers(foo)
-                ).protocol(),
-                voids.size()
+                ).program()
             ).trim(),
             Matchers.equalTo(story.map().get("protocol").toString().trim())
         );
@@ -117,7 +118,7 @@ final class LoweringTest {
                     8,
                     story.map().getOrDefault("unit", "").toString(),
                     LoweringTest.helpers(foo)
-                )::protocol,
+                )::program,
                 "a fragment the pack calls stuck cannot reduce, but it did"
             ).getMessage(),
             Matchers.containsString(story.map().get("stuck").toString())
@@ -220,19 +221,28 @@ final class LoweringTest {
         return out;
     }
 
-    private static String printed(final Protocol protocol, final int voids) {
-        final String out;
-        if (protocol.repeats()) {
-            final StringBuilder head = new StringBuilder("loop");
-            for (int idx = 0; idx < voids; ++idx) {
-                head.append(" v").append(idx);
+    private static String printed(final Program program) {
+        final StringBuilder out = new StringBuilder(64);
+        final Body first = program.bodies().get(0);
+        if (program.repeats()) {
+            out.append("loop");
+            for (int idx = 0; idx < program.inputs().size(); ++idx) {
+                out.append(" v").append(idx);
             }
-            out = head.append(System.lineSeparator())
-                .append(LoweringTest.rendered(protocol, "  ")).toString();
+            out.append(System.lineSeparator())
+                .append(LoweringTest.rendered(first.protocol(), "  "));
+            for (final Body body : program.bodies().subList(1, program.bodies().size())) {
+                out.append("body ").append(body.name());
+                for (int idx = 0; idx < body.formas().size(); ++idx) {
+                    out.append(" v").append(body.offset() + idx);
+                }
+                out.append(System.lineSeparator())
+                    .append(LoweringTest.rendered(body.protocol(), "  "));
+            }
         } else {
-            out = LoweringTest.rendered(protocol, "");
+            out.append(LoweringTest.rendered(first.protocol(), ""));
         }
-        return out;
+        return out.toString();
     }
 
     private static String rendered(final Protocol protocol, final String pad) {
@@ -274,6 +284,9 @@ final class LoweringTest {
                 .append(' ').append(protocol.carrier());
         } else {
             out.append("repeat");
+            if (!protocol.target().isEmpty()) {
+                out.append(' ').append(protocol.target());
+            }
             for (final String key : protocol.again()) {
                 out.append(' ').append(key);
             }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/endless-helpers.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/endless-helpers.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Two helpers that only apply each other never reach an answer: every
+# body of the program resumes another, so the program answers nothing,
+# the reduction refuses it, and the formation stays as written.
+input: |
+  [] > foo
+    [x] > bounce
+      [^ i] >> ping
+        pong (i.plus 1) > @
+      [^ j] >> pong
+        ping (j.times 2) > @
+      ping x > @
+    bounce 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bounce
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bounce 5 > @
+    [x] > bounce
+      ping x > @
+      pong > [^ i] >> ping
+        i.plus 1
+      ping > [^ j] >> pong
+        j.times 2
+stuck: "The program never answers"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
@@ -1,19 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Two helpers applying each other never settle by application alone:
-# reading either where it is named reads the other, and then the first
-# again, so the reduction refuses the cycle before phino is asked and the
-# formation stays as written. Such a pair needs the loop, not the
-# application, the way `walk` and `spec` of `printf` do.
+# yamllint disable rule:line-length
+# Two privatized helpers that apply each other in tail positions are
+# mutual tail recursion, the shape of `walk` and `spec` in `printf`, and
+# one loop expresses it: each helper is a body of its own, reduced once
+# over voids of its own, a state says which body runs next, and every
+# tail call hands the next body its values, sets the state, and goes
+# round again. The formation's own body only starts the first helper,
+# and the answer comes from whichever body reaches the base case.
 input: |
   [] > foo
     [x] > bounce
-      [^ i] >> ping
-        pong (i.plus 1) > @
-      [^ j] >> pong
-        ping (j.times 2) > @
-      ping x > @
+      [^ n acc] >> ping
+        if. > @
+          n.eq 0
+          acc
+          pong (n.plus -1) (acc.plus 1)
+      [^ n acc] >> pong
+        if. > @
+          n.eq 0
+          acc
+          ping (n.plus -1) (acc.times 2)
+      ping x 1 > @
     bounce 5 > @
 prelude:
   number.eo: |
@@ -25,10 +34,75 @@ voids:
 lowered: |
   [] > foo
     bounce 5 > @
-    [x] > bounce
-      ping x > @
-      pong > [^ i] >> ping
-        i.plus 1
-      ping > [^ j] >> pong
-        j.times 2
-stuck: "reads itself, so the fragment never settles"
+    [] > bounce /Q.number
+      ? > x /Q.number
+protocol: |
+  loop v0
+    repeat a🌵3-4 sym:v0 number:3F-F0-00-00-00-00-00-00
+  body a🌵3-4 v1 v2
+    s1 ← L_bytes_eq sym:v1 number:00-00-00-00-00-00-00-00
+    s2 ← fork sym:s1 number
+      then
+        answer sym:v2 number
+      else
+        s3 ← L_number_plus sym:v1 number:BF-F0-00-00-00-00-00-00
+        s4 ← L_number_plus sym:v2 number:3F-F0-00-00-00-00-00-00
+        repeat a🌵8-4 sym:s3 sym:s4
+    answer sym:s2 number
+  body a🌵8-4 v3 v4
+    s5 ← L_bytes_eq sym:v3 number:00-00-00-00-00-00-00-00
+    s6 ← fork sym:s5 number
+      then
+        answer sym:v4 number
+      else
+        s7 ← L_number_plus sym:v3 number:BF-F0-00-00-00-00-00-00
+        s8 ← L_number_times sym:v4 number:40-00-00-00-00-00-00-00
+        repeat a🌵3-4 sym:s7 sym:s8
+    answer sym:s6 number
+java: |
+  double v0 = new Dataized(this.take("x")).asNumber();
+  double v1 = 0.0;
+  double v2 = 0.0;
+  double v3 = 0.0;
+  double v4 = 0.0;
+  int body = 0;
+  final double out;
+  while (true) {
+      if (body == 0) {
+          v1 = v0;
+          v2 = Double.longBitsToDouble(0x3FF0000000000000L);
+          body = 1;
+          continue;
+      } else if (body == 1) {
+          final boolean s1 = Double.doubleToRawLongBits(v1) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+          final double s2;
+          if (s1) {
+              s2 = v2;
+          } else {
+              final double s3 = v1 + Double.longBitsToDouble(0xBFF0000000000000L);
+              final double s4 = v2 + Double.longBitsToDouble(0x3FF0000000000000L);
+              v3 = s3;
+              v4 = s4;
+              body = 2;
+              continue;
+          }
+          out = s2;
+          break;
+      } else {
+          final boolean s5 = Double.doubleToRawLongBits(v3) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+          final double s6;
+          if (s5) {
+              s6 = v4;
+          } else {
+              final double s7 = v3 + Double.longBitsToDouble(0xBFF0000000000000L);
+              final double s8 = v4 * Double.longBitsToDouble(0x4000000000000000L);
+              v1 = s7;
+              v2 = s8;
+              body = 1;
+              continue;
+          }
+          out = s6;
+          break;
+      }
+  }
+  return new Data.ToPhi(out);


### PR DESCRIPTION
Closes #8409.

The reduction saw one shape of recursion — a formation calling itself through `ξ.ρ.<self>` — and `printf` does not recurse that way: `walk` and `spec` are two privatized helpers that apply each other in tail positions, so that the format is traversed exactly once. Mutual tail recursion is one loop with a state saying which body runs next, the union of the bodies' voids carried across, and every tail call setting the state before `continue`. This teaches the lowering that loop.

## What changed

**Cycles.** The helpers of a formation that apply themselves, directly or through one another. Every synthetic `a🌵` name standing anywhere under a helper is a helper it may reach, and a helper that reaches itself along those names is in a cycle. Such a helper cannot be read where it is named, since the reading would never end; when it is a formation, it is a body of its own, resumed where it is named. An application in a cycle has no voids to carry and is left to the reading, which refuses it as the cycle it is.

**Again, Reference.** `Again` carries the name of the body it resumes, empty for the formation itself. `Reference` turns naming a recursive helper into the `Again` of that helper over the arguments, and the reduction turns it into a repeat when it stands in a tail position, exactly as the self-call of #8382; anywhere else phino parks on the marker and the fragment refuses, so a non-tail call into the cycle refuses by construction. The cycle guard of #8402 stays for helpers nested inside a helper, which are never bodies.

**Bodies, Body, Program, Repeat.** `Bodies` reduces the formation's own body first, over the symbols of its voids, then every helper a repeat declared, over symbols of its own voids at positions after the formation's, in a `Scope` opened inside the root, until every declared body is reduced; the result is a `Program` of `Body` parts, the formation's own first. `Repeat` settles a tree that resumes a body: the first repeat into a helper declares the formas of its voids in the `Minted` ledger, with the formas of the values it hands over, and every later repeat must agree. `Protocol` names the body its repeat resumes. A program whose bodies only resume one another never answers and is refused, and so is one whose bodies answer different formas.

**JavaAtom, Rendering.** A program of several bodies renders as one `while (true)` over an `int body`: the formation's voids are read before the loop, the helpers' are blank locals until a repeat hands them values, each body is one branch on the state, a body that answers assigns the one `out` and breaks, and a repeat assigns the voids of the body it resumes — through a temporary only where a value names a void that same repeat rebinds — then the state, and continues. A fork whose both arms resume has no value and declares no local. A program of one body renders as before.

**Lowered.** Lowers whole programs now, and its docblock says what a helper may reach through `ρ`: the voids and the other helpers of the formation, which the atom carries, since #8416 already read them.

## Where the application happens

As in #8416, the β-application phino would do is done on the tree side, once per body, over symbolic voids, so that the records phino returns can anchor to the sites of each body. What the issue calls "the union of their arguments carried across" is the list of all voids of all bodies, each body knowing the offset of its own, which is what makes `printf`'s two helpers with the same three voids six locals rather than three: correct in every case, and the simpler rule.

## Packs

- `mutual-helpers` now lowers: two helpers applying each other with a base case each, the shape of `walk` and `spec`, become three bodies and one loop, and the answer comes from whichever body reaches the base case. The pack shows the protocol of every body and the Java of the machine.
- `endless-helpers`: two helpers that only apply each other never answer and stay as written.

## Verified

- `eo-lowering`: 240 tests pass, qulice clean, simian clean; `eo-maven-plugin`: all 164 lowering pack checks pass, two of them new; the generated Java of `mutual-helpers` is what the pack shows, one `while (true)` over three bodies.
- `eo-runtime` re-lowered end to end with phino 0.0.115 and compiled: still 144 fragments. `printf` itself still stops at the gate before recursion: its `args` void is a tuple the inference tables never witness as data, and its `φ` builds a `string` from bytes, which the reduction reads as a malformed literal, so nothing in it reaches `walk` and `spec` yet. The other 53 formations with privatized helpers stop where #8403 and #8416 found them.

## Notes

- **pr-size** is over the cap, as the previous lowering PRs were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_