### PR TITLE
#8446: drop the receiver void nothing fills

### DIFF
--- a/eo-runtime/src/main/eo/dataized.eo
+++ b/eo-runtime/src/main/eo/dataized.eo
@@ -38,7 +38,6 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > dataized /Q.bytes
-  ? > ^
   ? > target
 
   ++> can-avoid-recalculation

--- a/eo-runtime/src/main/eo/recovered.eo
+++ b/eo-runtime/src/main/eo/recovered.eo
@@ -12,7 +12,6 @@
 +spdx SPDX-License-Identifier: MIT
 
 [] > recovered /A
-  ? > ^
   ? > value /A?
   ? > alternative /A
 


### PR DESCRIPTION
`dataized` and `recovered` are only ever applied, never dispatched into, and the Java
atoms behind them declare no receiver: `EOdataized` has `target`, `EOrecovered` has `value`
and `alternative`. The `? > ^` in each was a void that nobody could fill.

Both lines are gone. The whole `eo-runtime` suite passes (2754 tests).

Closes #8446
