### PR TITLE
#8397: name the conversion failure in Cstring

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Cstring.java
+++ b/eo-runtime/src/main/java/org/eolang/Cstring.java
@@ -46,6 +46,7 @@ public final class Cstring {
     public String it() {
         return this.expect
             .that(phi -> new Dataized(phi).asString())
+            .otherwise("must be a text")
             .must(text -> text.indexOf('\0') < 0)
             .otherwise("must not contain the NUL character, since a C string ends there")
             .it();

--- a/eo-runtime/src/test/java/org/eolang/CstringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CstringTest.java
@@ -27,6 +27,24 @@ final class CstringTest {
     }
 
     @Test
+    void namesTheConversionFailure() {
+        MatcherAssert.assertThat(
+            "an argument that is not a text must be named as such, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Cstring(
+                    new Expect<>("the 'name' argument", () -> new PhTerminator("boom"))
+                ).it(),
+                "a non-text argument was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("the 'name' argument must be a text"),
+                Matchers.not(Matchers.containsString("NUL"))
+            )
+        );
+    }
+
+    @Test
     void refusesTextWithNul() {
         MatcherAssert.assertThat(
             "text carrying a NUL must be refused by name, but it wasnt",


### PR DESCRIPTION
`Cstring` had no `otherwise` after its `that`, so `Expect` carried the failure of the
conversion into the next message in the chain and every argument that is not a text was
announced as a NUL problem. `Natural`, `Int` and `Numeric` all put the message right after
the conversion; this does the same with `must be a text`.

The wording only exists on the Java side and EO has no way to read the message of a
failure, so the test is a JUnit one.

Closes #8397
