### PR TITLE
#8399: read the low half without a branch, the way times does

### DIFF
--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -29,47 +29,24 @@
       cant-divide
         "Can't divide %d by i16 zero".printf
           * ^.as-i32.as-i64.as-number
-      if.
-        or.
-          eq.
-            b.slice 0 2 >> left
-            00-00
-          left.eq FF-FF
-        i16
-          slice.
-            as-bytes. >> b
-              ^.as-i32.div other.as-i32
-            2
-            2
-        plus.
-          i16
-            b.slice 0 2
-          i16
-            b.slice 2 2
+      i16
+        slice.
+          as-bytes.
+            ^.as-i32.div other.as-i32
+          2
+          2
   ^.as-i32.gt x.as-i16.as-i32 > [^ x] > gt
   ^.as-i32.gte x.as-i16.as-i32 > [^ x] > gte
   ^.as-i32.lt x.as-i16.as-i32 > [^ x] > lt
   ^.as-i32.lte x.as-i16.as-i32 > [^ x] > lte
   ^.plus x.as-i16.neg > [^ x] > minus
   times -1.as-i64.as-i32.as-i16 > neg
-  [^ x] > plus
-    if. > @
-      or.
-        eq.
-          b.slice 0 2 >> left
-          00-00
-        left.eq FF-FF
-      i16
-        slice.
-          as-bytes. >> b
-            ^.as-i32.plus x.as-i16.as-i32
-          2
-          2
-      plus.
-        i16
-          b.slice 0 2
-        i16
-          b.slice 2 2
+  i16 > [^ x] > plus
+    slice.
+      as-bytes.
+        ^.as-i32.plus x.as-i16.as-i32
+      2
+      2
   i16 > [^ x] > times
     slice.
       as-bytes.
@@ -122,6 +99,10 @@
   eq. ++> can-divide-with-a-remainder
     13.as-i64.as-i32.as-i16.div -5.as-i64.as-i32.as-i16
     -2.as-i64.as-i32.as-i16
+
+  eq. ++> can-divide-with-overflow
+    -32768.as-i64.as-i32.as-i16.div -1.as-i64.as-i32.as-i16
+    -32768.as-i64.as-i32.as-i16
 
   123.as-i64.as-i32.as-i16.eq 123.as-i64.as-i32.as-i16 ++> can-equal-the-same-i16
 

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -37,47 +37,24 @@
       cant-divide
         "Can't divide %d by i32 zero".printf
           * ^.as-i64.as-number
-      if.
-        or.
-          eq.
-            b.slice 0 4 >> left
-            00-00-00-00
-          left.eq FF-FF-FF-FF
-        i32
-          slice.
-            as-bytes. >> b
-              ^.as-i64.div other.as-i64
-            4
-            4
-        plus.
-          i32
-            b.slice 0 4
-          i32
-            b.slice 4 4
+      i32
+        slice.
+          as-bytes.
+            ^.as-i64.div other.as-i64
+          4
+          4
   ^.as-i64.gt x.as-i32.as-i64 > [^ x] > gt
   ^.as-i64.gte x.as-i32.as-i64 > [^ x] > gte
   ^.as-i64.lt x.as-i32.as-i64 > [^ x] > lt
   ^.as-i64.lte x.as-i32.as-i64 > [^ x] > lte
   ^.plus x.as-i32.neg > [^ x] > minus
   times -1.as-i64.as-i32 > neg
-  [^ x] > plus
-    if. > @
-      or.
-        eq.
-          b.slice 0 4 >> left
-          00-00-00-00
-        left.eq FF-FF-FF-FF
-      i32
-        slice.
-          as-bytes. >> b
-            ^.as-i64.plus x.as-i32.as-i64
-          4
-          4
-      plus.
-        i32
-          b.slice 0 4
-        i32
-          b.slice 4 4
+  i32 > [^ x] > plus
+    slice.
+      as-bytes.
+        ^.as-i64.plus x.as-i32.as-i64
+      4
+      4
   i32 > [^ x] > times
     slice.
       as-bytes.
@@ -134,6 +111,10 @@
   eq. ++> can-divide-with-a-remainder
     13.as-i64.as-i32.div -5.as-i64.as-i32
     -2.as-i64.as-i32
+
+  eq. ++> can-divide-with-overflow
+    -2147483648.as-i64.as-i32.div -1.as-i64.as-i32
+    -2147483648.as-i64.as-i32
 
   123.as-i64.as-i32.eq 123.as-i64.as-i32 ++> can-equal-the-same-i32
 


### PR DESCRIPTION
The else-branch of `i16.plus`, `i16.div`, `i32.plus` and `i32.div` added the two halves of
the wide result instead of dropping the high one. That is the arithmetic #5366 and #5342
removed from `times`, and it cannot be reached here: `plus` widens both operands, so the
sum's high half is always `00-00` or `FF-FF`, which are the two values the guard admits,
and the same holds for `div`.

All four now take the low half unconditionally, the way `times` does. Two tests are added
for the overflow the guard was supposed to be about, `-32768 / -1` and `-2147483648 / -1`,
which wrap to themselves.

Closes #8399
