### PR TITLE
reject a void outside a formation's direct children

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1441,6 +1441,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | `+alias` target with an empty dotted segment (R-3.2.3) | `'+alias' target must not have an empty segment` |
 | `+alias` target that is a scope token rather than an object name (R-3.2.3) | `'+alias' target must be an object name, not a scope token` |
 | `?` line whose suffix is neither a name nor an auto-name, or carries `!` (R-3.4.7) | `` a void attribute must be written as `? > name` or `? >> name` `` |
+| `?` line whose parent is not a formation (R-3.4.7) | `a void attribute is legal only as a direct child of a formation` |
 | Void type annotation `/` with no type after it (R-3.4.8) | `a void type annotation requires a type` |
 | `/{…}` argument list with no closing `}` (R-3.4.8) | `` a `/{…}` argument list must end with `}` `` |
 | Empty `/{…}` argument list (R-3.4.8) | `` a `/{…}` argument list must name at least one type `` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -95,12 +95,11 @@ final class LnVoid implements Line {
         final Stack stack, final Globals globals, final Emit emit, final int slash
     ) {
         globals.seal(emit, this.span);
-        this.checkTyped(
-            new Transition(stack, this.span).apply(
-                Kind.VOID, Openness.VCOMPLETED, new Admission("^", true)
-            ),
-            slash
+        final Level level = new Transition(stack, this.span).apply(
+            Kind.VOID, Openness.VCOMPLETED, new Admission("^", true)
         );
+        this.checkPlaced(level);
+        this.checkTyped(level, slash);
         globals.clearBlanks();
         globals.markEmitted();
         emit.object("ρ", "∅", this.span.line(), this.span.indent());
@@ -121,12 +120,11 @@ final class LnVoid implements Line {
             );
         }
         globals.seal(emit, this.span);
-        this.checkTyped(
-            new Transition(stack, this.span).apply(
-                Kind.VOID, Openness.VCOMPLETED, new Admission(suffix.named(), true)
-            ),
-            slash
+        final Level level = new Transition(stack, this.span).apply(
+            Kind.VOID, Openness.VCOMPLETED, new Admission(suffix.named(), true)
         );
+        this.checkPlaced(level);
+        this.checkTyped(level, slash);
         globals.clearBlanks();
         globals.markEmitted();
         emit.object(
@@ -135,6 +133,15 @@ final class LnVoid implements Line {
         );
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());
+        }
+    }
+
+    private void checkPlaced(final Level level) {
+        if (!level.parent().formation()) {
+            throw new ParseError(
+                this.span.line(), this.span.indent(),
+                "a void attribute is legal only as a direct child of a formation"
+            );
         }
     }
 

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-outside-a-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-outside-a-formation.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 1
+message: "a void attribute is legal only as a direct child of a formation"
+input: |
+  ? > x

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-under-an-application.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/void-under-an-application.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 2
+message: "a void attribute is legal only as a direct child of a formation"
+input: |
+  bar > x
+    ? > y


### PR DESCRIPTION
LnVoid never checked what the vertical void's parent was. Transition.apply hands back a Level that already carries the parent kind, and LnVoid only ever asked it for patom() (the atom-annotation check) — never for whether the parent was a formation at all, per R-3.4.7 ("legal only as a direct child of a formation").

So `? > x` written at indent 0 pushed onto an empty stack and emitted a top-level void, and a `? > y` indented under a plain application landed inside it, where later passes went on to treat it as an ordinary argument. Nothing in between objected, so the mistake surfaced far downstream with no clue where the void came from.

The fix adds a `checkPlaced` check next to the existing `checkTyped` one, using `Level.parent().formation()` — the same predicate `Stack` already reads for the analogous only-phi-argument-position check — and rejects the line otherwise. Also added the missing §9.9 canonical-message row for the new diagnostic, and two eo-typos fixtures reproducing the two cases from the issue: a void at the top level, and a void indented under a plain application.

Closes #8483