### PR TITLE
#8367: name a bool filling by the state it copies

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Formas.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Formas.java
@@ -34,16 +34,6 @@ import org.w3c.dom.Node;
  * literal — answers with the empty string, and the caller refuses.</p>
  *
  * @since 0.76.0
- * @todo #8365:30min Witness a bool void filled with {@code true} or
- *  {@code false}. The provides table records such an argument by the
- *  locator of the argument itself, {@code Φ.foo.φ.α0} say, with no
- *  links row behind it, where a number literal is recorded as
- *  {@code Φ.number} outright. So {@code admitted} finds no carrier, and
- *  the {@code pick} formation of the {@code fork-on-flag} pack stays as
- *  written, though its reduction forks on the void fine. Find out how
- *  {@code eo:inference} names the fillings of a void, teach it to name
- *  {@code Φ.true} and {@code Φ.false} the way it names {@code Φ.number},
- *  and let that pack lower into Java.
  */
 public final class Formas {
 

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-bool-literal-fills-a-void-with-the-state-it-names.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-bool-literal-fills-a-void-with-the-state-it-names.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A bool literal is a copy of the object its state names, so a void filled
+# with `true` is witnessed as `Φ.true` and a void filled with `false` as
+# `Φ.false`, the way a void filled with a number literal is witnessed as
+# `Φ.number`. What names the filling is the base resolving against the
+# sources of the program and nothing about the literal itself: a program
+# that carries no `true` names the same filling by the locator of the
+# argument, and a void so witnessed has no forma for a reader to use.
+eo:
+  app.eo: |
+    [] > app
+      pick true false > @
+  pick.eo: |
+    [on off] > pick
+      on > @
+  true.eo: |
+    [] > true
+  false.eo: |
+    [] > false
+provides:
+  - "//type[@id='Φ.pick']/attr[@name='on'][@void='true']/witnessed/ref[@loc='Φ.true']"
+  - "//type[@id='Φ.pick']/attr[@name='off'][@void='true']/witnessed/ref[@loc='Φ.false']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/fork-on-flag.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/fork-on-flag.yaml
@@ -5,9 +5,11 @@
 # symbolic bool at once, with no guard to reduce first, so the fork is
 # the first and only step at the top, each arm holds one step of its
 # own, and the label of the else arm counts on from the then arm. The
-# formation stays as written all the same: the tables witness the
-# `true` filling `flag` by the locator of the argument, not as a bool
-# carrier, so the lowering never learns the forma of that void.
+# `true` filling `flag` is a copy of the object the state names, so the
+# tables witness the void as `Φ.true` the way they witness a number
+# literal as `Φ.number`, and the formation leaves the EO as one atom.
+# Both arms read `x`, so it is read at the top beside the flag rather
+# than inside either block.
 input: |
   [] > foo
     [flag x] > pick
@@ -20,6 +22,8 @@ prelude:
   number.eo: |
     [as-bytes] > number
       as-bytes > @
+  true.eo: |
+    [] > true
 unit: pick
 voids:
   flag: bool
@@ -29,9 +33,9 @@ lowered: |
     pick > @
       true
       5
-    flag.if > [flag x] > pick
-      x.plus 1
-      x.times 2
+    [] > pick /Q.number
+      ? > flag /Q.bool
+      ? > x /Q.number
 protocol: |
   s1 ← fork sym:v0 number
     then
@@ -41,3 +45,15 @@ protocol: |
       s3 ← L_number_times sym:v1 number:40-00-00-00-00-00-00-00
       answer sym:s3 number
   answer sym:s1 number
+java: |
+  final boolean v0 = new Dataized(this.take("flag")).asBool();
+  final double v1 = new Dataized(this.take("x")).asNumber();
+  final double s1;
+  if (v0) {
+      final double s2 = v1 + Double.longBitsToDouble(0x3FF0000000000000L);
+      s1 = s2;
+  } else {
+      final double s3 = v1 * Double.longBitsToDouble(0x4000000000000000L);
+      s1 = s3;
+  }
+  return new Data.ToPhi(s1);


### PR DESCRIPTION
Closes #8367

The puzzle asked to teach `eo:inference` to name `Φ.true` and `Φ.false` the way it names `Φ.number`. It already does: a filling is named by resolving its base against the sources of the program, and nothing about the literal itself. Dumping the tables for the pack's own program shows the symmetry — drop `number.eo` from the prelude and the `x` void falls back to `Φ.foo.φ.α1`, the argument's own locator, exactly as `flag` fell back to `Φ.foo.φ.α0`.

What the `fork-on-flag` pack lacked was the object the literal names. Its prelude held `number.eo` and no `true`, so `Φ.true` resolved to nothing, `flag` was witnessed by a locator with no forma behind it, and `Lowered` refused the formation. With `true` in the prelude the void is witnessed as a bool and the formation leaves the EO as one atom that forks on the flag, with `x` read once above the fork since both arms touch it.

A new inference pack pins the rule so a later change cannot take it away silently.

Verified without a phino binary at hand: the `java:` block is what `JavaAtom` renders from the pack's protocol, the `lowered:` block is what the printer gives for the XMIR `Lowered.marked` leaves behind, and `InferringTest` is green with the new pack.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V1MzBiwvqUcwoX4EpkZuLo