### PR TITLE
Correct LnReversed docblock on method attribute emission

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -29,11 +29,15 @@ import java.util.List;
  * at close time if no receiver appeared.</li>
  * </ul>
  *
- * <p>Emission: opens {@code <o base='.<name>' method=''>} at the
- * current cursor and stays inside. For horizontal form, the receiver
- * and method args are appended as children before the cursor closes.
- * For vertical form, deeper-indent lines (dispatched through
- * {@link LnApplication} etc.) attach as children automatically.</p>
+ * <p>Emission: opens {@code <o base='.<name>'>} at the current cursor
+ * and stays inside. No {@code @method} is written: {@code @method}
+ * marks an {@code <o>} as a link continuing a dispatch chain, and a
+ * reversed dispatch opens a chain instead of continuing one (§9.4).
+ * A fragile {@code ?.} head gains {@code @fragile=''} alone. For
+ * horizontal form, the receiver and method args are appended as
+ * children before the cursor closes. For vertical form,
+ * deeper-indent lines (dispatched through {@link LnApplication} etc.)
+ * attach as children automatically.</p>
  *
  * <p>R-3.8.1 restricts the head identifier to a single {@code NAME},
  * {@code @}, {@code ^}, or {@code $} token — no dotted paths and no

--- a/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LnReversedTest.java
@@ -81,6 +81,66 @@ final class LnReversedTest {
     }
 
     @Test
+    void emitsHorizontalFormWithoutMethodAttribute() {
+        final Emit emit = new Emit();
+        new LnReversed(new Span("if. cond then else > x", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "the horizontal form heads a chain too, so it must emit <o base='.if'> without @method",
+            LnReversedTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='x' and @base='.if' and not(@method)]"
+            )
+        );
+    }
+
+    @Test
+    void emitsFragileDispatchWithoutMethodAttribute() {
+        final Emit emit = new Emit();
+        new LnReversed(new Span("if?. cond then > x", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a fragile reversed dispatch must carry @fragile alone, never @method alongside it (R-3.5.3a)",
+            LnReversedTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='x' and @base='.if' and @fragile='' and not(@method)]"
+            )
+        );
+    }
+
+    @Test
+    void emitsRootHeadWithoutMethodAttribute() {
+        final Emit emit = new Emit();
+        new LnReversed(new Span("@. > x", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a root head maps to .φ and still heads a chain, so it must carry no @method",
+            LnReversedTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='x' and @base='.φ' and not(@method)]"
+            )
+        );
+    }
+
+    @Test
+    void emitsConstantDispatchWithoutMethodAttribute() {
+        final Emit emit = new Emit();
+        new LnReversed(new Span("if. cond then > x!", 1))
+            .into(new Stack(), new Globals(), emit);
+        emit.close();
+        MatcherAssert.assertThat(
+            "a const-marked reversed dispatch must gain @const and still no @method",
+            LnReversedTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='x' and @base='.if' and @const='' and not(@method)]"
+            )
+        );
+    }
+
+    @Test
     void emitsHorizontalArgsAsChildren() {
         final Emit emit = new Emit();
         new LnReversed(new Span("if. cond then else > x", 1))


### PR DESCRIPTION
The class docblock of `LnReversed` said the line opens `<o base='.<name>' method=''>`. It does not, and it must not: `LnReversed.emit` goes through `Emit.object`, which writes `@name`, `@base`, `@line` and `@pos` and nothing more. §9.4 of `PARSER_SPEC.md` says the same thing — a method link keeps `@method=''` and gains `@fragile=''`, while a reversed dispatch carries `@fragile=''` without `@method`.

The difference matters downstream. `@method` is what marks an `<o>` as a link inside a dispatch chain for `wrap-method-calls.xsl` to fold, and R-3.5.3b keys off exactly that: a method dispatch with `@method` and no `@fragile`, preceded by a childless fragile link. A reversed dispatch heads a chain rather than continuing one, so the attribute would be wrong there. The paragraph now says that, and says why.

Four tests cover the corners of the same emission that had none: the horizontal form, a fragile `?.` head carrying `@fragile` alone, a root `@.` head mapping to `.φ`, and a const-marked `> x!`. Each asserts the absence of `@method` alongside whatever else the line is supposed to produce.

Closes #8492
