### PR TITLE
Fix two lowering bugs that broke the codecov build

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Call.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Call.java
@@ -11,13 +11,14 @@ import java.util.List;
 /**
  * The Java of one {@link Dispatch} step: a call back into EO.
  *
- * <p>The receiver and the arguments are Java locals, so each is wrapped
- * back into the object it stands for: a number, a bool and bytes
- * through {@code Data.ToPhi}, a string through the same after the bytes
- * are read as text, since that is what the runtime makes a string of,
- * and a tuple or an object as the {@code Phi} it already is. The method
- * is taken of the receiver with {@code PhDispatch} and applied to the
- * arguments by position with {@code PhApplication}, the way the
+ * <p>Every operand is the object it is: a void hands over the object it
+ * holds, read straight off the atom, and a step or a literal hands over
+ * the datum it is, wrapped back into an object — a number, a bool and
+ * bytes through {@code Data.ToPhi}, a string through the same after the
+ * bytes are read as text, since that is what the runtime makes a string
+ * of, and a tuple or an object as the {@code Phi} it already is. The
+ * method is taken of the receiver with {@code PhDispatch} and applied to
+ * the arguments by position with {@code PhApplication}, the way the
  * transpiler spells a call, and the value is dataized into the forma the step
  * carries — a number, a bool, or the bytes of bytes and a string — or
  * left as the object when the forma is {@code object}.</p>
@@ -54,13 +55,15 @@ public final class Call {
         final List<String> keys = this.step.keys();
         String call = String.format(
             "new PhDispatch(%s, \"%s\")",
-            this.wrapped(keys.get(0)), this.step.atom().substring(1)
+            this.values.held(keys.get(0)), this.step.atom().substring(1)
         );
         if (keys.size() > 1) {
             final Collection<String> binds = new ArrayList<>(keys.size());
             for (int idx = 1; idx < keys.size(); ++idx) {
                 binds.add(
-                    String.format("new Bind(%d, %s)", idx - 1, this.wrapped(keys.get(idx)))
+                    String.format(
+                        "new Bind(%d, %s)", idx - 1, this.values.held(keys.get(idx))
+                    )
                 );
             }
             call = String.format("new PhApplication(%s, %s)", call, String.join(", ", binds));
@@ -75,22 +78,6 @@ public final class Call {
             out = String.format("new Dataized(%s).take()", call);
         } else {
             out = call;
-        }
-        return out;
-    }
-
-    private String wrapped(final String key) {
-        final String kind = this.values.kind(key);
-        final String expr = this.values.expression(key);
-        final String out;
-        if ("string".equals(kind)) {
-            out = String.format(
-                "new Data.ToPhi(new String(%s, java.nio.charset.StandardCharsets.UTF_8))", expr
-            );
-        } else if ("tuple".equals(kind) || "object".equals(kind)) {
-            out = expr;
-        } else {
-            out = String.format("new Data.ToPhi(%s)", expr);
         }
         return out;
     }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Call.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Call.java
@@ -11,14 +11,15 @@ import java.util.List;
 /**
  * The Java of one {@link Dispatch} step: a call back into EO.
  *
- * <p>Every operand is the object it is: a void hands over the object it
- * holds, read straight off the atom, and a step or a literal hands over
- * the datum it is, wrapped back into an object — a number, a bool and
- * bytes through {@code Data.ToPhi}, a string through the same after the
- * bytes are read as text, since that is what the runtime makes a string
- * of, and a tuple or an object as the {@code Phi} it already is. The
- * method is taken of the receiver with {@code PhDispatch} and applied to
- * the arguments by position with {@code PhApplication}, the way the
+ * <p>Every operand is the object it is: a void holds one already and
+ * hands it over, read off the atom by the name {@link Rendering} knows
+ * it under, while a step and a literal are the datum they are and are
+ * wrapped back into an object — a number, a bool and bytes through
+ * {@code Data.ToPhi}, a string through the same after the bytes are read
+ * as text, since that is what the runtime makes a string of, and a tuple
+ * or an object as the {@code Phi} it already is. The method
+ * is taken of the receiver with {@code PhDispatch} and applied to the
+ * arguments by position with {@code PhApplication}, the way the
  * transpiler spells a call, and the value is dataized into the forma the step
  * carries — a number, a bool, or the bytes of bytes and a string — or
  * left as the object when the forma is {@code object}.</p>
@@ -55,15 +56,13 @@ public final class Call {
         final List<String> keys = this.step.keys();
         String call = String.format(
             "new PhDispatch(%s, \"%s\")",
-            this.values.held(keys.get(0)), this.step.atom().substring(1)
+            this.wrapped(keys.get(0)), this.step.atom().substring(1)
         );
         if (keys.size() > 1) {
             final Collection<String> binds = new ArrayList<>(keys.size());
             for (int idx = 1; idx < keys.size(); ++idx) {
                 binds.add(
-                    String.format(
-                        "new Bind(%d, %s)", idx - 1, this.values.held(keys.get(idx))
-                    )
+                    String.format("new Bind(%d, %s)", idx - 1, this.wrapped(keys.get(idx)))
                 );
             }
             call = String.format("new PhApplication(%s, %s)", call, String.join(", ", binds));
@@ -78,6 +77,24 @@ public final class Call {
             out = String.format("new Dataized(%s).take()", call);
         } else {
             out = call;
+        }
+        return out;
+    }
+
+    private String wrapped(final String key) {
+        final String kind = this.values.kind(key);
+        final String out;
+        if (key.startsWith("sym:v")) {
+            out = String.format("this.take(\"%s\")", this.values.named(key));
+        } else if ("string".equals(kind)) {
+            out = String.format(
+                "new Data.ToPhi(new String(%s, java.nio.charset.StandardCharsets.UTF_8))",
+                this.values.expression(key)
+            );
+        } else if ("tuple".equals(kind) || "object".equals(kind)) {
+            out = this.values.expression(key);
+        } else {
+            out = String.format("new Data.ToPhi(%s)", this.values.expression(key));
         }
         return out;
     }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
@@ -26,10 +26,10 @@ import java.util.stream.Stream;
  * protocol that repeats, the way its answer would, and so does the
  * reason of a protocol that fails.</p>
  *
- * <p>The operands of a {@link Dispatch} are no reads: a call back into
- * EO takes the object a void holds, not the datum of its bytes, so a
- * void nothing but a call reaches is never dataized here — the way EO
- * itself leaves it to the method to dataize what it needs.</p>
+ * <p>The operands of a {@link Dispatch} are no reads: a call takes the
+ * object a void holds, not the datum of its bytes, so a void nothing but
+ * a call reaches is never dataized here, the way EO leaves that to the
+ * method.</p>
  *
  * @since 0.76.0
  */

--- a/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Reads.java
@@ -26,6 +26,11 @@ import java.util.stream.Stream;
  * protocol that repeats, the way its answer would, and so does the
  * reason of a protocol that fails.</p>
  *
+ * <p>The operands of a {@link Dispatch} are no reads: a call back into
+ * EO takes the object a void holds, not the datum of its bytes, so a
+ * void nothing but a call reaches is never dataized here — the way EO
+ * itself leaves it to the method to dataize what it needs.</p>
+ *
  * @since 0.76.0
  */
 public final class Reads {
@@ -80,7 +85,9 @@ public final class Reads {
     private SortedSet<Integer> direct() {
         final SortedSet<Integer> out = new TreeSet<>();
         final Stream<String> keys = Stream.concat(
-            this.protocol.moves().stream().flatMap(step -> step.keys().stream()),
+            this.protocol.moves().stream()
+                .filter(step -> step.atom().charAt(0) != '.')
+                .flatMap(step -> step.keys().stream()),
             Stream.concat(
                 Stream.of(this.protocol.answer(), this.protocol.reason()),
                 this.protocol.again().stream()

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -39,11 +39,6 @@ import java.util.stream.Stream;
 public final class Rendering {
 
     /**
-     * The forma of a tuple, which Java carries as the {@code Phi} it is.
-     */
-    private static final String TUPLE = "tuple";
-
-    /**
      * The program.
      */
     private final Program program;
@@ -99,7 +94,7 @@ public final class Rendering {
             out = String.format(
                 "byte[] v%d = new Dataized(this.take(\"%s\")).take();", index, name
             );
-        } else if (Rendering.TUPLE.equals(forma)) {
+        } else if ("tuple".equals(forma)) {
             out = String.format("Phi v%d = this.take(\"%s\");", index, name);
         } else {
             throw new IllegalStateException(
@@ -245,34 +240,34 @@ public final class Rendering {
     }
 
     /**
-     * The Java expression of the object a key names, for a call back
-     * into EO.
+     * The name of the void a key names, under which the atom holds the
+     * object it was given.
      *
-     * <p>A step and a literal are the datum they are, so each is wrapped
-     * back into an object the way {@link Call} explains. A void is not:
-     * the tables witness the forma its value dataizes to, which an
-     * object decorating a datum — a chunk of memory, an input of bytes —
-     * answers as well as the datum itself, and such an object owns
-     * methods the datum has never heard of. A datum rebuilt from the
-     * bytes of one would refuse the very method the call takes, so the
-     * void hands over the object it holds instead, read straight off the
-     * atom, which is the object EO would dispatch on. A program that
-     * repeats has no such object to hand over — its voids are locals the
-     * loop rebinds, and the one the atom holds is only the first value
-     * of them — so a call in one is refused.</p>
+     * <p>A {@link Call} needs that object, not the datum of its bytes:
+     * the tables witness the forma a void dataizes to, and an object
+     * decorating a datum — a chunk of memory, an input of bytes —
+     * answers there as well as the datum itself while owning methods the
+     * datum never heard of. A program that repeats has no such object to
+     * name, since its voids are locals the loop rebinds, so a call in
+     * one is refused.</p>
      *
-     * @param key The key, such as {@code sym:v0} or {@code number:40-...}
-     * @return The expression, such as {@code this.take("x")}
+     * @param key The key of a void, such as {@code sym:v0}
+     * @return The name, such as {@code x}
      */
-    public String held(final String key) {
-        final String[] parts = key.split(":", 2);
-        final String out;
-        if ("sym".equals(parts[0]) && parts[1].charAt(0) == 'v') {
-            out = String.format("this.take(\"%s\")", this.named(parts[1]));
-        } else {
-            out = this.wrapped(key);
+    public String named(final String key) {
+        if (this.program.repeats()) {
+            throw new IllegalStateException(
+                String.format("The void '%s' is rebound by a repeat, so no call can reach it", key)
+            );
         }
-        return out;
+        final List<String> names = new ArrayList<>(this.program.inputs().keySet());
+        final int index = Integer.parseInt(key.split(":", 2)[1].substring(1));
+        if (index >= names.size()) {
+            throw new IllegalStateException(
+                String.format("A call reads void #%d, which the fragment lacks", index)
+            );
+        }
+        return names.get(index);
     }
 
     /**
@@ -310,42 +305,6 @@ public final class Rendering {
         return out;
     }
 
-    private String named(final String symbol) {
-        if (this.program.repeats()) {
-            throw new IllegalStateException(
-                String.format(
-                    "The void '%s' is rebound by a repeat, so no call can reach the object it holds",
-                    symbol
-                )
-            );
-        }
-        final List<String> names = new ArrayList<>(this.program.inputs().keySet());
-        final int index = Integer.parseInt(symbol.substring(1));
-        if (index >= names.size()) {
-            throw new IllegalStateException(
-                String.format("A call reads void #%d, which the fragment lacks", index)
-            );
-        }
-        return names.get(index);
-    }
-
-    private String wrapped(final String key) {
-        final String kind = this.kind(key);
-        final String expression = this.expression(key);
-        final String out;
-        if ("string".equals(kind)) {
-            out = String.format(
-                "new Data.ToPhi(new String(%s, java.nio.charset.StandardCharsets.UTF_8))",
-                expression
-            );
-        } else if (Rendering.TUPLE.equals(kind) || "object".equals(kind)) {
-            out = expression;
-        } else {
-            out = String.format("new Data.ToPhi(%s)", expression);
-        }
-        return out;
-    }
-
     private static String typed(final String carrier, final String what) {
         final String out;
         if ("number".equals(carrier)) {
@@ -354,7 +313,7 @@ public final class Rendering {
             out = "boolean";
         } else if ("bytes".equals(carrier)) {
             out = "byte[]";
-        } else if (Rendering.TUPLE.equals(carrier) || "object".equals(carrier)) {
+        } else if ("tuple".equals(carrier) || "object".equals(carrier)) {
             out = "Phi";
         } else {
             throw new IllegalStateException(

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -39,6 +39,11 @@ import java.util.stream.Stream;
 public final class Rendering {
 
     /**
+     * The forma of a tuple, which Java carries as the {@code Phi} it is.
+     */
+    private static final String TUPLE = "tuple";
+
+    /**
      * The program.
      */
     private final Program program;
@@ -94,7 +99,7 @@ public final class Rendering {
             out = String.format(
                 "byte[] v%d = new Dataized(this.take(\"%s\")).take();", index, name
             );
-        } else if ("tuple".equals(forma)) {
+        } else if (Rendering.TUPLE.equals(forma)) {
             out = String.format("Phi v%d = this.take(\"%s\");", index, name);
         } else {
             throw new IllegalStateException(
@@ -333,7 +338,7 @@ public final class Rendering {
                 "new Data.ToPhi(new String(%s, java.nio.charset.StandardCharsets.UTF_8))",
                 expression
             );
-        } else if ("tuple".equals(kind) || "object".equals(kind)) {
+        } else if (Rendering.TUPLE.equals(kind) || "object".equals(kind)) {
             out = expression;
         } else {
             out = String.format("new Data.ToPhi(%s)", expression);
@@ -349,7 +354,7 @@ public final class Rendering {
             out = "boolean";
         } else if ("bytes".equals(carrier)) {
             out = "byte[]";
-        } else if ("tuple".equals(carrier) || "object".equals(carrier)) {
+        } else if (Rendering.TUPLE.equals(carrier) || "object".equals(carrier)) {
             out = "Phi";
         } else {
             throw new IllegalStateException(

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -240,6 +240,37 @@ public final class Rendering {
     }
 
     /**
+     * The Java expression of the object a key names, for a call back
+     * into EO.
+     *
+     * <p>A step and a literal are the datum they are, so each is wrapped
+     * back into an object the way {@link Call} explains. A void is not:
+     * the tables witness the forma its value dataizes to, which an
+     * object decorating a datum — a chunk of memory, an input of bytes —
+     * answers as well as the datum itself, and such an object owns
+     * methods the datum has never heard of. A datum rebuilt from the
+     * bytes of one would refuse the very method the call takes, so the
+     * void hands over the object it holds instead, read straight off the
+     * atom, which is the object EO would dispatch on. A program that
+     * repeats has no such object to hand over — its voids are locals the
+     * loop rebinds, and the one the atom holds is only the first value
+     * of them — so a call in one is refused.</p>
+     *
+     * @param key The key, such as {@code sym:v0} or {@code number:40-...}
+     * @return The expression, such as {@code this.take("x")}
+     */
+    public String held(final String key) {
+        final String[] parts = key.split(":", 2);
+        final String out;
+        if ("sym".equals(parts[0]) && parts[1].charAt(0) == 'v') {
+            out = String.format("this.take(\"%s\")", this.named(parts[1]));
+        } else {
+            out = this.wrapped(key);
+        }
+        return out;
+    }
+
+    /**
      * The Java expression the atom hands to {@code Data.ToPhi}.
      *
      * <p>Where the fragment settled into a view of a local rather than
@@ -270,6 +301,42 @@ public final class Rendering {
                     key, own, carrier
                 )
             );
+        }
+        return out;
+    }
+
+    private String named(final String symbol) {
+        if (this.program.repeats()) {
+            throw new IllegalStateException(
+                String.format(
+                    "The void '%s' is rebound by a repeat, so no call can reach the object it holds",
+                    symbol
+                )
+            );
+        }
+        final List<String> names = new ArrayList<>(this.program.inputs().keySet());
+        final int index = Integer.parseInt(symbol.substring(1));
+        if (index >= names.size()) {
+            throw new IllegalStateException(
+                String.format("A call reads void #%d, which the fragment lacks", index)
+            );
+        }
+        return names.get(index);
+    }
+
+    private String wrapped(final String key) {
+        final String kind = this.kind(key);
+        final String expression = this.expression(key);
+        final String out;
+        if ("string".equals(kind)) {
+            out = String.format(
+                "new Data.ToPhi(new String(%s, java.nio.charset.StandardCharsets.UTF_8))",
+                expression
+            );
+        } else if ("tuple".equals(kind) || "object".equals(kind)) {
+            out = expression;
+        } else {
+            out = String.format("new Data.ToPhi(%s)", expression);
         }
         return out;
     }

--- a/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
@@ -39,6 +39,16 @@ import org.cactoos.text.UncheckedText;
  * renders as the Java {@code ==} of two doubles, the very comparison the
  * contract asks for.</p>
  *
+ * <p>Such a λ of our own has to be a name phino does not know, since a
+ * name it knows it evaluates by its own meaning, and the meaning is not
+ * ours to choose. The one for the equality is {@code L_number_equal} and
+ * not {@code L_number_eq} for exactly that reason: phino owns the latter
+ * and answers it with the receiver when the two agree and with an error
+ * when they do not, so a fragment folding {@code 2.eq 2} came back as
+ * the number two instead of refusing to fold. A λ phino does not know
+ * parks instead, the way {@code bool.if} and {@code string.slice} park,
+ * and a parked run is no data, which is what a refusal is made of.</p>
+ *
  * @since 0.76.0
  */
 public final class Universe {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Universe.java
@@ -39,15 +39,13 @@ import org.cactoos.text.UncheckedText;
  * renders as the Java {@code ==} of two doubles, the very comparison the
  * contract asks for.</p>
  *
- * <p>Such a λ of our own has to be a name phino does not know, since a
- * name it knows it evaluates by its own meaning, and the meaning is not
- * ours to choose. The one for the equality is {@code L_number_equal} and
- * not {@code L_number_eq} for exactly that reason: phino owns the latter
- * and answers it with the receiver when the two agree and with an error
- * when they do not, so a fragment folding {@code 2.eq 2} came back as
- * the number two instead of refusing to fold. A λ phino does not know
- * parks instead, the way {@code bool.if} and {@code string.slice} park,
- * and a parked run is no data, which is what a refusal is made of.</p>
+ * <p>Such a λ of our own has to be a name phino does not know, or phino
+ * evaluates it by its own meaning. The equality is {@code L_number_equal}
+ * and not {@code L_number_eq} for that reason: phino owns the latter and
+ * answers it with the receiver when the two agree, so {@code 2.eq 2}
+ * folded into the number two instead of refusing to fold. An unknown λ
+ * parks, the way {@code bool.if} and {@code string.slice} park, and a
+ * parked run is no data — which is what a refusal is made of.</p>
  *
  * @since 0.76.0
  */

--- a/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/ops.tsv
@@ -2,7 +2,7 @@ L_number_plus	plus	number	number	x	%1$s + %2$s
 L_number_times	times	number	number	x	%1$s * %2$s
 L_number_div	div	number	number	x	%1$s / %2$s
 L_number_gt	gt	number	bool	x	%1$s > %2$s
-L_number_eq	eq	number	bool	x
+L_number_equal	eq	number	bool	x
 L_bool_if	if	bool		t,f
 L_bytes_and	and	bytes	bytes	b	new BytesOf(%1$s).and(new BytesOf(%2$s)).take()
 L_bytes_or	or	bytes	bytes	b	new BytesOf(%1$s).or(new BytesOf(%2$s)).take()

--- a/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
+++ b/eo-lowering/src/main/resources/org/eolang/lowering/universe.phi
@@ -3,7 +3,7 @@
     as-bytes ↦ ∅,
     φ ↦ ξ.as-bytes,
     div ↦ ⟦ x ↦ ∅, λ ⤍ L_number_div ⟧,
-    eq ↦ ⟦ x ↦ ∅, λ ⤍ L_number_eq ⟧,
+    eq ↦ ⟦ x ↦ ∅, λ ⤍ L_number_equal ⟧,
     gt ↦ ⟦ x ↦ ∅, λ ⤍ L_number_gt ⟧,
     plus ↦ ⟦ x ↦ ∅, λ ⤍ L_number_plus ⟧,
     times ↦ ⟦ x ↦ ∅, λ ⤍ L_number_times ⟧

--- a/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
@@ -21,7 +21,7 @@ final class CallTest {
     @Test
     void wrapsNumberAndDataizesNumber() {
         MatcherAssert.assertThat(
-            "a number receiver must be wrapped and the number answer dataized, but it isnt",
+            "a number receiver must be the object the void holds, and the answer dataized, but it isnt",
             CallTest.call(
                 new Dispatch(
                     "s1", "minus", Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00"),
@@ -32,7 +32,7 @@ final class CallTest {
             Matchers.equalTo(
                 String.join(
                     "",
-                    "new Dataized(new PhApplication(new PhDispatch(new Data.ToPhi(v0), ",
+                    "new Dataized(new PhApplication(new PhDispatch(this.take(\"x\"), ",
                     "\"minus\"), new Bind(0, new Data.ToPhi(",
                     "Double.longBitsToDouble(0x3FF0000000000000L))))).asNumber()"
                 )
@@ -49,7 +49,7 @@ final class CallTest {
                 Collections.singletonMap("x", "number")
             ),
             Matchers.equalTo(
-                "new Dataized(new PhDispatch(new Data.ToPhi(v0), \"is-nan\")).asBool()"
+                "new Dataized(new PhDispatch(this.take(\"x\"), \"is-nan\")).asBool()"
             )
         );
     }
@@ -57,7 +57,7 @@ final class CallTest {
     @Test
     void readsStringReceiverAsText() {
         MatcherAssert.assertThat(
-            "a string receiver must be made a string again, and bytes taken, but it isnt",
+            "a string receiver must be the object the void holds, and bytes taken, but it isnt",
             CallTest.call(
                 new Dispatch("s1", "trimmed", Collections.singletonList("sym:v0"), "string"),
                 Collections.singletonMap("t", "string")
@@ -65,8 +65,8 @@ final class CallTest {
             Matchers.equalTo(
                 String.join(
                     "",
-                    "new Dataized(new PhDispatch(new Data.ToPhi(",
-                    "new String(v0, java.nio.charset.StandardCharsets.UTF_8)), \"trimmed\")).take()"
+                    "new Dataized(new PhDispatch(",
+                    "this.take(\"t\"), \"trimmed\")).take()"
                 )
             )
         );
@@ -83,7 +83,11 @@ final class CallTest {
                 Collections.singletonMap("items", "tuple")
             ),
             Matchers.equalTo(
-                "new PhApplication(new PhDispatch(v0, \"with\"), new Bind(0, new Data.ToPhi(true)))"
+                String.join(
+                    "",
+                    "new PhApplication(new PhDispatch(this.take(\"items\"), \"with\"), ",
+                    "new Bind(0, new Data.ToPhi(true)))"
+                )
             )
         );
     }
@@ -100,7 +104,9 @@ final class CallTest {
                 new Dispatch("s1", "slice", Arrays.asList("sym:v0", "sym:v1", "sym:v2"), "object"),
                 voids
             ),
-            Matchers.endsWith(", new Bind(0, new Data.ToPhi(v1)), new Bind(1, new Data.ToPhi(v2)))")
+            Matchers.endsWith(
+                ", new Bind(0, this.take(\"a\")), new Bind(1, this.take(\"b\")))"
+            )
         );
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/ConstantTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ConstantTest.java
@@ -177,6 +177,32 @@ final class ConstantTest {
     }
 
     @Test
+    void refusesNumericEquality(@Mktmp final Path temp) {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Constant(
+                phino,
+                new Xnav(
+                    String.join(
+                        "",
+                        "<o base='.eq'>",
+                        "<o base='Φ.number'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>40-00-00-00-00-00-00-00</o></o>",
+                        "</o>",
+                        "<o as='α0' base='Φ.number'>",
+                        "<o as='α0' base='Φ.bytes'><o as='α0'>40-00-00-00-00-00-00-00</o></o>",
+                        "</o>",
+                        "</o>"
+                    )
+                ).element("o")
+            )::value,
+            "the equality of two numbers is a λ phino never fires, so it must not fold, but it did"
+        );
+    }
+
+    @Test
     void refusesForeignMethod(@Mktmp final Path temp) {
         final Phino phino = new Phino("phino", 1000, temp);
         Assumptions.assumeTrue(phino.suitable());

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -84,7 +84,7 @@ final class JavaAtomTest {
                             new Protocol(
                                 Arrays.asList(
                                     new Application(
-                                        "s1", "L_number_eq",
+                                        "s1", "L_number_equal",
                                         Arrays.asList("sym:v1", "number:00-00-00-00-00-00-00-00")
                                     ),
                                     new Fork(
@@ -307,7 +307,7 @@ final class JavaAtomTest {
                 new Protocol(
                     Arrays.asList(
                         new Application("s1", "L_number_div", Arrays.asList("sym:v0", "sym:v1")),
-                        new Application("s2", "L_number_eq", Arrays.asList("sym:s1", "sym:v0"))
+                        new Application("s2", "L_number_equal", Arrays.asList("sym:s1", "sym:v0"))
                     ),
                     "sym:s2",
                     "bool"
@@ -927,7 +927,7 @@ final class JavaAtomTest {
         return new Protocol(
             Arrays.asList(
                 new Application(
-                    "s1", "L_number_eq", Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
+                    "s1", "L_number_equal", Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
                 ),
                 new Fork(
                     "s2", "L_bool_if", "sym:s1",

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -458,14 +458,34 @@ final class JavaAtomTest {
                 Collections.singletonMap("x", "number")
             ).text(),
             Matchers.stringContainsInOrder(
-                "final double v0 = new Dataized(this.take(\"x\")).asNumber();",
                 String.format(
                     "final double s1 = new Dataized(new PhApplication(new PhDispatch(%s, %s), new Bind(0, %s))).asNumber();",
-                    "new Data.ToPhi(v0)", "\"minus\"",
+                    "this.take(\"x\")", "\"minus\"",
                     "new Data.ToPhi(Double.longBitsToDouble(0x3FF0000000000000L))"
                 ),
                 "return new Data.ToPhi(s1);"
             )
+        );
+    }
+
+    @Test
+    void leavesVoidOfCallUndataized() {
+        MatcherAssert.assertThat(
+            "a void nothing but a call reaches must not be dataized, but it was",
+            new JavaAtom(
+                new Protocol(
+                    Collections.singletonList(
+                        new Dispatch(
+                            "s1", "minus",
+                            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00"),
+                            "number"
+                        )
+                    ),
+                    "sym:s1", "number"
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.not(Matchers.containsString("final double v0"))
         );
     }
 
@@ -486,7 +506,7 @@ final class JavaAtomTest {
                 Collections.singletonMap("x", "number")
             ).text(),
             Matchers.stringContainsInOrder(
-                "final Phi s1 = new PhDispatch(new Data.ToPhi(v0), \"neg\");",
+                "final Phi s1 = new PhDispatch(this.take(\"x\"), \"neg\");",
                 "final byte[] s2 = new Dataized(s1).take();",
                 "return new Data.ToPhi(s2);"
             )

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -469,27 +469,6 @@ final class JavaAtomTest {
     }
 
     @Test
-    void leavesVoidOfCallUndataized() {
-        MatcherAssert.assertThat(
-            "a void nothing but a call reaches must not be dataized, but it was",
-            new JavaAtom(
-                new Protocol(
-                    Collections.singletonList(
-                        new Dispatch(
-                            "s1", "minus",
-                            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00"),
-                            "number"
-                        )
-                    ),
-                    "sym:s1", "number"
-                ),
-                Collections.singletonMap("x", "number")
-            ).text(),
-            Matchers.not(Matchers.containsString("final double v0"))
-        );
-    }
-
-    @Test
     void holdsObjectOfCallUntilDataized() {
         MatcherAssert.assertThat(
             "an object a call answers must be held as a Phi until something dataizes it",

--- a/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
@@ -167,15 +167,16 @@ final class RenderingTest {
 
     @Test
     void refusesObjectOfVoidRebound() {
+        final Rendering rendering = new Rendering(
+            new Protocol(
+                Collections.emptyList(),
+                Collections.singletonList("number:3F-F0-00-00-00-00-00-00")
+            ),
+            Collections.singletonMap("x", "number")
+        );
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> new Rendering(
-                new Protocol(
-                    Collections.emptyList(),
-                    Collections.singletonList("number:3F-F0-00-00-00-00-00-00")
-                ),
-                Collections.singletonMap("x", "number")
-            ).held("sym:v0"),
+            () -> rendering.held("sym:v0"),
             "a repeat rebinds its voids, so no call may reach the object one holds, but it did"
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
@@ -142,6 +142,45 @@ final class RenderingTest {
     }
 
     @Test
+    void handsOverObjectOfVoid() {
+        MatcherAssert.assertThat(
+            "a void must hand over the object it holds, not a datum of its bytes, but it didnt",
+            new Rendering(
+                new Protocol(Collections.emptyList(), "sym:v0", "bytes"),
+                Collections.singletonMap("b", "bytes")
+            ).held("sym:v0"),
+            Matchers.equalTo("this.take(\"b\")")
+        );
+    }
+
+    @Test
+    void wrapsLiteralHandedOver() {
+        MatcherAssert.assertThat(
+            "a literal handed over must be wrapped back into an object, but it wasnt",
+            new Rendering(
+                new Protocol(Collections.emptyList(), "sym:v0", "bytes"),
+                Collections.singletonMap("b", "bytes")
+            ).held("bool:FF-"),
+            Matchers.equalTo("new Data.ToPhi(true)")
+        );
+    }
+
+    @Test
+    void refusesObjectOfVoidRebound() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> new Rendering(
+                new Protocol(
+                    Collections.emptyList(),
+                    Collections.singletonList("number:3F-F0-00-00-00-00-00-00")
+                ),
+                Collections.singletonMap("x", "number")
+            ).held("sym:v0"),
+            "a repeat rebinds its voids, so no call may reach the object one holds, but it did"
+        );
+    }
+
+    @Test
     void refusesOperandOfForeignForma() {
         Assertions.assertThrows(
             IllegalStateException.class,

--- a/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
@@ -142,31 +142,19 @@ final class RenderingTest {
     }
 
     @Test
-    void handsOverObjectOfVoid() {
+    void namesVoidBehindKey() {
         MatcherAssert.assertThat(
-            "a void must hand over the object it holds, not a datum of its bytes, but it didnt",
+            "the void a key names must be named, so a call reaches its object, but it isnt",
             new Rendering(
                 new Protocol(Collections.emptyList(), "sym:v0", "bytes"),
                 Collections.singletonMap("b", "bytes")
-            ).held("sym:v0"),
-            Matchers.equalTo("this.take(\"b\")")
+            ).named("sym:v0"),
+            Matchers.equalTo("b")
         );
     }
 
     @Test
-    void wrapsLiteralHandedOver() {
-        MatcherAssert.assertThat(
-            "a literal handed over must be wrapped back into an object, but it wasnt",
-            new Rendering(
-                new Protocol(Collections.emptyList(), "sym:v0", "bytes"),
-                Collections.singletonMap("b", "bytes")
-            ).held("bool:FF-"),
-            Matchers.equalTo("new Data.ToPhi(true)")
-        );
-    }
-
-    @Test
-    void refusesObjectOfVoidRebound() {
+    void refusesToNameVoidRebound() {
         final Rendering rendering = new Rendering(
             new Protocol(
                 Collections.emptyList(),
@@ -176,8 +164,8 @@ final class RenderingTest {
         );
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> rendering.held("sym:v0"),
-            "a repeat rebinds its voids, so no call may reach the object one holds, but it did"
+            () -> rendering.named("sym:v0"),
+            "a repeat rebinds its voids, so no call may reach one of them, but it did"
         );
     }
 

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/dispatched-guard.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/dispatched-guard.yaml
@@ -8,10 +8,11 @@
 # the marker into a call back into EO over the void and the literal. The
 # tables of eo:inference witness what the call answers: `lt` is a
 # formation whose body is the atom `gt`, declared to answer a bool, so
-# the step is a bool and the `if` forks on it. The Java wraps the void
-# back into a number, takes `lt` of it, applies the literal, and
-# dataizes the call with asBool before choosing an arm, while the EO
-# behind `lt` stays where it is.
+# the step is a bool and the `if` forks on it. The Java takes `lt` of
+# the object the void holds, applies the literal, and dataizes the call
+# with asBool before choosing an arm, while the EO behind `lt` stays
+# where it is. Nothing but the call reaches the void, so the atom never
+# dataizes it: the method does that, the way it would in EO.
 input: |
   [] > foo
     [x] > sign
@@ -46,8 +47,7 @@ protocol: |
       answer number:3F-F0-00-00-00-00-00-00 number
   answer sym:s2 number
 java: |
-  final double v0 = new Dataized(this.take("x")).asNumber();
-  final boolean s1 = new Dataized(new PhApplication(new PhDispatch(new Data.ToPhi(v0), "lt"), new Bind(0, new Data.ToPhi(Double.longBitsToDouble(0x0000000000000000L))))).asBool();
+  final boolean s1 = new Dataized(new PhApplication(new PhDispatch(this.take("x"), "lt"), new Bind(0, new Data.ToPhi(Double.longBitsToDouble(0x0000000000000000L))))).asBool();
   final double s2;
   if (s1) {
       s2 = Double.longBitsToDouble(0xBFF0000000000000L);

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-countdown.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-countdown.yaml
@@ -38,7 +38,7 @@ lowered: |
       ? > acc /Q.number
 protocol: |
   loop v0 v1
-    s1 ← L_number_eq sym:v0 number:00-00-00-00-00-00-00-00
+    s1 ← L_number_equal sym:v0 number:00-00-00-00-00-00-00-00
     s2 ← fork sym:s1 number
       then
         answer sym:v1 number

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-helper.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/looped-helper.yaml
@@ -36,7 +36,7 @@ lowered: |
       ? > acc /Q.number
 protocol: |
   loop v0 v1
-    s1 ← L_number_eq sym:v0 number:00-00-00-00-00-00-00-00
+    s1 ← L_number_equal sym:v0 number:00-00-00-00-00-00-00-00
     s2 ← fork sym:s1 number
       then
         answer sym:v1 number

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/mutual-helpers.yaml
@@ -40,7 +40,7 @@ protocol: |
   loop v0
     repeat a🌵3-4 sym:v0 number:3F-F0-00-00-00-00-00-00
   body a🌵3-4 v1 v2
-    s1 ← L_number_eq sym:v1 number:00-00-00-00-00-00-00-00
+    s1 ← L_number_equal sym:v1 number:00-00-00-00-00-00-00-00
     s2 ← fork sym:s1 number
       then
         answer sym:v2 number
@@ -50,7 +50,7 @@ protocol: |
         repeat a🌵8-4 sym:s3 sym:s4
     answer sym:s2 number
   body a🌵8-4 v3 v4
-    s5 ← L_number_eq sym:v3 number:00-00-00-00-00-00-00-00
+    s5 ← L_number_equal sym:v3 number:00-00-00-00-00-00-00-00
     s6 ← fork sym:s5 number
       then
         answer sym:v4 number

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/numeric-equality.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/numeric-equality.yaml
@@ -29,7 +29,7 @@ lowered: |
       ? > x /Q.number
       ? > y /Q.number
 protocol: |
-  s1 ← L_number_eq sym:v0 sym:v1
+  s1 ← L_number_equal sym:v0 sym:v1
   answer sym:s1 bool
 java: |
   final double v0 = new Dataized(this.take("x")).asNumber();


### PR DESCRIPTION
The `codecov` workflow is the only one that builds with `-Deo.loweringRequired=true`, and it has been red on `master` since run 7113 or so — [run 7121](https://github.com/objectionary/eo/actions/runs/34181954280/job/101922676100) failed `eo-runtime` with 21 errors. Two independent lowering bugs are behind them; both are reproduced and fixed here.

## `number.eq` folded into its own receiver

`universe.phi` bound `number.eq` to `L_number_eq`, a λ meant only to park so that a reduction mints a step of it and the `Op` row renders the Java `==`. That name is not free: phino owns an atom called `L_number_eq`, and it is not IEEE equality. With two data operands it answers with the receiver and writes the answer as an atom that *fired*:

```
$ phino dataize --evaluations ev.tsv merged.phi     # ⟦ φ ↦ (1.plus 1).eq 2 ⟧
40-00-00-00-00-00-00-00
$ cut -f1,3 ev.tsv
L_number_plus   Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-00-... ⟧ ) )
L_number_equal  Φ.number( as-bytes ↦ Φ.bytes( data ↦ ⟦ Δ ⤍ 40-00-... ⟧ ) )
```

`Folded` believes a fired record, so `(1.plus 1).eq 2` folded into the number two, and every test whose whole body is such an equality dataized to eight bytes where a bool was asked for — `TestEOnumber.can_add_one_to_one`, `TestEObytes.can_count_the_size_of_bytes` and five more.

The λ is `L_number_equal` now, a name phino does not know, so it parks the way `bool.if` and `string.slice` park. A numeric equality over data alone no longer folds at build time, which is the honest answer, and one over symbols still becomes a step rendering as `==`, exactly as `numeric-equality.yaml` promises. A new `ConstantTest` case pins the refusal, so a phino release that later claims the name fails loudly instead of miscompiling.

## a call back into EO dispatched on a datum, not on the object

A `Dispatch` step rebuilt every operand from its Java local, so the receiver of a call was `new Data.ToPhi(v0)`. The tables of `eo:inference` witness the forma a void *dataizes to*, chasing into the `φ` of whatever fills it, and an object decorating a datum answers there as well as the datum itself — a `chunk` of memory is witnessed as bytes because dataizing it reads its bytes. Such an object owns methods the datum has never heard of, and `chunk.write` is one of them. The atom lowered out of `chunk.to-output` came out as

```java
final Phi s4 = new PhApplication(new PhDispatch(new Data.ToPhi(v3), "resized"), ...);
```

so the call reached `Φ.bytes.resized`, found nothing, and the terminator it got instead took the first bound argument for its reason — which is how fourteen `chunk`, `input` and `output` tests failed with a blank message.

The operands of a call are the objects they are now: a void hands over `this.take("...")`, the very object EO would dispatch on, while a step and a literal keep the datum they are. A void nothing but a call reaches is therefore no read at all, and `Reads` leaves it undataized, the way EO leaves that to the method. A program that repeats rebinds its voids and has no such object to hand over, so a call in one is refused and the fragment stays as written.

## How it was checked

phino 0.0.115 built from Hackage, then the codecov command run locally over `eo-runtime`:

| | errors in `eo-runtime` |
| --- | --- |
| `master`, `mvn test -Deo.coverageTracking=true -Deo.loweringRequired=true` | 23 |
| this branch, same command | 0 |

`TestEOnumber`, `TestEObytes`, `TestEOchunk`, `TestEOinput` and `TestEOoutput` are all green. The 11 remaining failures in the local full run are this sandbox, not the build: `MainTest.printsVersion` trips over the `JAVA_TOOL_OPTIONS` line the JVM prints, and `SyscallTest` cannot resolve an `@Ephemeral` port without sockets. Also green: all 327 `eo-lowering` tests, and `LoweringTest`, `MjLowerTest` and `MjTranspileTest` in `eo-maven-plugin` (the 78 skips in `LoweringTest` are packs without a `protocol` or `stuck` key). `mvn -Pqulice verify` passes on `eo-lowering`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ymd1r1eERyxjWDvB6oX7t

---
_Generated by [Claude Code](https://claude.ai/code/session_015ymd1r1eERyxjWDvB6oX7t)_