### PR TITLE
Follow a void that hands back what it is given

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Branched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Branched.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * What a call hands back, where every formation it reaches hands back what the
+ * call put into it.
+ *
+ * <p>A formation whose whole body is one of its own voids gives back whatever
+ * was put there and nothing of its own: the {@code [? >> left ? >> right]}
+ * that {@code Φ.true} hands to {@code Φ.bool.if} answers with its {@code left}
+ * and the one {@code Φ.false} hands answers with its {@code right}. So a call
+ * on that void is one of the two arguments, and which one is not known —
+ * whichever it is, it is what they both are.</p>
+ *
+ * <p>Nothing is guessed, since a formation that binds a body of its own is
+ * passed over: the call goes into it and what comes back is that body, which
+ * is a question for whoever walks a delegation and not for this.</p>
+ *
+ * @since 0.71.0
+ */
+final class Branched {
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * What the call put into the voids, by the locator of the void.
+     */
+    private final Map<String, String> binds;
+
+    /**
+     * Ctor.
+     * @param provided What the types certainly have
+     * @param filled What the call put into the voids, by the locator of the
+     *  void
+     */
+    Branched(final Provided provided, final Map<String, String> filled) {
+        this.owned = provided;
+        this.binds = filled;
+    }
+
+    /**
+     * The one thing every formation this call reaches hands back.
+     * @return The locator, empty when no formation hands back what it was
+     *  given or they share nothing
+     */
+    String names() {
+        final Collection<String> handed = new LinkedHashSet<>(0);
+        for (final String hollow : this.binds.keySet()) {
+            final int dot = hollow.lastIndexOf('.');
+            if (dot > 0) {
+                final String body = this.owned.behind(hollow.substring(0, dot));
+                if (this.binds.containsKey(body)) {
+                    handed.add(this.binds.get(body));
+                }
+            }
+        }
+        return new Joined(handed, this.owned).names();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -100,7 +100,8 @@ final class Dispatched {
         final Filled filled = new Filled(
             pairs,
             owned,
-            new Bound(this.args, this.named, this.receivers, pairs, owned).all()
+            new Bound(this.args, this.named, this.receivers, pairs, owned).all(),
+            this.hollows
         );
         final Map<String, String> found = new HashMap<>(0);
         for (final Site dispatch : this.all) {

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -28,6 +28,17 @@ import java.util.Map;
  * {@code held.next} asks. A void filled nearer the question wins over one
  * filled further away, and a void nobody fills keeps the answer as it was.</p>
  *
+ * <p>The chain is followed through the pairs as well as through the bodies,
+ * since what a receiver turns out to be is often worked out a pass later than
+ * the application that filled the void: a name settled this pass leads to an
+ * object whose voids were filled the pass before, and the fillings are wanted
+ * from both ends of that.</p>
+ *
+ * <p>An answer rooted at a void nothing here fills is not the end of it
+ * either. The void may hold a formation that hands back what it is given, in
+ * which case the answer is one of the things this call put in, and
+ * {@link Branched} says which.</p>
+ *
  * @since 0.69.0
  */
 final class Filled {
@@ -48,20 +59,28 @@ final class Filled {
     private final Provided owned;
 
     /**
+     * The locator of every void.
+     */
+    private final Collection<String> hollows;
+
+    /**
      * Ctor.
      * @param links The pairs, each name against the one it is a copy of
      * @param provided The provides table, by the name a type goes by
      * @param bound What every application and every dispatch fills, from
      *  {@link Bound}
+     * @param voids The locator of every void, from {@link Hollows}
      */
     Filled(
         final Map<String, String> links,
         final Provided provided,
-        final Map<String, Map<String, String>> bound
+        final Map<String, Map<String, String>> bound,
+        final Collection<String> voids
     ) {
         this.fills = bound;
         this.pairs = links;
         this.owned = provided;
+        this.hollows = voids;
     }
 
     /**
@@ -85,12 +104,42 @@ final class Filled {
                 }
             }
             if (longest.isEmpty()) {
-                found = answer;
+                found = this.branch(answer, fillings);
             } else {
                 found = this.asked(
                     fillings.get(longest), answer.substring(longest.length() + 1), answer
                 );
             }
+        }
+        return found;
+    }
+
+    private String branch(final String answer, final Map<String, String> fillings) {
+        final String root = this.root(answer);
+        String found = answer;
+        if (!root.isEmpty()) {
+            final String handed = new Branched(this.owned, fillings).names();
+            if (!handed.isEmpty()) {
+                found = this.asked(
+                    handed, answer.substring(Math.min(root.length() + 1, answer.length())), answer
+                );
+            }
+        }
+        return found;
+    }
+
+    private String root(final String answer) {
+        String found = "";
+        String walked = answer;
+        while (!walked.isEmpty()) {
+            if (this.hollows.contains(walked)) {
+                found = walked;
+                break;
+            }
+            if (!walked.contains(".")) {
+                break;
+            }
+            walked = walked.substring(0, walked.lastIndexOf('.'));
         }
         return found;
     }
@@ -126,7 +175,11 @@ final class Filled {
                 : this.fills.getOrDefault(walked, Collections.emptyMap()).entrySet()) {
                 found.putIfAbsent(fill.getKey(), this.end(fill.getValue()));
             }
-            walked = this.owned.body(walked);
+            if (this.pairs.containsKey(walked)) {
+                walked = this.pairs.get(walked);
+            } else {
+                walked = this.owned.body(walked);
+            }
         }
     }
 

--- a/eo-inference/src/main/java/org/eolang/inference/Joined.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Joined.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * The one thing several objects all are.
+ *
+ * <p>Where a place in a program holds one of two objects and it is not known
+ * which, there is still something to say about it, as long as the two of them
+ * have a common ancestor: whichever one arrives, it is a copy of that. So each
+ * object is walked back along what it delegates to, and the nearest step every
+ * walk passes through is what they all are.</p>
+ *
+ * <p>Nearest is the point of it. Every object in EO ends at {@code Φ} and
+ * saying so is saying nothing, so the walks are kept in the order they were
+ * made and the first step they share is taken, which is the one furthest from
+ * the root.</p>
+ *
+ * @since 0.71.0
+ */
+final class Joined {
+
+    /**
+     * The objects to join.
+     */
+    private final Collection<String> told;
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * Ctor.
+     * @param objects The objects to join
+     * @param provided What the types certainly have
+     */
+    Joined(final Collection<String> objects, final Provided provided) {
+        this.told = objects;
+        this.owned = provided;
+    }
+
+    /**
+     * The nearest object all of them are copies of.
+     * @return The locator, empty when they share nothing
+     */
+    String names() {
+        final Iterator<String> rest = this.told.iterator();
+        final List<String> shared = new ArrayList<>(0);
+        if (rest.hasNext()) {
+            shared.addAll(this.chain(rest.next()));
+        }
+        while (rest.hasNext()) {
+            shared.retainAll(new HashSet<>(this.chain(rest.next())));
+        }
+        String found = "";
+        if (!shared.isEmpty()) {
+            found = shared.get(0);
+        }
+        return found;
+    }
+
+    private List<String> chain(final String type) {
+        final List<String> found = new ArrayList<>(0);
+        final Collection<String> seen = new HashSet<>(0);
+        String walked = type;
+        while (!walked.isEmpty() && seen.add(walked)) {
+            found.add(walked);
+            walked = this.owned.behind(walked);
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Promoted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Promoted.java
@@ -75,16 +75,28 @@ final class Promoted {
     private final Map<String, Type> others;
 
     /**
+     * The locator of every void.
+     */
+    private final Collection<String> hollows;
+
+    /**
      * Ctor.
      * @param woven The rows that follow from a set of pairs
      * @param provides The provides table, which says where a filling can land
      * @param kept The rows of the links table that are not pairs, without which
      *  a filling that arrives at a literal is not seen to be one
+     * @param voids The locator of every void, from {@link Hollows}
      */
-    Promoted(final Woven woven, final XML provides, final Map<String, Type> kept) {
+    Promoted(
+        final Woven woven,
+        final XML provides,
+        final Map<String, Type> kept,
+        final Collection<String> voids
+    ) {
         this.table = woven;
         this.given = provides;
         this.others = kept;
+        this.hollows = voids;
     }
 
     /**
@@ -96,10 +108,16 @@ final class Promoted {
      */
     Map<String, String> from(final Map<String, String> pairs) {
         final Collection<String> known = this.known();
+        final Provided owned = new Provided(
+            this.given, new Ends(pairs).names(), this.hollows
+        );
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Collection<Type>> hollow
             : new Fillings(this.links(pairs), this.given).all().entrySet()) {
-            final String sole = new Sole(hollow.getValue(), known).names();
+            String sole = new Sole(hollow.getValue(), known).names();
+            if (sole.isEmpty()) {
+                sole = new Shared(hollow.getValue(), known, owned).names();
+            }
             if (!sole.isEmpty() && !pairs.containsKey(hollow.getKey())) {
                 found.put(hollow.getKey(), sole);
             }

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -198,6 +198,23 @@ final class Provided {
         return found;
     }
 
+    /**
+     * The type this one stands in front of.
+     * @param type The name the type goes by
+     * @return The locator of what it delegates to, or an empty string when it
+     *  delegates to nothing
+     */
+    String behind(final String type) {
+        String next = this.bound(type, "φ");
+        if (next.isEmpty()) {
+            next = this.cell(type, "returns");
+        }
+        if (next.isEmpty()) {
+            next = this.held.getOrDefault(type, "");
+        }
+        return this.names.getOrDefault(next, next);
+    }
+
     private boolean hollow(final String type) {
         boolean found = false;
         String walked = type;
@@ -225,17 +242,6 @@ final class Provided {
             found = this.kept(behind, name, walked);
         }
         return found;
-    }
-
-    private String behind(final String type) {
-        String next = this.bound(type, "φ");
-        if (next.isEmpty()) {
-            next = this.cell(type, "returns");
-        }
-        if (next.isEmpty()) {
-            next = this.held.getOrDefault(type, "");
-        }
-        return this.names.getOrDefault(next, next);
     }
 
     private boolean blank(final String type) {

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -90,7 +90,7 @@ public final class Resolved implements Clue {
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Map<String, Type> kept = written.others();
         final Woven woven = new Woven(given, applied, receivers, voids);
-        final Promoted promoted = new Promoted(woven, given, kept);
+        final Promoted promoted = new Promoted(woven, given, kept, voids);
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, dispatches, args, named, receivers, voids), promoted
         ).from(

--- a/eo-inference/src/main/java/org/eolang/inference/Shared.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Shared.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+/**
+ * The one thing a void holds, where the program fills it several ways.
+ *
+ * <p>{@link Sole} refuses a void filled with a {@code Φ.true} here and a
+ * {@code Φ.false} there, since naming either would be picking a favourite
+ * among facts. Naming what the two of them are is not picking one: both hand
+ * their answers to a {@code Φ.bool}, so every caller of that void puts a
+ * {@code Φ.bool} there, whichever one it is. That is worth having, because a
+ * dispatch rooted at the void can go on past it.</p>
+ *
+ * <p>It is worth having for the dispatches and not for the void itself, whose
+ * band stays where a name rooted at a void belongs, with the union of what was
+ * seen in it beside it. A reader asking about the void wants the callers, not
+ * their common ancestor.</p>
+ *
+ * @since 0.71.0
+ */
+final class Shared {
+
+    /**
+     * What the program was seen putting into the void, from {@link Fillings}.
+     */
+    private final Collection<Type> told;
+
+    /**
+     * The objects the provides table has a row for.
+     */
+    private final Collection<String> known;
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * Ctor.
+     * @param witnesses What the program was seen putting into the void, from
+     *  {@link Fillings}
+     * @param objects The objects the provides table has a row for
+     * @param provided What the types certainly have
+     */
+    Shared(
+        final Collection<Type> witnesses,
+        final Collection<String> objects,
+        final Provided provided
+    ) {
+        this.told = witnesses;
+        this.known = objects;
+        this.owned = provided;
+    }
+
+    /**
+     * The object every filling of this void is.
+     * @return The locator, empty where the fillings share nothing a reader
+     *  could go and look at
+     */
+    String names() {
+        final Collection<String> handed = new LinkedHashSet<>(0);
+        for (final Type one : this.told) {
+            handed.add(one.names());
+        }
+        String found = new Joined(handed, this.owned).names();
+        if (!this.known.contains(found)) {
+            found = "";
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
@@ -41,7 +41,8 @@ final class FilledTest {
                     Map.of("app", List.of("value-x", "value-foo")),
                     Collections.emptyMap(), Collections.emptyMap(),
                     Map.of("app", "form"), owned
-                ).all()
+                ).all(),
+                Collections.emptyList()
             ).instead("Φ.node.x", "app"),
             Matchers.equalTo("value-x")
         );
@@ -70,7 +71,8 @@ final class FilledTest {
                     Map.of("app", List.of("short-fill", "long-fill")),
                     Collections.emptyMap(), Collections.emptyMap(),
                     Map.of("app", "form"), owned
-                ).all()
+                ).all(),
+                Collections.emptyList()
             ).instead("Φ.node.x.y", "app"),
             Matchers.equalTo("Φ.result")
         );

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-filled-two-ways-answers-what-both-branches-hand-back.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-filled-two-ways-answers-what-both-branches-hand-back.yaml
@@ -1,0 +1,41 @@
+eo:
+  choice.eo: |
+    [pick] > choice
+      pick > @
+  yes.eo: |
+    [^] > yes
+      choice > @
+        [^]
+          ? >> left
+          ? >> right
+          left > @
+  no.eo: |
+    [^] > no
+      choice > @
+        [^]
+          ? >> left
+          ? >> right
+          right > @
+  sock.eo: |
+    [^ flag] > sock
+      flag.pick > @
+        impl 03-
+        impl 04-
+      [^ sys] > impl
+        [^ size] > listen
+          size > @
+  held.eo: |
+    [] > held
+      sock yes > @
+  other.eo: |
+    [] > other
+      sock no > @
+  app.eo: |
+    [] > app
+      listen. > @
+        held
+        05-
+links:
+  - "/links/type[@id='Φ.sock.flag']/var"
+  - "/links/type[@id='Φ.sock.φ']/ref[@loc='Φ.choice.pick']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.sock.impl.listen']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-filled-two-ways-answers-what-both-branches-hand-back.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-filled-two-ways-answers-what-both-branches-hand-back.yaml
@@ -1,3 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void the program fills two ways still says something, as long as the two
+# fillings are copies of one object: whichever arrives, it is a copy of that,
+# so a call rooted at the void goes on past it. Where the filling hands back
+# what the call put into it, as both arms of a choice do, the call is one of
+# its own arguments, and it does not matter which one when they agree.
 eo:
   choice.eo: |
     [pick] > choice


### PR DESCRIPTION
A dispatch rooted at a void used to stop there, and every name asked after it got appended to the void's own locator. A chain that went through an `if` came out as `Φ.bool.if.and.if`, which is not an object anybody wrote, so nothing downstream of it meant anything. In `eo-runtime` that swallowed the whole socket chain: `Φ.string.contains.φ` was the dead `Φ.bool.if.and` and `Φ.socket.φ` was `Φ.bool.if.and.if`.

Three things carry the walk past that point, and they only work together.

`Branched` reads a formation whose whole body is one of the voids the call filled, and hands back what was put in. That is exactly the shape of `Φ.true` and `Φ.false`, so the two arms of an `if` finally answer:

```java
final String body = this.owned.behind(hollow.substring(0, dot));
if (this.binds.containsKey(body)) {
    handed.add(this.binds.get(body));
}
```

`Joined` takes the nearest object several locators are all copies of, walking each one back along what it delegates to and keeping the first step they share. `Shared` uses it to say what a void filled several ways holds, where `Sole` refuses to pick a favourite between a `Φ.true` and a `Φ.false`. That answer goes to the dispatches only, not to the void's own row: a reader asking about the void wants its callers, not their common ancestor.

`Filled` now gathers the fillings along the pairs as well as along the bodies, since the application that fills a void is usually settled a pass apart from the dispatch that asks about it.

On `eo-runtime` this moves 207 objects out of the two unresolved bands: 1456 unfilled becomes 1421 and 7535 rooted becomes 7363. `Φ.string.contains.φ` is now `Φ.bool.and`, and `Φ.socket.φ` is `Φ.bool.if` with four relayed binds.

Left for later: three near-identical pair-chain walks now sit in `Bound.base`, `Filled.end` and `Filled.gathered`, and they want folding into one object.

Closes #8390
