### PR TITLE
fix(#8495): name identity object in the pipe predecessor docblock

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -16,8 +16,9 @@ import java.util.List;
  * predecessor is formed, then the pipe supplies its arguments.</p>
  *
  * <p>The predecessor (stack top at the pipe's indent) must be a formation
- * ({@link Kind#BARE_FORMATION} / {@link Kind#ONLY_PHI}) or
- * another {@link Kind#PIPE_APPLICATION}, and must be named — a pipe refers
+ * ({@link Kind#BARE_FORMATION} / {@link Kind#ONLY_PHI}), the identity
+ * object {@link Kind#IDENTITY_OBJECT} of §3.16, or another
+ * {@link Kind#PIPE_APPLICATION}, and must be named — a pipe refers
  * to it by name, so an unnamed formation is not a valid target (R-3.14.2).
  * A pipe after a {@code .method} dispatch is rejected (R-3.14.4): the
  * attribute has already been taken, so the formation is no longer in

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-identity-object-chained.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-identity-object-chained.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A pipe whose predecessor is a pipe over the identity object `I` (#6834) is
+# still pipeable (R-3.14.2): the first pipe leaves a `PIPE_APPLICATION` on the
+# stack, and that kind is a legal predecessor whatever the head under it was.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='foo' and not(@base)][o[@base='∅' and @name='x']]
+  - //o[@name='bar' and count(o)=1]
+  - //o[@name='bar']/o[@base='Φ.number']
+input: |
+  [] > app
+    I > foo
+    | 5 >>
+    | 6 > bar

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-identity-object-vertical.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-identity-object-vertical.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The vertical form of a pipe (R-3.14.3) accepts the identity object `I` as its
+# predecessor exactly as the horizontal form does: the kind of the predecessor
+# is checked before the pipe splits into its two forms.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='app']/o[@name='five' and @base='Φ.number']
+  - //o[@base='ξ.foo']/o[@base='ξ.five']
+input: |
+  [] > app
+    I > foo
+    | >>
+      5 > five

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-method-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/pipe-after-method-is-rejected.yaml
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A `.method` dispatch takes the attribute and leaves a method on the stack, and
+# a method is not among the kinds a pipe may attach to (R-3.14.4), so the pipe
+# below has no formation left in hand.
+sheets: []
+asserts:
+  - /object/errors/error[@severity='error']
+  - /object/errors/error[contains(text(),'pipe')]
+input: |
+  [] > app
+    I > foo
+    .neg > y
+    | 5 > z


### PR DESCRIPTION
The class docblock of `LnPipe` listed only formations and other pipes as legal predecessors, but `Kind.pipeable()` admits `IDENTITY_OBJECT` too, through an arm of its own. A reader who trusted the docblock before touching `precheck` would read that arm as dead code and could drop it. The sentence now names the identity object alongside the other two kinds, with the pointer to §3.16 that `Kind` already carries.

Three packs go with it, covering the corners of that guard the existing `pipe-after-identity-object.yaml` leaves open: a pipe chained onto a pipe whose head was `I`, the vertical form of a pipe over `I`, and a pipe after a `.method` dispatch, which is rejected because a method is not among the pipeable kinds.

Closes #8495
