### PR TITLE
#8432: drop the abs helper no call reaches

### DIFF
--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -75,10 +75,6 @@
             value.minus operand
           err
         0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
 
   ++> can-integrate-a-linear-function
     close-to > @
@@ -97,10 +93,6 @@
             value.minus operand
           err
         0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
 
   ++> can-integrate-a-quadratic-function
     close-to > @
@@ -119,10 +111,6 @@
             value.minus operand
           err
         0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
 
   ++> can-integrate-with-a-single-partition
     close-to > @
@@ -141,10 +129,6 @@
             value.minus operand
           err
         0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
 
   ++> can-integrate-with-an-evenly-dividing-step
     close-to > @
@@ -163,10 +147,6 @@
             value.minus operand
           err
         0
-      if. > [value] > abs
-        value.gte 0
-        value
-        value.neg
 
   eq. ++> can-recover-from-partitions-at-the-precision-boundary
     "recovered"

--- a/eo-runtime/src/main/eo/number/integral.eo
+++ b/eo-runtime/src/main/eo/number/integral.eo
@@ -68,13 +68,12 @@
           100
       2499.75
       1.0e-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs.
-            value.minus operand
-          err
-        0
+    lte. > [value operand err] > close-to
+      minus.
+        abs.
+          value.minus operand
+        err
+      0
 
   ++> can-integrate-a-linear-function
     close-to > @
@@ -86,13 +85,12 @@
           15
       49.5
       1.0e-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs.
-            value.minus operand
-          err
-        0
+    lte. > [value operand err] > close-to
+      minus.
+        abs.
+          value.minus operand
+        err
+      0
 
   ++> can-integrate-a-quadratic-function
     close-to > @
@@ -104,13 +102,12 @@
           100
       333
       1.0e-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs.
-            value.minus operand
-          err
-        0
+    lte. > [value operand err] > close-to
+      minus.
+        abs.
+          value.minus operand
+        err
+      0
 
   ++> can-integrate-with-a-single-partition
     close-to > @
@@ -122,13 +119,12 @@
           1
       0.5
       1.0e-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs.
-            value.minus operand
-          err
-        0
+    lte. > [value operand err] > close-to
+      minus.
+        abs.
+          value.minus operand
+        err
+      0
 
   ++> can-integrate-with-an-evenly-dividing-step
     close-to > @
@@ -140,13 +136,12 @@
           10
       50
       1.0e-7
-    [value operand err] > close-to
-      lte. > @
-        minus.
-          abs.
-            value.minus operand
-          err
-        0
+    lte. > [value operand err] > close-to
+      minus.
+        abs.
+          value.minus operand
+        err
+      0
 
   eq. ++> can-recover-from-partitions-at-the-precision-boundary
     "recovered"


### PR DESCRIPTION
The five test blocks each declared a `[value] > abs` that nothing copies: the `abs.` above
it is a reversed dispatch on the result of `value.minus operand`, which is a number, so it
resolves to `Q.number.abs`.

The five formations are gone. The calls above them are unchanged and still reach
`Q.number.abs`.

Closes #8432
