### PR TITLE
#8319: let a text literal stand as the receiver of a step

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
@@ -73,15 +73,6 @@ import java.util.Optional;
  * not a failure.</p>
  *
  * @since 0.76.0
- * @todo #8308:30min Let a string literal stand as the receiver of a step.
- *  A record shows its receiver as the instance the atom fired on, and a
- *  string has already dispatched into its own bytes by then, so the
- *  shape names a bytes datum while the tree still holds a string one,
- *  the two never match, and {@code "abc".concat b} refuses where
- *  {@code b.concat "abc"} reduces. Teach {@link Shape} that a bytes
- *  receiver covers a string one carrying the same datum — the two
- *  compute the same value for every atom of the {@link Universe}, since
- *  the only method a string answers differently is shadowed there.
  */
 public final class Reduction {
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/Shape.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Shape.java
@@ -19,6 +19,14 @@ import java.util.stream.Collectors;
  * name the record shows, or the {@code α}-positional name the XMIR
  * wrote.</p>
  *
+ * <p>A bytes receiver covers a string one carrying the same datum. A
+ * record shows its receiver as the instance the atom fired on, and a
+ * string has dispatched into its own bytes by then, so the record names
+ * a bytes datum where the tree still holds a string one and the texts
+ * would never meet themselves. The two compute the same value for every
+ * atom of the {@link Universe}, since the one method a string answers
+ * differently, {@code slice}, is shadowed there and parks.</p>
+ *
  * @since 0.76.0
  */
 public final class Shape {
@@ -84,7 +92,7 @@ public final class Shape {
     public boolean covers(final String verb, final String self, final List<Binding> args) {
         boolean good = this.method.equals(verb)
             && !self.isEmpty()
-            && this.receiver.equals(self)
+            && (this.receiver.equals(self) || this.receiver.equals(Shape.bytewise(self)))
             && this.names.size() == args.size();
         for (int idx = 0; good && idx < args.size(); ++idx) {
             final Binding arg = args.get(idx);
@@ -95,6 +103,16 @@ public final class Shape {
                 && (expected.isEmpty() || expected.equals(Shape.identity(arg.value())));
         }
         return good;
+    }
+
+    private static String bytewise(final String self) {
+        final String out;
+        if (self.startsWith("string:")) {
+            out = String.format("bytes:%s", self.substring("string:".length()));
+        } else {
+            out = self;
+        }
+        return out;
     }
 
     private static String identity(final Term term) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Shape.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Shape.java
@@ -91,8 +91,7 @@ public final class Shape {
      */
     public boolean covers(final String verb, final String self, final List<Binding> args) {
         boolean good = this.method.equals(verb)
-            && !self.isEmpty()
-            && (this.receiver.equals(self) || this.receiver.equals(Shape.bytewise(self)))
+            && this.same(self)
             && this.names.size() == args.size();
         for (int idx = 0; good && idx < args.size(); ++idx) {
             final Binding arg = args.get(idx);
@@ -103,6 +102,11 @@ public final class Shape {
                 && (expected.isEmpty() || expected.equals(Shape.identity(arg.value())));
         }
         return good;
+    }
+
+    private boolean same(final String self) {
+        return !self.isEmpty()
+            && (this.receiver.equals(self) || this.receiver.equals(Shape.bytewise(self)));
     }
 
     private static String bytewise(final String self) {

--- a/eo-lowering/src/test/java/org/eolang/lowering/ShapeTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ShapeTest.java
@@ -54,6 +54,46 @@ final class ShapeTest {
     }
 
     @Test
+    void coversTextReceiverRecordedAsBytes() {
+        MatcherAssert.assertThat(
+            "a bytes receiver must cover the string of the same datum, but it doesnt",
+            new Shape(
+                "concat",
+                "bytes:68-",
+                Collections.singletonList("b"),
+                Collections.singletonList("sym:v0")
+            ).covers(
+                "concat",
+                "string:68-",
+                Collections.singletonList(
+                    new Binding("α0", new Symbol("v0", "bytes"))
+                )
+            ),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void rejectsTextReceiverOfAnotherDatum() {
+        MatcherAssert.assertThat(
+            "a string of another datum must stay uncovered, but it doesnt",
+            new Shape(
+                "concat",
+                "bytes:68-",
+                Collections.singletonList("b"),
+                Collections.singletonList("sym:v0")
+            ).covers(
+                "concat",
+                "string:69-",
+                Collections.singletonList(
+                    new Binding("α0", new Symbol("v0", "bytes"))
+                )
+            ),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
     void coversAnyArgumentWhereBlank() {
         MatcherAssert.assertThat(
             "a blank identity must let any argument through, but it doesnt",

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/text-receiver.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/text-receiver.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A text literal stands as the receiver of a byte atom, not as its
+# operand. The string has dispatched into its own bytes by the time the
+# atom fires, so the record names a bytes datum where the tree still
+# holds a string one, and the site is met all the same.
+input: |
+  [] > foo
+    [t] > greets
+      "h".concat t > @
+    greets "i" > @
+prelude:
+  string.eo: |
+    [as-bytes] > string
+      as-bytes > @
+  bytes.eo: |
+    [data] > bytes
+      data > @
+unit: greets
+voids:
+  t: string
+lowered: |
+  [] > foo
+    greets "i" > @
+    [] > greets /Q.bytes
+      ? > t /Q.string
+protocol: |
+  s1 ← L_bytes_concat bytes:68- sym:v0
+  answer sym:s1 bytes


### PR DESCRIPTION
Closes #8319. Resolves the `8308-100dc517` puzzle in `Reduction.java`.

A record shows its receiver as the instance the atom fired on, and a string has
dispatched into its own bytes by the time a bytes atom fires. So the shape named
`bytes:68-` where the tree still held `string:68-`, the two never met, and
`"h".concat t` refused where `t.concat "h"` reduced.

`Shape.covers` now reads a bytes receiver as covering a string one carrying the
same datum. That is sound for every atom of the `Universe`: the one method a
string answers differently is `slice`, which counts characters where the bytes
one counts bytes, and it is already shadowed there behind `L_string_slice`,
which no row of `ops.tsv` knows — so a string slice parks rather than folding,
and never reaches this comparison. The relaxation is one-way, and only on the
receiver: a string datum does not cover a bytes one, and the arguments still
match exactly.

## Verified

Reproduced first. The new `text-receiver` pack, against `master`, leaves the
formation as written:

```
Expected: "[] > foo\n  greets \"i\" > @\n  [] > greets /Q.bytes\n    ? > t /Q.string"
     but: was "[] > foo\n  greets \"i\" > @\n  \"h\".concat t > [t] > greets"
```

With the fix it lowers, and the pack pins the protocol it lowers into:

```
s1 ← L_bytes_concat bytes:68- sym:v0
answer sym:s1 bytes
```

`LoweringTest`: `Tests run: 160, Failures: 0, Errors: 0` — the new pack plus
every existing one, run against a real `phino 0.0.115`, so the packs are not
being skipped. `eo-lowering` in full: `Tests run: 242, Failures: 0, Errors: 0`,
including two new `ShapeTest` cases — one that the datum has to agree, one that
it covers when it does. Qulice clean on `eo-lowering`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JnAM3hYZqXYYKA2MZ8iVw2


---
_Generated by [Claude Code](https://claude.ai/code/session_01JnAM3hYZqXYYKA2MZ8iVw2)_