### PR TITLE
#8476: say why a fragment did not lower

### DIFF
--- a/eo-lowering/pom.xml
+++ b/eo-lowering/pom.xml
@@ -32,6 +32,11 @@
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>
+      <artifactId>jcabi-log</artifactId>
+      <!-- version from parent POM -->
+    </dependency>
+    <dependency>
+      <groupId>com.jcabi</groupId>
       <artifactId>jcabi-matchers</artifactId>
       <!-- version from parent POM -->
       <scope>test</scope>

--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -6,6 +6,7 @@ package org.eolang.lowering;
 
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -53,7 +54,9 @@ import org.w3c.dom.Element;
  * never reads is what makes its own dataization reenter itself (#8439).
  * Whatever refuses along the way — an unwitnessed void, an operation
  * outside the tables, a body that needs no computation — leaves the
- * formation as written.</p>
+ * formation as written and says at debug level why: a refusal is normal
+ * and must not fail the build, but a build that cannot tell one refusal
+ * from another cannot be reasoned about either.</p>
  *
  * @since 0.76.0
  */
@@ -106,16 +109,29 @@ public final class Lowered implements Rewrite {
         final List<Xnav> kids = Lowered.kids(node);
         final long rhos = kids.stream().filter(Lowered::rho).count();
         final long hidden = kids.stream().filter(Lowered::hidden).count();
+        final int shape = inputs.size() + 1 + (int) rhos + (int) hidden;
         boolean done = false;
-        if (!inputs.isEmpty() && bodies.size() == 1
-            && kids.size() == inputs.size() + 1 + (int) rhos + (int) hidden) {
-            done = this.spliced(node, bodies.get(0), inputs);
+        if (!inputs.isEmpty()) {
+            if (bodies.size() == 1 && kids.size() == shape) {
+                done = this.spliced(node, bodies.get(0), inputs, place);
+            } else {
+                Logger.debug(
+                    this,
+                    String.join(
+                        "",
+                        "The formation at %s is not shaped to lower: ",
+                        "%d body(-ies) and %d attribute(s), ",
+                        "where one body and %d attribute(s) are expected"
+                    ),
+                    place, bodies.size(), kids.size(), shape
+                );
+            }
         }
         return done;
     }
 
     private boolean spliced(final Xnav node, final Xnav body,
-        final Map<String, String> inputs) throws IOException {
+        final Map<String, String> inputs, final String place) throws IOException {
         String text = "";
         String carrier = "";
         try {
@@ -131,6 +147,10 @@ public final class Lowered implements Rewrite {
             }
         } catch (final IllegalStateException | IOException ex) {
             carrier = "";
+            Logger.debug(
+                this, "The formation at %s refused to lower: %s",
+                place, ex.getMessage()
+            );
         }
         final boolean done = !carrier.isEmpty();
         if (done) {
@@ -179,6 +199,15 @@ public final class Lowered implements Rewrite {
             }
             final String forma = this.formas.given(String.format("%s.%s", place, name));
             if (forma.isEmpty()) {
+                Logger.debug(
+                    this,
+                    String.join(
+                        "",
+                        "The void '%s' of the formation at %s is witnessed ",
+                        "by no single data forma, so nothing can carry it"
+                    ),
+                    name, place
+                );
                 out.clear();
                 break;
             }

--- a/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
@@ -21,13 +21,22 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
 
 /**
  * Test case for {@link Lowered}.
+ *
+ * <p>The logger of {@link Lowered} is one object for the whole JVM, and
+ * a capture of it is a level and an appender set on that object, so two
+ * of these tests in flight at once read each other's messages, or none
+ * at all. They run in one thread for that reason.</p>
+ *
  * @since 0.76.0
  */
 @ExtendWith(MktmpResolver.class)
+@Execution(ExecutionMode.SAME_THREAD)
 @ResourceLock("org.eolang.lowering.Lowered.log")
 final class LoweredTest {
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
@@ -1,0 +1,146 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.log4j.Appender;
+import org.apache.log4j.AppenderSkeleton;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+import org.apache.log4j.spi.LoggingEvent;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.ResourceLock;
+
+/**
+ * Test case for {@link Lowered}.
+ * @since 0.76.0
+ */
+@ExtendWith(MktmpResolver.class)
+@ResourceLock("org.eolang.lowering.Lowered.log")
+final class LoweredTest {
+
+    @Test
+    void namesTheVoidNothingWitnesses(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the void no table witnesses must be named in the log, but it isnt",
+            LoweredTest.spoken(
+                new Formas(
+                    Collections.singletonMap("Φ.foo.calc.φ", "Φ.number"),
+                    Collections.emptyMap()
+                ),
+                String.join(
+                    "",
+                    "<object><o name='foo'><o loc='Φ.foo.calc' name='calc'>",
+                    "<o base='∅' name='x'/><o base='Φ.number' name='φ'/>",
+                    "</o></o></object>"
+                ),
+                temp
+            ),
+            Matchers.hasItem(
+                Matchers.<String>allOf(
+                    Matchers.containsString("'x'"),
+                    Matchers.containsString("Φ.foo.calc")
+                )
+            )
+        );
+    }
+
+    @Test
+    void countsTheAttributesOfAFormationItCannotShape(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "a formation of the wrong shape must be counted in the log, but it isnt",
+            LoweredTest.spoken(
+                new Formas(
+                    Collections.emptyMap(),
+                    Collections.singletonMap("Φ.foo.calc.x", "number")
+                ),
+                String.join(
+                    "",
+                    "<object><o name='foo'><o loc='Φ.foo.calc' name='calc'>",
+                    "<o base='∅' name='x'/><o base='Φ.number' name='φ'/>",
+                    "<o base='Φ.number' name='bar'/>",
+                    "</o></o></object>"
+                ),
+                temp
+            ),
+            Matchers.hasItem(
+                Matchers.<String>allOf(
+                    Matchers.containsString("Φ.foo.calc"),
+                    Matchers.containsString("3 attribute(s)")
+                )
+            )
+        );
+    }
+
+    @Test
+    void tellsTheReasonAFragmentRefused(@Mktmp final Path temp) throws IOException {
+        MatcherAssert.assertThat(
+            "the reason a fragment did not lower must reach the log, but it doesnt",
+            LoweredTest.spoken(
+                new Formas(
+                    Collections.emptyMap(),
+                    Collections.singletonMap("Φ.foo.calc.x", "number")
+                ),
+                String.join(
+                    "",
+                    "<object><o name='foo'><o loc='Φ.foo.calc' name='calc'>",
+                    "<o base='∅' name='x'/>",
+                    "<o base='Φ.number' name='φ'><o as='α0' base='Φ.foo.calc.x'/></o>",
+                    "</o></o></object>"
+                ),
+                temp
+            ),
+            Matchers.hasItem(
+                Matchers.<String>allOf(
+                    Matchers.containsString("Φ.foo.calc"),
+                    Matchers.containsString("refused to lower")
+                )
+            )
+        );
+    }
+
+    private static List<String> spoken(final Formas formas, final String xmir,
+        final Path temp) throws IOException {
+        final List<String> messages = new ArrayList<>(0);
+        final Appender appender = new AppenderSkeleton() {
+            @Override
+            protected void append(final LoggingEvent event) {
+                messages.add(String.valueOf(event.getRenderedMessage()));
+            }
+
+            @Override
+            public void close() {
+                // Nothing to release.
+            }
+
+            @Override
+            public boolean requiresLayout() {
+                return false;
+            }
+        };
+        final Logger logger = Logger.getLogger(Lowered.class);
+        final Level level = logger.getLevel();
+        logger.setLevel(Level.ALL);
+        logger.addAppender(appender);
+        try {
+            new Lowered(new Phino("phino-of-no-machine", 1, temp), formas, temp)
+                .rewrite(new Xnav(xmir));
+        } finally {
+            logger.removeAppender(appender);
+            logger.setLevel(level);
+        }
+        return messages;
+    }
+}


### PR DESCRIPTION
Closes #8476.

Three gates in `Lowered` refused in silence: the `catch` in `spliced` replaced every message with an empty carrier, `voids` cleared its whole map on the first unwitnessed void, and the shape check in `lowered` returned false. All three now speak at debug level and name the formation, so a build can tell a formation that refused for a missing method from one whose void nothing witnesses, and from one the pass never shaped.

A refusal stays normal and still does not fail the build — `eo.loweringRequired` covers that.

`LoweredTest` is new: it captures the logger of `Lowered` and asserts each of the three messages. All three fail on `master`. The class holds a `@ResourceLock` because the tests share one global logger and the suite runs concurrently.

`eo-lowering` had no logging at all, so `com.jcabi:jcabi-log` (version from the parent POM) is declared in its POM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx)_