### PR TITLE
Relay an argument along the whole chain of copies

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -46,7 +46,9 @@ import java.util.Map;
  * {@code "bar" > [message]} puts that {@code message} in the way of the
  * {@code "foo"}. So what the program is seen to put into a void is read off
  * the fillings gathered here, and the arguments of an application on that void
- * are passed on to every formation it holds.</p>
+ * are passed on to every formation it holds. A void may itself be a copy of
+ * another one, and filling the second fills the first, so the formations are
+ * gathered along the whole chain of copies rather than off its end alone.</p>
  *
  * <p>It is evidence and not a contract, as everything gathered from callers
  * is: the caller written tomorrow may put a formation of another shape there.
@@ -61,7 +63,8 @@ import java.util.Map;
  *  this very application is about to fill are counted as taken already and
  *  the fillings are lost. {@link Ends} settles a ring on one of its names for
  *  everyone else; the chain here wants the whole path rather than its end, so
- *  it needs a rule of its own about where a ring starts and stops.
+ *  it needs a rule of its own about where a ring starts and stops. Once there
+ *  is one, {@code copies} walks the same path and both can share it.
  */
 final class Bound {
 
@@ -151,8 +154,7 @@ final class Bound {
     private void relayed(final Map<String, Map<String, String>> found) {
         final Map<String, Collection<String>> fillers = this.puts(found);
         for (final Map.Entry<String, List<String>> application : this.args.entrySet()) {
-            for (final String filler
-                : fillers.getOrDefault(this.base(application.getKey()), Collections.emptyList())) {
+            for (final String filler : this.held(fillers, application.getKey())) {
                 final Map<String, String> passed = this.passed(filler, application.getValue());
                 if (!passed.isEmpty()) {
                     found.computeIfAbsent(application.getKey(), key -> new LinkedHashMap<>(1))
@@ -160,6 +162,25 @@ final class Bound {
                 }
             }
         }
+    }
+
+    private Collection<String> held(
+        final Map<String, Collection<String>> fillers, final String application
+    ) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        for (final String step : this.copies(application)) {
+            found.addAll(fillers.getOrDefault(step, Collections.emptyList()));
+        }
+        return found;
+    }
+
+    private Collection<String> copies(final String name) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        String walked = name;
+        while (found.add(walked) && this.pairs.containsKey(walked)) {
+            walked = this.pairs.get(walked);
+        }
+        return found;
     }
 
     private Map<String, String> passed(final String filler, final List<String> given) {

--- a/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
@@ -80,6 +80,43 @@ final class BoundTest {
     }
 
     @Test
+    void passesArgumentsOnToAFormationHeldByAVoidMidwayAlongAChain() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put(
+            "Φ.app.gate",
+            List.of(Map.of("void", "true", "name", "func", "type", "Φ.app.gate.func"))
+        );
+        rows.put(
+            "Φ.app.leaf",
+            List.of(Map.of("void", "true", "name", "item", "type", "Φ.app.leaf.item"))
+        );
+        rows.put(
+            "Φ.app.twig",
+            List.of(Map.of("void", "true", "name", "item", "type", "Φ.app.twig.item"))
+        );
+        final Map<String, List<String>> args = new HashMap<>(0);
+        args.put("Φ.app.call", List.of("Φ.app.arg"));
+        args.put("Φ.app.put", List.of("Φ.app.leaf"));
+        final Map<String, String> pairs = new HashMap<>(0);
+        pairs.put("Φ.app.call", "Φ.app.gate.func");
+        pairs.put("Φ.app.gate.func", "Φ.app.twig");
+        pairs.put("Φ.app.put", "Φ.app.gate");
+        MatcherAssert.assertThat(
+            "an argument must reach the formation a void in the middle of the chain holds, but it didnt",
+            new Bound(
+                args, Collections.emptyMap(), Collections.emptyMap(), pairs,
+                new Provided(
+                    rows, Collections.emptyMap(),
+                    Collections.emptyList(), Collections.emptyMap()
+                )
+            ).all().get("Φ.app.call"),
+            Matchers.equalTo(
+                Map.of("Φ.app.twig.item", "Φ.app.arg", "Φ.app.leaf.item", "Φ.app.arg")
+            )
+        );
+    }
+
+    @Test
     void readsTheReceiverOfARingOffTheNameTheRingGoesBy() {
         final Map<String, String> pairs = new HashMap<>(0);
         pairs.put("Φ.app.zebra", "Φ.app.alpha");


### PR DESCRIPTION
`Bound.relayed` hands the arguments of an application on to whatever the void it copies is seen to hold. It looked those formations up by the end of the chain of copies alone:

```java
for (final String filler
    : fillers.getOrDefault(this.base(application.getKey()), Collections.emptyList())) {
```

`fillers` is keyed by the locator of a void, so the two met only where the void happened to be the last step of that walk. Where the chain ran on past the void the lookup missed and nothing was relayed at all. `tuple/mappedi.eo` is such a place: two callers put a formation into its `func`, the void is a copy of one of them, and the `item` and `idx` of the other were left filled by nobody.

The fillings are now gathered along every step of the walk rather than off its end. Nothing that was found before is lost, since the end is one of those steps. Across `eo-runtime` it closes 48 voids the tables saw nothing fill, in 46 objects.

The reproduction sits in `BoundTest` and not in an inference pack. The chain only runs past a void once the void has been frozen onto one of the things put into it, and no program small enough for a pack reaches that state — the two packs I wrote for it pass either way.

Closes #8447
