### PR TITLE
#8400: call a byte a boolean only when it is one

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
+++ b/eo-runtime/src/main/java/org/eolang/VerboseBytesAsString.java
@@ -38,7 +38,7 @@ public final class VerboseBytesAsString implements Supplier<String> {
         final String result;
         if (this.data.length == 0) {
             result = "[<no bytes>]";
-        } else if (this.data.length == 1) {
+        } else if (this.data.length == 1 && (this.data[0] == 0 || this.data[0] == -1)) {
             result = String.format(
                 "[0x%02X] = %s",
                 this.data[0],

--- a/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/VerboseBytesAsStringTest.java
@@ -72,10 +72,11 @@ final class VerboseBytesAsStringTest {
             ),
             Arguments.of(new byte[]{-1}, "[0xFF] = true"),
             Arguments.of(new byte[]{0}, "[0x00] = false"),
-            Arguments.of(new byte[]{1}, "[0x01] = false"),
-            Arguments.of(new byte[]{2}, "[0x02] = false"),
+            Arguments.of(new byte[]{1}, "[0x01] = \"\\u0001\""),
+            Arguments.of(new byte[]{2}, "[0x02] = \"\\u0002\""),
             Arguments.of(new byte[]{}, "[<no bytes>]"),
-            Arguments.of(new byte[]{12}, "[0x0C] = false"),
+            Arguments.of(new byte[]{12}, "[0x0C] = \"\\u000c\""),
+            Arguments.of(new byte[]{0x41}, "[0x41] = \"A\""),
             Arguments.of(
                 new byte[]{0x61, 0x22, 0x62, 0x5C, 0x63, 0x7F},
                 "[0x6122625C-637F] = \"a\\\"b\\\\c\\u007f\""


### PR DESCRIPTION
The one-byte branch printed `= true` or `= false` for every byte, so a one-character text,
a `u8` or an `i8` was reported as a boolean, and `Main.run` prints the last line of every
program through this class. The runtime itself refuses those bytes as booleans:
"only 00- and FF- are booleans".

The branch now takes only `00-` and `FF-`. Everything else falls to the branch below it and
is printed the way a short byte string is, so `[65]` reads `[0x41] = "A"`.

Closes #8400
