### PR TITLE
#8419: compile a regex pattern once and keep it

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Compiled.java
+++ b/eo-runtime/src/main/java/org/eolang/Compiled.java
@@ -1,0 +1,61 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * A regular expression built from its source once, for every caller that
+ * asks for the same source afterwards.
+ *
+ * <p>Building a regular expression costs more than matching with it, and
+ * the two atoms of {@code string.regex} read their source afresh on every
+ * run: {@code pattern.checked} to learn whether it builds at all and
+ * {@code pattern.match.searched} to search with it, once for every block a
+ * walk over the text finds. A walk over ten blocks therefore paid for
+ * eleven builds of one expression. Keeping the built patterns here, under
+ * the source they came from, leaves one build per source.</p>
+ *
+ * <p>The patterns are shared by every caller in the process, and the one
+ * asked for longest ago goes first once there are too many of them, so a
+ * program that keeps making new expressions does not fill the heap with
+ * them. A source the engine chokes on is not kept, so the next caller hears
+ * the same refusal.</p>
+ *
+ * @since 0.77
+ */
+final class Compiled {
+
+    /**
+     * The patterns built so far, under the sources they came from.
+     */
+    private static final Map<String, Pattern> PATTERNS = Collections.synchronizedMap(
+        new Lru<>(256)
+    );
+
+    /**
+     * The source of the expression.
+     */
+    private final String source;
+
+    /**
+     * Ctor.
+     * @param src The source of the expression, as the engine reads it
+     */
+    Compiled(final String src) {
+        this.source = src;
+    }
+
+    /**
+     * Return it.
+     * @return The pattern built from the source
+     */
+    Pattern it() {
+        return Compiled.PATTERNS.computeIfAbsent(this.source, Pattern::compile);
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOchecked.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOchecked.java
@@ -5,7 +5,6 @@
 
 package org.eolang;
 
-import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -53,7 +52,7 @@ public final class EOstring$EOregex$EOpattern$EOchecked extends PhDefault implem
         final Phi pattern = this.take(Phi.RHO);
         Phi result = pattern;
         try {
-            Pattern.compile(new Dataized(pattern.take("source")).asString());
+            new Compiled(new Dataized(pattern.take("source")).asString()).it();
         } catch (final PatternSyntaxException ex) {
             result = this.take(EOstring$EOregex$EOpattern$EOchecked.FALLBACK);
             result.put(0, new Data.ToPhi(ex.getDescription()));

--- a/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOsearched.java
+++ b/eo-runtime/src/main/java/org/eolang/EOstring$EOregex$EOpattern$EOmatch$EOsearched.java
@@ -7,7 +7,6 @@ package org.eolang;
 
 import java.util.Optional;
 import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 
 /**
@@ -70,7 +69,7 @@ public final class EOstring$EOregex$EOpattern$EOmatch$EOsearched extends PhDefau
         }
         final Matcher matcher;
         try {
-            matcher = Pattern.compile(source).matcher(text);
+            matcher = new Compiled(source).it().matcher(text);
         } catch (final PatternSyntaxException ex) {
             throw new ExFailure(
                 String.format("cannot search with the regex pattern '%s'", source),

--- a/eo-runtime/src/main/java/org/eolang/Lru.java
+++ b/eo-runtime/src/main/java/org/eolang/Lru.java
@@ -23,14 +23,15 @@ import java.util.Set;
  * {@link java.util.Collections#synchronizedMap(Map)} when several
  * threads share it.</p>
  *
+ * @param <T> The type of the values kept
  * @since 0.75
  */
-final class Lru implements Map<String, byte[]> {
+final class Lru<T> implements Map<String, T> {
 
     /**
      * The entries, in the order of access.
      */
-    private final Map<String, byte[]> origin;
+    private final Map<String, T> origin;
 
     /**
      * How many entries to keep.
@@ -70,13 +71,13 @@ final class Lru implements Map<String, byte[]> {
     }
 
     @Override
-    public byte[] get(final Object key) {
+    public T get(final Object key) {
         return this.origin.get(key);
     }
 
     @Override
-    public byte[] put(final String key, final byte[] value) {
-        final byte[] result;
+    public T put(final String key, final T value) {
+        final T result;
         if (this.capacity == 0) {
             result = null;
         } else {
@@ -91,13 +92,13 @@ final class Lru implements Map<String, byte[]> {
     }
 
     @Override
-    public byte[] remove(final Object key) {
+    public T remove(final Object key) {
         return this.origin.remove(key);
     }
 
     @Override
-    public void putAll(final Map<? extends String, ? extends byte[]> map) {
-        for (final Map.Entry<? extends String, ? extends byte[]> entry : map.entrySet()) {
+    public void putAll(final Map<? extends String, ? extends T> map) {
+        for (final Map.Entry<? extends String, ? extends T> entry : map.entrySet()) {
             this.put(entry.getKey(), entry.getValue());
         }
     }
@@ -113,12 +114,12 @@ final class Lru implements Map<String, byte[]> {
     }
 
     @Override
-    public Collection<byte[]> values() {
+    public Collection<T> values() {
         return this.origin.values();
     }
 
     @Override
-    public Set<Map.Entry<String, byte[]>> entrySet() {
+    public Set<Map.Entry<String, T>> entrySet() {
         return this.origin.entrySet();
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/PhSticky.java
+++ b/eo-runtime/src/main/java/org/eolang/PhSticky.java
@@ -101,7 +101,7 @@ public final class PhSticky implements Phi {
     public PhSticky(final Phi obj, final int capacity) {
         this(
             obj,
-            Collections.synchronizedMap(new Lru(capacity)),
+            Collections.synchronizedMap(new Lru<>(capacity)),
             new CopyOnWriteArrayList<>(),
             new ConcurrentHashMap<>(0)
         );

--- a/eo-runtime/src/test/java/org/eolang/CompiledTest.java
+++ b/eo-runtime/src/test/java/org/eolang/CompiledTest.java
@@ -1,0 +1,55 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.PatternSyntaxException;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Compiled}.
+ * @since 0.77
+ */
+final class CompiledTest {
+
+    @Test
+    void handsBackThePatternItBuiltBefore() {
+        final String source = String.format(
+            "(?i)\\bζ%d[a-z]{2,}\\b", ThreadLocalRandom.current().nextInt()
+        );
+        MatcherAssert.assertThat(
+            "a source built once must be handed back as the very pattern it was built into, or every match would compile it again",
+            new Compiled(source).it(),
+            Matchers.sameInstance(new Compiled(source).it())
+        );
+    }
+
+    @Test
+    void tellsOneSourceFromAnother() {
+        final int seed = ThreadLocalRandom.current().nextInt();
+        MatcherAssert.assertThat(
+            "two sources must be built into two patterns, or a search would run the expression it was not asked for",
+            new Compiled(String.format("ζ%d[0-9]{3}", seed)).it(),
+            Matchers.not(
+                Matchers.sameInstance(new Compiled(String.format("ζ%d[0-9]{4}", seed)).it())
+            )
+        );
+    }
+
+    @Test
+    void refusesASourceTheEngineChokesOn() {
+        Assertions.assertThrows(
+            PatternSyntaxException.class,
+            () -> new Compiled(
+                String.format("ζ%d**", ThreadLocalRandom.current().nextInt())
+            ).it(),
+            "a source that does not compile must be refused, so that 'checked' can still name the construct the engine choked on"
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/LruTest.java
+++ b/eo-runtime/src/test/java/org/eolang/LruTest.java
@@ -18,7 +18,7 @@ final class LruTest {
 
     @Test
     void keepsNothingWhenCapacityIsZero() {
-        final Lru map = new Lru(0);
+        final Lru<byte[]> map = new Lru<>(0);
         map.put("a", new byte[] {(byte) 0x01});
         MatcherAssert.assertThat(
             "a map of no capacity must not remember what was put into it, but it did",
@@ -29,7 +29,7 @@ final class LruTest {
 
     @Test
     void staysEmptyWhenCapacityIsZero() {
-        final Lru map = new Lru(0);
+        final Lru<byte[]> map = new Lru<>(0);
         map.put("a", new byte[] {(byte) 0x01});
         map.put("b", new byte[] {(byte) 0x02});
         MatcherAssert.assertThat(
@@ -43,7 +43,7 @@ final class LruTest {
     void refusesNegativeCapacity() {
         Assertions.assertThrows(
             IllegalArgumentException.class,
-            () -> new Lru(-1),
+            () -> new Lru<byte[]>(-1),
             "a negative capacity must be refused by the constructor, but it wasnt"
         );
     }


### PR DESCRIPTION
Closes #8419.

`pattern.checked` compiled the source only to throw the result away, and `pattern.match.searched` compiled it again for every block a walk finds, so a walk over ten blocks paid for eleven builds of one expression.

`Compiled` keeps the built patterns under their sources, in a bounded LRU shared by the process, and both atoms go through it. `Lru` became generic to hold them; `PhSticky` keeps its `byte[]` values. A source the engine chokes on is not kept, so `checked` still names the construct.

A `match` walk over five blocks now leaves one entry in the cache — one build, was six.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012fytJaYxro3yQyw8njaAGW