### PR TITLE
#8359: put a terminating expression in the unchosen branch of `if`

### DIFF
--- a/eo-runtime/src/main/eo/false.eo
+++ b/eo-runtime/src/main/eo/false.eo
@@ -17,7 +17,7 @@
 
   eq. ++> can-avoid-evaluating-the-left-argument
     false.if
-      1.div 0
+      20-1F.and CA-FE-BE
       42
     42
 

--- a/eo-runtime/src/main/eo/true.eo
+++ b/eo-runtime/src/main/eo/true.eo
@@ -19,10 +19,11 @@
 
   true.or true ++> can-disjoin-true-with-true
 
-  not. ++> can-ignore-the-right-argument-of-if
-    eq.
-      true.if 1 2
-      2
+  eq. ++> can-ignore-the-right-argument-of-if
+    true.if
+      42
+      20-1F.and CA-FE-BE
+    42
 
   true.if ++> can-pick-itself-as-the-left-branch
     true


### PR DESCRIPTION
Closes #8359.

`false.eo:18` asserted `false.if (1.div 0) 42` equals `42`. Division by zero
in EO is total and answers infinity, which `number.eo` pins on purpose in
`can-divide-by-zero`, so the left branch was a perfectly good value and the
assertion held under an eager `if` exactly as it held under the lazy one. The
only test naming the laziness contract of `if` could not fail for the reason
its name gives. `true.eo:22` had the same hole: `true.if 1 2` is not `2` under
an eager implementation either.

Both branches now carry `20-1F.and CA-FE-BE`, which terminates when it is
dataized — `bytes.eo:235` already relies on that. `true.eo` moves the
expression into the right branch and asserts the left one comes back.

Verified that the tests can now fail: with the branches flipped in `false.eo`,
so that the terminating expression is the one chosen,
`TestEOfalse.can_avoid_evaluating_the_left_argument` errors with
`bytes.and requires operands of the same length, got 2 and 3`. Restored, both
`TestEOfalse` (6 tests) and `TestEOtrue` (10 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAM3hYZqXYYKA2MZ8iVw2


---
_Generated by [Claude Code](https://claude.ai/code/session_01JnAM3hYZqXYYKA2MZ8iVw2)_