### PR TITLE
route LnVoid's void-name promotions through VoidName

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -103,7 +103,9 @@ final class LnVoid implements Line {
         );
         globals.clearBlanks();
         globals.markEmitted();
-        emit.object("ρ", "∅", this.span.line(), this.span.indent());
+        emit.object(
+            new VoidName("^").asString(), "∅", this.span.line(), this.span.indent()
+        );
     }
 
     private void attribute(

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -185,8 +185,8 @@ final class Suffix {
 
     /**
      * Resolve the {@code @name} attribute value for the line carrying
-     * this suffix, applying R-9.3 source-token mapping: {@code @} becomes
-     * {@code φ} for an explicit name.
+     * this suffix, asking {@link VoidName} for the R-9.3 source-token
+     * promotion of an explicit name.
      *
      * <p>This is the single source of truth for naming any line shape
      * — formations, applications, method chains, reversed dispatches,
@@ -200,7 +200,7 @@ final class Suffix {
     String attribute(final int line, final int indent) {
         final String name;
         if (this.form == Form.NAME) {
-            name = Suffix.phi(this.label);
+            name = new VoidName(this.label).asString();
         } else if (this.form == Form.TEST) {
             name = "+".concat(this.label);
         } else if (this.form == Form.THROWS) {
@@ -365,16 +365,6 @@ final class Suffix {
 
     private static int clamped(final int pos, final Span span) {
         return Math.min(pos, span.text().length() - 1);
-    }
-
-    private static String phi(final String raw) {
-        final String mapped;
-        if ("@".equals(raw)) {
-            mapped = "φ";
-        } else {
-            mapped = raw;
-        }
-        return mapped;
     }
 
     private static Suffix parse(final String tail, final Span span, final int home) {

--- a/eo-parser/src/test/java/org/eolang/parser/LnVoidTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnVoidTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.parser;
+
+import com.jcabi.matchers.XhtmlMatchers;
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * Test case for {@link LnVoid}.
+ * @since 0.1
+ */
+final class LnVoidTest {
+
+    @Test
+    void emitsRhoForReceiverVoid() {
+        final Emit emit = new Emit();
+        new LnVoid(new Span("? > ^", 1)).into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `? > ^` receiver void must emit the same name `VoidName` promotes `^` to",
+            LnVoidTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "/object/o[@name='%s' and @base='∅']", new VoidName("^").asString()
+                )
+            )
+        );
+    }
+
+    @Test
+    void emitsPhiForAtVoidAttribute() {
+        final Emit emit = new Emit();
+        new LnVoid(new Span("? > @", 1)).into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a `? > @` void attribute must emit the same name `VoidName` promotes `@` to",
+            LnVoidTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                String.format(
+                    "/object/o[@name='%s' and @base='∅']", new VoidName("@").asString()
+                )
+            )
+        );
+    }
+
+    private static String render(final Emit emit) {
+        return new Xembler(
+            new Directives().add("object").append(emit.directives())
+        ).xmlQuietly();
+    }
+}


### PR DESCRIPTION
`VoidName` says of itself that the §9.3 table is the single source of truth for the void-name promotions, and that every parameter loop asks it rather than deciding for itself. `LnVoid`'s receiver branch already asks it on master (since #8491), but its attribute branch still reached `φ` through `Suffix.attribute`, which called a private `Suffix.phi` that duplicated the same one-row `@` → `φ` mapping `VoidName` already owns.

`Suffix.attribute` now delegates to `VoidName` instead of keeping its own copy, and the dead `Suffix.phi` is removed, leaving `VoidName` the only place the §9.3 promotions live. A `^` never reaches that branch, since `Suffix` classifies it as `Form.RECEIVER`, which `attribute` refuses.

Added `LnVoidTest`, which didn't exist before. It drives `? > ^` and `? > @` under an atom formation and asserts the literal `ρ` and `φ` names, so a wrong promotion in `VoidName` fails it.

Closes #8486
