### PR TITLE
#8316: compare two numbers by value, not by their bytes

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
@@ -34,8 +34,7 @@ import java.util.Optional;
  *  it hands {@code Data.ToPhi} the Java local as it is, a double where
  *  the formation answered bytes, and {@link Reduction} refuses such an
  *  answer for now, wherever a tree settles. Render the view through the
- *  raw bits of the local instead, the way {@code L_bytes_eq} already
- *  compares two numbers, and let the answer carry bytes.
+ *  raw bits of the local instead, and let the answer carry bytes.
  */
 public final class Forced implements Term {
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -24,7 +24,9 @@ import java.util.stream.Stream;
  * answers carried as the {@code Phi} itself, since neither is a datum
  * and every operation on either dispatches back into EO. The value of an application
  * comes from the format the {@link Op} table holds for its atom, except
- * an equality, which compares by the forma of its operands; and a void
+ * an equality, which compares by the forma of its operands: two numbers
+ * by their value, so that a not-a-number equals nothing and the two
+ * zeroes equal each other, and anything else by its bytes; and a void
  * is read through the public runtime API. The forma of a key is looked
  * up in the voids of the program or in the steps of its bodies,
  * nested arms included. Whatever the table cannot spell — an operation
@@ -272,10 +274,7 @@ public final class Rendering {
             .collect(Collectors.toList());
         final String out;
         if ("number".equals(kinds)) {
-            out = String.format(
-                "Double.doubleToRawLongBits(%s) == Double.doubleToRawLongBits(%s)",
-                sides.get(0), sides.get(1)
-            );
+            out = String.format("%s == %s", sides.get(0), sides.get(1));
         } else if ("bytes".equals(kinds)) {
             out = String.format(
                 "java.util.Arrays.equals(%s, %s)",

--- a/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
@@ -15,7 +15,7 @@ import org.cactoos.text.UncheckedText;
  * dispatches into, and phino resolves a {@code Φ.x} reference against the
  * root formation of the document it evaluates. This is that root, read
  * from the {@code universe.phi} resource: {@code number} and {@code bytes}
- * with their twelve λ methods, {@code string} which owns none and reaches
+ * with their thirteen λ methods, {@code string} which owns none and reaches
  * every one of them through its {@code φ}, {@code bool} with the one
  * {@code if} that phino never fires but always parks, so that the
  * reduction learns where a choice stands, and {@code true}/{@code false}
@@ -31,7 +31,13 @@ import org.cactoos.text.UncheckedText;
  * them — {@code slice}, which counts characters where {@code bytes.slice}
  * counts bytes — names a method this universe models. It therefore stands
  * here bound to a λ no {@link Op} row knows, so a text slicing refuses
- * instead of quietly reaching the bytes atom below it.</p>
+ * instead of quietly reaching the bytes atom below it. The same shadowing
+ * keeps {@code number.eq} honest: its contract is IEEE 754, where a
+ * not-a-number equals nothing and the two zeroes equal each other, while
+ * {@code bytes.eq} below it reads eight raw bytes and answers the opposite
+ * on both. It stands here bound to a λ of its own, which an {@link Op} row
+ * renders as the Java {@code ==} of two doubles, the very comparison the
+ * contract asks for.</p>
  *
  * @since 0.76.0
  */

--- a/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
@@ -2,6 +2,7 @@ L_number_plus	plus	number	number	x	%1$s + %2$s
 L_number_times	times	number	number	x	%1$s * %2$s
 L_number_div	div	number	number	x	%1$s / %2$s
 L_number_gt	gt	number	bool	x	%1$s > %2$s
+L_number_eq	eq	number	bool	x
 L_bool_if	if	bool		t,f
 L_bytes_and	and	bytes	bytes	b	new BytesOf(%1$s).and(new BytesOf(%2$s)).take()
 L_bytes_or	or	bytes	bytes	b	new BytesOf(%1$s).or(new BytesOf(%2$s)).take()

--- a/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
@@ -3,6 +3,7 @@
     as-bytes ↦ ∅,
     φ ↦ ξ.as-bytes,
     div ↦ ⟦ x ↦ ∅, λ ⤍ L_number_div ⟧,
+    eq ↦ ⟦ x ↦ ∅, λ ⤍ L_number_eq ⟧,
     gt ↦ ⟦ x ↦ ∅, λ ⤍ L_number_gt ⟧,
     plus ↦ ⟦ x ↦ ∅, λ ⤍ L_number_plus ⟧,
     times ↦ ⟦ x ↦ ∅, λ ⤍ L_number_times ⟧

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -84,7 +84,7 @@ final class JavaAtomTest {
                             new Protocol(
                                 Arrays.asList(
                                     new Application(
-                                        "s1", "L_bytes_eq",
+                                        "s1", "L_number_eq",
                                         Arrays.asList("sym:v1", "number:00-00-00-00-00-00-00-00")
                                     ),
                                     new Fork(
@@ -297,30 +297,24 @@ final class JavaAtomTest {
     }
 
     @Test
-    void rendersNumberEqualityAsBitComparison() {
+    void rendersNumberEqualityAsValueComparison() {
         final Map<String, String> voids = new LinkedHashMap<>();
         voids.put("x", "number");
         voids.put("y", "number");
         MatcherAssert.assertThat(
-            "equality over numbers must compare their raw bits, but it doesnt",
+            "equality over numbers must compare their values, but it doesnt",
             new JavaAtom(
                 new Protocol(
                     Arrays.asList(
                         new Application("s1", "L_number_div", Arrays.asList("sym:v0", "sym:v1")),
-                        new Application("s2", "L_bytes_eq", Arrays.asList("sym:s1", "sym:v0"))
+                        new Application("s2", "L_number_eq", Arrays.asList("sym:s1", "sym:v0"))
                     ),
                     "sym:s2",
                     "bool"
                 ),
                 voids
             ).text(),
-            Matchers.containsString(
-                String.format(
-                    "final boolean s2 = %s == %s;",
-                    "Double.doubleToRawLongBits(s1)",
-                    "Double.doubleToRawLongBits(v0)"
-                )
-            )
+            Matchers.containsString("final boolean s2 = s1 == v0;")
         );
     }
 
@@ -566,9 +560,8 @@ final class JavaAtomTest {
                     "        final double s2;",
                     "        while (true) {",
                     String.format(
-                        "            final boolean s1 = %s == %s;",
-                        "Double.doubleToRawLongBits(v0)",
-                        "Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L))"
+                        "            final boolean s1 = v0 == %s;",
+                        "Double.longBitsToDouble(0x0000000000000000L)"
                     ),
                     "            if (s1) {",
                     "                s2 = v1;",
@@ -749,7 +742,7 @@ final class JavaAtomTest {
         return new Protocol(
             Arrays.asList(
                 new Application(
-                    "s1", "L_bytes_eq", Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
+                    "s1", "L_number_eq", Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
                 ),
                 new Fork(
                     "s2", "L_bool_if", "sym:s1",

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/const-number.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/const-number.yaml
@@ -4,8 +4,8 @@
 # yamllint disable rule:line-length
 # A const of a number is the bytes of that number, so the const reads
 # through its bytes and keeps the key of the step it forces, and the
-# equality that compares it compares the raw bits of two doubles, which
-# is what comparing two dataized values means.
+# equality that compares it compares the two doubles themselves, the
+# way `number.eq` does.
 input: |
   [] > foo
     [x] > same
@@ -27,11 +27,11 @@ lowered: |
 protocol: |
   s1 ← L_number_times sym:v0 sym:v0
   s2 ← L_number_plus sym:v0 sym:v0
-  s3 ← L_bytes_eq sym:s1 sym:s2
+  s3 ← L_number_eq sym:s1 sym:s2
   answer sym:s3 bool
 java: |
   final double v0 = new Dataized(this.take("x")).asNumber();
   final double s1 = v0 * v0;
   final double s2 = v0 + v0;
-  final boolean s3 = Double.doubleToRawLongBits(s1) == Double.doubleToRawLongBits(s2);
+  final boolean s3 = s1 == s2;
   return new Data.ToPhi(s3);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/const-number.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/const-number.yaml
@@ -4,8 +4,9 @@
 # yamllint disable rule:line-length
 # A const of a number is the bytes of that number, so the const reads
 # through its bytes and keeps the key of the step it forces, and the
-# equality that compares it compares the two doubles themselves, the
-# way `number.eq` does.
+# equality that compares it is the byte one, since `number.eq` shadows
+# nothing once the receiver is no longer a number. It still renders as
+# the `==` of two doubles, because both of its operands are numbers.
 input: |
   [] > foo
     [x] > same
@@ -27,7 +28,7 @@ lowered: |
 protocol: |
   s1 ← L_number_times sym:v0 sym:v0
   s2 ← L_number_plus sym:v0 sym:v0
-  s3 ← L_number_eq sym:s1 sym:s2
+  s3 ← L_bytes_eq sym:s1 sym:s2
   answer sym:s3 bool
 java: |
   final double v0 = new Dataized(this.take("x")).asNumber();

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-countdown.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-countdown.yaml
@@ -38,7 +38,7 @@ lowered: |
       ? > acc /Q.number
 protocol: |
   loop v0 v1
-    s1 ← L_bytes_eq sym:v0 number:00-00-00-00-00-00-00-00
+    s1 ← L_number_eq sym:v0 number:00-00-00-00-00-00-00-00
     s2 ← fork sym:s1 number
       then
         answer sym:v1 number
@@ -52,7 +52,7 @@ java: |
   double v1 = new Dataized(this.take("acc")).asNumber();
   final double s2;
   while (true) {
-      final boolean s1 = Double.doubleToRawLongBits(v0) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+      final boolean s1 = v0 == Double.longBitsToDouble(0x0000000000000000L);
       if (s1) {
           s2 = v1;
           break;

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-helper.yaml
@@ -36,7 +36,7 @@ lowered: |
       ? > acc /Q.number
 protocol: |
   loop v0 v1
-    s1 ← L_bytes_eq sym:v0 number:00-00-00-00-00-00-00-00
+    s1 ← L_number_eq sym:v0 number:00-00-00-00-00-00-00-00
     s2 ← fork sym:s1 number
       then
         answer sym:v1 number
@@ -50,7 +50,7 @@ java: |
   double v1 = new Dataized(this.take("acc")).asNumber();
   final double s2;
   while (true) {
-      final boolean s1 = Double.doubleToRawLongBits(v0) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+      final boolean s1 = v0 == Double.longBitsToDouble(0x0000000000000000L);
       if (s1) {
           s2 = v1;
           break;

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
@@ -40,7 +40,7 @@ protocol: |
   loop v0
     repeat a🌵3-4 sym:v0 number:3F-F0-00-00-00-00-00-00
   body a🌵3-4 v1 v2
-    s1 ← L_bytes_eq sym:v1 number:00-00-00-00-00-00-00-00
+    s1 ← L_number_eq sym:v1 number:00-00-00-00-00-00-00-00
     s2 ← fork sym:s1 number
       then
         answer sym:v2 number
@@ -50,7 +50,7 @@ protocol: |
         repeat a🌵8-4 sym:s3 sym:s4
     answer sym:s2 number
   body a🌵8-4 v3 v4
-    s5 ← L_bytes_eq sym:v3 number:00-00-00-00-00-00-00-00
+    s5 ← L_number_eq sym:v3 number:00-00-00-00-00-00-00-00
     s6 ← fork sym:s5 number
       then
         answer sym:v4 number
@@ -74,7 +74,7 @@ java: |
           body = 1;
           continue;
       } else if (body == 1) {
-          final boolean s1 = Double.doubleToRawLongBits(v1) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+          final boolean s1 = v1 == Double.longBitsToDouble(0x0000000000000000L);
           final double s2;
           if (s1) {
               s2 = v2;
@@ -89,7 +89,7 @@ java: |
           out = s2;
           break;
       } else {
-          final boolean s5 = Double.doubleToRawLongBits(v3) == Double.doubleToRawLongBits(Double.longBitsToDouble(0x0000000000000000L));
+          final boolean s5 = v3 == Double.longBitsToDouble(0x0000000000000000L);
           final double s6;
           if (s5) {
               s6 = v4;

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/numeric-equality.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/numeric-equality.yaml
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# Two numbers compare as the doubles they are, not as the eight bytes
+# that encode them. The contract `number.eq` states is IEEE 754: a
+# not-a-number equals nothing, not even itself, and the two zeroes equal
+# each other. Raw bytes disagree with both, so `number` owns an `eq` of
+# its own here, shadowing the byte atom its `φ` would otherwise reach,
+# and the equality renders as the Java `==` the contract asks for.
+input: |
+  [] > foo
+    [x y] > same
+      x.eq y > @
+    same 2 3 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: same
+voids:
+  x: number
+  y: number
+lowered: |
+  [] > foo
+    same > @
+      2
+      3
+    [] > same /Q.bool
+      ? > x /Q.number
+      ? > y /Q.number
+protocol: |
+  s1 ← L_number_eq sym:v0 sym:v1
+  answer sym:s1 bool
+java: |
+  final double v0 = new Dataized(this.take("x")).asNumber();
+  final double v1 = new Dataized(this.take("y")).asNumber();
+  final boolean s1 = v0 == v1;
+  return new Data.ToPhi(s1);


### PR DESCRIPTION
Closes #8316.

`number` owned no `eq` in `universe.phi`, so a numeric equality fell through its `φ` to `bytes.eq` and folded as eight raw bytes: `0.eq -0` came out false and `nan.eq nan` came out true, both against the contract `number/eq.eo` states.

It owns one now, bound to `L_number_eq`, whose `ops.tsv` row renders the Java `==` of two doubles — which is IEEE 754 itself, so a not-a-number equals nothing and the two zeroes equal each other.

`const-number` keeps `bytes.eq`, since a const reads through its bytes and `number.eq` shadows nothing once the receiver is no longer a number. Its Java is the `==` of two doubles all the same, because `Rendering` compares by the forma of the operands, not by the name of the atom.

The issue suggested parking numeric equality instead, with no `ops.tsv` row. That would have made `looped-countdown`, `looped-helper` and `mutual-helpers` stuck — every factorial-shaped recursion guards on `n.eq 0`. Rendering `==` fixes the same folding and keeps them lowering.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDwiQUQSqbNvxVLuBUwEGt
