### PR TITLE
fix(#8485): delete openTextBlock(int) overload with no production caller

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Globals.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Globals.java
@@ -247,14 +247,6 @@ final class Globals {
     }
 
     /**
-     * Mark a text block as opened on the given line.
-     * @param line Open line
-     */
-    void openTextBlock(final int line) {
-        this.openTextBlock(line, 0);
-    }
-
-    /**
      * Mark a text block as opened with a recorded indent.
      * @param line Open line
      * @param indent Open indent

--- a/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/GlobalsTest.java
@@ -88,7 +88,7 @@ final class GlobalsTest {
     @Test
     void recordsTextBlockOpenLine() {
         final Globals globals = new Globals();
-        globals.openTextBlock(17);
+        globals.openTextBlock(17, 0);
         MatcherAssert.assertThat(
             "textBlockOpenLine must round-trip the opener line for the unclosed-text-block error",
             globals.textBlockOpenLine(),
@@ -197,7 +197,7 @@ final class GlobalsTest {
     @Test
     void closesTextBlockState() {
         final Globals globals = new Globals();
-        globals.openTextBlock(3);
+        globals.openTextBlock(3, 0);
         globals.closeTextBlock();
         MatcherAssert.assertThat(
             "closeTextBlock must drop the in-text flag back to false",


### PR DESCRIPTION
Globals.openTextBlock(int) hard-coded the opening indent to zero and had no production caller. The parser always opens a text block through the two-argument form, at Eo.java, passing the opener's real indent. The overload survived only because GlobalsTest called it directly at two call sites.

This deletes the overload and updates those two tests to call the two-argument form explicitly, passing zero for the block opened at column zero. The tests keep the same coverage and there is now one way to open a text block.

Closes #8485

https://claude.ai/code/session_01QSYiJ4m2dVwvs14y6SmaHV
