### PR TITLE
Require a space after the pipe only when something follows it

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -623,7 +623,7 @@ size.
 
 A line whose first non-space character is `|` is a *pipe-application line*. It applies arguments to the **same-indent predecessor** — the object declared on the lines just above it — without naming that object at the call site. This is the surface form of phi-calculus *formation-with-application* `⟦…⟧(…)`: the predecessor is formed, then the pipe supplies its arguments. The `|` reads as an up-arrow to "the object above".
 
-R-3.14.1. The `|` is followed by a single space, then either a horizontal argument list (§3.6) or nothing, then an optional name suffix (§3.10). Its tail is parsed exactly as an application's argument list plus suffix — the pipe supplies the arguments; the *head* is the implicit predecessor.
+R-3.14.1. When anything follows the `|` — a horizontal argument list (§3.6), a name suffix (§3.10), or both — a single space separates it from the pipe. Nothing has to follow: the vertical form (R-3.14.3) carries no argument list and may carry no suffix either, and then the line is the bare `|` alone, since `| ` with a trailing space is rejected by R-2.2.5. The tail is parsed exactly as an application's argument list plus suffix — the pipe supplies the arguments; the *head* is the implicit predecessor.
 
 R-3.14.2. **Predecessor requirement.** The stack top at the pipe's indent must be a **formation** (`bare-formation`, `inline-phi-formation` or `identity-object`) or another **pipe-application**, and it must be **named** (an explicit `> name` or an auto-generated `>>`). A pipe with no predecessor (top-level / empty stack), a deeper-indent ("descending") pipe, or a pipe whose predecessor is an unnamed formation, a plain value, an application, or any `.method` dispatch is an error. The named requirement is what lets the pipe refer to the predecessor by name (R-3.14.7); an unnamed formation cannot be a pipe target — give it a `>>`.
 
@@ -1455,7 +1455,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Compact tuple count wider than a signed 32-bit value (§3.9) | `compact tuple count is too large` |
 | `.method` line whose body does not open with a dot (§3.5) | `method continuation must start with a dot` |
 | Reversed dispatch whose receiver is not followed by a dot (§3.8) | `reversed dispatch must end with a dot` |
-| Pipe line whose `\|` is not followed by a space (§3.14) | `` a pipe `\|` must be followed by a space before its arguments `` |
+| Pipe line whose `\|` is glued to the argument list or suffix that follows it (§3.14) | `` a pipe `\|` must be followed by a space before its arguments `` |
 | Test attribute on a pipe application (§3.14) | `a pipe application cannot declare a test attribute` |
 | Text block closer that does not open with `"""` (R-3.11.3) | `text block closer must start with triple-quote` |
 | Text block body line shallower than its opener (R-3.11.2) | `text block body line indented less than opener` |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-bare-after-pipe.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-bare-after-pipe.yaml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The space after `|` separates the pipe from what follows it, so a pipe with
+# nothing to follow is the bare `|` (R-3.14.1). That spelling opens the
+# vertical form anywhere the horizontal one is allowed, including as the next
+# link of a chain (R-3.14.5), where the predecessor is the named pipe above.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@pipe]/o[@base='Φ.number']
+  - //o[@pipe]/following-sibling::o[@pipe]/o[@base='Φ.number']
+input: |
+  [] > app
+    foo > @
+      [a b] >>
+        a.plus b > @
+      | 2 >>
+      |
+        3

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-bare-after-pipe.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-bare-after-pipe.yaml
@@ -9,8 +9,8 @@
 sheets: []
 asserts:
   - /object[not(errors)]
-  - //o[@pipe]/o[@base='Φ.number']
-  - //o[@pipe]/following-sibling::o[@pipe]/o[@base='Φ.number']
+  - //o[@pipe and @name]/o[@base='Φ.number']
+  - //o[@pipe and not(@name)]/o[@base='Φ.number']
 input: |
   [] > app
     foo > @

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-glued-to-arguments.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-glued-to-arguments.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: "a pipe `|` must be followed by a space before its arguments"
+input: |
+  [] > app
+    [x] > foo
+      x > @
+    |1 > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-glued-to-suffix.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-glued-to-suffix.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+line: 4
+message: "a pipe `|` must be followed by a space before its arguments"
+input: |
+  [] > app
+    [x] > foo
+      x > @
+    |> n


### PR DESCRIPTION
R-3.14.1 demanded a single space after the `|` unconditionally, which left the vertical pipe with nothing it could legally be written as: `| ` is trailing whitespace under R-2.2.5, and a bare `|` was out because of the space requirement. The parser has always accepted the bare `|`, and the printer emits it, so the spec was the side that was wrong.

The rule now asks for the space only when a horizontal argument list or a name suffix actually follows, and says outright that the vertical form's opener is the `|` alone. The §9.9 row describing the error condition gets the same qualification, so the table no longer reads as a blanket ban.

Three fixtures pin the corrected reading: a bare `|` chained after a named pipe parses clean, and gluing either arguments or a suffix to the pipe still raises the canonical message. That message had no coverage in the typo packs at all before this.

Closes #8494
