### PR TITLE
#8388: refuse bytes that are not valid UTF-8

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Dataized.java
+++ b/eo-runtime/src/main/java/org/eolang/Dataized.java
@@ -5,6 +5,9 @@
 
 package org.eolang;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 
@@ -94,7 +97,22 @@ public final class Dataized {
      * @return Data as string
      */
     public String asString() {
-        return new String(this.take(), StandardCharsets.UTF_8);
+        final byte[] bytes = this.take();
+        try {
+            return StandardCharsets.UTF_8.newDecoder()
+                .onMalformedInput(CodingErrorAction.REPORT)
+                .onUnmappableCharacter(CodingErrorAction.REPORT)
+                .decode(ByteBuffer.wrap(bytes))
+                .toString();
+        } catch (final CharacterCodingException ex) {
+            throw new ExFailure(
+                String.format(
+                    "Can't dataize the bytes %s to string, they are not valid UTF-8",
+                    new VerboseBytesAsString(bytes).get()
+                ),
+                ex
+            );
+        }
     }
 
     /**

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -91,8 +91,9 @@ final class DataizedTest {
             Matchers.containsString("length 0")
         );
     }
+
     @Test
-    void refusesBytesThatAreNotValidUtf8() {
+    void refusesBytesThatAreNotValidText() {
         MatcherAssert.assertThat(
             "bytes that are not UTF-8 must be refused, not replaced with U+FFFD",
             Assertions.assertThrows(
@@ -103,5 +104,4 @@ final class DataizedTest {
             Matchers.containsString("not valid UTF-8")
         );
     }
-
 }

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -91,4 +91,17 @@ final class DataizedTest {
             Matchers.containsString("length 0")
         );
     }
+    @Test
+    void refusesBytesThatAreNotValidUtf8() {
+        MatcherAssert.assertThat(
+            "bytes that are not UTF-8 must be refused, not replaced with U+FFFD",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Dataized(new Data.ToPhi(new byte[]{(byte) 0xFF})).asString(),
+                "a lone FF byte was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.containsString("not valid UTF-8")
+        );
+    }
+
 }

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -104,7 +104,7 @@ final class SyscallTest {
         listen.put(1, Phi.Φ.take("dataized").copy());
         MatcherAssert.assertThat(
             "the limited-broadcast address 255.255.255.255 must be accepted as a valid IPv4 conversion, not rejected as unparsable",
-            new Dataized(listen).asString(),
+            new String(new Dataized(listen).take(), StandardCharsets.UTF_8),
             Matchers.not(Matchers.containsString("into a 32-bit integer"))
         );
     }


### PR DESCRIPTION
`asBool` and `asNumber` refuse what they cannot read; `asString` was
`new String(bytes, UTF_8)`, which replaces every malformed byte with `U+FFFD`, so a
corrupted string came back as a different string instead of stopping. The EO side of the
same runtime treats those bytes as an error: `string.length` and `string.slice` terminate
on them.

It decodes with `CodingErrorAction.REPORT` now and fails with the offending bytes in the
message.

Closes #8388
