### PR TITLE
Stop counting the reversed-dispatch receiver in the all-or-nothing group

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -86,9 +86,9 @@ final class Emissions {
         if (Emissions.reversedDispatch(tokens, head)) {
             final boolean fragile = tokens.consumeDispatch();
             final List<Value> rargs = tokens.readArgs();
-            Bindings.checkAllOrNothing(rargs, span);
             if (!rargs.isEmpty()) {
                 Bindings.checkReceiver(rargs.get(0), span);
+                Bindings.checkAllOrNothing(rargs.subList(1, rargs.size()), span);
             }
             emit.object(name, ".".concat(Emissions.reversedHead(head)), line, head.pos());
             if (fragile) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bound-reversed-application-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bound-reversed-application-inside-paren-group.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.false.if' and o[@base='Φ.number' and @as='a']]
+  - //o[@base='Φ.false.if' and o[@base='Φ.number' and @as='b']]
+input: |
+  [] > main
+    q.f (if. false 1:a 2:b) > z


### PR DESCRIPTION
Emissions.expression handed the whole reversed-dispatch argument list to Bindings.checkAllOrNothing, receiver included. Per R-6.6.3 the receiver isn't an argument, only the args after it form the application-arg group governed by R-6.6.2. Because the receiver never carries a binding, it always read as unbound and dragged every bound method arg after it into disagreement, so a legal expression like `if. false 1:a 2:b > second` parsed fine on its own line but failed as "argument bindings must be all-or-nothing" once written inside parentheses as `q.f (if. false 1:a 2:b) > z`.

The check order was also backwards: checkAllOrNothing ran before checkReceiver, so a genuinely bad receiver reported the wrong message.

This splits the two checks the way LnReversed.into already does: check the receiver first, then pass only the remaining args to checkAllOrNothing. Added a fixture covering the previously-rejected paren form to lock the fix in.

Closes #8487