### PR TITLE
#8395: refuse a negative timeout before the thread starts

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
@@ -46,6 +46,14 @@ final class Deadline {
      * @param unroll Whether the chain of causes goes to the log
      */
     Deadline(final Object mojo, final long seconds, final boolean unroll) {
+        if (seconds < 0L) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The timeout must not be negative, while %d was given through eo.timeout",
+                    seconds
+                )
+            );
+        }
         this.mojo = mojo;
         this.seconds = seconds;
         this.unroll = unroll;

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Deadline.java
@@ -46,14 +46,6 @@ final class Deadline {
      * @param unroll Whether the chain of causes goes to the log
      */
     Deadline(final Object mojo, final long seconds, final boolean unroll) {
-        if (seconds < 0L) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "The timeout must not be negative, while %d was given through eo.timeout",
-                    seconds
-                )
-            );
-        }
         this.mojo = mojo;
         this.seconds = seconds;
         this.unroll = unroll;
@@ -78,6 +70,14 @@ final class Deadline {
      * @throws MojoFailureException If the deadline passes or the body fails
      */
     void spent(final Callable<?> body) throws MojoFailureException {
+        if (this.seconds < 0L) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The timeout must not be negative, while %d was given through eo.timeout",
+                    this.seconds
+                )
+            );
+        }
         final FutureTask<?> task = new FutureTask<>(body);
         final Thread thread = new Thread(
             task,

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
@@ -32,7 +32,7 @@ final class DeadlineTest {
             "a negative timeout must be reported as a configuration mistake, not as a timeout",
             Assertions.assertThrows(
                 IllegalArgumentException.class,
-                () -> new Deadline(this, -1L, false),
+                () -> new Deadline(this, -1L, false).spent(() -> "never"),
                 "a negative timeout was expected to be refused"
             ).getMessage(),
             Matchers.containsString("must not be negative")

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DeadlineTest.java
@@ -27,6 +27,19 @@ final class DeadlineTest {
     }
 
     @Test
+    void refusesANegativeDeadline() {
+        MatcherAssert.assertThat(
+            "a negative timeout must be reported as a configuration mistake, not as a timeout",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new Deadline(this, -1L, false),
+                "a negative timeout was expected to be refused"
+            ).getMessage(),
+            Matchers.containsString("must not be negative")
+        );
+    }
+
+    @Test
     @Timeout(30)
     void interruptsAHungBodyPromptlyOnTimeout() {
         final long start = System.nanoTime();

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/SavedTest.java
@@ -41,6 +41,17 @@ final class SavedTest {
     }
 
     @Test
+    void savesContentToFileWithShortName(@Mktmp final Path temp) throws IOException {
+        final Path target = temp.resolve("x");
+        new Saved("hi", target).value();
+        MatcherAssert.assertThat(
+            "a one-character file name must be saved, not refused by the temporary prefix",
+            Files.readString(target, StandardCharsets.UTF_8),
+            Matchers.equalTo("hi")
+        );
+    }
+
+    @Test
     void savesContentToRelativeFilenameWithoutParentDirectory() throws IOException {
         final Path target = Path.of(String.format("saved-%s.tmp", UUID.randomUUID()));
         try {


### PR DESCRIPTION
`eo.timeout` went straight into `FutureTask.get(long, TimeUnit)`, which treats a negative
value as no time to wait, so a misconfigured build was reported as an ordinary timeout:

```
Timeout -1000ms for Mojo execution is reached: TimeoutException
```

and the Mojo thread had already been started by then.

`Deadline` refuses such a value in its constructor now, before the thread is made, and
names the parameter that carries it.

Closes #8395
