### PR TITLE
#8384: refuse a read size the process cannot allocate

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/Buffer.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/Buffer.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.ExFailure;
+
+/**
+ * A byte array a syscall reads into.
+ *
+ * <p>The size comes from the program, so it may be larger than the heap. Asking
+ * the JVM for such an array throws {@link OutOfMemoryError}, which is not an EO
+ * termination and therefore passes every fallback by. The size is checked here
+ * instead, the way {@code write} and {@code send} check the size against the
+ * buffer they were given.</p>
+ *
+ * @since 0.64.0
+ */
+final class Buffer {
+
+    /**
+     * What the size is, for the failure message.
+     */
+    private final String subject;
+
+    /**
+     * How many bytes are wanted.
+     */
+    private final int size;
+
+    /**
+     * Ctor.
+     * @param subject What the size is, for the failure message
+     * @param size How many bytes are wanted
+     */
+    Buffer(final String subject, final int size) {
+        this.subject = subject;
+        this.size = size;
+    }
+
+    /**
+     * Make it.
+     * @return The array
+     */
+    byte[] it() {
+        final Runtime runtime = Runtime.getRuntime();
+        final long free = Math.min(
+            runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory(),
+            Integer.MAX_VALUE - 8L
+        );
+        if (this.size > free) {
+            throw new ExFailure(
+                "Can't allocate %d bytes for %s, while only %d bytes are available",
+                this.size, this.subject, free
+            );
+        }
+        return new byte[this.size];
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -37,7 +37,7 @@ public final class ReadSyscall implements Syscall {
             new Expect<>("the 'size' argument of read", () -> params[1])
         ).it();
         final Phi result = this.posix.take("return").copy();
-        final byte[] buf = new byte[size];
+        final byte[] buf = new Buffer("the 'size' argument of read", size).it();
         final int count = CStdLib.INSTANCE.read(
             new Int("the 'descriptor' argument of read", params[0]).it(), buf, size
         );

--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -37,7 +37,7 @@ public final class RecvSyscall implements Syscall {
         final int size = new Natural(
             new Expect<>("the 'size' argument of recv", () -> params[1])
         ).it();
-        final byte[] buf = new byte[size];
+        final byte[] buf = new Buffer("the 'size' argument of recv", size).it();
         final int received = CStdLib.INSTANCE.recv(
             new Int("the 'descriptor' argument of recv", params[0]).it(),
             buf,

--- a/eo-runtime/src/test/java/org/eolang/posix/ReadSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/ReadSyscallTest.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.posix;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link ReadSyscall}.
+ * @since 0.64.0
+ */
+final class ReadSyscallTest {
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsSizeLargerThanTheHeap() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new ReadSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(Integer.MAX_VALUE)
+            ),
+            "A posix read of more bytes than the heap holds must fail with ExFailure"
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/RecvSyscallTest.java
@@ -73,6 +73,18 @@ final class RecvSyscallTest {
         );
     }
 
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void rejectsSizeLargerThanTheHeap() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new RecvSyscall(Phi.Φ.take("posix").copy()).make(
+                new Data.ToPhi(0), new Data.ToPhi(Integer.MAX_VALUE), new Data.ToPhi(0)
+            ),
+            "A posix recv of more bytes than the heap holds must fail with ExFailure"
+        );
+    }
+
     private static List<Integer> outcome(final Phi result) {
         return Arrays.asList(
             new Dataized(result.take("code")).asNumber().intValue(),


### PR DESCRIPTION
`read` and `recv` took the size from the program and went straight to `new byte[size]`.
`Natural` accepts everything up to `Integer.MAX_VALUE`, so a large size reached the
allocation and the run died with `OutOfMemoryError`, which is a JVM error and not an EO
termination, so no fallback could see it.

The allocation goes through a small `Buffer` now, which refuses a size larger than what is
free, or larger than the biggest array the JVM will make, with an `ExFailure` naming the
argument the way `write` and `send` name theirs.

Closes #8384
