### PR TITLE
#8479: negate by two's complement, not by multiplying

### DIFF
--- a/eo-runtime/src/main/eo/i64.eo
+++ b/eo-runtime/src/main/eo/i64.eo
@@ -7,6 +7,11 @@
 # nearest double of `9223372036854775807` is `2^63`, which is one past the
 # `long` range that `printf`'s own `%d` guard accepts, so the message itself
 # used to terminate instead of being printed.
+#
+# Negation is two's complement, one `plus` over the flipped bits, and not
+# `times` by minus one. Every bit of minus one is set, so the shift-and-add
+# loop of `times` ran a full addition on all sixty four of them, which is
+# what `minus`, `lt`, `lte`, `gt` and `gte` all rest on.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -138,7 +143,9 @@
         x >> value!
       ^.eq value
   ^.plus (i64 x!).neg > [^ x] > minus
-  times -1.as-i64 > neg
+  plus. > [^] > neg
+    i64 ^.as-bytes.not
+    i64 00-00-00-00-00-00-00-01
   [^ x] > plus
     if. > [^ a b] >> carried
       b.eq 00-00-00-00-00-00-00-00
@@ -275,6 +282,17 @@
   eq. ++> can-multiply-two-negatives
     -7.as-i64.times -6.as-i64
     42.as-i64
+
+  -42.as-i64.neg.eq 42.as-i64 ++> can-negate-a-negative
+
+  42.as-i64.neg.eq -42.as-i64 ++> can-negate-a-positive
+
+  eq. ++> can-negate-the-smallest-i64-to-itself
+    neg.
+      i64 80-00-00-00-00-00-00-00
+    i64 80-00-00-00-00-00-00-00
+
+  0.as-i64.neg.eq 0.as-i64 ++> can-negate-zero-to-zero
 
   eq. ++> can-recover-from-an-out-of-bounds-conversion-to-i32
     "recovered"


### PR DESCRIPTION
Closes #8479.

`neg` was `times -1.as-i64`. `times` is a shift-and-add loop over the bits of
its argument, and every one of the sixty four bits of minus one is set, so
each negation ran sixty four full carry additions. `minus` is `plus` of a
negated operand and `gt` is a sign test on `minus`, so `minus`, `lt`, `lte`,
`gt` and `gte` all inherited the cost.

Two's complement negation is one `plus` over the flipped bits. The file
already does exactly this inside `as-number.magnitude`, so the change moves
`neg` onto the idiom its own neighbour uses rather than inventing one.

## Measured

The harness from the issue, one operation per JVM with `-Xmx3g`, allocation
from `ThreadMXBean.getThreadAllocatedBytes`, operands `1234567890123` and
`987654321`:

| op | before | after |
|:--|--:|--:|
| `plus` | 5MB / 87ms | 5MB / 86ms |
| `neg` | 266MB / 651ms | **2MB / 57ms** |
| `minus` | `StackOverflowError` | **25MB / 150ms** |
| `lt` | `StackOverflowError` | **6MB / 91ms** |
| `gt` | `StackOverflowError` | **25MB / 163ms** |

`neg` drops by a factor of about 130, and `plus` is untouched, which is the
control. On this machine the three operands built on `neg` do not merely
allocate heavily on `master`, they exhaust the stack outright — the issue saw
them survive at 170-220MB, so how far it goes depends on the machine, but the
cause is the same sixty-four-deep chain of additions.

## Correctness

Four tests come with it, in `i64.eo`:

* `can-negate-a-positive` — `42.as-i64.neg` is `-42.as-i64`
* `can-negate-a-negative` — `-42.as-i64.neg` is `42.as-i64`
* `can-negate-zero-to-zero` — the wrap of `~0 + 1`
* `can-negate-the-smallest-i64-to-itself` — `80-00-00-00-00-00-00-00`
  negates to itself, which is what `times -1` also gave, since both wrap
  modulo `2^64`

Verified with `mvn test -pl :eo-runtime -Deo.deadline=3600 -Deo.maxmem=2G -Dtest=TestEOi64`:
`Tests run: 65, Failures: 0, Errors: 0, Skipped: 6`, all four new tests
passing. The 6 skips are pre-existing and unrelated to negation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQGPGb7H5Q2viyvTgHzsqG

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQGPGb7H5Q2viyvTgHzsqG)_