### PR TITLE
Document the pipe-predecessor error in the canonical table

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1457,6 +1457,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Reversed dispatch whose receiver is not followed by a dot (§3.8) | `reversed dispatch must end with a dot` |
 | Pipe line whose `\|` is not followed by a space (§3.14) | `` a pipe `\|` must be followed by a space before its arguments `` |
 | Test attribute on a pipe application (§3.14) | `a pipe application cannot declare a test attribute` |
+| Pipe whose predecessor is missing, unnamed, or not a formation or pipe (§3.14) | `a pipe must follow a named formation or another pipe` |
 | Text block closer that does not open with `"""` (R-3.11.3) | `text block closer must start with triple-quote` |
 | Text block body line shallower than its opener (R-3.11.2) | `text block body line indented less than opener` |
 | Two or more consecutive blank lines (R-6.5.3) | `consecutive blank lines forbidden — at most one blank may separate two non-blank lines (R-6.5.3)` |

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-unnamed-pipe.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-unnamed-pipe.yaml
@@ -11,5 +11,5 @@ input: |
   [] > app
     [x] > foo
       x > @
-    .x
+    | 5
     | 6 > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-value.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-after-value.yaml
@@ -3,6 +3,10 @@
 ---
 # yamllint disable rule:line-length
 line: 3
+message: |-
+  [3:2] error: 'a pipe must follow a named formation or another pipe'
+    | 6 > n
+    ^
 input: |
   [] > app
     5 > five

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-descending.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-descending.yaml
@@ -3,6 +3,10 @@
 ---
 # yamllint disable rule:line-length
 line: 3
+message: |-
+  [3:4] error: 'a pipe must follow a named formation or another pipe'
+      | 5 > n
+      ^
 input: |
   [] > app
     [x] > foo

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation-vertical.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation-vertical.yaml
@@ -3,6 +3,10 @@
 ---
 # yamllint disable rule:line-length
 line: 4
+message: |-
+  [4:2] error: 'a pipe must follow a named formation or another pipe'
+    | >>
+    ^
 input: |
   [] > app
     [a b]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-formation.yaml
@@ -3,6 +3,10 @@
 ---
 # yamllint disable rule:line-length
 line: 4
+message: |-
+  [4:2] error: 'a pipe must follow a named formation or another pipe'
+    | 5 > y
+    ^
 input: |
   [] > app
     [x]

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-identity.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-on-nameless-identity.yaml
@@ -2,14 +2,12 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 5
+line: 3
 message: |-
-  [5:2] error: 'a pipe must follow a named formation or another pipe'
-    | 6 > n
+  [3:2] error: 'a pipe must follow a named formation or another pipe'
+    | 5 > n
     ^
 input: |
   [] > app
-    [x] > foo
-      x > @
-    .x
-    | 6 > n
+    I
+    | 5 > n

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-without-predecessor.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-typos/pipe-without-predecessor.yaml
@@ -3,5 +3,9 @@
 ---
 # yamllint disable rule:line-length
 line: 1
+message: |-
+  [1:0] error: 'a pipe must follow a named formation or another pipe'
+  | 5 > n
+  ^
 input: |
   | 5 > n


### PR DESCRIPTION
R-5.2.4a, R-5.2.5a and R-5.2.11a all send the reader to the §9.9 canonical-text table for the message `a pipe must follow a named formation or another pipe`, but the table had no row for it, so the pointer led nowhere. This adds the one row that covers all three rules, describing the condition as a pipe whose predecessor is missing, unnamed, or not a formation or pipe.

The same gap showed up in the tests. Every one of the 137 typo packs asserts its canonical text through the optional `message` key, except the six pipe packs, which only checked the line number — so this text was neither documented nor pinned anywhere. Those six now carry the full located message with its caret, which is what makes the new table row verifiable rather than decorative.

Two more packs cover the remaining pipeable kinds that the existing six missed: a pipe following an unnamed pipe, and a pipe following an unnamed identity object. Both reach the same rejection through a different branch of the precheck.

Closes #8496
