### PR TITLE
#8144: pad the temporary prefix for a short file name

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Saved.java
@@ -110,7 +110,7 @@ final class Saved implements Scalar<Path> {
             }
             final Path tmp = Files.createTempFile(
                 dir,
-                this.target.getFileName().toString(),
+                Saved.prefix(this.target),
                 ".tmp"
             );
             try {
@@ -140,6 +140,25 @@ final class Saved implements Scalar<Path> {
             );
         }
         return this.target;
+    }
+
+    /**
+     * The prefix of the temporary file that sits next to the target.
+     *
+     * <p>{@link Files#createTempFile(Path, String, String, java.nio.file.attribute.FileAttribute[])}
+     * refuses a prefix shorter than three characters, while a file name of one or two
+     * characters is valid everywhere, so the name is padded here.</p>
+     *
+     * @param target The file we are going to save
+     * @return The prefix, at least three characters long
+     */
+    private static String prefix(final Path target) {
+        final String name = target.getFileName().toString();
+        final StringBuilder out = new StringBuilder(name);
+        while (out.length() < 3) {
+            out.append('_');
+        }
+        return out.toString();
     }
 
     @RetryOnFailure(


### PR DESCRIPTION
`Files.createTempFile` refuses a prefix shorter than three characters, and `Saved` passed
the target's file name straight through, so saving to `x`, `ab` or `a.eo` failed with
`IllegalArgumentException: Prefix string "x" too short` before anything was written.

The prefix is padded with underscores up to three characters. The temporary file still
sits next to the target and the final path is unchanged.

Closes #8144
