### PR TITLE
bug(#8439): let a lowered atom declare no receiver

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -47,8 +47,10 @@ import org.w3c.dom.Element;
  * protocol, the protocol is rendered into a Java body, the body goes
  * into a sidecar file named by its own digest, and the formation keeps
  * only its voids, the digest, and a {@code λ} marker — the shape
- * {@code lowered.xsl} later renders into an atom class, which binds
- * {@code ρ} of its own, so a declared {@code ρ} leaves with the body.
+ * {@code lowered.xsl} later renders into an atom class, which declares
+ * no {@code ρ} at all, since the body that could have read one leaves
+ * with the digest and an atom holding a receiver it never reads is what
+ * makes its own dataization reenter itself (#8439).
  * Whatever refuses
  * along the way — an unwitnessed void, an operation outside the tables,
  * a body that needs no computation — leaves the formation as

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/lowered.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/lowered.xsl
@@ -21,6 +21,18 @@
   A lowered formation without its sidecar stops the build: the stamp and
   the sidecar are written together by the goal, so one without the other
   is an invariant violation, not an input to tolerate.
+
+  The constructor registers the voids of the formation and nothing else,
+  never a receiver of its own (see #8439). The goal leaves no "ρ" behind,
+  since the body that could have read one is gone, and "purify.xsl" gave
+  the formation its "@pure" label on exactly that reading: a receiver
+  never declared is a receiver never looked at, so it is no input of the
+  atom. A class declaring a vacant "ρ" would contradict that label at run
+  time, because "AtWithRho" fills such a "ρ" with the object the atom
+  hangs on, "PhSticky" counts every fill as an input of the answer it
+  remembers, and the key it builds normalizes that object - which is the
+  very object whose body is asking for this answer. The dataization would
+  then reenter itself and never end.
   -->
   <xsl:import href="/org/eolang/parser/_funcs.xsl"/>
   <xsl:import href="/org/eolang/maven/transpile/_java-names.xsl"/>
@@ -92,7 +104,7 @@
     <xsl:variable name="pkg" select="/object/metas/meta[head='package'][1]/part[1]"/>
     <xsl:variable name="voids" as="xs:string*" select="for $v in o[@base = $eo:empty] return concat('new Attr(&quot;', eo:literal(eo:attr-name($v/@name, false())), '&quot;, new AtVoid(&quot;', eo:literal(eo:attr-name($v/@name, false())), '&quot;))')"/>
     <xsl:variable name="header" as="xs:string*" select="(concat('/* ', $disclaimer, ' */'), '', concat('package org.eolang', if ($pkg) then concat('.', eo:package-name($pkg)) else '', ';'), '', 'import org.eolang.*;', '')"/>
-    <xsl:variable name="ctor" as="xs:string*" select="('    /**', '     * Ctor.', '     */', concat('    public ', $class, '() {'), concat('        super(new Attrs(', string-join(('new Attr(Phi.RHO, new AtRho())', $voids), ', '), '));'), '    }')"/>
+    <xsl:variable name="ctor" as="xs:string*" select="('    /**', '     * Ctor.', '     */', concat('    public ', $class, '() {'), concat('        super(new Attrs(', string-join($voids, ', '), '));'), '    }')"/>
     <xsl:variable name="lambda" as="xs:string*" select="('    @Override', '    public Phi lambda() {', replace(unparsed-text($file, 'UTF-8'), '[&#13;&#10;]+$', ''), '    }')"/>
     <class lowered="true">
       <xsl:attribute name="java-name">

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -359,7 +359,10 @@
   "o[1]"), and its instance is wrapped in PhSticky, the same way the
   "abstract" template below wraps a pure formation: the class of such an
   atom is a straight-line computation rendered by "lowered.xsl", and its
-  result is decided by its inputs alone.
+  result is decided by its inputs alone. Those inputs are its voids and
+  nothing more, which is why "lowered.xsl" gives the class no "ρ" of its
+  own: a vacant one would be filled with the object the atom hangs on and
+  counted among the inputs PhSticky keys its answers by (see #8439).
   -->
   <xsl:template match="atom">
     <xsl:param name="name"/>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/StLoweredTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/StLoweredTest.java
@@ -66,13 +66,22 @@ final class StLoweredTest {
     }
 
     @Test
-    void registersReceiverAndVoidInCtor(@Mktmp final Path temp) throws IOException {
+    void registersEveryVoidInCtor(@Mktmp final Path temp) throws IOException {
         MatcherAssert.assertThat(
-            "the ctor must register the receiver and every void through super(), but it doesnt",
+            "the ctor must register every void through super(), but it doesnt",
             StLoweredTest.generated(temp, "0b54e17d92cc"),
             Matchers.containsString(
-                "super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr(\"x\", new AtVoid(\"x\"))));"
+                "super(new Attrs(new Attr(\"x\", new AtVoid(\"x\"))));"
             )
+        );
+    }
+
+    @Test
+    void declaresNoReceiverInCtor(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the ctor must leave the receiver out, but it registers one",
+            StLoweredTest.generated(temp, "1a2b3c4d5e6f"),
+            Matchers.not(Matchers.containsString("new AtRho()"))
         );
     }
 


### PR DESCRIPTION
Closes #8439.

## What was happening

On a build where `phino` is present and the `lower` goal really runs,
`TestEOnumber` gave `Tests run: 509, Failures: 1, Errors: 21, Skipped: 75`,
every error a `StackOverflowError`. Reproduced here exactly, same numbers and
the same 22 test names.

## Why

It is not the Java the lowering writes — those bodies compute the right thing.
It is the shape of the class around them. `lowered.xsl` always rendered

```java
super(new Attrs(new Attr(Phi.RHO, new AtRho()), new Attr("v0", new AtVoid("v0"))));
```

but the goal strips `ρ` from the formation (`Lowered.marked` removes it,
`Outlined.formation` never writes one), and `purify.xsl` grants the `@pure`
label on exactly that reading — "a receiver never declared is a receiver never
looked at" (#7613), so it is no input of the atom.

The class contradicted the label at run time. A vacant `ρ` makes `needsRho()`
true, so `AtWithRho` fills it with the object the atom hangs on; `PhSticky` —
which `to-java.xsl` wraps every lowered atom in — counts every fill as an input
of the answer it remembers; and `PhSticky.key()` normalizes each input before
looking at what it is. Normalizing that object evaluates its `φ`, and that body
is the one asking for this very answer:

```
PhSticky.delta → PhSticky.key → ρ.normalized() → … → dataize(k) → PhSticky.delta → …
```

In `as-fixed` the object is the `positive` helper and the answer is its `k`
attribute (`if. (^.places.gt 15) 15 ^.places`, outlined into
`l🌵292f0c4ffb83`), so `3.14159.as-fixed 2` never terminates. `as-scientific`
and `printf`'s `%f` reach it through `as-fixed`; `integral` hits the same shape
in `subsection`. `bytes.concat` sits at the top of every trace because that is
what `as-fixed` builds its answer with.

The cache never worked for these atoms either: the container's forma is no
datum, so the key was rejected on every read and nothing was ever remembered.

## The fix

The constructor registers the voids of the formation and nothing else. The key
is then the data the atom really takes, so its answers are remembered instead
of never being remembered at all, and nothing normalizes the object asking the
question.

## Changes

- `lowered.xsl` — the constructor no longer declares a receiver, with the
  reasoning written next to the rest of the invariants of that sheet.
- `to-java.xsl`, `Lowered.java` — the comments stated the old invariant
  ("binds `ρ` of its own"); they now state the new one and why it matters.
- `StLoweredTest` — `registersReceiverAndVoidInCtor` becomes
  `registersEveryVoidInCtor`, and `declaresNoReceiverInCtor` is added so the
  receiver cannot come back unnoticed.

## Verified

Built with `phino 0.0.115` on `PATH`, so the `lower` goal ran (`Folded or
lowered 144 fragment(s) in 50 XMIR(s)`, the same 144 as the issue reports):

| tree | result |
| --- | --- |
| `master` | `Tests run: 509, Failures: 1, Errors: 21, Skipped: 75` |
| this branch | `Tests run: 509, Failures: 0, Errors: 0, Skipped: 22` |

The run also went from 715s to 153s, and 53 tests that the memory budget used
to report as skipped now finish inside it — the cache doing the work it was
always meant to do. `StLoweredTest` passes. The full `eo-runtime` suite under
lowering is running as well.

## Not addressed here

`PhSticky.key()` forcing `normalized()` on every input before checking whether
it can be part of a key is a re-entrancy trap in its own right: any pure
formation handed a non-datum input would step on it. Nothing in the normal
pipeline can reach that today — `purify.xsl` and `to-java.xsl` agree on which
formations get a `ρ` — so this change restores the invariant rather than
hardening the decorator. Worth a look of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RuTMxzBoGTS4tWvJc1wH2

---
_Generated by [Claude Code](https://claude.ai/code/session_019RuTMxzBoGTS4tWvJc1wH2)_