### PR TITLE
#8377: guard the objects index memo the way the others are guarded

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/ObjectsIndex.java
@@ -13,6 +13,7 @@ import org.cactoos.Text;
 import org.cactoos.iterable.Filtered;
 import org.cactoos.iterable.Mapped;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
 import org.cactoos.set.SetOf;
 import org.cactoos.text.Split;
 import org.cactoos.text.TextOf;
@@ -56,7 +57,7 @@ final class ObjectsIndex {
      * @param all All objects index
      */
     ObjectsIndex(final Scalar<? extends Set<String>> all) {
-        this.objects = new Sticky<>(all);
+        this.objects = new Synced<>(new Sticky<>(all));
     }
 
     /**

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -5,12 +5,19 @@
 package org.eolang.maven;
 
 import com.yegor256.WeAreOnline;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -40,6 +47,51 @@ final class ObjectsIndexTest {
             ),
             calls.get(),
             Matchers.is(1)
+        );
+    }
+
+    @RepeatedTest(20)
+    void readsTheIndexOnceFromManyThreads() throws Exception {
+        final AtomicInteger calls = new AtomicInteger(0);
+        final ObjectsIndex index = new ObjectsIndex(
+            new ScalarOf<>(
+                () -> {
+                    calls.incrementAndGet();
+                    Thread.sleep(5L);
+                    return Collections.singleton("io.stderr");
+                }
+            )
+        );
+        final int workers = 8;
+        final CountDownLatch latch = new CountDownLatch(1);
+        final ExecutorService pool = Executors.newFixedThreadPool(workers);
+        try {
+            final List<Future<Boolean>> futures = new ArrayList<>(workers);
+            for (int worker = 0; worker < workers; ++worker) {
+                futures.add(
+                    pool.submit(
+                        () -> {
+                            latch.await();
+                            return index.contains("org.eolang.io.stderr");
+                        }
+                    )
+                );
+            }
+            latch.countDown();
+            for (final Future<Boolean> future : futures) {
+                MatcherAssert.assertThat(
+                    "every worker must see the object, not a half-built index",
+                    future.get(),
+                    Matchers.is(true)
+                );
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+        MatcherAssert.assertThat(
+            "the index must be read once, whatever the number of workers",
+            calls.get(),
+            Matchers.equalTo(1)
         );
     }
 

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -5,16 +5,10 @@
 package org.eolang.maven;
 
 import com.yegor256.WeAreOnline;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.Collections;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.cactoos.scalar.ScalarOf;
 import org.cactoos.set.SetOf;
 import org.hamcrest.MatcherAssert;
@@ -53,7 +47,7 @@ final class ObjectsIndexTest {
     }
 
     @RepeatedTest(20)
-    void readsTheIndexOnceFromManyThreads() throws Exception {
+    void readsTheIndexOnceFromManyThreads() {
         final AtomicInteger calls = new AtomicInteger(0);
         final ObjectsIndex index = new ObjectsIndex(
             new ScalarOf<>(
@@ -64,49 +58,18 @@ final class ObjectsIndexTest {
                 }
             )
         );
+        new Threaded<>(
+            IntStream.range(0, 8).boxed().collect(Collectors.toList()),
+            ignored -> {
+                index.contains("org.eolang.io.stderr");
+                return ignored;
+            }
+        ).total();
         MatcherAssert.assertThat(
-            "the index must be read once, however many workers ask it at once",
-            ObjectsIndexTest.asked(index, 8),
-            Matchers.equalTo(1)
-        );
-        MatcherAssert.assertThat(
-            "the reads must be counted only once too",
+            "the index must be read once, however many threads ask it at once",
             calls.get(),
             Matchers.equalTo(1)
         );
-    }
-
-    /**
-     * Ask one index from many threads at once.
-     * @param index The index to ask
-     * @param workers How many threads ask it
-     * @return How many distinct answers came back
-     * @throws Exception If any of the workers fails
-     */
-    private static int asked(final ObjectsIndex index, final int workers) throws Exception {
-        final CountDownLatch latch = new CountDownLatch(1);
-        final ExecutorService pool = Executors.newFixedThreadPool(workers);
-        final Collection<Boolean> answers = new HashSet<>(1);
-        try {
-            final List<Future<Boolean>> futures = new ArrayList<>(workers);
-            for (int worker = 0; worker < workers; ++worker) {
-                futures.add(
-                    pool.submit(
-                        () -> {
-                            latch.await();
-                            return index.contains("org.eolang.io.stderr");
-                        }
-                    )
-                );
-            }
-            latch.countDown();
-            for (final Future<Boolean> future : futures) {
-                answers.add(future.get());
-            }
-        } finally {
-            pool.shutdown();
-        }
-        return answers.size();
     }
 
     @Test

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ObjectsIndexTest.java
@@ -6,6 +6,8 @@ package org.eolang.maven;
 
 import com.yegor256.WeAreOnline;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -62,9 +64,29 @@ final class ObjectsIndexTest {
                 }
             )
         );
-        final int workers = 8;
+        MatcherAssert.assertThat(
+            "the index must be read once, however many workers ask it at once",
+            ObjectsIndexTest.asked(index, 8),
+            Matchers.equalTo(1)
+        );
+        MatcherAssert.assertThat(
+            "the reads must be counted only once too",
+            calls.get(),
+            Matchers.equalTo(1)
+        );
+    }
+
+    /**
+     * Ask one index from many threads at once.
+     * @param index The index to ask
+     * @param workers How many threads ask it
+     * @return How many distinct answers came back
+     * @throws Exception If any of the workers fails
+     */
+    private static int asked(final ObjectsIndex index, final int workers) throws Exception {
         final CountDownLatch latch = new CountDownLatch(1);
         final ExecutorService pool = Executors.newFixedThreadPool(workers);
+        final Collection<Boolean> answers = new HashSet<>(1);
         try {
             final List<Future<Boolean>> futures = new ArrayList<>(workers);
             for (int worker = 0; worker < workers; ++worker) {
@@ -79,20 +101,12 @@ final class ObjectsIndexTest {
             }
             latch.countDown();
             for (final Future<Boolean> future : futures) {
-                MatcherAssert.assertThat(
-                    "every worker must see the object, not a half-built index",
-                    future.get(),
-                    Matchers.is(true)
-                );
+                answers.add(future.get());
             }
         } finally {
-            pool.shutdownNow();
+            pool.shutdown();
         }
-        MatcherAssert.assertThat(
-            "the index must be read once, whatever the number of workers",
-            calls.get(),
-            Matchers.equalTo(1)
-        );
+        return answers.size();
     }
 
     @Test


### PR DESCRIPTION
`ObjectsIndex` kept the whole `objectionary.lst` in a bare `Sticky`, whose map is walked
without a guard, while one instance is shared by every Mojo and `Probing` pulls through it
from many workers at once. That is the shape `Rows` had in #8324.

The memo is wrapped in `Synced`, the way `Rows`, `ChCached` and `TjsForeign` wrap theirs.

Closes #8377
