### PR TITLE
remove unreachable triple-quote guard in LnTextBlock

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1457,7 +1457,6 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Reversed dispatch whose receiver is not followed by a dot (§3.8) | `reversed dispatch must end with a dot` |
 | Pipe line whose `\|` is not followed by a space (§3.14) | `` a pipe `\|` must be followed by a space before its arguments `` |
 | Test attribute on a pipe application (§3.14) | `a pipe application cannot declare a test attribute` |
-| Text block closer that does not open with `"""` (R-3.11.3) | `text block closer must start with triple-quote` |
 | Text block body line shallower than its opener (R-3.11.2) | `text block body line indented less than opener` |
 | Two or more consecutive blank lines (R-6.5.3) | `consecutive blank lines forbidden — at most one blank may separate two non-blank lines (R-6.5.3)` |
 | First object of the file at an indent other than 0 (§5.2) | `unexpected indentation, the first object must start at indent 0` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -45,12 +45,6 @@ final class LnTextBlock implements Line {
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
         final String body = this.span.body();
-        if (!body.startsWith("\"\"\"")) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "text block closer must start with triple-quote"
-            );
-        }
         final Tokens tokens = new Tokens(body, this.span);
         tokens.seek(3);
         final List<MethodChain> chain = tokens.readChain();

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -44,8 +44,7 @@ final class LnTextBlock implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        final String body = this.span.body();
-        final Tokens tokens = new Tokens(body, this.span);
+        final Tokens tokens = new Tokens(this.span.body(), this.span);
         tokens.seek(3);
         final List<MethodChain> chain = tokens.readChain();
         final String outer = LnApplication.readOuterBinding(tokens, this.span);


### PR DESCRIPTION
LnTextBlock.into opens with a guard that throws when the closer line's body does not start with a triple-quote. Nothing ever reaches it: the only caller, Eo.continueTextBlock, only builds a LnTextBlock after Eo.closesTextBlock already required that same prefix on the same span. The other branch of that dispatch (a line that does not open with a triple-quote while inside a text block) is treated as an ordinary body line and never reaches LnTextBlock either.

No test asserted the message and no yaml fixture produced it, so dropping the five lines changes nothing observable and puts the check in the one place that actually needs it. The matching row in PARSER_SPEC.md's §9.9 canonical error table is removed along with it, since it described a condition the parser can no longer report anywhere.

Closes #8484