### PR TITLE
reject a Q-rooted reversed head inside a paren group

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -438,7 +438,7 @@ final class Emissions {
 
     private static boolean reversedDispatch(final Tokens tokens, final Value head) {
         final boolean reversed;
-        if (head.reversible() && !tokens.atEnd() && tokens.dispatchAhead()) {
+        if (head.reversible() && !head.global() && !tokens.atEnd() && tokens.dispatchAhead()) {
             final int skip;
             if (tokens.current() == '?') {
                 skip = 2;
@@ -457,7 +457,7 @@ final class Emissions {
     private static String reversedHead(final Value head) {
         final String mapped;
         if (head.kind() == Value.Kind.ROOT) {
-            mapped = LnReversed.rootSymbol(head.raw().charAt(0));
+            mapped = head.rootSymbol();
         } else {
             mapped = head.raw();
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -269,6 +269,15 @@ final class Value {
     }
 
     /**
+     * The {@code Q} global-root glyph — R-3.8.1 excludes it from the
+     * reversed-head whitelist ({@code @}, {@code ^}, {@code $})?
+     * @return True for {@link Kind#ROOT} whose raw text is {@code Q}
+     */
+    boolean global() {
+        return this.kind == Kind.ROOT && "Q".equals(this.raw);
+    }
+
+    /**
      * The XMIR symbol a {@link Kind#ROOT} glyph maps to per §9.3 —
      * {@code Q} to {@code Φ}, {@code @} to {@code φ}, {@code ^} to
      * {@code ρ}, {@code $} to {@code ξ}. Call only when {@link #kind()}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/q-rooted-reversed-dispatch-inside-parens-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/q-rooted-reversed-dispatch-inside-parens-is-rejected.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# #8489: inside a paren group, Emissions.reversedDispatch let a Q-rooted
+# head open a reversed dispatch and Emissions.reversedHead then mapped it
+# through a partial glyph table that has no Q case, so "(Q. a b)" silently
+# emitted ".ξ" instead of failing the way "Q. a b" does on a line.
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'expected identifier')]
+input: |
+  [] > main
+    q.f (Q. a b) > z


### PR DESCRIPTION
Emissions.reversedDispatch let any reversible head open a reversed dispatch, including a ROOT value carrying Q, so `(Q. a b)` inside a paren group parsed silently instead of failing the way `Q. a b` does on a line. reversedHead then mapped that head through a second, partial copy of the §9.3 glyph table that has no Q case and falls back to ξ, so the parenthesised form emitted `.ξ` — wrong XMIR that reads as an ordinary, unremarkable base downstream.

Value now exposes `global()`, true only for a ROOT value carrying Q, and reversedDispatch refuses a head for which it holds. reversedHead reads the glyph mapping off `head.rootSymbol()` instead of keeping its own copy of the table, so there is one place left that knows the §9.3 mapping.

Closes #8489