### PR TITLE
Leave a terminating arm out of a choice

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Branched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Branched.java
@@ -21,7 +21,17 @@ import java.util.Map;
  *
  * <p>Nothing is guessed, since a formation that binds a body of its own is
  * passed over: the call goes into it and what comes back is that body, which
- * is a question for whoever walks a delegation and not for this.</p>
+ * is a question for whoever walks a delegation and not for this. A void does
+ * go by a name of its own once one thing has been seen in it, though, so the
+ * body that was {@code left} yesterday is a {@code Φ.dial} today and reads
+ * like a body the formation binds. What the call put in says which it is: a
+ * body that is one of the arguments is a void wearing the argument's name.</p>
+ *
+ * <p>An arm rooted at a void this call leaves empty is left out of the
+ * agreement. Reading a void nobody filled terminates, so that arm never hands
+ * a value to anyone, and a caller holding one got it from another arm. Every
+ * fragile object is written this way, with the excuse in one arm and the
+ * answer in the other, and the callers who want the answer fill nothing.</p>
  *
  * @since 0.71.0
  */
@@ -38,14 +48,25 @@ final class Branched {
     private final Map<String, String> binds;
 
     /**
+     * The locator of every void.
+     */
+    private final Collection<String> hollows;
+
+    /**
      * Ctor.
      * @param provided What the types certainly have
      * @param filled What the call put into the voids, by the locator of the
      *  void
+     * @param voids The locator of every void, from {@link Hollows}
      */
-    Branched(final Provided provided, final Map<String, String> filled) {
+    Branched(
+        final Provided provided,
+        final Map<String, String> filled,
+        final Collection<String> voids
+    ) {
         this.owned = provided;
         this.binds = filled;
+        this.hollows = voids;
     }
 
     /**
@@ -55,15 +76,24 @@ final class Branched {
      */
     String names() {
         final Collection<String> handed = new LinkedHashSet<>(0);
-        for (final String hollow : this.binds.keySet()) {
-            final int dot = hollow.lastIndexOf('.');
-            if (dot > 0) {
-                final String body = this.owned.behind(hollow.substring(0, dot));
-                if (this.binds.containsKey(body)) {
-                    handed.add(this.binds.get(body));
-                }
+        for (final Map.Entry<String, String> bind : this.binds.entrySet()) {
+            final int dot = bind.getKey().lastIndexOf('.');
+            if (dot > 0
+                && this.hands(bind.getKey().substring(0, dot), bind)
+                && this.stands(bind.getValue())) {
+                handed.add(bind.getValue());
             }
         }
         return new Joined(handed, this.owned).names();
+    }
+
+    private boolean hands(final String owner, final Map.Entry<String, String> bind) {
+        final String body = this.owned.behind(owner);
+        return body.equals(bind.getKey()) || body.equals(bind.getValue());
+    }
+
+    private boolean stands(final String arm) {
+        final String root = new Rooted(this.hollows).names(arm);
+        return root.isEmpty() || this.binds.containsKey(root);
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -91,6 +91,12 @@ final class Filled {
      *  no caller says what the void holds
      */
     String instead(final String answer, final String bearer) {
+        return this.instead(answer, bearer, new HashSet<>(0));
+    }
+
+    private String instead(
+        final String answer, final String bearer, final Collection<String> seen
+    ) {
         final Map<String, String> fillings = this.fillings(bearer);
         final String found;
         if (fillings.containsKey(answer)) {
@@ -104,7 +110,7 @@ final class Filled {
                 }
             }
             if (longest.isEmpty()) {
-                found = this.branch(answer, fillings);
+                found = this.branch(answer, fillings, seen);
             } else {
                 found = this.asked(
                     fillings.get(longest), answer.substring(longest.length() + 1), answer
@@ -114,32 +120,29 @@ final class Filled {
         return found;
     }
 
-    private String branch(final String answer, final Map<String, String> fillings) {
-        final String root = this.root(answer);
+    private String branch(
+        final String answer, final Map<String, String> fillings, final Collection<String> seen
+    ) {
+        final String root = new Rooted(this.hollows).names(answer);
         String found = answer;
         if (!root.isEmpty()) {
-            final String handed = new Branched(this.owned, fillings).names();
-            if (!handed.isEmpty()) {
-                found = this.asked(
-                    handed, answer.substring(Math.min(root.length() + 1, answer.length())), answer
-                );
+            final String handed = new Branched(this.owned, fillings, this.hollows).names();
+            if (!handed.isEmpty() && seen.add(handed)) {
+                found = this.through(answer, root, handed, seen);
             }
         }
         return found;
     }
 
-    private String root(final String answer) {
-        String found = "";
-        String walked = answer;
-        while (!walked.isEmpty()) {
-            if (this.hollows.contains(walked)) {
-                found = walked;
-                break;
-            }
-            if (!walked.contains(".")) {
-                break;
-            }
-            walked = walked.substring(0, walked.lastIndexOf('.'));
+    private String through(
+        final String answer, final String root, final String handed,
+        final Collection<String> seen
+    ) {
+        String found = this.asked(
+            handed, answer.substring(Math.min(root.length() + 1, answer.length())), answer
+        );
+        if (found.equals(answer)) {
+            found = this.instead(answer, handed, seen);
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Rooted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Rooted.java
@@ -19,7 +19,8 @@ import java.util.Collection;
  * <p>Which facts belong to a void is therefore a question about locators and
  * not about the facts, and every kind of fact asks it the same way:
  * {@link Demands} for a name taken off a void, {@link Applies} for a call made
- * on one.</p>
+ * on one. Which of the voids it is belongs here too, since a reader who has to
+ * go and look the void up is asking the same question one answer further.</p>
  *
  * @since 0.72.0
  */
@@ -45,12 +46,27 @@ final class Rooted {
      * @return True when it is one of the voids, or a name rooted at one
      */
     boolean covers(final String object) {
-        boolean found = false;
-        for (final String root : this.voids) {
-            if (object.equals(root) || object.startsWith(root.concat("."))) {
-                found = true;
+        return !this.names(object).isEmpty();
+    }
+
+    /**
+     * The void this object is rooted at.
+     * @param object The locator of the object the fact is written against
+     * @return The locator of the nearest of these voids the name is taken off,
+     *  empty when the name is rooted at none of them
+     */
+    String names(final String object) {
+        String found = "";
+        String walked = object;
+        while (!walked.isEmpty()) {
+            if (this.voids.contains(walked)) {
+                found = walked;
                 break;
             }
+            if (!walked.contains(".")) {
+                break;
+            }
+            walked = walked.substring(0, walked.lastIndexOf('.'));
         }
         return found;
     }

--- a/eo-inference/src/test/java/org/eolang/inference/RootedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/RootedTest.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Rooted}.
+ * @since 0.72.0
+ */
+final class RootedTest {
+
+    @Test
+    void namesTheNearestVoidTheNameIsTakenOff() {
+        MatcherAssert.assertThat(
+            "the void closest to the name must be the one it is rooted at, but a further one came back",
+            new Rooted(Arrays.asList("Φ.pump.x", "Φ.pump.x.hose")).names("Φ.pump.x.hose.tip"),
+            Matchers.equalTo("Φ.pump.x.hose")
+        );
+    }
+
+    @Test
+    void namesNothingForANameRootedAtNoVoidOfThese() {
+        MatcherAssert.assertThat(
+            "a name that goes back to none of these voids must come back empty, but it named one",
+            new Rooted(Collections.singletonList("Φ.pump.x")).names("Φ.pump.y.hose"),
+            Matchers.equalTo("")
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-choice-with-an-arm-that-cannot-hand-anything-back-answers-with-the-other-arm.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-choice-with-an-arm-that-cannot-hand-anything-back-answers-with-the-other-arm.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An arm of a choice that reads a void nobody filled hands nothing back: the
+# moment anyone looks at it, it terminates. A caller who gets a value from the
+# choice therefore got it from the other arm, and that is the only arm worth
+# joining. This is how every fragile object is written, with a fallback void
+# left empty by everyone who wants the answer rather than the excuse.
+eo:
+  choice.eo: |
+    [pick] > choice
+      pick > @
+  yes.eo: |
+    [^] > yes
+      choice > @
+        [^]
+          ? >> left
+          ? >> right
+          left > @
+  no.eo: |
+    [^] > no
+      choice > @
+        [^]
+          ? >> left
+          ? >> right
+          right > @
+  dial.eo: |
+    [^ sys] > dial
+      [^ size] > listen
+        size > @
+  gauge.eo: |
+    [^ flag cant-read] > gauge
+      flag.pick > @
+        dial 03-
+        cant-read
+          "the gauge cannot be read"
+  held.eo: |
+    [] > held
+      gauge yes > @
+  other.eo: |
+    [] > other
+      gauge no > @
+  app.eo: |
+    [] > app
+      listen. > @
+        held
+        05-
+links:
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.dial.listen']"


### PR DESCRIPTION
A choice hands back one of the things the caller put into it, and until now
`Branched` joined every one of them. That is wrong for a fragile object, which
is written with the excuse in one arm and the answer in the other:

```
[^ flag cant-read] > gauge
  flag.pick > @
    dial 03-
    cant-read
      "the gauge cannot be read"
```

A caller who wants the answer leaves `cant-read` empty, so reading that arm
terminates and nobody ever holds its value. Joining it with the other arm gave
`Φ` — nothing worth writing down — and the whole chain behind the choice went
unanswered. That arm is now dropped before the join.

Two smaller things had to go with it. A void that has been seen holding one
object goes by that object's name afterwards, so a pass-through formation whose
body is `left` reads a pass later like a formation binding a body of its own,
and the arm was never collected; the body is now matched against the argument's
name too. And the arm that survives is followed through, so a choice made of
choices resolves rather than stopping at the first one.

On `eo-runtime` this settles 50 dispatches that used to stop at `Φ.bool.if`,
with no row changing to anything else. The regex family stays where it was. It
sits behind two other defects, #8442 and #8351, which want doing together and
neither of which is touched here.

Closes #8434
