### PR TITLE
#8449: walk a ring of copies once in taken too

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -57,14 +57,6 @@ import java.util.Map;
  * turns out to be (#8405).</p>
  *
  * @since 0.69.0
- * @todo #8424:35min Walk a ring of copies once in {@code taken} too.
- *  The chain it collects is the copies further along than this application,
- *  and on a ring it comes back round to the application itself, so the voids
- *  this very application is about to fill are counted as taken already and
- *  the fillings are lost. {@link Ends} settles a ring on one of its names for
- *  everyone else; the chain here wants the whole path rather than its end, so
- *  it needs a rule of its own about where a ring starts and stops. Once there
- *  is one, {@code copies} walks the same path and both can share it.
  */
 final class Bound {
 
@@ -176,9 +168,34 @@ final class Bound {
 
     private Collection<String> copies(final String name) {
         final Collection<String> found = new LinkedHashSet<>(0);
+        found.add(name);
+        found.addAll(this.chain(name));
+        return found;
+    }
+
+    /**
+     * The copies further along the chain than the given name.
+     *
+     * <p>The pairs may close into a ring, and a walk on a ring comes back to
+     * where it started. The walk stops at the first name it has seen already,
+     * and the name it started from is not part of the answer: an application
+     * is not a copy of itself, and counting it as one would mark the voids it
+     * is about to fill as filled by somebody else.</p>
+     *
+     * @param name The name to walk from
+     * @return The names further along, in the order they are reached
+     */
+    private List<String> chain(final String name) {
+        final List<String> found = new ArrayList<>(0);
+        final Collection<String> seen = new HashSet<>(0);
+        seen.add(name);
         String walked = name;
-        while (found.add(walked) && this.pairs.containsKey(walked)) {
+        while (this.pairs.containsKey(walked)) {
             walked = this.pairs.get(walked);
+            if (!seen.add(walked)) {
+                break;
+            }
+            found.add(walked);
         }
         return found;
     }
@@ -214,13 +231,7 @@ final class Bound {
     }
 
     private Collection<String> taken(final String application) {
-        final List<String> chain = new ArrayList<>(0);
-        final Collection<String> seen = new HashSet<>(0);
-        String walked = application;
-        while (this.pairs.containsKey(walked) && seen.add(walked)) {
-            walked = this.pairs.get(walked);
-            chain.add(walked);
-        }
+        final List<String> chain = this.chain(application);
         Collections.reverse(chain);
         final Collection<String> found = new HashSet<>(0);
         for (final String step : chain) {

--- a/eo-inference/src/main/java/org/eolang/inference/Bound.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Bound.java
@@ -173,18 +173,11 @@ final class Bound {
         return found;
     }
 
-    /**
-     * The copies further along the chain than the given name.
-     *
-     * <p>The pairs may close into a ring, and a walk on a ring comes back to
-     * where it started. The walk stops at the first name it has seen already,
-     * and the name it started from is not part of the answer: an application
-     * is not a copy of itself, and counting it as one would mark the voids it
-     * is about to fill as filled by somebody else.</p>
-     *
-     * @param name The name to walk from
-     * @return The names further along, in the order they are reached
-     */
+    // The pairs may close into a ring, and a walk on a ring comes back to
+    // where it started, so the walk stops at the first name it has seen
+    // already. The name it started from is not part of the answer: an
+    // application is not a copy of itself, and counting it as one would mark
+    // the voids it is about to fill as filled by somebody else.
     private List<String> chain(final String name) {
         final List<String> found = new ArrayList<>(0);
         final Collection<String> seen = new HashSet<>(0);

--- a/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
@@ -117,6 +117,32 @@ final class BoundTest {
     }
 
     @Test
+    void fillsAVoidFromAnApplicationInsideARing() {
+        final Map<String, String> pairs = new HashMap<>(0);
+        pairs.put("\u03a6.app.zebra", "\u03a6.app.alpha");
+        pairs.put("\u03a6.app.alpha", "\u03a6.app.zebra");
+        MatcherAssert.assertThat(
+            "an application on a ring must still fill the void it names, but it didnt",
+            new Bound(
+                Map.of("\u03a6.app.zebra", List.of("\u03a6.app.one")),
+                Collections.emptyMap(),
+                Collections.emptyMap(),
+                pairs,
+                new Provided(
+                    Map.of(
+                        "\u03a6.app.alpha",
+                        List.of(Map.of("void", "true", "type", "\u03a6.app.alpha.x"))
+                    ),
+                    Collections.emptyMap(),
+                    Collections.emptyList(),
+                    Collections.emptyMap()
+                )
+            ).all().get("\u03a6.app.zebra"),
+            Matchers.equalTo(Map.of("\u03a6.app.alpha.x", "\u03a6.app.one"))
+        );
+    }
+
+    @Test
     void readsTheReceiverOfARingOffTheNameTheRingGoesBy() {
         final Map<String, String> pairs = new HashMap<>(0);
         pairs.put("Φ.app.zebra", "Φ.app.alpha");

--- a/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BoundTest.java
@@ -119,26 +119,26 @@ final class BoundTest {
     @Test
     void fillsAVoidFromAnApplicationInsideARing() {
         final Map<String, String> pairs = new HashMap<>(0);
-        pairs.put("\u03a6.app.zebra", "\u03a6.app.alpha");
-        pairs.put("\u03a6.app.alpha", "\u03a6.app.zebra");
+        pairs.put("Φ.app.zebra", "Φ.app.alpha");
+        pairs.put("Φ.app.alpha", "Φ.app.zebra");
         MatcherAssert.assertThat(
             "an application on a ring must still fill the void it names, but it didnt",
             new Bound(
-                Map.of("\u03a6.app.zebra", List.of("\u03a6.app.one")),
+                Map.of("Φ.app.zebra", List.of("Φ.app.one")),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 pairs,
                 new Provided(
                     Map.of(
-                        "\u03a6.app.alpha",
-                        List.of(Map.of("void", "true", "type", "\u03a6.app.alpha.x"))
+                        "Φ.app.alpha",
+                        List.of(Map.of("void", "true", "type", "Φ.app.alpha.x"))
                     ),
                     Collections.emptyMap(),
                     Collections.emptyList(),
                     Collections.emptyMap()
                 )
-            ).all().get("\u03a6.app.zebra"),
-            Matchers.equalTo(Map.of("\u03a6.app.alpha.x", "\u03a6.app.one"))
+            ).all().get("Φ.app.zebra"),
+            Matchers.equalTo(Map.of("Φ.app.alpha.x", "Φ.app.one"))
         );
     }
 


### PR DESCRIPTION
`taken` walked the chain of copies with the seen-check on the name it was leaving rather
than on the one it was reaching, so on a ring the walk came back round and put the
application itself into the chain. `filled` then counted the voids that application is
about to fill as taken already, and the fillings were lost.

The walk is one method now, `chain`, which stops at the first name it has seen and never
answers with the name it started from. `copies` is that walk plus the name itself, so both
follow the same path, which is what the puzzle asked for.

The test builds a two-name ring where one of the names is an application with one
argument. On `master` `all()` has nothing for it.

Closes #8449
