### PR TITLE
fix(#8482): carry the blank count across a text block to its closer

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -288,7 +288,6 @@ final class Eo implements Iterable<Directive> {
             Blanks.enterAfterMeta(span, globals, emit);
             globals.openTextBlock(span.line(), span.indent());
             globals.markEmitted();
-            globals.clearBlanks();
         } else {
             failed = Eo.dispatch(span, tail, stack, globals, emit);
         }
@@ -310,6 +309,7 @@ final class Eo implements Iterable<Directive> {
                 point.apply();
                 emit.error(err.line(), err.pos(), err.getMessage());
                 globals.closeTextBlock();
+                globals.clearBlanks();
             }
         } else {
             final String raw = span.text();

--- a/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnTextBlockTest.java
@@ -180,9 +180,9 @@ final class LnTextBlockTest {
     @Test
     void acceptsAttributeAfterBlankLine() {
         final Globals globals = new Globals();
+        globals.blank();
         globals.openTextBlock(1, 2);
         globals.appendTextLine("hello");
-        globals.blank();
         final Emit emit = new Emit();
         final Stack stack = new Stack();
         stack.push(0, 1, Kind.BARE_FORMATION, Openness.OPEN);

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-test-attribute-after-blank-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-test-attribute-after-blank-line.yaml
@@ -5,7 +5,7 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@name='tests-foo-works']
+  - /object/o[@name='foo']/o[@base='Φ.string' and @name='+tests-foo-works']
 input: |
   [] > foo
     42 > @
@@ -13,4 +13,3 @@ input: |
     """
     hi
     """ +> tests-foo-works
-      true > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-test-attribute-after-blank-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-test-attribute-after-blank-line.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='tests-foo-works']
+input: |
+  [] > foo
+    42 > @
+
+    """
+    hi
+    """ +> tests-foo-works
+      true > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-text-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/empty-lines/empty-line-before-text-block.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 6
+message: |-
+  [6:2] error: 'blank line not allowed between non-master siblings'
+    """ > b
+    ^
+input: |
+  [] > main
+    42 > a
+
+    """
+    hi
+    """ > b


### PR DESCRIPTION
The text block opener in Eo.java called globals.clearBlanks() right after opening, before the closer ever gets a chance to read the count. A blank line inside the block body never reaches globals.blank() either — it goes straight to Globals.appendTextLine — so by the time LnTextBlock.into asks Blanks for the pending blank count, it is always zero, whatever the source actually had.

Both rules that depend on that count were broken as a result. R-6.5.4 could never fire for a text block, so a blank line between a plain sibling and a text block was accepted where the same blank in front of any other object is rejected. And Blanks.checkTest always saw zero, so a `+>` or `->` test attribute on a closing `"""` was rejected as missing its blank line even when one was right there above the opener.

The fix lets the count survive: the opener no longer clears it, so whatever was pending before `"""` stays untouched through the body (which never touches the counter) until the closer's own checkPlain/checkTest reads it. The closer's error-recovery path now clears the count explicitly, so a text block that fails to close doesn't leak a stale blank count into whatever follows. The existing unit test that exercised this only by calling globals.blank() after openTextBlock — a state the real parser can never reach — now calls it in the order the parser actually produces. Two new fixture tests cover the real parse path: one confirms a `+>` test attribute after a genuine blank line above the opener is accepted, the other confirms a blank line before a plain text-block sibling is now rejected.

Closes #8482