### PR TITLE
#8340: assert the exclusive open the way `posix.eo` does

### DIFF
--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -141,6 +141,23 @@
           "::1"
       win32.unresolved
 
+  os.is-windows.not.or ++> can-report-eexist-when-creating-an-existing-file-exclusively
+    seq *
+      code.
+        win32 *1
+          "_open"
+          mktemp.tmpfile.as-path
+          plus.
+            win32.rdonly.plus win32.creat
+            win32.exclusive
+          win32.mode
+      eq.
+        code.
+          win32
+            "_errno"
+            *
+        win32.eexist
+
   os.is-windows.not.or ++> can-return-an-inet-address-above-the-signed-range
     eq.
       code.
@@ -164,24 +181,6 @@
       win32 *1
         "_stat64"
         "NUL"
-
-  os.is-windows.not.if --> stops-on-creating-an-existing-file-exclusively
-    1.div 0
-    seq *
-      code.
-        win32 *1
-          "_open"
-          "NUL"
-          plus.
-            win32.rdonly.plus win32.creat
-            win32.exclusive
-          win32.mode
-      eq.
-        code.
-          win32
-            "_errno"
-            *
-        win32.eexist
 
   --> stops-on-write-size-being-negative
     os.is-windows.not.if > @

--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -106,9 +106,9 @@
     code. > fd
       win32 *1
         "_open"
-        "NUL"
+        mktemp.tmpfile.as-path
         win32.wronly.plus win32.trunc
-        0
+        win32.mode
 
   ++> can-open-a-tcp-socket
     os.is-windows.not.or > @


### PR DESCRIPTION
Closes #8340.

`stops-on-creating-an-existing-file-exclusively` could not pass on Windows, for
two independent reasons.

The shape: `-->` is the throwing form, so the transpiler wraps the result in
`assertThrows(Exception, asBool(result))`. Off Windows the `1.div 0` branch was
taken, that threw, and the test passed without touching Windows. On Windows the
body was a `seq` ending in an `eq.` — a boolean — and `asBool` on a boolean does
not throw, so a correct `EEXIST` outcome failed the assertion just as surely as
a wrong one.

The premise: `_O_EXCL` asks the OS to refuse a file that already exists, and the
`NUL` device is not a file that can be created, so `_open` succeeded and left
`errno` at zero. The check compared `0` with `17`.

`posix.eo` already carries the same test, written correctly —
`can-report-eexist-when-creating-an-existing-file-exclusively`, an
`os.is-windows.or` guard with a `++>` assertion, against `/dev/null`, which
unlike `NUL` is a real filesystem entry. This makes the win32 test its mirror:
same name, same shape, over a temporary file that does exist, so `_O_EXCL` has
something to refuse. Keeping the `errno` assertion rather than testing the
returned `-1` keeps `win32.eexist` covered and keeps the two files symmetric; an
unexpectedly successful open leaves `errno` at `0`, which fails the assertion
all the same.

`TestEOwin32` passes here (13 tests), though on Linux the guard short-circuits
before any syscall — the Windows branch cannot be exercised on this machine, and
`.eo` tests only run in the `ec2` job, since `mvn` and `fast` both build with
`-Deo.transpileTests=false`.

Two other tests in the same file, `stops-on-write-size-being-negative` and
`stops-on-write-size-exceeding-buffer-length`, carry the same defective shape —
a `-->` over a body that ends in `true`. They are outside this issue, so I filed
them separately rather than widening the change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAM3hYZqXYYKA2MZ8iVw2


---
_Generated by [Claude Code](https://claude.ai/code/session_01JnAM3hYZqXYYKA2MZ8iVw2)_