### PR TITLE
Take the name every filling of a void agrees on

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Agreed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Agreed.java
@@ -1,0 +1,110 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * The names every filling of a void answers the same way, where the program
+ * fills it several ways.
+ *
+ * <p>{@link Sole} and {@link Shared} name a void as a whole, and where the
+ * fillings share no ancestor there is no such name: a void holding a
+ * {@code Φ.file} and a {@code Φ.directory.tmpfile} is neither of them and is
+ * not a third thing either, so a dispatch rooted at it stops there and
+ * {@link Dispatched} invents a name nothing has a row for.</p>
+ *
+ * <p>Sharing no ancestor is not the same as having nothing in common. Both of
+ * those fillings answer {@code size} with the same {@code Φ.file.size}, one of
+ * them because it says so and the other because it cannot answer at all, and a
+ * name they agree on is not picking a favourite among facts. It is asked of
+ * every filling that has a row, and taken when one answer comes back — a
+ * filling that says nothing about the name says nothing against it, since most
+ * rows are incomplete and silence is not denial.</p>
+ *
+ * <p>An answer with no row of its own is silence as well. {@link Provided}
+ * invents a member for a void it walks through, the way it names the
+ * {@code size} of a {@code Φ.directory.tmpfile} after the void that object
+ * delegates into, and a made-up name disagreeing with a real one would sink
+ * every question the two fillings do agree on. It is the same demand
+ * {@link Sole} and {@link Shared} make of what they name: a locator a reader
+ * can go and look at, since whoever reads on needs a row to read the next
+ * answer off.</p>
+ *
+ * <p>What comes back is a fact about the dispatch and not about the void,
+ * which keeps the standing {@link Shared} already has: the void is still
+ * whatever the next caller puts there, and the answer is a waypoint the chain
+ * carries on from rather than a name for the hole.</p>
+ *
+ * @since 0.72.0
+ */
+final class Agreed {
+
+    /**
+     * What the program was seen putting into the void, from {@link Fillings}.
+     */
+    private final Collection<Type> told;
+
+    /**
+     * The objects the provides table has a row for.
+     */
+    private final Collection<String> known;
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * Ctor.
+     * @param witnesses What the program was seen putting into the void, from
+     *  {@link Fillings}
+     * @param objects The objects the provides table has a row for
+     * @param provided What the types certainly have
+     */
+    Agreed(
+        final Collection<Type> witnesses,
+        final Collection<String> objects,
+        final Provided provided
+    ) {
+        this.told = witnesses;
+        this.known = objects;
+        this.owned = provided;
+    }
+
+    /**
+     * The names taken off this void that every filling answers the same way.
+     * @param hollow The locator of the void
+     * @param asked The names the program takes off it, without the void in
+     *  front of them
+     * @return The object each name is, by the locator the name goes by, empty
+     *  where the fillings answer none of them with one voice
+     */
+    Map<String, String> members(final String hollow, final Collection<String> asked) {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final String name : asked) {
+            final Collection<String> replies = this.replies(name);
+            final String member = String.join(".", hollow, name);
+            if (replies.size() == 1 && !replies.contains(member)) {
+                found.put(member, replies.iterator().next());
+            }
+        }
+        return found;
+    }
+
+    private Collection<String> replies(final String name) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        for (final Type one : this.told) {
+            if (this.known.contains(one.names())) {
+                found.add(this.owned.attribute(one.names(), name));
+            }
+        }
+        found.retainAll(this.known);
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Promoted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Promoted.java
@@ -7,6 +7,7 @@ package org.eolang.inference;
 import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -26,6 +27,14 @@ import java.util.Map;
  *
  * <p>{@link Sole} decides what a void is worth and this asks it, of every void
  * at once, off the table {@link Woven} builds from the pairs settled so far.
+ * {@link Shared} is asked where the fillings share an ancestor and {@link
+ * Agreed} where they share nothing but their answers, so a void nothing can be
+ * called as a whole still carries the dispatches its fillings agree on. Which
+ * names those are is read back off the answers themselves, since a dispatch a
+ * void leaves unanswered is answered with a name rooted at the void. Only the
+ * first hop is read: what a further hop asks is asked of an answer nobody has
+ * settled yet, and once this settles the first the next pass reaches the
+ * second.
  * Being asked off a table is what makes the answer improve as the passes go on:
  * an argument whose own type was worked out this pass is a filling with a type
  * next pass, and a void nothing could be said about becomes a void filled one
@@ -111,6 +120,7 @@ final class Promoted {
         final Provided owned = new Provided(
             this.given, new Ends(pairs).names(), this.hollows
         );
+        final Map<String, Collection<String>> asked = this.asked(pairs);
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Collection<Type>> hollow
             : new Fillings(this.links(pairs), this.given).all().entrySet()) {
@@ -118,8 +128,31 @@ final class Promoted {
             if (sole.isEmpty()) {
                 sole = new Shared(hollow.getValue(), known, owned).names();
             }
-            if (!sole.isEmpty() && !pairs.containsKey(hollow.getKey())) {
+            if (sole.isEmpty()) {
+                found.putAll(
+                    new Agreed(hollow.getValue(), known, owned).members(
+                        hollow.getKey(),
+                        asked.getOrDefault(hollow.getKey(), Collections.emptyList())
+                    )
+                );
+            } else {
                 found.put(hollow.getKey(), sole);
+            }
+        }
+        found.keySet().removeAll(pairs.keySet());
+        return found;
+    }
+
+    private Map<String, Collection<String>> asked(final Map<String, String> pairs) {
+        final Rooted rooted = new Rooted(this.hollows);
+        final Map<String, Collection<String>> found = new LinkedHashMap<>(0);
+        for (final String answer : pairs.values()) {
+            final String hollow = rooted.names(answer);
+            if (!hollow.isEmpty() && answer.length() > hollow.length()) {
+                final String name = answer.substring(hollow.length() + 1);
+                if (!name.contains(".")) {
+                    found.computeIfAbsent(hollow, key -> new HashSet<>(0)).add(name);
+                }
             }
         }
         return found;

--- a/eo-inference/src/test/java/org/eolang/inference/AgreedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AgreedTest.java
@@ -1,0 +1,129 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Agreed}.
+ * @since 0.72.0
+ */
+final class AgreedTest {
+
+    @Test
+    void namesWhatEveryFillingCallsTheSame() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("Φ.oak", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        rows.put("Φ.elm", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        MatcherAssert.assertThat(
+            "an oak and an elm both call their leaf green, but the dispatch was left unanswered",
+            new Agreed(
+                Arrays.asList(new Ref("Φ.oak"), new Ref("Φ.elm")),
+                Arrays.asList("Φ.oak", "Φ.elm", "Φ.green"),
+                new Provided(
+                    rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+                )
+            ).members("Φ.grove.tree", Collections.singletonList("leaf")),
+            Matchers.hasEntry("Φ.grove.tree.leaf", "Φ.green")
+        );
+    }
+
+    @Test
+    void namesNothingWhereTheFillingsCallItDifferently() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("Φ.oak", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        rows.put("Φ.elm", List.of(Map.of("name", "leaf", "type", "Φ.brown")));
+        MatcherAssert.assertThat(
+            "a green leaf and a brown one cannot both be the answer, but one was named",
+            new Agreed(
+                Arrays.asList(new Ref("Φ.oak"), new Ref("Φ.elm")),
+                Arrays.asList("Φ.oak", "Φ.elm", "Φ.green", "Φ.brown"),
+                new Provided(
+                    rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+                )
+            ).members("Φ.grove.tree", Collections.singletonList("leaf")),
+            Matchers.anEmptyMap()
+        );
+    }
+
+    @Test
+    void ignoresAFillingThatCannotAnswer() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("Φ.oak", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        rows.put("Φ.rock", List.of(Map.of("name", "weight", "type", "Φ.number")));
+        MatcherAssert.assertThat(
+            "a rock has no leaf to disagree about, but its silence was counted against the oak",
+            new Agreed(
+                Arrays.asList(new Ref("Φ.oak"), new Ref("Φ.rock")),
+                Arrays.asList("Φ.oak", "Φ.rock", "Φ.green"),
+                new Provided(
+                    rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+                )
+            ).members("Φ.grove.tree", Collections.singletonList("leaf")),
+            Matchers.hasEntry("Φ.grove.tree.leaf", "Φ.green")
+        );
+    }
+
+    @Test
+    void ignoresAFillingThatAnswersWithAnInventedName() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("Φ.oak", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        rows.put("Φ.vine", List.of(Map.of("void", "true", "name", "φ", "type", "Φ.vine.host")));
+        MatcherAssert.assertThat(
+            "the leaf of a vine is a name nobody wrote down, but it outvoted the oak",
+            new Agreed(
+                Arrays.asList(new Ref("Φ.oak"), new Ref("Φ.vine")),
+                Arrays.asList("Φ.oak", "Φ.vine", "Φ.green"),
+                new Provided(
+                    rows, Collections.emptyMap(),
+                    Collections.singletonList("Φ.vine.host"), Collections.emptyMap()
+                )
+            ).members("Φ.grove.tree", Collections.singletonList("leaf")),
+            Matchers.hasEntry("Φ.grove.tree.leaf", "Φ.green")
+        );
+    }
+
+    @Test
+    void namesNothingWhereAFillingHasNoRowToRead() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("Φ.oak", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        MatcherAssert.assertThat(
+            "a filling nobody wrote a row for cannot be asked anything, but it was believed",
+            new Agreed(
+                Collections.singletonList(new Ref("Φ.moss")),
+                Arrays.asList("Φ.oak", "Φ.green"),
+                new Provided(
+                    rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+                )
+            ).members("Φ.grove.tree", Collections.singletonList("leaf")),
+            Matchers.anEmptyMap()
+        );
+    }
+
+    @Test
+    void namesNothingWhereNobodyAsksAnything() {
+        final Map<String, Collection<Map<String, String>>> rows = new HashMap<>(0);
+        rows.put("Φ.oak", List.of(Map.of("name", "leaf", "type", "Φ.green")));
+        MatcherAssert.assertThat(
+            "a void no dispatch is rooted at has nothing to answer, but an answer appeared",
+            new Agreed(
+                Collections.singletonList(new Ref("Φ.oak")),
+                Arrays.asList("Φ.oak", "Φ.green"),
+                new Provided(
+                    rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
+                )
+            ).members("Φ.grove.tree", Collections.emptyList()),
+            Matchers.anEmptyMap()
+        );
+    }
+}


### PR DESCRIPTION
`Sole` and `Shared` name a void as a whole, and where its fillings share no
ancestor there is no such name, so a dispatch rooted at the void stops there and
`Provided` invents a locator nothing has a row for. Sharing no ancestor is not
the same as having nothing in common: `Φ.directory.file` holds a `Φ.file` and a
`Φ.directory.tmpfile`, whose chains never meet, yet both answer `exists` with
the same `Φ.file.exists`, one because it says so and the other because it cannot
answer at all.

`Agreed` asks each name of every filling that has a row and takes the answer
when one comes back:

```java
private Collection<String> replies(final String name) {
    final Collection<String> found = new LinkedHashSet<>(0);
    for (final Type one : this.told) {
        if (this.known.contains(one.names())) {
            found.add(this.owned.attribute(one.names(), name));
        }
    }
    found.retainAll(this.known);
    return found;
}
```

The `retainAll` matters as much as the vote. `Provided` invents a member for a
void it walks through, and a made-up name disagreeing with a real one would sink
every question the two fillings do agree on — so an answer with no row of its
own counts as silence, the same demand `Sole` and `Shared` already make.

Which names to ask is read back off the answers themselves, one hop out, since a
dispatch a void leaves unanswered is answered with a name rooted at the void. A
further hop is left to the next pass, which reaches it once the first is
settled.

On `eo-runtime` this settles 74 more pairs, and through them 248 objects move
from the amber band to the green one, with nothing moving down. The issue quotes
398 agreeing names from a model that walked declared attributes only; the real
figure is smaller, because `Provided` also finds members through the package,
and two fillings that each find a different real one genuinely disagree.

Closes #8450
