### PR TITLE
feat(lowering): #8410 hold a tuple as the object it is

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.lowering;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -21,7 +22,11 @@ import java.util.Optional;
  * bytes themselves. A const is such a view: the parser turns {@code x!}
  * into {@code (dataized x).as-bytes}, and forcing is already what a
  * protocol does, since every step of it is a Java local computed once,
- * in order, so the view is all that is left of the wrapper.</p>
+ * in order, so the view is all that is left of the wrapper. Over an
+ * object that is no datum — an element a tuple answers — {@code as-bytes}
+ * is not a view but the one operation such an object takes, its
+ * dataization, so there the term stands unsettled like a site until the
+ * atom of the universe parks on it and a step takes its place.</p>
  *
  * @since 0.76.0
  * @todo #8407:30min Let a fragment answer the bytes of a number. The view
@@ -62,10 +67,12 @@ public final class Forced implements Term {
     public String key() {
         final String key = this.inner.key();
         final String out;
-        if (key.isEmpty() || key.startsWith("sym:")) {
+        if (this.viewed() && key.startsWith("sym:")) {
             out = key;
-        } else {
+        } else if (this.viewed()) {
             out = String.format("bytes:%s", key.split(":", 2)[1]);
+        } else {
+            out = "";
         }
         return out;
     }
@@ -73,22 +80,28 @@ public final class Forced implements Term {
     @Override
     public String forma() {
         final String out;
-        if (this.inner.key().isEmpty()) {
-            out = "";
-        } else {
+        if (this.viewed()) {
             out = "bytes";
+        } else {
+            out = "";
         }
         return out;
     }
 
     @Override
     public boolean matches(final Shape shape) {
-        return this.inner.matches(shape);
+        return this.covered(shape) || this.inner.matches(shape);
     }
 
     @Override
     public Optional<List<Binding>> arguments(final Shape shape) {
-        return this.inner.arguments(shape);
+        final Optional<List<Binding>> out;
+        if (this.covered(shape)) {
+            out = Optional.of(Collections.emptyList());
+        } else {
+            out = this.inner.arguments(shape);
+        }
+        return out;
     }
 
     @Override
@@ -98,6 +111,25 @@ public final class Forced implements Term {
 
     @Override
     public Term swapped(final Shape shape, final Term swap) {
-        return new Forced(this.inner.swapped(shape, swap));
+        final Term out;
+        if (this.covered(shape)) {
+            out = swap;
+        } else {
+            out = new Forced(this.inner.swapped(shape, swap));
+        }
+        return out;
+    }
+
+    private boolean viewed() {
+        return Forced.datum(this.inner.forma());
+    }
+
+    private boolean covered(final Shape shape) {
+        return shape.covers("as-bytes", this.inner.key(), Collections.emptyList());
+    }
+
+    private static boolean datum(final String forma) {
+        return "number".equals(forma) || "string".equals(forma)
+            || "bool".equals(forma) || "bytes".equals(forma);
     }
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Formas.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Formas.java
@@ -194,6 +194,8 @@ public final class Formas {
         out.put("Φ.bytes", "bytes");
         out.put("Φ.true", "bool");
         out.put("Φ.false", "bool");
+        out.put("Φ.tuple", "tuple");
+        out.put("Φ.tuple.empty", "tuple");
         return out;
     }
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -89,9 +89,17 @@ public final class JavaAtom {
      * @return Java statements, one per line, without a trailing newline
      */
     public String text() {
-        if ("string".equals(this.program.carrier())) {
+        final String carrier = this.program.carrier();
+        if ("string".equals(carrier)) {
             throw new IllegalStateException(
                 "A string answer cannot be handed over, since Data.ToPhi makes bytes of a byte array"
+            );
+        }
+        if ("tuple".equals(carrier) || "object".equals(carrier)) {
+            throw new IllegalStateException(
+                String.format(
+                    "A %s answer cannot be handed over, since Data.ToPhi takes data alone", carrier
+                )
             );
         }
         final Protocol first = this.program.bodies().get(0).protocol();

--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -23,8 +23,10 @@ import org.w3c.dom.Element;
  * <p>A formation qualifies when it is a named direct attribute of a
  * top-level object, its body is voids plus one {@code φ} plus helpers
  * nothing outside can name, and every void is witnessed in the tables
- * of {@code eo:inference} as a number, a string or bytes, so a symbolic
- * carrier can stand for it. A helper is an attribute the source
+ * of {@code eo:inference} as a number, a string, bytes or a bool, so a
+ * symbolic carrier can stand for it, or as a tuple, which the atom holds
+ * as the object itself and asks its length and its elements of by
+ * dispatching back into EO. A helper is an attribute the source
  * privatized with {@code >>}, or a const the parser wrapped, and it
  * shows up under a synthetic {@code a🌵} name: the body reads it in
  * place, applying it to its arguments when it is a formation of its

--- a/eo-lowering/src/main/java/org/eolang/lowering/Op.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Op.java
@@ -59,7 +59,8 @@ public final class Op {
 
     /**
      * The forma of the receiver.
-     * @return Either {@code number} or {@code bytes}
+     * @return One of {@code number}, {@code string}, {@code bytes},
+     *  {@code bool}, {@code tuple} or {@code object}
      */
     public String carrier() {
         return this.row()[2];
@@ -103,6 +104,36 @@ public final class Op {
      * @return The names, such as {@code start} and {@code len}
      */
     public List<String> args() {
+        return this.columns().stream()
+            .map(cell -> cell.split(":", 2)[0])
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * The formas of the arguments, in their positional order. An argument
+     * carries the forma of the receiver unless its cell says otherwise,
+     * as {@code i:number} does for the index of a tuple.
+     * @return The formas, one per argument
+     */
+    public List<String> formas() {
+        final String carrier = this.carrier();
+        return this.columns().stream()
+            .map(cell -> Op.forma(cell, carrier))
+            .collect(Collectors.toList());
+    }
+
+    private static String forma(final String cell, final String carrier) {
+        final String[] parts = cell.split(":", 2);
+        final String out;
+        if (parts.length > 1) {
+            out = parts[1];
+        } else {
+            out = carrier;
+        }
+        return out;
+    }
+
+    private List<String> columns() {
         final String[] row = this.row();
         final List<String> out;
         if (row.length > 4 && !row[4].isEmpty()) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -20,7 +20,9 @@ import java.util.stream.Stream;
  * encode, a bool is {@code true} or {@code false}, and bytes or a string
  * are a byte array. Every forma has one Java type, with a string carried
  * as bytes, since its Δ is the very UTF-8 sequence the byte atoms it
- * reaches through {@code φ} operate on. The value of an application
+ * reaches through {@code φ} operate on, and a tuple or an object it
+ * answers carried as the {@code Phi} itself, since neither is a datum
+ * and every operation on either dispatches back into EO. The value of an application
  * comes from the format the {@link Op} table holds for its atom, except
  * an equality, which compares by the forma of its operands; and a void
  * is read through the public runtime API. The forma of a key is looked
@@ -89,6 +91,8 @@ public final class Rendering {
             out = String.format(
                 "byte[] v%d = new Dataized(this.take(\"%s\")).take();", index, name
             );
+        } else if ("tuple".equals(forma)) {
+            out = String.format("Phi v%d = this.take(\"%s\");", index, name);
         } else {
             throw new IllegalStateException(
                 String.format("The void '%s' of forma '%s' cannot be read in Java", name, forma)
@@ -110,6 +114,8 @@ public final class Rendering {
             out = String.format("double v%d = 0.0;", index);
         } else if ("boolean".equals(type)) {
             out = String.format("boolean v%d = false;", index);
+        } else if ("Phi".equals(type)) {
+            out = String.format("Phi v%d = Phi.Φ;", index);
         } else {
             out = String.format("byte[] v%d = new byte[0];", index);
         }
@@ -128,12 +134,16 @@ public final class Rendering {
             out = this.compared(step);
         } else {
             final String format = operation.java();
-            for (final String key : step.keys()) {
-                if (!operation.carrier().equals(this.forma(key))) {
+            final List<String> expected = new ArrayList<>(step.keys().size());
+            expected.add(operation.carrier());
+            expected.addAll(operation.formas());
+            for (int idx = 0; idx < step.keys().size(); ++idx) {
+                final String key = step.keys().get(idx);
+                if (!expected.get(idx).equals(this.forma(key))) {
                     throw new IllegalStateException(
                         String.format(
                             "The operand '%s' of '%s' does not carry a %s",
-                            key, step.atom(), operation.carrier()
+                            key, step.atom(), expected.get(idx)
                         )
                     );
                 }
@@ -242,6 +252,8 @@ public final class Rendering {
             out = "boolean";
         } else if ("bytes".equals(carrier)) {
             out = "byte[]";
+        } else if ("tuple".equals(carrier) || "object".equals(carrier)) {
+            out = "Phi";
         } else {
             throw new IllegalStateException(
                 String.format("The value '%s' has no Java type to carry it", what)

--- a/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
@@ -51,8 +51,9 @@ public final class Symbol implements Term {
             out = String.format(
                 "Φ.%s(α0 ↦ Φ.bytes(α0 ↦ ⟦ λ ⤍ Sym_%s ⟧))", this.forma, this.name
             );
-        } else if ("bytes".equals(this.forma)) {
-            out = String.format("Φ.bytes(α0 ↦ ⟦ λ ⤍ Sym_%s ⟧)", this.name);
+        } else if ("bytes".equals(this.forma) || "tuple".equals(this.forma)
+            || "object".equals(this.forma)) {
+            out = String.format("Φ.%s(α0 ↦ ⟦ λ ⤍ Sym_%s ⟧)", this.forma, this.name);
         } else {
             throw new IllegalStateException(
                 String.format(

--- a/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
@@ -11,3 +11,6 @@ L_bytes_eq	eq	bytes	bool	b
 L_bytes_right	right	bytes	bytes	x
 L_bytes_size	size	bytes	number		%1$s.length
 L_bytes_slice	slice	bytes	bytes	start,len
+L_tuple_length	length	tuple	number		new Dataized(%1$s.take("length")).asNumber()
+L_tuple_at	at	tuple	object	i:number	new PhWith(new PhCopy(new PhMethod(%1$s, "at")), 0, new Data.ToPhi(%2$s))
+L_object_as_bytes	as-bytes	object	bytes		new Dataized(%1$s).take()

--- a/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
@@ -29,6 +29,15 @@
     φ ↦ ξ.as-bytes,
     if ↦ ⟦ t ↦ ∅, f ↦ ∅, λ ⤍ L_bool_if ⟧
   ⟧,
+  tuple ↦ ⟦
+    self ↦ ∅,
+    length ↦ ⟦ λ ⤍ L_tuple_length ⟧,
+    at ↦ ⟦ i ↦ ∅, λ ⤍ L_tuple_at ⟧
+  ⟧,
+  object ↦ ⟦
+    self ↦ ∅,
+    as-bytes ↦ ⟦ λ ⤍ L_object_as_bytes ⟧
+  ⟧,
   true ↦ Φ.bool(α0 ↦ Φ.bytes(α0 ↦ ⟦ Δ ⤍ FF- ⟧)),
   false ↦ Φ.bool(α0 ↦ Φ.bytes(α0 ↦ ⟦ Δ ⤍ 00- ⟧))
 ⟧

--- a/eo-lowering/src/test/java/org/eolang/lowering/ForcedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ForcedTest.java
@@ -70,6 +70,38 @@ final class ForcedTest {
     }
 
     @Test
+    void waitsForTheAtomOverAnObject() {
+        MatcherAssert.assertThat(
+            "the bytes of an object are no view and must stay unsettled, but they didnt",
+            new Forced(new Symbol("s1", "object")).key(),
+            Matchers.equalTo("")
+        );
+    }
+
+    @Test
+    void matchesDataizationOfAnObject() {
+        MatcherAssert.assertThat(
+            "the dataization of an object must match the as-bytes record, but it doesnt",
+            new Forced(new Symbol("s1", "object")).matches(
+                new Shape("as-bytes", "sym:s1", Collections.emptyList())
+            ),
+            Matchers.is(true)
+        );
+    }
+
+    @Test
+    void givesWayToTheStepOfDataization() {
+        MatcherAssert.assertThat(
+            "the dataization of an object must become the step that parked on it, but it didnt",
+            new Forced(new Symbol("s1", "object")).swapped(
+                new Shape("as-bytes", "sym:s1", Collections.emptyList()),
+                new Symbol("s2", "bytes")
+            ).key(),
+            Matchers.equalTo("sym:s2")
+        );
+    }
+
+    @Test
     void swapsInsideTheView() {
         MatcherAssert.assertThat(
             "the view must follow the site it wraps into its step, but it doesnt",

--- a/eo-lowering/src/test/java/org/eolang/lowering/FormasTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/FormasTest.java
@@ -125,6 +125,22 @@ final class FormasTest {
     }
 
     @Test
+    void witnessesTupleVoid(@Mktmp final Path temp) throws IOException {
+        Files.write(
+            temp.resolve("provides.xml"),
+            String.format(
+                "<provides><type id=\"Φ.foo.calc\">%s</type></provides>",
+                "<attr name=\"items\" void=\"true\"> <witnessed><ref loc=\"Φ.tuple\"/></witnessed> </attr>"
+            ).getBytes(StandardCharsets.UTF_8)
+        );
+        MatcherAssert.assertThat(
+            "a void filled only with tuples must be witnessed as one, but it wasnt",
+            new Formas(temp).given("Φ.foo.calc.items"),
+            Matchers.equalTo("tuple")
+        );
+    }
+
+    @Test
     void witnessesStringVoid(@Mktmp final Path temp) throws IOException {
         Files.write(
             temp.resolve("provides.xml"),

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -26,6 +26,46 @@ import org.junit.jupiter.api.Test;
 final class JavaAtomTest {
 
     @Test
+    void holdsTupleAndReadsItsLength() {
+        MatcherAssert.assertThat(
+            "a tuple void must be held as a Phi and its length dataized, but it isnt",
+            new JavaAtom(
+                new Protocol(
+                    Arrays.asList(
+                        new Application(
+                            "s1", "L_tuple_length", Collections.singletonList("sym:v0")
+                        ),
+                        new Application(
+                            "s2", "L_number_plus",
+                            Arrays.asList("sym:s1", "number:3F-F0-00-00-00-00-00-00")
+                        )
+                    ),
+                    "sym:s2", "number"
+                ),
+                Collections.singletonMap("items", "tuple")
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "final Phi v0 = this.take(\"items\");",
+                "final double s1 = new Dataized(v0.take(\"length\")).asNumber();",
+                "final double s2 = s1 + Double.longBitsToDouble(0x3FF0000000000000L);",
+                "return new Data.ToPhi(s2);"
+            )
+        );
+    }
+
+    @Test
+    void refusesTupleAnswer() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new JavaAtom(
+                new Protocol(Collections.emptyList(), "sym:v0", "tuple"),
+                Collections.singletonMap("items", "tuple")
+            )::text,
+            "a tuple cannot be handed to Data.ToPhi, but it was rendered"
+        );
+    }
+
+    @Test
     void rendersBodiesAsStateMachine() {
         MatcherAssert.assertThat(
             "bodies resuming one another must run as one loop over a state, but they dont",

--- a/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
@@ -52,6 +52,33 @@ final class OpTest {
     }
 
     @Test
+    void namesFormaOfIndexArgument() {
+        MatcherAssert.assertThat(
+            "the index of a tuple must carry a number where the tuple carries none, but it doesnt",
+            new Op("L_tuple_at").formas(),
+            Matchers.contains("number")
+        );
+    }
+
+    @Test
+    void namesArgumentWithoutItsForma() {
+        MatcherAssert.assertThat(
+            "the forma of an argument must not leak into its name, but it did",
+            new Op("L_tuple_at").args(),
+            Matchers.contains("i")
+        );
+    }
+
+    @Test
+    void carriesArgumentsAsTheReceiverByDefault() {
+        MatcherAssert.assertThat(
+            "an argument without a forma of its own must carry the receiver's, but it doesnt",
+            new Op("L_number_plus").formas(),
+            Matchers.contains("number")
+        );
+    }
+
+    @Test
     void namesNoFormaOfChoice() {
         MatcherAssert.assertThat(
             "a choice answers whatever its arms answer, so it must name no forma, but it does",

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
@@ -11,6 +11,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -190,6 +191,55 @@ final class ReductionTest {
                 "a fragment answering the bytes of a number reduced, but it must not"
             ).getMessage(),
             Matchers.containsString("carries a number")
+        );
+    }
+
+    @Test
+    void readsLengthOfTuple(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "the length of a symbolic tuple must become a step, but it doesnt",
+            new Reduction(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='ξ.items.length.plus'>",
+                        ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00"),
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("items", "tuple"),
+                8
+            ).protocol().moves().get(0).atom(),
+            Matchers.equalTo("L_tuple_length")
+        );
+    }
+
+    @Test
+    void dataizesElementOfTuple(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "an element of a tuple must be taken and dataized in two steps, but it isnt",
+            new Reduction(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='.eq'>",
+                        "<o base='.as-bytes'><o base='ξ.items.at'>",
+                        ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00"),
+                        "</o></o>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>01-02</o></o>",
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("items", "tuple"),
+                8
+            ).protocol().moves().stream().map(Step::atom).collect(Collectors.toList()),
+            Matchers.contains("L_tuple_at", "L_object_as_bytes", "L_bytes_eq")
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
@@ -84,6 +84,64 @@ final class RenderingTest {
     }
 
     @Test
+    void readsTupleVoidAsPhi() {
+        MatcherAssert.assertThat(
+            "a tuple void must be held as the Phi itself, but it isnt",
+            new Rendering(
+                new Protocol(Collections.emptyList(), "sym:v0", "tuple"),
+                Collections.singletonMap("items", "tuple")
+            ).reading(0),
+            Matchers.equalTo("Phi v0 = this.take(\"items\");")
+        );
+    }
+
+    @Test
+    void typesObjectAsPhi() {
+        MatcherAssert.assertThat(
+            "an object a tuple answers must be typed as Phi, but it isnt",
+            new Rendering(
+                new Protocol(
+                    Collections.singletonList(
+                        new Application(
+                            "s1", "L_tuple_at",
+                            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+                        )
+                    ),
+                    "sym:s1", "object"
+                ),
+                Collections.singletonMap("items", "tuple")
+            ).type("sym:s1"),
+            Matchers.equalTo("Phi")
+        );
+    }
+
+    @Test
+    void dispatchesIntoTheTupleForItsElement() {
+        MatcherAssert.assertThat(
+            "the element of a tuple must be taken through the at attribute, but it isnt",
+            new Rendering(
+                new Protocol(
+                    Collections.singletonList(
+                        new Application(
+                            "s1", "L_tuple_at",
+                            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+                        )
+                    ),
+                    "sym:s1", "object"
+                ),
+                Collections.singletonMap("items", "tuple")
+            ).applied(
+                new Application(
+                    "s1", "L_tuple_at", Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+                )
+            ),
+            Matchers.equalTo(
+                "new PhWith(new PhCopy(new PhMethod(v0, \"at\")), 0, new Data.ToPhi(Double.longBitsToDouble(0x3FF0000000000000L)))"
+            )
+        );
+    }
+
+    @Test
     void refusesOperandOfForeignForma() {
         Assertions.assertThrows(
             IllegalStateException.class,

--- a/eo-lowering/src/test/java/org/eolang/lowering/SymbolTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/SymbolTest.java
@@ -34,6 +34,15 @@ final class SymbolTest {
     }
 
     @Test
+    void rendersTupleAsMarkedCarrier() {
+        MatcherAssert.assertThat(
+            "a symbolic tuple must be the tuple carrier around its marker, but it isnt",
+            new Symbol("v0", "tuple").phi(),
+            Matchers.equalTo("Φ.tuple(α0 ↦ ⟦ λ ⤍ Sym_v0 ⟧)")
+        );
+    }
+
+    @Test
     void namesKey() {
         MatcherAssert.assertThat(
             "the key must carry the name of the symbol, but it doesnt",
@@ -55,8 +64,8 @@ final class SymbolTest {
     void refusesUnmodelledCarrier() {
         Assertions.assertThrows(
             IllegalStateException.class,
-            new Symbol("s2", "tuple")::phi,
-            "a tuple has no symbolic carrier to render, but one rendered"
+            new Symbol("s2", "file")::phi,
+            "a file has no symbolic carrier to render, but one rendered"
         );
     }
 }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/tuple-element.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/tuple-element.yaml
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# An element a tuple answers is an object of no known forma, so the atom
+# takes it through `at` as the Phi it is, without dataizing it, and only
+# the `as-bytes` the body asks of it dataizes it, into the bytes every
+# object has. The comparison then runs over those bytes in Java.
+input: |
+  [] > foo
+    [items] > second
+      (items.at 1).as-bytes.eq 40-00-00-00-00-00-00-00 > @
+    second (* 1 2 3) > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  tuple.eo: |
+    [tail head length] > tuple
+      [] > empty
+        0 > length
+unit: second
+voids:
+  items: tuple
+lowered: |
+  [] > foo
+    second * > @
+      1
+      2
+      3
+    [] > second /Q.bool
+      ? > items /Q.tuple
+protocol: |
+  s1 ← L_tuple_at sym:v0 number:3F-F0-00-00-00-00-00-00
+  s2 ← L_object_as_bytes sym:s1
+  s3 ← L_bytes_eq sym:s2 bytes:40-00-00-00-00-00-00-00
+  answer sym:s3 bool
+java: |
+  final Phi v0 = this.take("items");
+  final Phi s1 = new PhWith(new PhCopy(new PhMethod(v0, "at")), 0, new Data.ToPhi(Double.longBitsToDouble(0x3FF0000000000000L)));
+  final byte[] s2 = new Dataized(s1).take();
+  final boolean s3 = java.util.Arrays.equals(s2, new byte[] {(byte) 0x40, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00});
+  return new Data.ToPhi(s3);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/tuple-length.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/tuple-length.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void witnessed as a tuple is no datum, so the atom holds the argument
+# object itself, and the one thing the body asks of it, its length, is a
+# step that dispatches back into EO and dataizes what the tuple answers.
+input: |
+  [] > foo
+    [items] > count
+      items.length.plus 1 > @
+    count (* 7 8 9) > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+  tuple.eo: |
+    [tail head length] > tuple
+      [] > empty
+        0 > length
+unit: count
+voids:
+  items: tuple
+lowered: |
+  [] > foo
+    count * > @
+      7
+      8
+      9
+    [] > count /Q.number
+      ? > items /Q.tuple
+protocol: |
+  s1 ← L_tuple_length sym:v0
+  s2 ← L_number_plus sym:s1 number:3F-F0-00-00-00-00-00-00
+  answer sym:s2 number
+java: |
+  final Phi v0 = this.take("items");
+  final double s1 = new Dataized(v0.take("length")).asNumber();
+  final double s2 = s1 + Double.longBitsToDouble(0x3FF0000000000000L);
+  return new Data.ToPhi(s2);


### PR DESCRIPTION
Closes #8410.

A formation over a tuple was refused at the first gate of the pass, before any reduction was tried: the tables of `eo:inference` witness such a void as `Φ.tuple`, and `Formas` had no carrier for that forma. A tuple is no datum, so no bytes can carry it, and there is no Java operation behind `at` or `length`. The one representation that works is the one the issue names: a symbolic tuple stands for the argument object itself, a `Phi` the atom holds, and `at` and `length` are steps that dispatch back into EO.

## What changed

**Universe, ops.** `tuple` binds `length` and `at`, `object` binds `as-bytes`, and `ops.tsv` renders the three: the length dataizes the attribute (`new Dataized(v0.take("length")).asNumber()`), the element is taken through `at` as the `Phi` it is, without dataizing it (`new PhWith(new PhCopy(new PhMethod(v0, "at")), 0, new Data.ToPhi(i))`), and `as-bytes` on an object is its dataization (`new Dataized(s1).take()`). Phino cannot fire any of them, so it records each as parked, with the whole formation as receiver — and `Evaluation` already reads the identity of such a receiver as the first marker inside `ρ`, which is the symbolic carrier, so the existing anchoring matches the records to the sites with no new path.

**Formas, Symbol.** `Φ.tuple` and `Φ.tuple.empty` witness a void as a `tuple`, which is what the provides table already holds for `printf`'s `args`. A symbolic tuple or object renders as its carrier around the marker, `Φ.tuple(α0 ↦ ⟦ λ ⤍ Sym_v0 ⟧)`.

**Forced.** An element a tuple answers is an object of no known forma, so `as-bytes` on it is not a view but the one operation such an object takes. `Forced` is now a view only over data; over an object it stands unsettled like a site, matches the `as-bytes` record on its inner key, and gives way to the step.

**Op, Rendering, JavaAtom.** An argument may carry a forma of its own in the table, as `i:number` does for the index of a tuple, and `Rendering` checks each operand against its own forma instead of the receiver's. A tuple or an object is typed `Phi`, a tuple void is held as it is taken, and a blank one is `Phi.Φ`. An answer that is no datum is refused, since `Data.ToPhi` takes data alone.

## What this does not do yet

The element's forma is not read from the tables: the issue points at `Φ.string.printf.args.at` as its locator, but the tables carry no row for it, in `printf` or anywhere, so an element is an object until dataized. That is the general dispatch step of #8412: an attribute of an object whose forma the tables witness, rendered as a call back into EO. Here the dataization is the one dispatch every object takes.

## Packs

- `tuple-length`: a formation over a tuple void lowers into an atom that holds the `Phi` and dataizes its length.
- `tuple-element`: an element is taken through `at`, dataized through `as-bytes`, and compared as bytes.

## Verified

- `eo-lowering`: 255 tests pass, qulice clean, simian clean; `eo-maven-plugin`: all 172 lowering pack checks pass, two of them new, and the Java of both tuple packs is what they show.
- `eo-runtime` re-lowered end to end with phino 0.0.115 and compiled: still 144 fragments. Five formations over a tuple void reach the reduction now, where witnessing refused them before: `printf` and `string.joined` stop at a `string` built from bytes, which the reduction reads as a malformed literal; `string.contains-all` and `string.contains-any` at a partial application of a helper; `tuple.eq` at reading the tuple's own length through `^`. So `printf` is one gate further along, and the next ones are the `Φ.string` construction and the terminal of #8411.

## Notes

- **pr-size** is over the cap, as the previous lowering PRs were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_