### PR TITLE
Reduce a type to the type of its φ when φ is all it binds

### DIFF
--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -4,12 +4,12 @@
 
 # eo-inference
 
-Works out, for every object in an EO program, which object it was copied from.
+Works out, for every object in an EO program, which formation it behaves as.
 
 EO has no types. It has objects, and every object is a copy of some other one,
 which is a copy of another, and so on until the chain arrives at a formation
-written in the source. That formation is the answer, and its FQN is the whole
-of what this module means by a type:
+written in the source. That formation is where the answer is looked for, and an
+FQN is the whole of what this module means by a type:
 
 ```eo
 [as-bytes] > number      # Φ.number.as-bytes is a Φ.bytes
@@ -18,9 +18,13 @@ of what this module means by a type:
     $.^.plus ($.x.times -1) > @      # Φ.number.minus.@ is a Φ.number
 ```
 
-Nothing else counts as an answer. `Φ.number.plus.x` is not "a number-ish
-thing", it is `Φ.number`, and if we cannot say which formation it is we say so
-rather than dressing up a guess.
+Where the chain arrives is not always where it stops. A formation that binds
+nothing the outside can read but its own `φ` has no behaviour of its own: it
+hands on everything it can be asked, and its name says less about an object
+than the name behind it. So `1.plus 2` is a `Φ.number` rather than a
+`Φ.number.plus`, and the `as-bytes` of a `Φ.bytes` is a `Φ.bytes`. A formation
+that does bind something of its own is where the walk ends, and if we cannot
+say which formation it is we say so rather than dressing up a guess.
 
 The goal runs after `pre-inference` and writes three XML tables into
 `target/eo/6-inference`. Nothing else in the compiler reads them yet.
@@ -48,8 +52,8 @@ the ground everything else stands on, and asking what more there is to know
 about them is asking nothing. So does a termination.
 
 Whether the formation still has voids free does not matter here. Knowing that
-something is a `Φ.number.plus` is knowing which object it is, even before
-knowing what went into its `x`.
+something is a `Φ.number` is knowing which object it is, even before knowing
+what went into its `as-bytes`.
 
 ### rooted at a void
 
@@ -128,7 +132,7 @@ No clue decides anything, and none of them can fail, so they compose in any
 order:
 
 ```java
-new Witnessed(new Demanded(new Resolved(new Clues())))
+new Witnessed(new Demanded(new Reduced(new Resolved(new Clues()))))
 ```
 
 `Clues` is the first pass and fills the three tables from the source text
@@ -149,6 +153,7 @@ more question:
 | Pass | Answers |
 | --- | --- |
 | `Resolved` | What every dispatch turns out to be. `a.b.c` is walked one hop at a time, each hop asked of the type the last one arrived at, looking behind a delegation and into a package where it has to. |
+| `Reduced` | Which name a type goes by when it has no behaviour of its own. A formation whose only public attribute is its `φ` hands on everything it can be asked, so the name behind it is written on the row and every object that settled on it is reported as that instead. |
 | `Demanded` | What a void will have to offer, gathered from every name ever asked of it, and what it will have to take, gathered from every call ever made on it. A contract: a caller that fills it owes these attributes, and the voids of what it fills with have to take these arguments. |
 | `Witnessed` | What the program is actually seen to put into a void. Evidence, never a contract — the callers a program happens to have today do not oblige the one written tomorrow, and a void filled with a `Φ.number` everywhere is still a void. Nothing may work out a type from it. |
 

--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -45,6 +45,13 @@ import java.util.Map;
  * {@code Φ.bool.and.x} turns out to be and would rather be told that
  * {@code Φ.true} and {@code Φ.false} have both been put there.</p>
  *
+ * <p>A type with no behaviour of its own is given the name it behaves as,
+ * which {@link Behaved} worked out and {@link Reduced} wrote on the row. Only
+ * the name is taken from there: the rung is asked of the type the walk
+ * actually arrived at, since that is the object whose voids were filled, and
+ * counting the voids of the name it goes by would describe a copy with nothing
+ * left to fill as still wanting an argument.</p>
+ *
  * @since 0.69.0
  */
 final class Answers {
@@ -108,13 +115,23 @@ final class Answers {
         if (this.ground.contains(end)) {
             found = new Answer(end, 4);
         } else if (this.table.containsKey(end)) {
-            found = new Answer(end, this.depth(end, this.free(end, filled)));
+            found = new Answer(this.behaves(end), this.depth(end, this.free(end, filled)));
         } else if (root.isEmpty()) {
             found = new Answer(end, 0);
         } else if (sole.isEmpty()) {
             found = new Answer(end, 1, this.hollows.get(root));
         } else {
-            found = new Answer(sole, this.depth(sole, this.free(sole, filled)));
+            found = new Answer(this.behaves(sole), this.depth(sole, this.free(sole, filled)));
+        }
+        return found;
+    }
+
+    private String behaves(final String type) {
+        String found = type;
+        for (final Map<String, String> row : this.own(type)) {
+            if (row.containsKey("id")) {
+                found = row.getOrDefault("reduced", type);
+            }
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Behaved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Behaved.java
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What every type of the program behaves as.
+ *
+ * <p>A formation that binds nothing but a body has no behaviour of its own.
+ * {@code Φ.bytes.as-bytes} hands back the object it was dispatched on and does
+ * nothing else, so every name it answers to it answers through its {@code @},
+ * and telling a reader that their object is a {@code Φ.bytes.as-bytes} gives
+ * them a name and nothing besides. It is a {@code Φ.bytes}, and that is what
+ * should be printed. Seven hundred objects of eo-runtime settle on the alias
+ * instead, which makes it the fifth most common answer in the library and
+ * leaves whoever reads the pages working out that the two names mean one
+ * thing.</p>
+ *
+ * <p>So a type is reduced to what stands behind its {@code @} when {@code @}
+ * is its only public attribute. Public means readable from outside the object,
+ * which is why the exclusions are not a matter of taste: a {@code 🌵}
+ * auto-name is kept out of the {@code NAME} token by R-9.2.2 of the parser
+ * spec and no source file can write one down, and a name that begins with a
+ * {@code +} or a {@code -} is a test attribute, which the syntax forbids
+ * anybody to name either. One more public attribute, though, is one more thing
+ * a reader loses by being told something else, so an {@code english} that
+ * hands back its receiver and binds {@code lower} and {@code upper} besides
+ * keeps its own name.</p>
+ *
+ * <p>A void is ignored as well, and that clause has an expiry on it. A void is
+ * public today, so the rule as it is meant to read — nothing public but
+ * {@code @} — would reduce almost nothing; voids are on their way to being
+ * named by the parser and unreadable from outside, like a moniker and a test,
+ * and the day they get there this clause is deleted and the rule reads as it
+ * was written. What it costs meanwhile is small and was measured: of the 1,444
+ * reads that land on a type this reduces, 25 ask for a void the new name
+ * cannot answer.</p>
+ *
+ * <p>The walk goes on for as long as each name it arrives at is as bare as the
+ * last, and gives back the final name that still has a row of its own, since a
+ * void has none and is walked through rather than settled on. What an atom
+ * says it comes back with counts as standing behind {@code @} — the whole of
+ * {@code Φ.number.plus} is an annotation saying {@code Φ.number}, so
+ * {@code 1.plus 2} is a number — which is {@link Provided}'s
+ * {@code behind}, and the rule is that method asked of a row that qualifies
+ * until it stops answering.</p>
+ *
+ * @since 0.71.0
+ */
+final class Behaved {
+
+    /**
+     * The provides table.
+     */
+    private final XML table;
+
+    /**
+     * The name every type goes by.
+     */
+    private final Map<String, String> names;
+
+    /**
+     * Ctor.
+     * @param provides The provides table, as {@link Provides} wrote it
+     * @param aliases The name every type goes by, from {@link Ends}
+     */
+    Behaved(final XML provides, final Map<String, String> aliases) {
+        this.table = provides;
+        this.names = aliases;
+    }
+
+    /**
+     * What every type of the program behaves as.
+     * @return The name to go by, by the locator of the type, without the types
+     *  that behave as themselves
+     */
+    Map<String, String> all() {
+        final Map<String, Collection<Map<String, String>>> rows =
+            new Ungrouped(this.table, Collections.emptyMap()).rows();
+        final Provided owned = new Provided(
+            this.table, this.names, this.table.xpath("//attr[@void='true']/@type")
+        );
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final String type : rows.keySet()) {
+            final String behaves = Behaved.walked(type, rows, owned);
+            if (!behaves.equals(type)) {
+                found.put(type, behaves);
+            }
+        }
+        return found;
+    }
+
+    private static String walked(
+        final String type,
+        final Map<String, Collection<Map<String, String>>> rows,
+        final Provided owned
+    ) {
+        final Collection<String> walked = new HashSet<>(0);
+        String found = type;
+        String hop = type;
+        while (walked.add(hop)
+            && Behaved.bare(rows.getOrDefault(hop, Collections.emptyList()))) {
+            final String behind = owned.behind(hop);
+            if (behind.isEmpty()) {
+                break;
+            }
+            hop = behind;
+            if (rows.containsKey(hop)) {
+                found = hop;
+            }
+        }
+        return found;
+    }
+
+    private static boolean bare(final Collection<Map<String, String>> rows) {
+        boolean found = true;
+        for (final Map<String, String> row : rows) {
+            final String name = row.getOrDefault("name", "");
+            if (!name.isEmpty() && !"φ".equals(name)
+                && !"true".equals(row.get("void")) && Behaved.open(name)) {
+                found = false;
+                break;
+            }
+        }
+        return found;
+    }
+
+    private static boolean open(final String name) {
+        return !name.startsWith("+") && !name.startsWith("-") && !name.contains("🌵");
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Behaved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Behaved.java
@@ -40,13 +40,20 @@ import java.util.Map;
  * {@code @} — would reduce almost nothing; voids are on their way to being
  * named by the parser and unreadable from outside, like a moniker and a test,
  * and the day they get there this clause is deleted and the rule reads as it
- * was written. What it costs meanwhile is small and was measured: of the 1,444
- * reads that land on a type this reduces, 25 ask for a void the new name
- * cannot answer.</p>
+ * was written. What it costs meanwhile was measured: of the 1,680 reads that
+ * land on a type this reduces, 104 ask for a void the new name has no answer
+ * for. Eighty-eight of those are inside a test and eight more ask for
+ * {@code ρ}, which leaves eight on the library proper — {@code printf} wanting
+ * its {@code args}, {@code with} its {@code key} and its {@code value}, and
+ * three besides.</p>
  *
  * <p>The walk goes on for as long as each name it arrives at is as bare as the
- * last, and gives back the final name that still has a row of its own, since a
- * void has none and is walked through rather than settled on. What an atom
+ * last, and gives back the final name that still has a row of its own and that
+ * a source file could write down, since a void has none and is walked through
+ * rather than settled on, and a name with a moniker or a test in it is walked
+ * through for the same reason it is not counted: nobody can say it. Trading
+ * {@code Φ.i64.plus} for the {@code Φ.i64.plus.a🌵143-4} its body happens to
+ * be would hand a reader a worse name than the one they came with. What an atom
  * says it comes back with counts as standing behind {@code @} — the whole of
  * {@code Φ.number.plus} is an annotation saying {@code Φ.number}, so
  * {@code 1.plus 2} is a number — which is {@link Provided}'s
@@ -113,7 +120,7 @@ final class Behaved {
                 break;
             }
             hop = behind;
-            if (rows.containsKey(hop)) {
+            if (rows.containsKey(hop) && Behaved.written(hop)) {
                 found = hop;
             }
         }
@@ -131,6 +138,11 @@ final class Behaved {
             }
         }
         return found;
+    }
+
+    private static boolean written(final String locator) {
+        return Behaved.open(locator)
+            && !locator.contains(".+") && !locator.contains(".-");
     }
 
     private static boolean open(final String name) {

--- a/eo-inference/src/main/java/org/eolang/inference/Provides.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provides.java
@@ -103,6 +103,12 @@ import java.util.stream.Collectors;
  * outright what it is dispatched on, and one that says nothing has no
  * {@code ρ} at all for anybody to name.</p>
  *
+ * <p>What goes into the {@code ρ} a formation does declare is written down,
+ * which is a different claim and {@link Received}'s: an attribute of an
+ * {@code oak} is reached by taking it off an {@code oak}, so the void holds
+ * one. Only a formation that asked for a receiver is told what it gets, and
+ * the row was already there for the asking.</p>
+ *
  * @since 0.67.0
  */
 final class Provides implements Clue {
@@ -116,6 +122,7 @@ final class Provides implements Clue {
                 Provides.fill(rows, new Xnav(formation.inner()));
             }
             new Members(made, world.roots()).fill(rows);
+            new Received(made).fill(rows);
             Files.createDirectories(tables);
             Files.write(
                 tables.resolve("provides.xml"),

--- a/eo-inference/src/main/java/org/eolang/inference/Received.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Received.java
@@ -1,0 +1,95 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import com.yegor256.tojos.Tojo;
+import com.yegor256.tojos.Tojos;
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * What the receiver of an attribute holds.
+ *
+ * <p>An attribute of an {@code oak} is reached by taking it off an
+ * {@code oak}, and there is no other way to reach it: a dispatch that lands on
+ * {@code Φ.oak.grow} landed there because what it was taken off was an
+ * {@code oak}, and one that goes through a decorator arrives no differently,
+ * since the lookup is handed down and the decoratee is the {@code oak}. So the
+ * void a formation declares for its receiver holds the object the formation is
+ * an attribute of, which is what {@link Held} reads back and {@link Provided}
+ * walks through.</p>
+ *
+ * <p>This is not the old rule of reading a receiver off a locator, which was
+ * taken out again in #6657 and should stay out. That one gave every object a
+ * {@code ρ} whether it had asked for one or not, and a formation that declares
+ * no receiver has none at all — the runtime terminates on the {@code ρ} of
+ * such an object. Nothing is invented here: the row is in the table already,
+ * written because the source declared the void, and only what goes into it is
+ * added.</p>
+ *
+ * <p>Nothing is said where the locator above the formation names no object of
+ * the program. A package is a prefix and nothing else until a file forms
+ * something of that name, so a {@code Φ.sys.posix.stdout} sits under a
+ * {@code Φ.sys.posix} nobody wrote and there is no type for its receiver to
+ * hold. What a void says for itself is left alone as well, an atom that
+ * annotates its own {@code ^} knowing better than a locator does.</p>
+ *
+ * @since 0.71.0
+ */
+final class Received {
+
+    /**
+     * The formations of the program.
+     */
+    private final Collection<XML> made;
+
+    /**
+     * Ctor.
+     * @param formations The formations of the program
+     */
+    Received(final Collection<XML> formations) {
+        this.made = formations;
+    }
+
+    /**
+     * Write what every declared receiver holds into the given table.
+     * @param rows The table to fill
+     */
+    void fill(final Tojos rows) {
+        final Collection<String> owners = new HashSet<>(0);
+        for (final XML formation : this.made) {
+            owners.add(new Noted(formation).says("loc"));
+        }
+        for (final XML formation : this.made) {
+            final String owner = new Noted(formation).says("loc");
+            final String above = Received.above(owner);
+            if (owners.contains(above) && Received.receives(formation)) {
+                final Tojo row = rows.add(String.join(" ", owner, "ρ"));
+                if (!row.exists("holds")) {
+                    row.set("holds", above);
+                }
+            }
+        }
+    }
+
+    private static String above(final String owner) {
+        String found = "";
+        final int last = owner.lastIndexOf('.');
+        if (last > 0) {
+            found = owner.substring(0, last);
+        }
+        return found;
+    }
+
+    private static boolean receives(final XML formation) {
+        return new Xnav(formation.inner())
+            .elements(Filter.withName("o"))
+            .map(Noted::new)
+            .anyMatch(kid -> "∅".equals(kid.says("base")) && "ρ".equals(kid.says("name")));
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Reduced.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Reduced.java
@@ -1,0 +1,82 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XML;
+import com.jcabi.xml.XMLDocument;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import org.xembly.Directives;
+import org.xembly.Xembler;
+
+/**
+ * The rows about a type, with the name its behaviour goes by.
+ *
+ * <p>{@link Behaved} works out which types have no behaviour of their own and
+ * what stands behind them; this writes the answer on the row, as one more cell
+ * of the table the rules already keep about a type:</p>
+ *
+ * <pre> &lt;type id="Φ.bytes.as-bytes" complete="false" reduced="Φ.bytes"&gt;</pre>
+ *
+ * <p>It goes into the table rather than onto the drawn page alone, so that the
+ * name a reader is given and the name the goal counts are one name. A cell and
+ * not a pair in the links: saying that a {@code Φ.bytes.as-bytes} is a copy of
+ * a {@code Φ.bytes} would put the fact where {@link Ends} and {@link Provided}
+ * already look, which is why it was worth trying, and it corrupts what an
+ * application fills — {@link Bound} settles the name of what a dispatch is
+ * taken from before asking which void an argument lands in, so a
+ * {@code plus 2} would fill a void of {@code Φ.number} instead of the
+ * {@code x} of {@code Φ.number.plus}. A pair says the two objects are one, and
+ * they are not: one of them behaves like the other, which is a weaker thing to
+ * say and needs a weaker place to say it.</p>
+ *
+ * <p>It is read where an object is asked what it turns out to be, and only the
+ * name travels. What is left to fill in stays as it was: the reduced name is
+ * the formation the body arrived at, and the body filled that formation's
+ * voids itself, inside itself, so counting them again against the new name
+ * would leave a {@code Φ.true.+can-conjoin-true-with-true} that has nothing
+ * left to fill described as still wanting an argument — 2,054 of the 4,469
+ * renamed objects of eo-runtime report a different number if it is asked of
+ * the new name.</p>
+ *
+ * @since 0.71.0
+ */
+public final class Reduced implements Clue {
+
+    /**
+     * The clues to follow first.
+     */
+    private final Clue origin;
+
+    /**
+     * Ctor.
+     * @param clues The clues to follow before the types are reduced
+     */
+    public Reduced(final Clue clues) {
+        this.origin = clues;
+    }
+
+    @Override
+    public void follow(final Path xmirs, final Path tables) throws IOException {
+        this.origin.follow(xmirs, tables);
+        final Path table = tables.resolve("provides.xml");
+        final XML given = new XMLDocument(table);
+        final Map<String, String> behaves = new Behaved(
+            given,
+            new Ends(new Pairs(new XMLDocument(tables.resolve("links.xml"))).all()).names()
+        ).all();
+        for (final XML row : given.nodes("/provides/type")) {
+            final String found = behaves.get(new Noted(row).says("id"));
+            if (found != null) {
+                new Xembler(new Directives().attr("reduced", found))
+                    .applyQuietly(row.inner());
+            }
+        }
+        Files.write(table, given.toString().getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
@@ -185,6 +185,50 @@ final class AnswersTest {
         );
     }
 
+    @Test
+    void answersWithTheNameATypeBehavesAs() {
+        final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
+        final Map<String, String> alias = new LinkedHashMap<>(0);
+        alias.put("id", "Φ.bytes.as-bytes");
+        alias.put("complete", "true");
+        alias.put("reduced", "Φ.bytes");
+        rows.put("Φ.bytes.as-bytes", Collections.singletonList(alias));
+        MatcherAssert.assertThat(
+            "an as-bytes has nothing of its own, so it must answer as bytes, but it kept its name",
+            new Answers(
+                rows, Collections.emptyMap(), Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.bytes.as-bytes", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.bytes")
+        );
+    }
+
+    @Test
+    void keepsTheRungOfTheTypeItArrivedAt() {
+        final Map<String, Collection<Map<String, String>>> rows = new LinkedHashMap<>(0);
+        final Map<String, String> alias = new LinkedHashMap<>(0);
+        alias.put("id", "Φ.bytes.as-bytes");
+        alias.put("complete", "true");
+        alias.put("reduced", "Φ.bytes");
+        rows.put("Φ.bytes.as-bytes", Collections.singletonList(alias));
+        final Map<String, String> whole = new LinkedHashMap<>(0);
+        whole.put("id", "Φ.bytes");
+        whole.put("complete", "true");
+        final Map<String, String> hollow = new LinkedHashMap<>(0);
+        hollow.put("name", "data");
+        hollow.put("void", "true");
+        hollow.put("type", "Φ.bytes.data");
+        rows.put("Φ.bytes", Arrays.asList(whole, hollow));
+        MatcherAssert.assertThat(
+            "an as-bytes has no void left free, but it was counted as wanting one",
+            new Answers(
+                rows, Collections.emptyMap(), Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.bytes.as-bytes", Collections.emptyList()).rung(),
+            Matchers.equalTo(4)
+        );
+    }
+
     private static Map<String, Collection<Map<String, String>>> formation(final String locator) {
         final Map<String, String> whole = new LinkedHashMap<>(0);
         whole.put("id", locator);

--- a/eo-inference/src/test/java/org/eolang/inference/BehavedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BehavedTest.java
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Behaved}.
+ * @since 0.70.0
+ */
+final class BehavedTest {
+
+    @Test
+    void namesATypeAfterTheOnlyThingItBinds() {
+        MatcherAssert.assertThat(
+            "an alias that binds nothing but a body must be what stands behind it, but it wasnt",
+            new Behaved(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides>",
+                        "<type id='Φ.oak'><attr name='leaf' type='Φ.oak.leaf'/></type>",
+                        "<type id='Φ.alias'><attr name='φ' type='Φ.oak'/></type>",
+                        "</provides>"
+                    )
+                ),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.hasEntry("Φ.alias", "Φ.oak")
+        );
+    }
+
+    @Test
+    void leavesATypeThatBindsMoreThanABodyAlone() {
+        MatcherAssert.assertThat(
+            "a trunk has a bark of its own, so it cannot be an oak, but it was named one",
+            new Behaved(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides>",
+                        "<type id='Φ.oak'><attr name='leaf' type='Φ.oak.leaf'/></type>",
+                        "<type id='Φ.trunk'>",
+                        "<attr name='φ' type='Φ.oak'/>",
+                        "<attr name='bark' type='Φ.trunk.bark'/>",
+                        "</type>",
+                        "</provides>"
+                    )
+                ),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.not(Matchers.hasKey("Φ.trunk"))
+        );
+    }
+
+    @Test
+    void countsNoVoidAmongTheAttributesThatKeepATypeApart() {
+        MatcherAssert.assertThat(
+            "a void is filled from outside and names nothing of its own, but it was counted",
+            new Behaved(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides>",
+                        "<type id='Φ.oak'><attr name='leaf' type='Φ.oak.leaf'/></type>",
+                        "<type id='Φ.grafted'>",
+                        "<attr name='φ' type='Φ.oak'/>",
+                        "<attr name='x' type='Φ.grafted.x' void='true'/>",
+                        "</type>",
+                        "</provides>"
+                    )
+                ),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.hasEntry("Φ.grafted", "Φ.oak")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/BehavedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BehavedTest.java
@@ -60,6 +60,28 @@ final class BehavedTest {
     }
 
     @Test
+    void refusesToLandOnANameNoSourceFileCanWrite() {
+        MatcherAssert.assertThat(
+            "a moniker is worse than the name it replaces, but the type was reduced to one",
+            new Behaved(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides>",
+                        "<type id='Φ.alias'><attr name='φ' type='Φ.alias.a🌵3-2'/></type>",
+                        "<type id='Φ.alias.a🌵3-2'>",
+                        "<attr name='leaf' type='Φ.alias.a🌵3-2.leaf'/>",
+                        "</type>",
+                        "</provides>"
+                    )
+                ),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.not(Matchers.hasKey("Φ.alias"))
+        );
+    }
+
+    @Test
     void countsNoVoidAmongTheAttributesThatKeepATypeApart() {
         MatcherAssert.assertThat(
             "a void is filled from outside and names nothing of its own, but it was counted",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -22,6 +22,7 @@ import org.eolang.inference.Clues;
 import org.eolang.inference.Demanded;
 import org.eolang.inference.Depth;
 import org.eolang.inference.Ladder;
+import org.eolang.inference.Reduced;
 import org.eolang.inference.Resolved;
 import org.eolang.inference.Witnessed;
 import org.eolang.parser.TrFull;
@@ -103,7 +104,7 @@ final class Inferring implements Step {
             }
             final int ready = this.ready();
             final long start = System.currentTimeMillis();
-            new Witnessed(new Demanded(new Resolved(new Clues())))
+            new Witnessed(new Demanded(new Reduced(new Resolved(new Clues()))))
                 .follow(this.prepared, this.tables);
             this.declared();
             Logger.info(

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caret-is-the-void-the-formation-declares.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-caret-is-the-void-the-formation-declares.yaml
@@ -3,9 +3,10 @@
 ---
 # `^` names the receiver a formation declares and not the object it happens to
 # be written inside. `inner` says `[^]`, so `^.held` asks `held` of that void
-# and the answer waits for whoever dispatches on `inner`. Walking outward
-# through the text would name `outer` here, which is only one of the things a
-# caller could hand over, and since #6657 the text no longer decides.
+# and the answer waits for whoever dispatches on `inner`. Since #6657 the void
+# is declared, so the demand is written against the void and not against the
+# `outer` the body happens to sit in. What the void will hold is a fact of its
+# own, written down apart and asserted apart.
 eo:
   outer.eo: |
     [] > outer

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-formation-that-binds-more-than-a-body-is-not-reduced.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-formation-that-binds-more-than-a-body-is-not-reduced.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# One more public attribute is one more thing a reader loses by being told
+# something else. A `trunk` hands its answers to an `oak` and has a `bark`
+# besides, which no `oak` has, so it is not one and keeps its own name.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  trunk.eo: |
+    [] > trunk
+      oak > @
+      [] > bark
+provides:
+  - "/provides/type[@id='Φ.trunk' and not(@reduced)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-formation-that-binds-nothing-but-a-body-is-what-stands-behind-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-formation-that-binds-nothing-but-a-body-is-what-stands-behind-it.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A formation that binds nothing but a body has no behaviour of its own: every
+# name it answers to, it answers through its `@`. Telling a reader that
+# something is a `Φ.alias` gives him a name and nothing else, so the type it
+# goes by is the type of its `@`, and the row says which.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  alias.eo: |
+    [] > alias
+      oak > @
+provides:
+  - "/provides/type[@id='Φ.alias' and @reduced='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-formation-that-hands-back-its-receiver-is-what-it-hangs-off.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-formation-that-hands-back-its-receiver-is-what-it-hangs-off.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# This is the shape that asked for the rule. `Φ.bytes.as-bytes` hands back the
+# object it was dispatched on and does nothing else, so it is a `Φ.bytes` and
+# 736 objects of eo-runtime should stop settling on the alias. Two facts meet
+# here to say so: the receiver holds the object the attribute belongs to, and a
+# formation with nothing public but its body is what stands behind that body.
+eo:
+  tree.eo: |
+    [] > tree
+      [^] > mine
+        ^ > @
+provides:
+  - "/provides/type[@id='Φ.tree.mine' and @reduced='Φ.tree']"
+  - "/provides/type[@id='Φ.tree' and not(@reduced)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-receiver-holds-what-the-attribute-belongs-to.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-receiver-holds-what-the-attribute-belongs-to.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A `grow` is reached by taking it off a `tree` and there is no other way to
+# reach it, so the void it declares for its receiver holds a `tree`. A
+# decorator changes nothing about that: it hands the lookup down, and what the
+# lookup arrives at is still the `tree`. The row is the one the source already
+# asked for by writing `^` — a formation that declares no receiver is still
+# told nothing, and neither is one whose locator sits under a package nobody
+# formed, `Φ` in the case of an `inc` written at the top of its own file.
+eo:
+  tree.eo: |
+    [] > tree
+      [^ x] > grow
+        x > @
+  inc.eo: |
+    [^ x] > inc
+      x > @
+provides:
+  - "/provides/type[@id='Φ.tree.grow']/attr[@name='ρ' and @holds='Φ.tree']"
+  - "/provides/type[@id='Φ.inc']/attr[@name='ρ' and not(@holds)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-reduction-lands-only-on-a-name-a-source-file-can-write.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-reduction-lands-only-on-a-name-a-source-file-can-write.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name with a moniker in it is walked through for the same reason it is not
+# counted: nobody can say it. `shaded` hands its answers to a formation the
+# author gave a file-local handle, so the only name behind it is the `a🌵` the
+# parser made up, and being told that is worse than being told `shaded`.
+eo:
+  tree.eo: |
+    [] > tree
+      [^] > shaded
+        hue 1 > @
+        [k] >> hue
+          k > @
+          [] > leaf
+provides:
+  - "/provides/type[@id='Φ.tree.shaded' and not(@reduced)]"
+  - "/provides/type[@id='Φ.tree.shaded']/attr[contains(@name, '🌵')]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-reduction-stops-at-the-last-name-that-has-a-row.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-reduction-stops-at-the-last-name-that-has-a-row.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The reduction chains, since a name with no behaviour of its own is no better
+# an answer at the second hop than at the first. A `second` is an `alias` and
+# an `alias` is an `oak`, so a `second` is an `oak`, and the walk stops there
+# because an `oak` has a `leaf` to lose.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  alias.eo: |
+    [] > alias
+      oak > @
+  second.eo: |
+    [] > second
+      alias > @
+provides:
+  - "/provides/type[@id='Φ.second' and @reduced='Φ.oak']"
+  - "/provides/type[@id='Φ.oak' and not(@reduced)]"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-test-attribute-does-not-keep-a-formation-from-being-reduced.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-test-attribute-does-not-keep-a-formation-from-being-reduced.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A test attribute is not public: the syntax forbids a name that begins with a
+# `+`, so no source file can dispatch on one and nothing is lost by leaving it
+# out of the count.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  checked.eo: |
+    [] > checked
+      oak > @
+
+      oak ++> can-be-an-oak
+provides:
+  - "/provides/type[@id='Φ.checked' and @reduced='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-does-not-keep-a-formation-from-being-reduced.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-does-not-keep-a-formation-from-being-reduced.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A void is public today and is on its way to being a moniker, named by the
+# parser and unreadable from outside, so it is not counted among the attributes
+# that keep a formation from being reduced. Almost nobody reads back the thing
+# he has just put in.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  grafted.eo: |
+    [x] > grafted
+      oak > @
+provides:
+  - "/provides/type[@id='Φ.grafted' and @reduced='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/an-atom-is-what-it-says-it-comes-back-with.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/an-atom-is-what-it-says-it-comes-back-with.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# What a `λ` does is written in Java and nobody here can read it, and it is
+# not public either — the syntax gives no way to name it. So an atom that says
+# what it comes back with says the whole of what it is, and a `grow` is an
+# `oak` in the same way that an alias is what it delegates to.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  grow.eo: |
+    [] > grow /Q.oak
+      ? > x
+provides:
+  - "/provides/type[@id='Φ.grow' and @reduced='Φ.oak']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/an-auto-named-attribute-does-not-keep-a-formation-from-being-reduced.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/an-auto-named-attribute-does-not-keep-a-formation-from-being-reduced.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An auto-named attribute is not public either. R-9.2.2 of the parser spec
+# keeps the cactus out of the `NAME` token, so a name the parser made up is
+# one no source file can write down, and it cannot be the name a reader was
+# going to ask about.
+eo:
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  handled.eo: |
+    [] > handled
+      oak >> held
+      held > @
+provides:
+  - "/provides/type[@id='Φ.handled' and @reduced='Φ.oak']"


### PR DESCRIPTION
`Φ.bytes.as-bytes` hands back the object it was dispatched on and does nothing
else, so a reader told that an object is a `Φ.bytes.as-bytes` has been given
the name of a doorway instead of the name of a thing. `1.plus 2` was the same
kind of answer: `Φ.number.plus`. A formation that binds nothing the outside can
read but its own `φ` has no behaviour of its own, so `Reduced` writes the name
behind it onto the provides row and `Answers` reports that instead.

Public means readable from outside the object, which leaves out a `🌵`
auto-name and a `+`/`-` test attribute, the syntax forbidding either from being
written at a dispatch:

```java
private static boolean open(final String name) {
    return !name.startsWith("+") && !name.startsWith("-") && !name.contains("🌵");
}
```

A void is public today and is left out anyway. That clause is a hack with an
expiry and says so in the docblock: when voids become private like the other
two, it goes.

The rule needs a second hop to reach the shape that asked for it, since an
`as-bytes` delegates to its own `^` and the walk used to stop at that void. So
`Received` writes down what the `ρ` a formation declares will hold: an
attribute of an `oak` is reached by taking it off an `oak`, and there is no
other way to reach it. Only a formation that asked for a receiver is told
anything, and nothing is said when the locator above it names no formation,
which is why 15 of eo-runtime's 525 declared receivers stay empty.

A name is only an answer if a source file could have written it, which is the
other half of the same thought and was missing at first: the walk counted a
moniker out of what keeps a type apart but took one as an answer, so
`Φ.i64.plus` came back `Φ.i64.plus.a🌵143-4` and 48 others like it came back
worse than they went in.

Over eo-runtime, 1,244 of 3,031 type rows reduce and 6,938 objects change the
name they answer with, leaving 12,853 distinct answers where there were 14,501.
`Φ.bytes.as-bytes` now answers `Φ.bytes`, and `Φ.number.plus` answers
`Φ.number`. The rung does not travel with the name: it is asked of the type the
walk arrived at, since counting the voids of the name an object goes by would
describe a copy with nothing left to fill as still wanting an argument.

The links table was the other place this could have lived, as a copy edge from
`as-bytes` to `bytes`. I tried that and dropped it. `Bound` resolves the
settled name before asking `Provided` which voids an application fills, so the
edge would make `plus 2` bind its argument into a void of `Φ.number`; and
`Ungrouped` groups rows under the settled name, which would let the `φ` of an
alias override the one belonging to the type it reduces to. A cell on the row
corrupts nothing.

Ten packs describe the rule, one behaviour each. `Φ.bool.and` does not reduce
and is #8508's business.

Closes #8507
