### PR TITLE
#8387: refuse a byte that is not a boolean

### DIFF
--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -1,4 +1,5 @@
-# Bytes as a boolean: TRUE when the single byte equals `FF-`, FALSE otherwise.
+# Bytes as a boolean: TRUE for `FF-` and FALSE for `00-`. Any other bytes
+# terminate, since only those two are booleans.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -8,7 +9,17 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-bool
-  ^.eq FF- > @
+  if. > @
+    ^.eq 00-
+    false
+    if.
+      ^.eq FF-
+      true
+      T
+        "Can't convert %x to bool, only 00- and FF- are booleans".printf
+          * ^
 
   not. ++> can-convert-bytes-to-a-bool
     FF-.as-bool.eq 00-.as-bool
+
+  01-.as-bool --> stops-on-bytes-that-are-not-a-boolean


### PR DESCRIPTION
`bytes.as-bool` was `^.eq FF-`, so every byte other than `FF-` read as `false`, including
the ones `Dataized.asBool` refuses with "only 00- and FF- are booleans". A wrong byte
coming from a file, a socket or a slice became a `false` that looked like an answer.

It now answers `false` for `00-`, `true` for `FF-` and terminates otherwise, with the same
message the Java side gives, the way `string.length` terminates on a byte it cannot read.
The signature stays as it is, so none of its twenty callers change.

Closes #8387
