### PR TITLE
#6096: name the glob that cannot be compiled

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Globbed.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Globbed.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.regex.PatternSyntaxException;
+import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Unchecked;
+
+/**
+ * A glob pattern that decides whether a walk takes a file.
+ *
+ * <p>The pattern arrives from a parameter in pom.xml, is compiled on the
+ * first file it is asked about, and the compiled matcher is kept for the
+ * files that follow. A pattern that cannot be compiled is reported with
+ * its own text and with the role it plays, because the error the JDK
+ * raises quotes the regular expression the glob was translated into and
+ * names neither the glob nor what it was meant to select.</p>
+ *
+ * <p>The name is not {@code Glob} on purpose. Plexus resolves the name of
+ * a configuration element to a class in this package, and {@code <glob>}
+ * is what {@code <keepBinaries>} in {@code eo-runtime/pom.xml} calls its
+ * members, so a class named {@code Glob} is taken for the type of those
+ * members and the build dies on its missing no-argument constructor.</p>
+ *
+ * @since 0.73.4
+ */
+final class Globbed {
+
+    /**
+     * The pattern, as pom.xml writes it.
+     */
+    private final String text;
+
+    /**
+     * What this glob does to the files it matches.
+     */
+    private final String role;
+
+    /**
+     * The matcher, compiled once.
+     */
+    private final Unchecked<PathMatcher> matcher;
+
+    /**
+     * Ctor.
+     * @param pattern The glob pattern
+     * @param does What the glob does to the files it matches
+     */
+    Globbed(final String pattern, final String does) {
+        this.text = pattern;
+        this.role = does;
+        this.matcher = new Unchecked<>(new Sticky<>(this::compiled));
+    }
+
+    /**
+     * Does this glob match the file?
+     * @param file The file, relative to the home of the walk
+     * @return TRUE if it matches
+     */
+    boolean matches(final Path file) {
+        return this.matcher.value().matches(file);
+    }
+
+    private PathMatcher compiled() {
+        try {
+            return FileSystems.getDefault().getPathMatcher(
+                String.format("glob:%s", this.text)
+            );
+        } catch (final PatternSyntaxException ex) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "The glob '%s', which %s, is not a valid pattern",
+                    this.text,
+                    this.role
+                ),
+                ex
+            );
+        }
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/WkDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/WkDefault.java
@@ -5,7 +5,6 @@
 package org.eolang.maven;
 
 import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -56,11 +55,14 @@ final class WkDefault extends ListEnvelope<Path> implements Walk {
 
     @Override
     public Walk includes(final Collection<String> globs) {
+        final Collection<Globbed> patterns = globs.stream()
+            .map(glob -> new Globbed(glob, "includes files into the walk"))
+            .collect(Collectors.toList());
         return new WkDefault(
             this.home,
             this.stream().filter(
-                file -> globs.stream().anyMatch(
-                    glob -> this.matches(glob, file)
+                file -> patterns.stream().anyMatch(
+                    glob -> glob.matches(this.relative(file))
                 )
             )
             .collect(Collectors.toList())
@@ -69,11 +71,14 @@ final class WkDefault extends ListEnvelope<Path> implements Walk {
 
     @Override
     public Walk excludes(final Collection<String> globs) {
+        final Collection<Globbed> patterns = globs.stream()
+            .map(glob -> new Globbed(glob, "excludes files from the walk"))
+            .collect(Collectors.toList());
         return new WkDefault(
             this.home,
             this.stream().filter(
-                file -> globs.stream().noneMatch(
-                    glob -> this.matches(glob, file)
+                file -> patterns.stream().noneMatch(
+                    glob -> glob.matches(this.relative(file))
                 )
             )
             .collect(Collectors.toList())
@@ -102,12 +107,10 @@ final class WkDefault extends ListEnvelope<Path> implements Walk {
         }
     }
 
-    private boolean matches(final String text, final Path file) {
-        return FileSystems.getDefault().getPathMatcher(String.format("glob:%s", text)).matches(
-            Paths.get(
-                file.toAbsolutePath().toString().substring(
-                    this.home.toAbsolutePath().toString().length() + 1
-                )
+    private Path relative(final Path file) {
+        return Paths.get(
+            file.toAbsolutePath().toString().substring(
+                this.home.toAbsolutePath().toString().length() + 1
             )
         );
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/WkDefaultTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/WkDefaultTest.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.DisabledOnOs;
@@ -39,6 +40,34 @@ final class WkDefaultTest {
             ),
             new WkDefault(temp).includes(new ListOf<>(pattern)),
             Matchers.iterableWithSize(count)
+        );
+    }
+
+    @Test
+    void namesTheGlobInsteadOfTheRegexItTranslatesTo(@Mktmp final Path temp) throws Exception {
+        new Saved("[] > foo", temp.resolve("foo.eo")).value();
+        MatcherAssert.assertThat(
+            "the error must quote the glob from the configuration, but it quoted the regex",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new WkDefault(temp).includes(new ListOf<>("src/[]/*.eo")),
+                "a glob that cannot be compiled must be refused"
+            ).getMessage(),
+            Matchers.containsString("src/[]/*.eo")
+        );
+    }
+
+    @Test
+    void namesTheRoleOfAGlobThatDeselects(@Mktmp final Path temp) throws Exception {
+        new Saved("[] > foo", temp.resolve("foo.eo")).value();
+        MatcherAssert.assertThat(
+            "the error must say that the glob deselects files, but it said nothing about it",
+            Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new WkDefault(temp).excludes(new ListOf<>("{foo")),
+                "a glob that cannot be compiled must be refused"
+            ).getMessage(),
+            Matchers.containsString("excludes")
         );
     }
 


### PR DESCRIPTION
Fixes #6096.

`WkDefault.matches` handed a glob straight to `getPathMatcher`, so a malformed one from pom.xml escaped as a raw `PatternSyntaxException`. For a bracket class the JDK quotes the regex the glob was translated into rather than the glob itself, so the pattern the user actually wrote never appeared:

```
glob:src/[]/*.eo
-> PatternSyntaxException: Unclosed character class near index 25
   ^src/[[^/]&&[]]/[^/]*\.eo$
```

Five pom parameters carry these globs — `<includeSources>`, `<excludeSources>`, `<placeBinaries>`, `<skipBinaries>`, `<keepBinaries>` — and the error named none of them, so a typo in one sent the reader looking at a regex they never wrote.

## What changed

`Globbed` owns one pattern. It compiles the pattern once for the whole walk instead of once per file, and a pattern it cannot compile is reported with its own text and with the role it plays:

```
The glob 'src/[]/*.eo', which includes files into the walk, is not a valid pattern
```

`WkDefault` builds its globs once per `includes`/`excludes` call and asks each one about a file, which also drops the per-file recompilation the issue notes as a secondary cost.

The role is passed in by the caller rather than fixed in the message, because `includes` and `excludes` share the class and a glob that deselects binaries should not be reported as source selection. The class cannot know the pom parameter itself, so the role is the closest true thing it can say.

Compilation stays lazy, on the first file the glob is asked about. That keeps the behaviour of `master` for a build whose bad glob no file ever reaches, so this fixes the message without turning previously-working builds red.

## Why the class is not called `Glob`

It was, in the first push, and that broke `eo-runtime`. Plexus resolves the name of a configuration element to a class in the plugin's package, and `<keepBinaries>` in `eo-runtime/pom.xml` names its members `<glob>`:

```xml
<keepBinaries>
  <glob>org/eolang/package-info.class</glob>
</keepBinaries>
```

With a class named `Glob` on the plugin's classpath, Plexus took it for the type of those members and the build died before any mojo ran:

```
Caused by: java.lang.NoSuchMethodException: org.eolang.maven.Glob.<init>()
  ...
  mvn <args> -rf :eo-runtime
```

Hence `Globbed`, with a note in its javadoc so it does not get renamed back. Verified: with the rename, `mvn -pl eo-runtime process-sources` configures and runs `register` and `format` — the very execution that carries `<keepBinaries>` — instead of failing at configuration time.

## Tests

Two tests in `WkDefaultTest`, one per behaviour: the bracket-class glob must appear in the message, and a glob that deselects must be reported as such. Both fail on `master` with the raw JDK text and pass here:

```
master:  Tests run: 6, Failures: 2   (the two new ones, "Unclosed character class near index 25" / "Missing '} near index 3")
branch:  Tests run: 6, Failures: 0
```

Full module: `Tests run: 1068, Failures: 2, Skipped: 181` — the two are `OyRemoteTest.checksPresenceOfDirectory` and `checksPresenceOfDirectoryWithNarrowHash`, which reach objectionary.com and fail the same way on `master` in this sandbox; they do not touch `Walk`. `qulice` on `eo-maven-plugin` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CeohJgvUiNrwuSfndfM1gs