### PR TITLE
#8423: let the write tests throw for the reason they name

### DIFF
--- a/eo-runtime/src/main/eo/win32.eo
+++ b/eo-runtime/src/main/eo/win32.eo
@@ -182,38 +182,16 @@
         "_stat64"
         "NUL"
 
-  --> stops-on-write-size-being-negative
-    os.is-windows.not.if > @
-      1.div 0
-      seq *
-        code.
-          win32 *1
-            "_write"
-            fd
-            "ab"
-            -1
-        true
-    code. > fd
-      win32 *1
-        "_open"
-        "NUL"
-        win32.wronly
-        0
+  code. --> stops-on-write-size-being-negative
+    win32 *1
+      "_write"
+      win32.stdout
+      "ab"
+      -1
 
-  --> stops-on-write-size-exceeding-buffer-length
-    os.is-windows.not.if > @
-      1.div 0
-      seq *
-        code.
-          win32 *1
-            "_write"
-            fd
-            "ab"
-            4096
-        true
-    code. > fd
-      win32 *1
-        "_open"
-        "NUL"
-        win32.wronly
-        0
+  code. --> stops-on-write-size-exceeding-buffer-length
+    win32 *1
+      "_write"
+      win32.stdout
+      "ab"
+      4096


### PR DESCRIPTION
Closes #8423.

The issue reads these two tests as failing on Windows. They do not: `seq`
dataizes every step but the last, and the first step already throws.
`WriteFuncCall` checks the size before it calls msvcrt — `Natural` refuses
`-1`, and an explicit guard refuses a size past the buffer — so `-->` is
satisfied on Windows for the reason each test names.

What is real is the other half: off Windows `os.is-windows.not.if` took the
`1.div 0` branch, so the tests only proved that a division by zero is not a
boolean.

Since both checks happen before any msvcrt call, a literal descriptor makes
them throw on every platform. The guard, the `_open` on `NUL` and the
trailing `true` are gone.

`posix.eo:207` and `posix.eo:225` carry the mirror pair, vacuous on Windows
for the same reason. Left alone here.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LDwiQUQSqbNvxVLuBUwEGt
