### PR TITLE
mark recovered text-block closer error as lossy

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -308,7 +308,7 @@ final class Eo implements Iterable<Directive> {
                 new LnTextBlock(span).into(stack, globals, emit);
             } catch (final ParseError err) {
                 point.apply();
-                emit.error(err.line(), err.pos(), err.getMessage());
+                emit.error(err.line(), err.pos(), err.getMessage(), true);
                 globals.closeTextBlock();
             }
         } else {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-swallow-rest-of-file.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/error-on-text-block-closer-does-not-swallow-rest-of-file.yaml
@@ -5,6 +5,7 @@
 sheets: []
 asserts:
   - /object/errors/error[contains(text(),'unicode')]
+  - /object/errors/error[contains(text(),'unicode')][@lossy]
   - /object[not(errors/error[contains(text(),'unclosed')])]
   - //o[@name='y']
   - //o[@name='z']

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-atom-sig-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-atom-sig-is-rejected.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'atom')][@lossy]
+  - /object[not(errors/error[contains(text(),'unclosed')])]
+  - //o[@name='y']
+  - //o[@name='z']
+input: |
+  [] > app
+    """
+    hello
+    """ > x/org.eolang.foo
+    42 > y
+    43 > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-inline-binding-non-last.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-inline-binding-non-last.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'inline binding allowed only on the last method in a chain')][@lossy]
+  - /object[not(errors/error[contains(text(),'unclosed')])]
+  - //o[@name='y']
+  - //o[@name='z']
+input: |
+  [] > app
+    """
+    hello
+    """.first:slot.second > x
+    42 > y
+    43 > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-octal-escape-out-of-range-is-lossy.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-octal-escape-out-of-range-is-lossy.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'out of range')][@lossy]
+  - /object[not(errors/error[contains(text(),'unclosed')])]
+  - //o[@name='y']
+  - //o[@name='z']
+input: |
+  [] > app
+    """
+    \777
+    """ > x
+    42 > y
+    43 > z

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-unrecognised-escape-is-lossy.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/text-block-closer-unrecognised-escape-is-lossy.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'unrecognised escape sequence')][@lossy]
+  - /object[not(errors/error[contains(text(),'unclosed')])]
+  - //o[@name='y']
+  - //o[@name='z']
+input: |
+  [] > app
+    """
+    \q
+    """ > x
+    42 > y
+    43 > z


### PR DESCRIPTION
`Eo.continueTextBlock` rolls the emitter and the stack back past the whole text-block literal when the closer line fails to parse, then reported that recovery through the three-argument `emit.error`, the overload that leaves `lossy` false. Every other recovery path in `Eo.dispatch` reports the same kind of rollback through the four-argument form with `true`, so the text block was the one construct that could disappear from the tree without saying so.

`MjFormat.parsed` reads that flag to decide whether a file with errors is still safe to reformat. Without it, a file whose text block failed to parse but whose surrounding lines parsed fine looked safe, and `-Deo.autoFix` would write the source back with the text block missing.

The fix passes `true` as the fourth argument at the call site, matching the recovery `Eo.dispatch` already does elsewhere. The existing fixture for the reported shape now also asserts that the recovered error carries `lossy`, and four more fixtures cover the other ways a text-block closer line can fail during recovery: an atom signature on the closer, an inline binding that isn't the last method in the chain, an out-of-range octal escape, and an unrecognised escape sequence. Each confirms the dropped `x` still leaves `y` and `z` intact and the error is marked `lossy`.

Closes #8481
