### PR TITLE
Walk a chain of copies in one place

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -55,6 +55,13 @@ import java.util.Map;
  * turns out to be (#8405).</p>
  *
  * @since 0.69.0
+ * @todo #8424:35min Walk a ring of copies once in {@code taken} too.
+ *  The chain it collects is the copies further along than this application,
+ *  and on a ring it comes back round to the application itself, so the voids
+ *  this very application is about to fill are counted as taken already and
+ *  the fillings are lost. {@link Ends} settles a ring on one of its names for
+ *  everyone else; the chain here wants the whole path rather than its end, so
+ *  it needs a rule of its own about where a ring starts and stops.
  */
 final class Bound {
 
@@ -202,11 +209,6 @@ final class Bound {
     }
 
     private String base(final String name) {
-        final Collection<String> seen = new HashSet<>(0);
-        String walked = name;
-        while (this.pairs.containsKey(walked) && seen.add(walked)) {
-            walked = this.pairs.get(walked);
-        }
-        return walked;
+        return new Ends(this.pairs).name(name);
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Ends.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ends.java
@@ -20,6 +20,13 @@ import java.util.Map;
  * the same thing, so every name on that ring answers with the same one - the
  * first of them in alphabetical order - no matter which of them is asked.</p>
  *
+ * <p>The walk lives here and nowhere else. It is short enough to write out by
+ * hand and it was written out by hand twice, but a hand-written walk stops at
+ * the first name it meets a second time, which on a ring is whichever name the
+ * walk started from. That is two answers about one object. So
+ * {@link #name(String)} answers for a single name the way {@link #names()}
+ * answers for all of them, and both go round a ring the same way.</p>
+ *
  * @since 0.68.0
  */
 final class Ends {
@@ -43,19 +50,28 @@ final class Ends {
      */
     Map<String, String> names() {
         final Map<String, String> ends = new HashMap<>(this.copies.size());
-        for (final Map.Entry<String, String> link : this.copies.entrySet()) {
-            final Collection<String> walked = new HashSet<>(0);
-            walked.add(link.getKey());
-            String end = link.getValue();
-            while (this.copies.containsKey(end) && walked.add(end)) {
-                end = this.copies.get(end);
-            }
-            if (this.copies.containsKey(end)) {
-                end = this.anchor(end);
-            }
-            ends.put(link.getKey(), end);
+        for (final String type : this.copies.keySet()) {
+            ends.put(type, this.name(type));
         }
         return ends;
+    }
+
+    /**
+     * The name one type goes by.
+     * @param type The name of the type
+     * @return The end of its chain of copies, or the type itself when it is a
+     *  copy of nothing
+     */
+    String name(final String type) {
+        final Collection<String> walked = new HashSet<>(0);
+        String end = type;
+        while (this.copies.containsKey(end) && walked.add(end)) {
+            end = this.copies.get(end);
+        }
+        if (this.copies.containsKey(end)) {
+            end = this.anchor(end);
+        }
+        return end;
     }
 
     private String anchor(final String node) {

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -173,7 +173,7 @@ final class Filled {
         while (!walked.isEmpty() && seen.add(walked)) {
             for (final Map.Entry<String, String> fill
                 : this.fills.getOrDefault(walked, Collections.emptyMap()).entrySet()) {
-                found.putIfAbsent(fill.getKey(), this.end(fill.getValue()));
+                found.putIfAbsent(fill.getKey(), new Ends(this.pairs).name(fill.getValue()));
             }
             if (this.pairs.containsKey(walked)) {
                 walked = this.pairs.get(walked);
@@ -196,15 +196,6 @@ final class Filled {
         }
         if (walked.isEmpty()) {
             walked = back;
-        }
-        return walked;
-    }
-
-    private String end(final String locator) {
-        final Collection<String> seen = new HashSet<>(0);
-        String walked = locator;
-        while (this.pairs.containsKey(walked) && seen.add(walked)) {
-            walked = this.pairs.get(walked);
         }
         return walked;
     }

--- a/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
@@ -78,4 +78,30 @@ final class BoundTest {
             Matchers.equalTo(Map.of("pair.y", "only.y", "pair.x", "only.x"))
         );
     }
+
+    @Test
+    void readsTheReceiverOfARingOffTheNameTheRingGoesBy() {
+        final Map<String, String> pairs = new HashMap<>(0);
+        pairs.put("Φ.app.zebra", "Φ.app.alpha");
+        pairs.put("Φ.app.alpha", "Φ.app.zebra");
+        MatcherAssert.assertThat(
+            "a dispatch into a ring must read its ρ off the name the ring goes by, but it didnt",
+            new Bound(
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                Map.of("Φ.app.zebra", "Φ.app.thing"),
+                pairs,
+                new Provided(
+                    Map.of(
+                        "Φ.app.alpha",
+                        List.of(Map.of("void", "true", "name", "ρ", "type", "Φ.app.alpha.ρ"))
+                    ),
+                    Collections.emptyMap(),
+                    Collections.emptyList(),
+                    Collections.emptyMap()
+                )
+            ).all().get("Φ.app.zebra"),
+            Matchers.equalTo(Map.of("Φ.app.alpha.ρ", "Φ.app.thing"))
+        );
+    }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/EndsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/EndsTest.java
@@ -71,6 +71,33 @@ final class EndsTest {
         );
     }
 
+    @Test
+    void walksOneNameToTheEndOfItsChain() {
+        MatcherAssert.assertThat(
+            "a name asked on its own must arrive where the whole chain arrives, but it didnt",
+            new Ends(this.pairs("a", "b", "b", "c")).name("a"),
+            Matchers.equalTo("c")
+        );
+    }
+
+    @Test
+    void answersForARingWhicheverOfItsNamesIsAsked() {
+        MatcherAssert.assertThat(
+            "a ring asked at one of its names must answer with the name the ring goes by, but it didnt",
+            new Ends(this.pairs("b", "c", "c", "a", "a", "b")).name("c"),
+            Matchers.equalTo("a")
+        );
+    }
+
+    @Test
+    void keepsANameTheTableSaysNothingAbout() {
+        MatcherAssert.assertThat(
+            "a name that is a copy of nothing must come back as it went in, but it didnt",
+            new Ends(this.pairs("a", "b")).name("z"),
+            Matchers.equalTo("z")
+        );
+    }
+
     private Map<String, String> pairs(final String... flat) {
         final Map<String, String> pairs = new LinkedHashMap<>(flat.length / 2);
         for (int idx = 0; idx < flat.length; idx = idx + 2) {

--- a/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
@@ -77,4 +77,31 @@ final class FilledTest {
             Matchers.equalTo("Φ.result")
         );
     }
+
+    @Test
+    void namesAFillingOnARingTheWayTheRestOfThePassNamesIt() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("form", List.of(Map.of("void", "true", "type", "Φ.node.x")));
+        final Map<String, String> pairs = new HashMap<>(0);
+        pairs.put("app", "form");
+        pairs.put("zebra", "alpha");
+        pairs.put("alpha", "zebra");
+        final Provided owned = new Provided(
+            rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+        );
+        MatcherAssert.assertThat(
+            "a filling that sits on a ring must come back under the name the ring goes by, but it didnt",
+            new Filled(
+                pairs,
+                owned,
+                new Bound(
+                    Map.of("app", List.of("zebra")),
+                    Collections.emptyMap(), Collections.emptyMap(),
+                    pairs, owned
+                ).all(),
+                Collections.emptyList()
+            ).instead("Φ.node.x", "app"),
+            Matchers.equalTo("alpha")
+        );
+    }
 }


### PR DESCRIPTION
`Ends` follows a chain of copies to its end, and where the chain closes into a ring it settles the whole ring on one of its names — the first in alphabetical order — so that every way in agrees. `Bound.base` and `Filled.end` followed the same chain themselves, in the same six lines as each other, without that last part:

```java
private String base(final String name) {
    final Collection<String> seen = new HashSet<>(0);
    String walked = name;
    while (this.pairs.containsKey(walked) && seen.add(walked)) {
        walked = this.pairs.get(walked);
    }
    return walked;
}
```

On a ring that loop stops at the first name it meets a second time, which is whichever name the walk started from. One object then went by two names inside a single pass: `alpha` everywhere `Ends` was asked, `zebra` in these two. `Filled` passes its answer on to the fillings that end up in `links.xml`, and `Bound` reads the voids of a formation off it.

`Ends` now answers for a single name as well as for all of them, and `names()` is that method in a loop. The two hand-written walks call it and are gone.

`Bound.taken` walks the same pairs a third time, but it wants the whole path rather than its end, so it does not fold onto `Ends` and stays where it is. It has a ring problem of its own — the chain comes back round to the application itself, so the voids that very application is about to fill are counted as filled already — and a puzzle now says so.

Nothing moves on `eo-runtime`. Its links table holds 39,626 pairs and not one ring, which is why the disagreement never showed up as a wrong answer there.

Closes #8424
