### PR TITLE
feat(lowering): #8411 let a path of a protocol fail

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Again.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Again.java
@@ -115,6 +115,11 @@ public final class Again implements Term {
     }
 
     @Override
+    public Optional<Fail> terminator() {
+        return Optional.empty();
+    }
+
+    @Override
     public Term swapped(final Shape shape, final Term swap) {
         return new Again(
             this.target,

--- a/eo-lowering/src/main/java/org/eolang/lowering/Fail.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Fail.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The terminator of the fragment, standing in the reduction tree with
+ * the reason it carries.
+ *
+ * <p>It is what {@code T "reason"} parses into: the one object of EO
+ * that has no value, since dataizing it aborts with its reason as the
+ * message. It renders as a formation binding the reason to {@code r},
+ * next to the marker λ {@code L_fail}, so that phino parks on it
+ * wherever it stands and never looks inside; the universe needs no row
+ * for it. It has no key and no forma, since it is not a value, and a
+ * reduction that finds it at the root of a tree settles that tree into
+ * a failure instead of an answer, with the reason reduced into a value
+ * of its own: the Java of such a path throws, so an arm that fails has
+ * no opinion about what its fork answers, the way an arm that repeats
+ * has none. Anywhere else it is refused, since an operation awaiting
+ * its value never gets one.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Fail implements Term {
+
+    /**
+     * The reason of the failure.
+     */
+    private final Term cause;
+
+    /**
+     * Ctor.
+     * @param reason The reason of the failure
+     */
+    public Fail(final Term reason) {
+        this.cause = reason;
+    }
+
+    /**
+     * The reason of the failure.
+     * @return The term the message is dataized from
+     */
+    public Term reason() {
+        return this.cause;
+    }
+
+    @Override
+    public String phi() {
+        return String.format("⟦ r ↦ %s, λ ⤍ L_fail ⟧", this.cause.phi());
+    }
+
+    @Override
+    public String key() {
+        return "";
+    }
+
+    @Override
+    public String forma() {
+        return "";
+    }
+
+    @Override
+    public boolean matches(final Shape shape) {
+        return this.cause.matches(shape);
+    }
+
+    @Override
+    public Optional<List<Binding>> arguments(final Shape shape) {
+        return this.cause.arguments(shape);
+    }
+
+    @Override
+    public Optional<Again> again() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<Fail> terminator() {
+        return Optional.of(this);
+    }
+
+    @Override
+    public Term swapped(final Shape shape, final Term swap) {
+        return new Fail(this.cause.swapped(shape, swap));
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Failure.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Failure.java
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * The protocol a tree settles into when it fails.
+ *
+ * <p>The reason of the terminator is reduced into the same list of
+ * steps, since a failure evaluates it to make its message, and the key
+ * it becomes is what the protocol fails with. The reason must settle
+ * into a value, not into a call or another terminator, and that value
+ * must be a string, or the bytes one is made of, since the message of
+ * the failure is the reason dataized and read as text: a reason of any
+ * other forma would abort with a message the atom cannot spell, so it
+ * is refused.</p>
+ *
+ * @since 0.76.0
+ */
+public final class Failure {
+
+    /**
+     * The reduction settling the reason.
+     */
+    private final Reduction reduction;
+
+    /**
+     * The ledger naming the carrier of the reason.
+     */
+    private final Minted ledger;
+
+    /**
+     * Ctor.
+     * @param core The reduction settling the reason
+     * @param minted The ledger naming the carrier of the reason
+     */
+    public Failure(final Reduction core, final Minted minted) {
+        this.reduction = core;
+        this.ledger = minted;
+    }
+
+    /**
+     * The protocol of the failure.
+     * @param fail The terminator the tree is
+     * @param steps The steps of the protocol so far, to add to
+     * @return The protocol, ending in the failure
+     * @throws IOException If the binary cannot be run
+     */
+    public Protocol protocol(final Fail fail, final List<Step> steps) throws IOException {
+        final Term reason = this.reduction.reduced(fail.reason(), steps, this.ledger);
+        if (reason.key().isEmpty()) {
+            throw new IllegalStateException(
+                "The reason of the terminator must settle into a value, but it repeats or fails"
+            );
+        }
+        final String forma = this.ledger.carried(reason);
+        if (!"string".equals(forma) && !"bytes".equals(forma)) {
+            throw new IllegalStateException(
+                String.format(
+                    "The reason of the terminator must be a string, but '%s' carries a %s",
+                    reason.key(), forma
+                )
+            );
+        }
+        return new Protocol(steps, reason.key());
+    }
+}

--- a/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Forced.java
@@ -110,6 +110,11 @@ public final class Forced implements Term {
     }
 
     @Override
+    public Optional<Fail> terminator() {
+        return Optional.empty();
+    }
+
+    @Override
     public Term swapped(final Shape shape, final Term swap) {
         final Term out;
         if (this.covered(shape)) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Fork.java
@@ -20,9 +20,10 @@ import java.util.List;
  * stay behind the bool that protects them. The value of the fork is
  * whatever the taken arm answers, so the two arms must answer the same
  * forma, and a fork whose arms disagree refuses to name one. An arm may
- * also resume a body instead of answering, and then the fork answers
- * what the other arm does; a fork resuming in both arms has no value
- * and names no forma, since nothing after it ever runs.</p>
+ * also resume a body, or fail, instead of answering, and then the fork
+ * answers what the other arm does; a fork resuming or failing in both
+ * arms has no value and names no forma, since nothing after it ever
+ * runs.</p>
  *
  * @since 0.76.0
  */

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -32,7 +32,10 @@ import java.util.stream.Collectors;
  * the fork that ends the program is assigned and followed by
  * {@code break}, and a repeat assigns the voids their next values,
  * through temporaries wherever a value names a void the same repeat
- * rebinds, and continues. A
+ * rebinds, and continues. A path that fails throws an {@code ExFailure}
+ * carrying the reason as its message, the way the terminator itself
+ * does when dataized, so an arm that fails assigns nothing and the
+ * statements after its fork run only when the other arm is taken. A
  * program of several bodies runs the same loop over a state naming the
  * body that runs next: the voids of every body are locals, the
  * formation's read before the loop and the helpers' blank until a repeat
@@ -196,12 +199,7 @@ public final class JavaAtom {
         final String pad = "        ";
         final List<String> out = this.computed(proto, pad, all, "");
         if (proto.again().isEmpty()) {
-            if (!proto.carrier().isEmpty()) {
-                out.add(
-                    String.format("%sout = %s;", pad, this.values.expression(proto.answer()))
-                );
-                out.add(String.format("%sbreak;", pad));
-            }
+            out.addAll(this.closed("out", proto, pad, true));
         } else {
             out.addAll(this.rebound(proto.target(), proto.again(), pad));
         }
@@ -274,16 +272,41 @@ public final class JavaAtom {
         final String pad, final Set<Integer> known, final String exit) {
         final List<String> out = this.computed(arm, pad, known, exit);
         if (arm.again().isEmpty()) {
-            out.add(
-                String.format("%s%s = %s;", pad, label, this.values.expression(arm.answer()))
-            );
-            if (label.equals(exit)) {
-                out.add(String.format("%sbreak;", pad));
-            }
+            out.addAll(this.closed(label, arm, pad, label.equals(exit)));
         } else {
             out.addAll(this.rebound(arm.target(), arm.again(), pad));
         }
         return out;
+    }
+
+    private List<String> closed(final String label, final Protocol proto,
+        final String pad, final boolean exits) {
+        final List<String> out = new ArrayList<>(2);
+        if (proto.reason().isEmpty()) {
+            out.add(
+                String.format("%s%s = %s;", pad, label, this.values.expression(proto.answer()))
+            );
+            if (exits) {
+                out.add(String.format("%sbreak;", pad));
+            }
+        } else {
+            out.add(this.thrown(proto.reason(), pad));
+        }
+        return out;
+    }
+
+    private String thrown(final String reason, final String pad) {
+        if (!"bytes".equals(this.values.forma(reason))) {
+            throw new IllegalStateException(
+                String.format(
+                    "The reason '%s' of the failure does not carry a string", reason
+                )
+            );
+        }
+        return String.format(
+            "%sthrow new ExFailure(\"%%s\", new String(%s, %s));",
+            pad, this.values.expression(reason), "java.nio.charset.StandardCharsets.UTF_8"
+        );
     }
 
     private List<String> rebound(final String target, final List<String> keys,

--- a/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Literal.java
@@ -91,6 +91,11 @@ public final class Literal implements Term {
     }
 
     @Override
+    public Optional<Fail> terminator() {
+        return Optional.empty();
+    }
+
+    @Override
     public Term swapped(final Shape shape, final Term swap) {
         return this;
     }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
@@ -20,24 +20,25 @@ import java.util.stream.Collectors;
  * {@link Carrier}, an {@code as-bytes} dispatch and a {@code dataized}
  * object alike become the {@link Forced} bytes of what they are applied
  * to, since a const is the latter followed by the former and forcing is
- * already what a protocol does, and a
- * {@code ξ} reference to a declared void becomes the symbol of that
- * void, named positionally so that no spelling of a void name ever
- * leaks into a marker, and a {@code ξ.ρ} reference to the formation
- * being lowered, with arguments, becomes the {@link Again} of its own
- * body. A {@code ξ} reference to a helper the formation binds next to
- * its body becomes the helper's own body, read in place: an application
- * over the same voids stands wherever it is named, and a formation of
- * its own is applied where it is named, its voids bound to the argument
- * terms in a {@link Scope} of its own, the way phino would bind them,
- * so its body stands there with every void spelled out. A helper named
- * twice stands twice, and identical sites collapse into one step
- * anyway. A helper that reads itself, directly or through another
- * helper, is a cycle and is refused. The parser rolls a dispatch chain
- * rooted in a reference into the base itself, so {@code ξ.b.size.plus}
- * unrolls here into nested sites, with the arguments of the element
- * attached to the last link. Anything else is refused, since its
- * meaning depends on a context the reduction does not carry.</p>
+ * already what a protocol does, and a {@code ξ} reference to a declared
+ * void becomes the symbol of that void, named positionally so that no
+ * spelling of a void name ever leaks into a marker, and a {@code ξ.ρ}
+ * reference to the formation being lowered, with arguments, becomes the
+ * {@link Again} of its own body, and the terminator {@code T} becomes
+ * the {@link Fail} of the one reason it carries. A {@code ξ} reference
+ * to a helper the formation binds next to its body becomes the helper's
+ * own body, read in place: an application over the same voids stands
+ * wherever it is named, and a formation of its own is applied where it
+ * is named, its voids bound to the argument terms in a {@link Scope} of
+ * its own, the way phino would bind them, so its body stands there with
+ * every void spelled out. A helper named twice stands twice, and
+ * identical sites collapse into one step anyway. A helper that reads
+ * itself, directly or through another helper, is a cycle and is refused.
+ * The parser rolls a dispatch chain rooted in a reference into the base
+ * itself, so {@code ξ.b.size.plus} unrolls here into nested sites, with
+ * the arguments of the element attached to the last link. Anything else
+ * is refused, since its meaning depends on a context the reduction does
+ * not carry.</p>
  *
  * @since 0.76.0
  */
@@ -117,8 +118,10 @@ public final class Parsed {
     private Term parsed(final Xnav node) {
         final String base = node.attribute("base").text().orElse("");
         final Term out;
-        if ("Φ.dataized".equals(base)) {
-            out = new Forced(this.parsed(Parsed.target(node)));
+        if ("⊥".equals(base)) {
+            out = new Fail(this.parsed(Parsed.only(node, "The terminator must carry")));
+        } else if ("Φ.dataized".equals(base)) {
+            out = new Forced(this.parsed(Parsed.only(node, "The dataized object must force")));
         } else if (base.startsWith("Φ.")) {
             out = new Carrier(node).literal();
         } else if (base.startsWith("ξ.")) {
@@ -205,13 +208,11 @@ public final class Parsed {
         return out;
     }
 
-    private static Xnav target(final Xnav node) {
+    private static Xnav only(final Xnav node, final String who) {
         final List<Xnav> kids = Parsed.kids(node);
         if (kids.size() != 1) {
             throw new IllegalStateException(
-                String.format(
-                    "The dataized object must force exactly one target, not %d", kids.size()
-                )
+                String.format("%s exactly one target, not %d", who, kids.size())
             );
         }
         return kids.get(0);

--- a/eo-lowering/src/main/java/org/eolang/lowering/Program.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Program.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
  * body the state names. A formation that never resumes anything is a
  * program of one body, the plain case. The program answers one forma,
  * whatever body the answer comes from, and a program whose bodies only
- * resume one another answers nothing and is refused.</p>
+ * resume one another, or fail, answers nothing and is refused.</p>
  *
  * @since 0.76.0
  */
@@ -122,7 +122,7 @@ public final class Program {
             .collect(Collectors.toList());
         if (formas.isEmpty()) {
             throw new IllegalStateException(
-                "The program never answers, since every body of it resumes another"
+                "The program never answers, since every body of it resumes another or fails"
             );
         }
         if (formas.size() > 1) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Protocol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Protocol.java
@@ -21,10 +21,13 @@ import java.util.List;
  * recursive helper of the formation, in a tail position settles into
  * the name of the body it resumes and the keys the voids of that body
  * take next, one per void in declaration order, and that body runs
- * over them. This is the whole input of code generation: rendering each step
- * as one Java statement, in order, with a block under each arm and a
- * loop around a program that repeats, is a faithful compilation of the
- * fragment.</p>
+ * over them. Or a path may end by failing: a fragment whose tail is the
+ * terminator {@code T} settles into the key of the reason it carries,
+ * and dataizing the fragment there aborts with that reason as the
+ * message. This is the whole input of code generation: rendering each step
+ * as one Java statement, in order, with a block under each arm, a
+ * loop around a program that repeats and a throw where a path fails,
+ * is a faithful compilation of the fragment.</p>
  *
  * @since 0.76.0
  */
@@ -58,13 +61,28 @@ public final class Protocol {
     private final List<String> next;
 
     /**
+     * The key of the reason the fragment fails with, when it fails
+     * instead of answering.
+     */
+    private final String cause;
+
+    /**
      * Ctor.
      * @param moves The steps, in their dependency order
      * @param answer The key of the value the fragment answers with
      * @param carrier The forma of that value
      */
     public Protocol(final List<Step> moves, final String answer, final String carrier) {
-        this(moves, answer, carrier, "", Collections.emptyList());
+        this(moves, answer, carrier, "", Collections.emptyList(), "");
+    }
+
+    /**
+     * Ctor, for a program that fails.
+     * @param moves The steps, in their dependency order
+     * @param reason The key of the reason the fragment fails with
+     */
+    public Protocol(final List<Step> moves, final String reason) {
+        this(moves, "", "", "", Collections.emptyList(), reason);
     }
 
     /**
@@ -85,7 +103,7 @@ public final class Protocol {
      *  next, in declaration order
      */
     public Protocol(final List<Step> moves, final String target, final List<String> again) {
-        this(moves, "", "", target, again);
+        this(moves, "", "", target, again, "");
     }
 
     /**
@@ -95,14 +113,17 @@ public final class Protocol {
      * @param carrier The forma of that value
      * @param target The name of the body resumed, empty for the formation
      * @param again The keys of the values the voids take next
+     * @param reason The key of the reason the fragment fails with
      */
     private Protocol(final List<Step> moves, final String answer,
-        final String carrier, final String target, final List<String> again) {
+        final String carrier, final String target, final List<String> again,
+        final String reason) {
         this.steps = moves;
         this.root = answer;
         this.forma = carrier;
         this.body = target;
         this.next = again;
+        this.cause = reason;
     }
 
     /**
@@ -116,7 +137,7 @@ public final class Protocol {
     /**
      * The key of the value the fragment answers with.
      * @return A key such as {@code sym:s2} or {@code number:40-14-...},
-     *  empty when the program repeats
+     *  empty when the program repeats or fails
      */
     public String answer() {
         return this.root;
@@ -125,7 +146,7 @@ public final class Protocol {
     /**
      * The forma of the value.
      * @return One of {@code number}, {@code bool}, {@code bytes}, empty
-     *  when the program repeats
+     *  when the program repeats or fails
      */
     public String carrier() {
         return this.forma;
@@ -147,6 +168,15 @@ public final class Protocol {
      */
     public List<String> again() {
         return Collections.unmodifiableList(this.next);
+    }
+
+    /**
+     * The key of the reason the program fails with.
+     * @return A key such as {@code sym:s3} or {@code string:68-69-},
+     *  empty when the program answers or repeats
+     */
+    public String reason() {
+        return this.cause;
     }
 
     /**

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
@@ -23,7 +23,8 @@ import java.util.stream.Stream;
  * left to the protocol of that arm, which decides the same way. Whatever
  * an enclosing block declared already is in scope and is not declared
  * again. The keys a repeat hands the voids count as reads of the
- * protocol that repeats, the way its answer would.</p>
+ * protocol that repeats, the way its answer would, and so does the
+ * reason of a protocol that fails.</p>
  *
  * @since 0.76.0
  */
@@ -81,7 +82,7 @@ public final class Reads {
         final Stream<String> keys = Stream.concat(
             this.protocol.moves().stream().flatMap(step -> step.keys().stream()),
             Stream.concat(
-                Stream.of(this.protocol.answer()),
+                Stream.of(this.protocol.answer(), this.protocol.reason()),
                 this.protocol.again().stream()
             )
         );

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reduction.java
@@ -55,6 +55,19 @@ import java.util.Optional;
  * the bodies a program is made of, and the order they are reduced in,
  * of {@link Bodies}.</p>
  *
+ * <p>The terminator {@code T} is the other term that never goes to
+ * phino: it has no value, and dataizing it aborts with its reason.
+ * When it is the root of the tree being settled, its reason is reduced
+ * into the same list of steps and must settle into a string, since that
+ * is what the message is made of, and the tree settles into a failure
+ * naming the key of the reason instead of an answer; the Java of that
+ * path throws, so a fork failing in one arm answers what the other arm
+ * does, and may stand anywhere, since nothing below the failing arm
+ * ever runs. When the terminator stands anywhere else, phino parks on
+ * its marker and the fragment is refused, since an operation awaiting
+ * its value would never get one; and a program whose every path fails
+ * answers nothing and is refused too.</p>
+ *
  * <p>A helper the formation binds next to its body is read in place
  * wherever the body names it, by {@link Parsed}, applied to its
  * arguments when it has voids of its own, so the tree phino sees
@@ -204,6 +217,8 @@ public final class Reduction {
         final Protocol out;
         if (tree.again().isPresent()) {
             out = new Repeat(this, minted).protocol(tree.again().get(), steps);
+        } else if (tree.terminator().isPresent()) {
+            out = new Failure(this, minted).protocol(tree.terminator().get(), steps);
         } else {
             out = new Protocol(steps, tree.key(), minted.carried(tree));
         }
@@ -215,14 +230,15 @@ public final class Reduction {
      * @param start The tree
      * @param steps The steps of the protocol being built
      * @param minted The ledger this reduction shares
-     * @return A term with a key, or the call the tree is
+     * @return A term with a key, or the call or the terminator the tree is
      * @throws IOException If the binary cannot be run
      */
     Term reduced(final Term start, final List<Step> steps, final Minted minted)
         throws IOException {
         Term tree = start;
         int round = 0;
-        while (tree.key().isEmpty() && !tree.again().isPresent()) {
+        while (tree.key().isEmpty() && !tree.again().isPresent()
+            && !tree.terminator().isPresent()) {
             if (round >= this.rounds) {
                 throw new IllegalStateException(
                     String.format("The reduction did not settle in %d rounds", this.rounds)
@@ -247,11 +263,7 @@ public final class Reduction {
             if (record.name().startsWith("Sym_")) {
                 continue;
             }
-            if ("L_self".equals(record.name())) {
-                throw new IllegalStateException(
-                    "The call to itself is not in a tail position, so the fragment cannot repeat"
-                );
-            }
+            Reduction.tailed(record);
             final Op operation = new Op(record.name());
             if (!operation.listed()) {
                 excuse = String.format(
@@ -276,6 +288,19 @@ public final class Reduction {
             );
         }
         return out;
+    }
+
+    private static void tailed(final Evaluation record) {
+        if ("L_self".equals(record.name())) {
+            throw new IllegalStateException(
+                "The call to itself is not in a tail position, so the fragment cannot repeat"
+            );
+        }
+        if ("L_fail".equals(record.name())) {
+            throw new IllegalStateException(
+                "The terminator is not in a tail position, so the fragment cannot fail there"
+            );
+        }
     }
 
     private static Optional<Term> applied(final Term tree, final Op operation,

--- a/eo-lowering/src/main/java/org/eolang/lowering/Site.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Site.java
@@ -105,6 +105,11 @@ public final class Site implements Term {
     }
 
     @Override
+    public Optional<Fail> terminator() {
+        return Optional.empty();
+    }
+
+    @Override
     public Term swapped(final Shape shape, final Term swap) {
         final Term out;
         if (shape.covers(this.method, this.receiver.key(), this.args)) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Symbol.java
@@ -86,12 +86,17 @@ public final class Symbol implements Term {
     }
 
     @Override
+    public Term swapped(final Shape shape, final Term swap) {
+        return this;
+    }
+
+    @Override
     public Optional<Again> again() {
         return Optional.empty();
     }
 
     @Override
-    public Term swapped(final Shape shape, final Term swap) {
-        return this;
+    public Optional<Fail> terminator() {
+        return Optional.empty();
     }
 }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Term.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Term.java
@@ -13,8 +13,9 @@ import java.util.Optional;
  * <p>The tree mirrors the XMIR fragment being lowered: a {@link Site} for
  * every application, a {@link Literal} for every datum, a {@link Symbol}
  * for every value that is not known yet — a void of the fragment, or a
- * step already minted — and an {@link Again} for every call of the
- * fragment to itself. The tree renders itself into phi text for each
+ * step already minted — an {@link Again} for every call of the
+ * fragment to itself, and a {@link Fail} for every terminator it
+ * holds. The tree renders itself into phi text for each
  * partial run, and rewrites itself as the records come back: a site
  * matching a fired record becomes the literal it computed, a site
  * matching a parked record becomes the symbol of a new step. Values
@@ -66,6 +67,12 @@ public interface Term {
      * @return The call, or empty for any other term
      */
     Optional<Again> again();
+
+    /**
+     * The terminator this term is, if it is one.
+     * @return The failure, or empty for any other term
+     */
+    Optional<Fail> terminator();
 
     /**
      * This tree with every site matching the shape replaced.

--- a/eo-lowering/src/test/java/org/eolang/lowering/BodiesTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/BodiesTest.java
@@ -1,0 +1,223 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Bodies}.
+ *
+ * <p>The programs here are made of several bodies, or of a body that
+ * reads a helper in place, so they run the real binary and hold only
+ * when it is installed and of the pinned version.</p>
+ *
+ * @since 0.76.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class BodiesTest {
+
+    @Test
+    void resumesHelpersApplyingEachOther(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "two helpers applying each other in tail positions must become two more bodies",
+            new Reduction(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='ξ.a🌵3-4'><o as='α0' base='ξ.x'/>",
+                        BodiesTest.number("α1", "3F-F0-00-00-00-00-00-00"),
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("x", "number"),
+                8,
+                "bounce",
+                BodiesTest.bouncers()
+            ).program().bodies(),
+            Matchers.hasSize(3)
+        );
+    }
+
+    @Test
+    void refusesHelpersThatNeverAnswer(@Mktmp final Path temp) {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        final Map<String, Xnav> helpers = new LinkedHashMap<>();
+        helpers.put(
+            "a🌵3-4",
+            BodiesTest.bouncer(
+                "a🌵3-4",
+                "<o base='ξ.ρ.a🌵8-4'><o as='α0' base='ξ.n'/><o as='α1' base='ξ.acc'/></o>"
+            )
+        );
+        helpers.put(
+            "a🌵8-4",
+            BodiesTest.bouncer(
+                "a🌵8-4",
+                "<o base='ξ.ρ.a🌵3-4'><o as='α0' base='ξ.n'/><o as='α1' base='ξ.acc'/></o>"
+            )
+        );
+        MatcherAssert.assertThat(
+            "helpers that only resume each other never answer and must refuse, but they didnt",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Reduction(
+                    phino,
+                    new Xnav(
+                        "<o base='ξ.a🌵3-4'><o as='α0' base='ξ.x'/><o as='α1' base='ξ.x'/></o>"
+                    ).element("o"),
+                    Collections.singletonMap("x", "number"),
+                    8,
+                    "bounce",
+                    helpers
+                )::program,
+                "a program that never answers reduced, but it must not"
+            ).getMessage(),
+            Matchers.containsString("never answers")
+        );
+    }
+
+    @Test
+    void appliesHelperFormationTwice(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a helper with a void must be applied to each argument it is handed, but it isnt",
+            new Reduction(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='.plus'>",
+                        "<o base='ξ.a🌵3-4'>",
+                        BodiesTest.number("α0", "40-00-00-00-00-00-00-00"),
+                        "</o>",
+                        "<o as='α0' base='ξ.a🌵3-4'>",
+                        BodiesTest.number("α0", "40-08-00-00-00-00-00-00"),
+                        "</o>",
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("x", "number"),
+                8,
+                "",
+                Collections.singletonMap(
+                    "a🌵3-4",
+                    new Xnav(
+                        String.join(
+                            "",
+                            "<o name='a🌵3-4'><o base='∅' name='ρ'/><o base='∅' name='i'/>",
+                            "<o base='ξ.ρ.x.times' name='φ'><o as='α0' base='ξ.i'/></o></o>"
+                        )
+                    ).element("o")
+                )
+            ).protocol().moves(),
+            Matchers.hasSize(3)
+        );
+    }
+
+    @Test
+    void foldsHelperNamedTwiceIntoOneStep(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a helper named twice must be read in place and cost one step, but it doesnt",
+            new Reduction(
+                phino,
+                new Xnav("<o base='ξ.a🌵3-4.plus'><o as='α0' base='ξ.a🌵3-4'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                8,
+                "",
+                Collections.singletonMap(
+                    "a🌵3-4",
+                    new Xnav("<o base='ξ.x.times'><o as='α0' base='ξ.x'/></o>").element("o")
+                )
+            ).protocol().moves(),
+            Matchers.hasSize(2)
+        );
+    }
+
+    private static Map<String, Xnav> bouncers() {
+        final Map<String, Xnav> out = new LinkedHashMap<>();
+        out.put(
+            "a🌵3-4",
+            BodiesTest.bouncer(
+                "a🌵3-4",
+                String.join(
+                    "",
+                    "<o base='.if'>",
+                    "<o base='ξ.n.eq'>",
+                    BodiesTest.number("α0", "00-00-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α0' base='ξ.acc'/>",
+                    "<o as='α1' base='ξ.ρ.a🌵8-4'>",
+                    "<o as='α0' base='ξ.n.plus'>",
+                    BodiesTest.number("α0", "BF-F0-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α1' base='ξ.acc.plus'>",
+                    BodiesTest.number("α0", "3F-F0-00-00-00-00-00-00"),
+                    "</o>",
+                    "</o>",
+                    "</o>"
+                )
+            )
+        );
+        out.put(
+            "a🌵8-4",
+            BodiesTest.bouncer(
+                "a🌵8-4",
+                String.join(
+                    "",
+                    "<o base='.if'>",
+                    "<o base='ξ.n.eq'>",
+                    BodiesTest.number("α0", "00-00-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α0' base='ξ.acc'/>",
+                    "<o as='α1' base='ξ.ρ.a🌵3-4'>",
+                    "<o as='α0' base='ξ.n.plus'>",
+                    BodiesTest.number("α0", "BF-F0-00-00-00-00-00-00"),
+                    "</o>",
+                    "<o as='α1' base='ξ.acc.times'>",
+                    BodiesTest.number("α0", "40-00-00-00-00-00-00-00"),
+                    "</o>",
+                    "</o>",
+                    "</o>"
+                )
+            )
+        );
+        return out;
+    }
+
+    private static Xnav bouncer(final String name, final String body) {
+        return new Xnav(
+            String.format(
+                "<o name='%s'><o base='∅' name='ρ'/><o base='∅' name='n'/><o base='∅' name='acc'/>%s</o>",
+                name, body.replaceFirst("<o base=", "<o name='φ' base=")
+            )
+        ).element("o");
+    }
+
+    private static String number(final String name, final String hex) {
+        return String.format(
+            "<o as='%s' base='Φ.number'><o as='α0' base='Φ.bytes'><o as='α0'>%s</o></o></o>",
+            name, hex
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/FailTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/FailTest.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Fail}.
+ * @since 0.76.0
+ */
+final class FailTest {
+
+    @Test
+    void rendersMarkerAroundReason() {
+        MatcherAssert.assertThat(
+            "the terminator must render as a formation of its reason and the marker, but it doesnt",
+            new Fail(new Literal("string", "6F-70-73")).phi(),
+            Matchers.equalTo(
+                "⟦ r ↦ Φ.string(α0 ↦ Φ.bytes(α0 ↦ ⟦ Δ ⤍ 6F-70-73 ⟧)), λ ⤍ L_fail ⟧"
+            )
+        );
+    }
+
+    @Test
+    void carriesNoKey() {
+        MatcherAssert.assertThat(
+            "a terminator is no value, but it names one",
+            new Fail(new Literal("string", "6F-70-73")).key(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void knowsItself() {
+        MatcherAssert.assertThat(
+            "the terminator must hand itself out as the failure it is, but it doesnt",
+            new Fail(new Symbol("v0", "string")).terminator().get().reason().key(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void isNoCall() {
+        MatcherAssert.assertThat(
+            "a terminator is no call to itself, but it claims to be one",
+            new Fail(new Symbol("v0", "string")).again().isPresent(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void swapsSiteInsideReason() {
+        MatcherAssert.assertThat(
+            "a site inside the reason must give way to the symbol, but it didnt",
+            new Fail(
+                new Site("concat", new Symbol("v0", "string"), Collections.emptyList())
+            ).swapped(
+                new Shape("concat", "sym:v0", Collections.emptyList(), Collections.emptyList()),
+                new Symbol("s1", "bytes")
+            ).phi(),
+            Matchers.containsString("r ↦ Φ.bytes(α0 ↦ ⟦ λ ⤍ Sym_s1 ⟧)")
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/FailureTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/FailureTest.java
@@ -1,0 +1,105 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Failure}.
+ *
+ * <p>A reason that is already a value settles without phino, so the
+ * tests here need no binary: they pin what a failure hands the
+ * protocol, and what it refuses.</p>
+ *
+ * @since 0.76.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class FailureTest {
+
+    @Test
+    void failsWithLiteralReason(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "the protocol must fail with the key of the reason, but it doesnt",
+            FailureTest.failure(temp).protocol(
+                new Fail(new Literal("string", "6F-70-73")), new ArrayList<>(0)
+            ).reason(),
+            Matchers.equalTo("string:6F-70-73")
+        );
+    }
+
+    @Test
+    void failsWithStringVoid(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a string void must stand as the reason as it is, but it doesnt",
+            FailureTest.failure(temp).protocol(
+                new Fail(new Symbol("v0", "string")), new ArrayList<>(0)
+            ).reason(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void answersNothing(@Mktmp final Path temp) throws Exception {
+        MatcherAssert.assertThat(
+            "a failing protocol must name no carrier, but it does",
+            FailureTest.failure(temp).protocol(
+                new Fail(new Literal("string", "6F-70-73")), new ArrayList<>(0)
+            ).carrier(),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void refusesNumberAsReason(@Mktmp final Path temp) {
+        MatcherAssert.assertThat(
+            "a reason that is no string cannot be the message, but it was taken",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                () -> FailureTest.failure(temp).protocol(
+                    new Fail(new Literal("number", "40-00-00-00-00-00-00-00")),
+                    new ArrayList<>(0)
+                ),
+                "a number reason settled, but it must not"
+            ).getMessage(),
+            Matchers.containsString("must be a string")
+        );
+    }
+
+    @Test
+    void refusesTerminatorAsReason(@Mktmp final Path temp) {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> FailureTest.failure(temp).protocol(
+                new Fail(new Fail(new Literal("string", "6F-70-73"))),
+                new ArrayList<>(0)
+            ),
+            "a terminator failing with a terminator settled, but it must not"
+        );
+    }
+
+    private static Failure failure(final Path temp) {
+        final Map<String, String> voids = Collections.singletonMap("t", "string");
+        return new Failure(
+            new Reduction(
+                new Phino("phino", 1000, temp),
+                new Xnav("<o base='ξ.t'/>").element("o"),
+                voids,
+                8
+            ),
+            new Minted(voids)
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/ForkTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ForkTest.java
@@ -69,6 +69,32 @@ final class ForkTest {
     }
 
     @Test
+    void answersWithArmThatDoesNotFail() {
+        MatcherAssert.assertThat(
+            "a fork failing in one arm must answer what the other arm does, but it doesnt",
+            new Fork(
+                "s2", "L_bool_if", "sym:s1",
+                new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                new Protocol(Collections.emptyList(), "string:6F-70-73")
+            ).forma(),
+            Matchers.equalTo("number")
+        );
+    }
+
+    @Test
+    void answersNothingWhenBothArmsFail() {
+        MatcherAssert.assertThat(
+            "a fork whose both arms fail has no value and must name no forma, but it did",
+            new Fork(
+                "s2", "L_bool_if", "sym:s1",
+                new Protocol(Collections.emptyList(), "string:6F-70-73"),
+                new Protocol(Collections.emptyList(), "sym:v1")
+            ).forma(),
+            Matchers.equalTo("")
+        );
+    }
+
+    @Test
     void readsOnlyItsCondition() {
         MatcherAssert.assertThat(
             "the one key a fork reads directly must be its condition, but it isnt",

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -447,6 +447,120 @@ final class JavaAtomTest {
     }
 
     @Test
+    void rendersFailingArmAsThrow() {
+        MatcherAssert.assertThat(
+            "an arm that fails must throw with its reason and assign nothing, but it doesnt",
+            new JavaAtom(
+                JavaAtomTest.guarded(
+                    new Protocol(Collections.emptyList(), "string:6F-70-73")
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.equalTo(
+                String.join(
+                    System.lineSeparator(),
+                    "        final double v0 = new Dataized(this.take(\"x\")).asNumber();",
+                    "        final boolean s1 = v0 > Double.longBitsToDouble(0x0000000000000000L);",
+                    "        final double s2;",
+                    "        if (s1) {",
+                    "            s2 = v0;",
+                    "        } else {",
+                    String.format(
+                        "            throw new ExFailure(\"%%s\", new String(%s, %s));",
+                        "new byte[] {(byte) 0x6F, (byte) 0x70, (byte) 0x73}",
+                        "java.nio.charset.StandardCharsets.UTF_8"
+                    ),
+                    "        }",
+                    "        return new Data.ToPhi(s2);"
+                )
+            )
+        );
+    }
+
+    @Test
+    void readsReasonInsideTheFailingArm() {
+        final Map<String, String> voids = new LinkedHashMap<>();
+        voids.put("x", "number");
+        voids.put("t", "string");
+        MatcherAssert.assertThat(
+            "a void only the reason names must be read inside the failing arm, but it isnt",
+            new JavaAtom(
+                JavaAtomTest.guarded(new Protocol(Collections.emptyList(), "sym:v1")),
+                voids
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "} else {",
+                "final byte[] v1 = new Dataized(this.take(\"t\")).take();",
+                "throw new ExFailure(\"%s\", new String(v1, java.nio.charset.StandardCharsets.UTF_8));",
+                "}"
+            )
+        );
+    }
+
+    @Test
+    void refusesNumberAsReason() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new JavaAtom(
+                JavaAtomTest.guarded(
+                    new Protocol(Collections.emptyList(), "number:3F-F0-00-00-00-00-00-00")
+                ),
+                Collections.singletonMap("x", "number")
+            )::text,
+            "a number is no message to fail with, but it rendered"
+        );
+    }
+
+    @Test
+    void rendersFailingBodyAsThrow() {
+        MatcherAssert.assertThat(
+            "a body that fails must throw inside its branch of the state machine, but it doesnt",
+            new JavaAtom(
+                new Program(
+                    Arrays.asList(
+                        new Body(
+                            "", 0, Collections.singletonList("number"),
+                            new Protocol(
+                                Arrays.asList(
+                                    new Application(
+                                        "s1", "L_bytes_eq",
+                                        Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
+                                    ),
+                                    new Fork(
+                                        "s2", "L_bool_if", "sym:s1",
+                                        new Protocol(
+                                            Collections.emptyList(), "a🌵3-4",
+                                            Collections.singletonList("sym:v0")
+                                        ),
+                                        new Protocol(Collections.emptyList(), "sym:v0", "number")
+                                    )
+                                ),
+                                "sym:s2", "number"
+                            )
+                        ),
+                        new Body(
+                            "a🌵3-4", 1, Collections.singletonList("number"),
+                            new Protocol(Collections.emptyList(), "string:6F-70-73")
+                        )
+                    ),
+                    Collections.singletonMap("n", "number")
+                )
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "out = s2;",
+                "break;",
+                "} else {",
+                String.format(
+                    "throw new ExFailure(\"%%s\", new String(%s, %s));",
+                    "new byte[] {(byte) 0x6F, (byte) 0x70, (byte) 0x73}",
+                    "java.nio.charset.StandardCharsets.UTF_8"
+                ),
+                "return new Data.ToPhi(out);"
+            )
+        );
+    }
+
+    @Test
     void readsVoidInsideTheArmThatAloneUsesIt() {
         final Map<String, String> voids = new LinkedHashMap<>();
         voids.put("f", "bool");
@@ -742,6 +856,24 @@ final class JavaAtomTest {
                 Collections.singletonMap("t", "string")
             )::text,
             "a byte array handed over as a string would change the forma, but it was"
+        );
+    }
+
+    private static Protocol guarded(final Protocol otherwise) {
+        return new Protocol(
+            Arrays.asList(
+                new Application(
+                    "s1", "L_number_gt",
+                    Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
+                ),
+                new Fork(
+                    "s2", "L_bool_if", "sym:s1",
+                    new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                    otherwise
+                )
+            ),
+            "sym:s2",
+            "number"
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
@@ -144,6 +144,65 @@ final class ParsedTest {
     }
 
     @Test
+    void readsTerminatorAsFailure() {
+        MatcherAssert.assertThat(
+            "the terminator must read as a failure carrying its reason, but it doesnt",
+            new Parsed(
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='⊥'>",
+                        "<o as='α0' base='Φ.string'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>6F-70-73</o></o>",
+                        "</o>",
+                        "</o>"
+                    )
+                ).element("o"),
+                Collections.singletonMap("x", "number")
+            ).term().terminator().get().reason().key(),
+            Matchers.equalTo("string:6F-70-73")
+        );
+    }
+
+    @Test
+    void readsTerminatorInsideChoice() {
+        MatcherAssert.assertThat(
+            "a terminator in an arm must stand there as a failure, but it doesnt",
+            new Parsed(
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='.if'><o base='ξ.x'/>",
+                        "<o as='α0' base='ξ.t'/>",
+                        "<o as='α1' base='⊥'><o as='α0' base='ξ.t'/></o>",
+                        "</o>"
+                    )
+                ).element("o"),
+                ParsedTest.flagged()
+            ).term().phi(),
+            Matchers.endsWith(
+                "α1 ↦ ⟦ r ↦ Φ.string(α0 ↦ Φ.bytes(α0 ↦ ⟦ λ ⤍ Sym_v1 ⟧)), λ ⤍ L_fail ⟧)"
+            )
+        );
+    }
+
+    @Test
+    void refusesTerminatorWithoutReason() {
+        MatcherAssert.assertThat(
+            "a terminator without a reason is malformed, but it parsed",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Parsed(
+                    new Xnav("<o base='⊥'/>").element("o"),
+                    Collections.singletonMap("x", "number")
+                )::term,
+                "a bare terminator parsed, but it must not"
+            ).getMessage(),
+            Matchers.containsString("The terminator must carry exactly one target, not 0")
+        );
+    }
+
+    @Test
     void refusesDataizedOfManyTargets() {
         Assertions.assertThrows(
             IllegalStateException.class,
@@ -296,6 +355,13 @@ final class ParsedTest {
             )::term,
             "a void applied to arguments cannot be reduced, but it was"
         );
+    }
+
+    private static Map<String, String> flagged() {
+        final Map<String, String> out = new LinkedHashMap<>();
+        out.put("x", "bool");
+        out.put("t", "string");
+        return out;
     }
 
     private static Xnav scaled() {

--- a/eo-lowering/src/test/java/org/eolang/lowering/ProgramTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ProgramTest.java
@@ -75,6 +75,27 @@ final class ProgramTest {
         );
     }
 
+    @Test
+    void refusesProgramThatAlwaysFails() {
+        MatcherAssert.assertThat(
+            "a program whose only body fails never answers and must refuse",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Program(
+                    Collections.singletonList(
+                        new Body(
+                            "", 0, Collections.singletonList("string"),
+                            new Protocol(Collections.emptyList(), "sym:v0")
+                        )
+                    ),
+                    Collections.singletonMap("t", "string")
+                )::carrier,
+                "a program that always fails was given a forma, but it must not be"
+            ).getMessage(),
+            Matchers.containsString("never answers")
+        );
+    }
+
     private static Program bouncing() {
         return new Program(
             Arrays.asList(

--- a/eo-lowering/src/test/java/org/eolang/lowering/ProtocolTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ProtocolTest.java
@@ -62,4 +62,44 @@ final class ProtocolTest {
             Matchers.equalTo("bool")
         );
     }
+
+    @Test
+    void failsWithGivenReason() {
+        MatcherAssert.assertThat(
+            "the reason must come back as given, but it didnt",
+            new Protocol(Collections.emptyList(), "sym:v0").reason(),
+            Matchers.equalTo("sym:v0")
+        );
+    }
+
+    @Test
+    void answersNothingWhenFailing() {
+        MatcherAssert.assertThat(
+            "a failing program has no answer and no carrier, but it named one",
+            String.join(
+                "",
+                new Protocol(Collections.emptyList(), "sym:v0").answer(),
+                new Protocol(Collections.emptyList(), "sym:v0").carrier()
+            ),
+            Matchers.emptyString()
+        );
+    }
+
+    @Test
+    void doesNotRepeatWhenFailing() {
+        MatcherAssert.assertThat(
+            "a failing program needs no loop, but it asks for one",
+            new Protocol(Collections.emptyList(), "sym:v0").repeats(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void failsWithNothingWhenAnswering() {
+        MatcherAssert.assertThat(
+            "an answering program has no reason to fail, but it names one",
+            new Protocol(Collections.emptyList(), "sym:v0", "bytes").reason(),
+            Matchers.emptyString()
+        );
+    }
 }

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReadsTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReadsTest.java
@@ -89,6 +89,36 @@ final class ReadsTest {
         );
     }
 
+    @Test
+    void countsReasonOfFailure() {
+        MatcherAssert.assertThat(
+            "the void a failure names as its reason must count as read, but it doesnt",
+            new Reads(new Protocol(Collections.emptyList(), "sym:v2")).all(),
+            Matchers.contains(2)
+        );
+    }
+
+    @Test
+    void leavesReasonOfOneArmToThatArm() {
+        MatcherAssert.assertThat(
+            "a void only the failing arm reads must be declared in that arm alone, but it isnt",
+            new Reads(
+                new Protocol(
+                    Collections.singletonList(
+                        new Fork(
+                            "s1", "L_bool_if", "sym:v0",
+                            new Protocol(Collections.emptyList(), "number:11-", "number"),
+                            new Protocol(Collections.emptyList(), "sym:v1")
+                        )
+                    ),
+                    "sym:s1",
+                    "number"
+                )
+            ).own(Collections.emptySet()),
+            Matchers.contains(0)
+        );
+    }
+
     private static Protocol forked(final String yes, final String not) {
         return new Protocol(
             Collections.singletonList(

--- a/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ReductionTest.java
@@ -244,130 +244,6 @@ final class ReductionTest {
     }
 
     @Test
-    void resumesHelpersApplyingEachOther(@Mktmp final Path temp) throws Exception {
-        final Phino phino = new Phino("phino", 1000, temp);
-        Assumptions.assumeTrue(phino.suitable());
-        MatcherAssert.assertThat(
-            "two helpers applying each other in tail positions must become two more bodies",
-            new Reduction(
-                phino,
-                new Xnav(
-                    String.join(
-                        "",
-                        "<o base='ξ.a🌵3-4'><o as='α0' base='ξ.x'/>",
-                        ReductionTest.number("α1", "3F-F0-00-00-00-00-00-00"),
-                        "</o>"
-                    )
-                ).element("o"),
-                Collections.singletonMap("x", "number"),
-                8,
-                "bounce",
-                ReductionTest.bouncers()
-            ).program().bodies(),
-            Matchers.hasSize(3)
-        );
-    }
-
-    @Test
-    void refusesHelpersThatNeverAnswer(@Mktmp final Path temp) {
-        final Phino phino = new Phino("phino", 1000, temp);
-        Assumptions.assumeTrue(phino.suitable());
-        final Map<String, Xnav> helpers = new LinkedHashMap<>();
-        helpers.put(
-            "a🌵3-4",
-            ReductionTest.bouncer(
-                "a🌵3-4",
-                "<o base='ξ.ρ.a🌵8-4'><o as='α0' base='ξ.n'/><o as='α1' base='ξ.acc'/></o>"
-            )
-        );
-        helpers.put(
-            "a🌵8-4",
-            ReductionTest.bouncer(
-                "a🌵8-4",
-                "<o base='ξ.ρ.a🌵3-4'><o as='α0' base='ξ.n'/><o as='α1' base='ξ.acc'/></o>"
-            )
-        );
-        MatcherAssert.assertThat(
-            "helpers that only resume each other never answer and must refuse, but they didnt",
-            Assertions.assertThrows(
-                IllegalStateException.class,
-                new Reduction(
-                    phino,
-                    new Xnav(
-                        "<o base='ξ.a🌵3-4'><o as='α0' base='ξ.x'/><o as='α1' base='ξ.x'/></o>"
-                    ).element("o"),
-                    Collections.singletonMap("x", "number"),
-                    8,
-                    "bounce",
-                    helpers
-                )::program,
-                "a program that never answers reduced, but it must not"
-            ).getMessage(),
-            Matchers.containsString("never answers")
-        );
-    }
-
-    @Test
-    void appliesHelperFormationTwice(@Mktmp final Path temp) throws Exception {
-        final Phino phino = new Phino("phino", 1000, temp);
-        Assumptions.assumeTrue(phino.suitable());
-        MatcherAssert.assertThat(
-            "a helper with a void must be applied to each argument it is handed, but it isnt",
-            new Reduction(
-                phino,
-                new Xnav(
-                    String.join(
-                        "",
-                        "<o base='.plus'>",
-                        "<o base='ξ.a🌵3-4'>",
-                        ReductionTest.number("α0", "40-00-00-00-00-00-00-00"),
-                        "</o>",
-                        "<o as='α0' base='ξ.a🌵3-4'>",
-                        ReductionTest.number("α0", "40-08-00-00-00-00-00-00"),
-                        "</o>",
-                        "</o>"
-                    )
-                ).element("o"),
-                Collections.singletonMap("x", "number"),
-                8,
-                "",
-                Collections.singletonMap(
-                    "a🌵3-4",
-                    new Xnav(
-                        String.join(
-                            "",
-                            "<o name='a🌵3-4'><o base='∅' name='ρ'/><o base='∅' name='i'/>",
-                            "<o base='ξ.ρ.x.times' name='φ'><o as='α0' base='ξ.i'/></o></o>"
-                        )
-                    ).element("o")
-                )
-            ).protocol().moves(),
-            Matchers.hasSize(3)
-        );
-    }
-
-    @Test
-    void foldsHelperNamedTwiceIntoOneStep(@Mktmp final Path temp) throws Exception {
-        final Phino phino = new Phino("phino", 1000, temp);
-        Assumptions.assumeTrue(phino.suitable());
-        MatcherAssert.assertThat(
-            "a helper named twice must be read in place and cost one step, but it doesnt",
-            new Reduction(
-                phino,
-                new Xnav("<o base='ξ.a🌵3-4.plus'><o as='α0' base='ξ.a🌵3-4'/></o>").element("o"),
-                Collections.singletonMap("x", "number"),
-                8,
-                "",
-                Collections.singletonMap(
-                    "a🌵3-4",
-                    new Xnav("<o base='ξ.x.times'><o as='α0' base='ξ.x'/></o>").element("o")
-                )
-            ).protocol().moves(),
-            Matchers.hasSize(2)
-        );
-    }
-
-    @Test
     void reducesBytesOperation(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());
@@ -643,6 +519,121 @@ final class ReductionTest {
     }
 
     @Test
+    void failsInArmOfChoice(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "the arm holding the terminator must end in a failure, but it doesnt",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    ReductionTest.guard(),
+                    "<o as='α0' base='ξ.x'/>",
+                    ReductionTest.terminator("α1", ReductionTest.text("α0", "6F-70-73"))
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            ).protocol().moves().get(1).branches().get(1).reason(),
+            Matchers.equalTo("string:6F-70-73")
+        );
+    }
+
+    @Test
+    void answersFormaOfArmThatDoesNotFail(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "the fork must answer what its surviving arm answers, but it doesnt",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    ReductionTest.guard(),
+                    ReductionTest.terminator("α0", ReductionTest.text("α0", "6F-70-73")),
+                    "<o as='α1' base='ξ.x'/>"
+                ),
+                Collections.singletonMap("x", "number"),
+                8
+            ).protocol().carrier(),
+            Matchers.equalTo("number")
+        );
+    }
+
+    @Test
+    void computesReasonOfFailure(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        final Map<String, String> voids = new LinkedHashMap<>();
+        voids.put("f", "bool");
+        voids.put("t", "string");
+        MatcherAssert.assertThat(
+            "the reason must be computed by a step of the failing arm, but it isnt",
+            new Reduction(
+                phino,
+                ReductionTest.choice(
+                    "<o base='ξ.f'/>",
+                    ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00"),
+                    ReductionTest.terminator(
+                        "α1",
+                        String.format(
+                            "<o as='α0' base='ξ.t.concat'>%s</o>",
+                            ReductionTest.text("α0", "21-")
+                        )
+                    )
+                ),
+                voids,
+                8
+            ).protocol().moves().get(0).branches().get(1).reason(),
+            Matchers.equalTo("sym:s2")
+        );
+    }
+
+    @Test
+    void refusesTerminatorOutsideTail(@Mktmp final Path temp) {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        MatcherAssert.assertThat(
+            "a terminator feeding an operation never hands it a value and must refuse",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Reduction(
+                    phino,
+                    new Xnav(
+                        String.format(
+                            "<o base='.plus'>%s%s</o>",
+                            ReductionTest.terminator("", ReductionTest.text("α0", "6F-70-73")),
+                            ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00")
+                        )
+                    ).element("o"),
+                    Collections.singletonMap("x", "number"),
+                    8
+                )::protocol,
+                "a terminator under an operation reduced, but it must not"
+            ).getMessage(),
+            Matchers.containsString("not in a tail position")
+        );
+    }
+
+    @Test
+    void refusesFragmentThatAlwaysFails(@Mktmp final Path temp) {
+        MatcherAssert.assertThat(
+            "a fragment that is the terminator alone never answers and must refuse",
+            Assertions.assertThrows(
+                IllegalStateException.class,
+                new Reduction(
+                    new Phino("phino", 1000, temp),
+                    new Xnav(
+                        ReductionTest.terminator("", ReductionTest.text("α0", "6F-70-73"))
+                    ).element("o"),
+                    Collections.singletonMap("x", "number"),
+                    8
+                )::program,
+                "a fragment that always fails reduced, but it must not"
+            ).getMessage(),
+            Matchers.containsString("never answers")
+        );
+    }
+
+    @Test
     void repeatsOnTailCallToItself(@Mktmp final Path temp) throws Exception {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());
@@ -873,6 +864,23 @@ final class ReductionTest {
         );
     }
 
+    private static String terminator(final String name, final String reason) {
+        final String out;
+        if (name.isEmpty()) {
+            out = String.format("<o base='⊥'>%s</o>", reason);
+        } else {
+            out = String.format("<o as='%s' base='⊥'>%s</o>", name, reason);
+        }
+        return out;
+    }
+
+    private static String text(final String name, final String hex) {
+        return String.format(
+            "<o as='%s' base='Φ.string'><o as='α0' base='Φ.bytes'><o as='α0'>%s</o></o></o>",
+            name, hex
+        );
+    }
+
     private static String number(final String name, final String hex) {
         return String.format(
             "<o as='%s' base='Φ.number'><o as='α0' base='Φ.bytes'><o as='α0'>%s</o></o></o>",
@@ -895,66 +903,6 @@ final class ReductionTest {
                 "<o as='α0' base='Φ.bytes'><o as='α0'>3F-F0-00-00-00-00-00-00</o></o>",
                 "</o>",
                 "</o>"
-            )
-        ).element("o");
-    }
-
-    private static Map<String, Xnav> bouncers() {
-        final Map<String, Xnav> out = new LinkedHashMap<>();
-        out.put(
-            "a🌵3-4",
-            ReductionTest.bouncer(
-                "a🌵3-4",
-                String.join(
-                    "",
-                    "<o base='.if'>",
-                    "<o base='ξ.n.eq'>",
-                    ReductionTest.number("α0", "00-00-00-00-00-00-00-00"),
-                    "</o>",
-                    "<o as='α0' base='ξ.acc'/>",
-                    "<o as='α1' base='ξ.ρ.a🌵8-4'>",
-                    "<o as='α0' base='ξ.n.plus'>",
-                    ReductionTest.number("α0", "BF-F0-00-00-00-00-00-00"),
-                    "</o>",
-                    "<o as='α1' base='ξ.acc.plus'>",
-                    ReductionTest.number("α0", "3F-F0-00-00-00-00-00-00"),
-                    "</o>",
-                    "</o>",
-                    "</o>"
-                )
-            )
-        );
-        out.put(
-            "a🌵8-4",
-            ReductionTest.bouncer(
-                "a🌵8-4",
-                String.join(
-                    "",
-                    "<o base='.if'>",
-                    "<o base='ξ.n.eq'>",
-                    ReductionTest.number("α0", "00-00-00-00-00-00-00-00"),
-                    "</o>",
-                    "<o as='α0' base='ξ.acc'/>",
-                    "<o as='α1' base='ξ.ρ.a🌵3-4'>",
-                    "<o as='α0' base='ξ.n.plus'>",
-                    ReductionTest.number("α0", "BF-F0-00-00-00-00-00-00"),
-                    "</o>",
-                    "<o as='α1' base='ξ.acc.times'>",
-                    ReductionTest.number("α0", "40-00-00-00-00-00-00-00"),
-                    "</o>",
-                    "</o>",
-                    "</o>"
-                )
-            )
-        );
-        return out;
-    }
-
-    private static Xnav bouncer(final String name, final String body) {
-        return new Xnav(
-            String.format(
-                "<o name='%s'><o base='∅' name='ρ'/><o base='∅' name='n'/><o base='∅' name='acc'/>%s</o>",
-                name, body.replaceFirst("<o base=", "<o name='φ' base=")
             )
         ).element("o");
     }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/LoweringTest.java
@@ -279,8 +279,12 @@ final class LoweringTest {
     private static String ended(final Protocol protocol, final String pad) {
         final StringBuilder out = new StringBuilder(pad);
         if (protocol.again().isEmpty()) {
-            out.append("answer ").append(protocol.answer())
-                .append(' ').append(protocol.carrier());
+            if (protocol.reason().isEmpty()) {
+                out.append("answer ").append(protocol.answer())
+                    .append(' ').append(protocol.carrier());
+            } else {
+                out.append("fail ").append(protocol.reason());
+            }
         } else {
             out.append("repeat");
             if (!protocol.target().isEmpty()) {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/always-failing.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/always-failing.yaml
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A body that is the terminator alone fails on every path, so the
+# program answers nothing: there is no value for the atom to hand
+# over, the reduction refuses it, and the formation stays as written.
+input: |
+  [] > foo
+    [x] > boom
+      T "boom" > @
+    boom 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: boom
+voids:
+  x: number
+lowered: |
+  [] > foo
+    boom 5 > @
+    T "boom" > [x] > boom
+stuck: "The program never answers"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/failure-mid-tree.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/failure-mid-tree.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The terminator feeds an operation, so the operation never gets its
+# value: phino parks on the marker of the terminator, the reduction
+# refuses the fragment, and the formation stays as written.
+input: |
+  [] > foo
+    [x] > bump
+      plus. > @
+        T "never"
+        x
+    bump 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: bump
+voids:
+  x: number
+lowered: |
+  [] > foo
+    bump 5 > @
+    plus. > [x] > bump
+      T "never"
+      x
+stuck: "The terminator is not in a tail position"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-failure.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/guarded-failure.yaml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A guard that aborts instead of answering: the `if` parks on the
+# symbolic bool and becomes a fork, whose else arm is the terminator
+# `T` with its reason. The arm settles into a failure, not an answer,
+# so it has no opinion about what the fork answers, and the fork
+# answers the number of the other arm. The Java of the failing arm
+# throws the reason as the message of an `ExFailure`, the way the
+# terminator itself does when dataized, so the statements after the
+# fork run only when the guard lets the number through.
+input: |
+  [] > foo
+    [x] > guard
+      if. > @
+        x.gt 0
+        x.plus 1
+        T "the number is not positive"
+    guard 5 > @
+prelude:
+  number.eo: |
+    [as-bytes] > number
+      as-bytes > @
+unit: guard
+voids:
+  x: number
+lowered: |
+  [] > foo
+    guard 5 > @
+    [] > guard /Q.number
+      ? > x /Q.number
+protocol: |
+  s1 ← L_number_gt sym:v0 number:00-00-00-00-00-00-00-00
+  s2 ← fork sym:s1 number
+    then
+      s3 ← L_number_plus sym:v0 number:3F-F0-00-00-00-00-00-00
+      answer sym:s3 number
+    else
+      fail string:74-68-65-20-6E-75-6D-62-65-72-20-69-73-20-6E-6F-74-20-70-6F-73-69-74-69-76-65
+  answer sym:s2 number
+java: |
+  final double v0 = new Dataized(this.take("x")).asNumber();
+  final boolean s1 = v0 > Double.longBitsToDouble(0x0000000000000000L);
+  final double s2;
+  if (s1) {
+      final double s3 = v0 + Double.longBitsToDouble(0x3FF0000000000000L);
+      s2 = s3;
+  } else {
+      throw new ExFailure("%s", new String(new byte[] {(byte) 0x74, (byte) 0x68, (byte) 0x65, (byte) 0x20, (byte) 0x6E, (byte) 0x75, (byte) 0x6D, (byte) 0x62, (byte) 0x65, (byte) 0x72, (byte) 0x20, (byte) 0x69, (byte) 0x73, (byte) 0x20, (byte) 0x6E, (byte) 0x6F, (byte) 0x74, (byte) 0x20, (byte) 0x70, (byte) 0x6F, (byte) 0x73, (byte) 0x69, (byte) 0x74, (byte) 0x69, (byte) 0x76, (byte) 0x65}, java.nio.charset.StandardCharsets.UTF_8));
+  }
+  return new Data.ToPhi(s2);


### PR DESCRIPTION
Closes #8411.

A protocol could end in two ways, an answer or a repeat, so a fragment holding the terminator `T` was refused at the parser ("The base '⊥' cannot stand in a lowered fragment"), and every guard that aborts instead of answering kept its whole formation in EO. The terminator is the one object of EO that has no value: dataizing it throws its reason. So a protocol gets a third terminal, `fail <reason>`, next to `answer` and `repeat`, and a path that reaches it throws in Java.

## What changed

**Parsed, Fail.** `⊥` reads into a `Fail` term around its one reason (a terminator with no reason or several is refused). Like `Again`, it has no key and no forma, and renders as a formation of the reason next to a marker, `⟦ r ↦ …, λ ⤍ L_fail ⟧`, so phino parks on it wherever it stands and never looks inside; the universe needs no row for it. `Term` gains `terminator()`, the way it has `again()`.

**Reduction, Failure.** A reduction that finds the terminator at the root of a tree settles the tree into a failing protocol, by `Failure`, the counterpart of `Repeat`: the reason is reduced into the same list of steps and must settle into a value that is a string, or the bytes one is made of, since the message of the failure is the reason read as text. A `T` anywhere else, under an operation or as an argument of a repeat, is refused: phino parks on `L_fail` and the reduction reports that the terminator is not in a tail position, the same way a call to itself outside the tail is refused.

**Protocol, Fork, Reads.** A protocol carries `reason()`, empty unless it fails; a failing protocol has no answer and no carrier. `Fork.forma()` already treats an arm with an empty carrier as having no opinion, so a fork failing in one arm answers what the other arm does, and a fork failing in both answers nothing — no change was needed there, only the Javadoc. Unlike a repeat, a failing arm may stand anywhere, since nothing below it ever runs, so a fork that fails in one arm can feed a later step. The reason counts as a read of the void it names, so a void only the reason mentions is dataized inside the failing arm alone. A program whose every path fails is refused as one that never answers, with the message widened to say so.

**JavaAtom.** A failing arm or body renders as

```java
throw new ExFailure("%s", new String(<reason>, java.nio.charset.StandardCharsets.UTF_8));
```

which is what `PhTerminator.delta()` throws when the terminator is dataized, so `try` and `recovered` catch a lowered failure the way they catch the original. The arm assigns nothing, and Java's definite-assignment rules accept the fork's blank final, since the throwing arm completes abruptly. A reason of any forma but string or bytes is refused at rendering as well.

## Packs

- `guarded-failure`: `if. (x.gt 0) (x.plus 1) (T "the number is not positive")` lowers into an atom whose else branch throws; the protocol shows `fail string:74-68-…` under the fork, and the fork answers `number`.
- `failure-mid-tree`: `plus. (T "never") x` is refused, since the terminator is not in a tail position, and the formation stays as written.
- `always-failing`: a body that is `T "boom"` alone never answers and is refused.

## Verified

- `eo-lowering`: 286 tests pass (new `FailTest`, `FailureTest`, and cases in `ParsedTest`, `ProtocolTest`, `ReadsTest`, `ForkTest`, `ProgramTest`, `JavaAtomTest`, `ReductionTest`); qulice clean, simian clean. The four helper-body tests of `ReductionTest` moved to a new `BodiesTest`, since the file crossed the 1,000-line limit and `Bodies` had no test class of its own.
- `eo-maven-plugin`: all 184 lowering pack checks pass, three of them new; qulice clean.
- `eo-runtime` re-lowered end to end with phino 0.0.115 and compiled: still 144 fragments. Eight runtime XMIRs hold a terminator, in `number.integral`, `string.printf`, `string.scanf`, `string.slice`, `tuple.back`, `tuple.front`, `tuple.slice`, `bytes.xor`, `chunk.put`, `file.open` and a few more, but every one of those formations is still refused before the reduction reaches its tail: at the shape gate (a public extra kid), at witnessing (`index`, `start`, `read` unwitnessed), or at the `Φ.string` construction the previous PR reported. So no new fragment lowers yet; the terminal was the gate each of them meets next, and this PR removes it.

## Notes

- **pr-size** is over the cap, as the previous lowering PRs were.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwmLf5vKVEmJUSs5dwq4fH)_