### PR TITLE
fix(#8490): merge @float-up marking into the pipe template to stop it colliding with the predecessor float-up rule

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/vars-float-up.xsl
@@ -72,7 +72,7 @@
   <xsl:template match="o[@float-up and @name and ancestor::o[1][not(eo:abstract(.))]]" priority="2"/>
   <xsl:template match="node()|@*" mode="#all">
     <xsl:copy>
-      <xsl:apply-templates select="node()|@*"/>
+      <xsl:apply-templates select="(node()|@*) except @float-up"/>
     </xsl:copy>
   </xsl:template>
 </xsl:stylesheet>

--- a/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/wrap-applications.xsl
@@ -35,6 +35,13 @@
   predecessor with @float-up; `vars-float-up` then hoists its definition
   to the nearest abstract object and drops the in-place slot, so only the
   pipe application reaches the enclosing application or tuple.
+
+  An intermediate pipe of a chain is itself such a predecessor for the
+  next pipe in the chain (R-3.14.5 forces it to carry a @name), so it
+  needs both the @base rewrite above and the @float-up marker. The two
+  concerns are handled together in the `o[@pipe]` template below instead
+  of splitting them across two templates matching the same node, which
+  would leave the match ambiguous (#8490).
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
   <!--
@@ -65,12 +72,15 @@
       <xsl:attribute name="base">
         <xsl:value-of select="preceding-sibling::o[1]/@name"/>
       </xsl:attribute>
+      <xsl:if test="@name and (../@base or ../@star) and following-sibling::o[1][@pipe]">
+        <xsl:attribute name="float-up"/>
+      </xsl:if>
       <xsl:apply-templates select="@*"/>
       <xsl:apply-templates select="node()"/>
     </xsl:copy>
   </xsl:template>
   <!-- Predecessor formation of a pipe in an argument block or star tuple: float it up. -->
-  <xsl:template match="o[@name and not(@base) and (../@base or ../@star) and following-sibling::o[1][@pipe]]">
+  <xsl:template match="o[@name and not(@base) and not(@pipe) and (../@base or ../@star) and following-sibling::o[1][@pipe]]">
     <xsl:copy>
       <xsl:attribute name="float-up"/>
       <xsl:apply-templates select="@*|node()"/>

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-chained-in-argument-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-chained-in-argument-block.yaml
@@ -9,7 +9,7 @@ asserts:
   - //o[@base='ξ.y.plus']/o[@base='ξ.result']
   - //o[@name='app']/o[@name='foo' and not(@base) and o[@base='∅' and @name='x']]
   - //o[@name='app']/o[starts-with(@base,'ξ.foo') and o[@base='Φ.number']]
-  - //o[@name='app']/o[@name='result']/@base = concat('ξ.', //o[@name='app']/o[starts-with(@base,'ξ.foo')]/@name)
+  - //o[@name='app']/o[@name='result'][@base = concat('ξ.', //o[@name='app']/o[starts-with(@base,'ξ.foo')]/@name)]
 input: |
   [y] > app
     y.plus > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-chained-in-argument-block.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-chained-in-argument-block.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='ξ.y.plus' and count(o)=1]
+  - //o[@base='ξ.y.plus']/o[@base='ξ.result']
+  - //o[@name='app']/o[@name='foo' and not(@base) and o[@base='∅' and @name='x']]
+  - //o[@name='app']/o[starts-with(@base,'ξ.foo') and o[@base='Φ.number']]
+  - //o[@name='app']/o[@name='result']/@base = concat('ξ.', //o[@name='app']/o[starts-with(@base,'ξ.foo')]/@name)
+input: |
+  [y] > app
+    y.plus > @
+      [x] > foo
+        x.plus 1 > @
+      | 1 >>
+      | 2 > result


### PR DESCRIPTION
Two templates in wrap-applications.xsl compete for the same node: the intermediate pipe of a chain sitting inside an argument block or star tuple carries @pipe, a forced @name (R-3.14.5), no @base yet, a parent carrying @base or @star, and a following sibling carrying @pipe.
It matched both the @base-rewrite template and the predecessor float-up template with equal default priority, and only one of them fired.

The fix merges the @float-up marking into the o[@pipe] template itself, so a chained pipe gets both @base and @float-up in one pass, and excludes @pipe nodes from the separate predecessor-float-up template so the two no longer collide.

That also uncovered a second, latent gap: vars-float-up.xsl only stripped the internal @float-up marker from hoisted abstract (formation) nodes, not from hoisted non-abstract nodes such as a chained pipe application, so the marker leaked into the final XMIR whenever this path actually ran. The generic copy template there now drops @float-up for every node, matching the behavior formations already had.

A new eo-syntax pack, pipe-chained-in-argument-block.yaml, reproduces the issue's own example and fails two of its five assertions on the old code before passing cleanly with the fix.

Closes #8490
