### PR TITLE
#8474: walk down every formation, not two levels

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Lowered.java
@@ -8,8 +8,6 @@ import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -20,8 +18,8 @@ import org.w3c.dom.Element;
 /**
  * Rewrite the pure formations of one XMIR into synthetic atoms.
  *
- * <p>A formation qualifies when it is a named direct attribute of a top-
- * level object, its body is voids plus one {@code φ} plus helpers
+ * <p>A formation qualifies when it is a named attribute of another
+ * formation, its body is voids plus one {@code φ} plus helpers
  * nothing outside can name, and every void is witnessed in the tables of
  * {@code eo:inference} as a number, a string, bytes or a bool, so a
  * symbolic carrier can stand for it, or as a tuple, which the atom holds
@@ -54,6 +52,14 @@ import org.w3c.dom.Element;
  * Whatever refuses along the way — an unwitnessed void, an operation
  * outside the tables, a body that needs no computation — leaves the
  * formation as written.</p>
+ *
+ * <p>Depth decides nothing: the walk goes down every formation of the
+ * document. In a merged XMIR the top object is the package, so its
+ * members are the shells and the work of a program sits deeper, in the
+ * helpers a source privatized with {@code >>} (#8474). A formation that
+ * lowers leaves with its whole body, so nothing inside it is walked
+ * afterwards, and one that refuses hands its own attributes to the same
+ * walk.</p>
  *
  * @since 0.76.0
  */
@@ -90,10 +96,24 @@ public final class Lowered implements Rewrite {
     public int rewrite(final Xnav doc) throws IOException {
         int count = 0;
         if (!this.formas.blank()) {
-            for (final Xnav node : Lowered.candidates(doc)) {
-                final String place = node.attribute("loc").text().orElse("");
-                if (!place.isEmpty() && this.lowered(node, place)) {
-                    ++count;
+            for (final Xnav top : Lowered.kids(doc.element("object"))) {
+                count += this.through(top);
+            }
+        }
+        return count;
+    }
+
+    private int through(final Xnav node) throws IOException {
+        int count = 0;
+        if (node.attribute("base").text().isEmpty()) {
+            final String name = node.attribute("name").text().orElse("");
+            final String place = node.attribute("loc").text().orElse("");
+            if (!name.isEmpty() && !"λ".equals(name) && !place.isEmpty()
+                && this.lowered(node, place)) {
+                count = 1;
+            } else {
+                for (final Xnav kid : Lowered.kids(node)) {
+                    count += this.through(kid);
                 }
             }
         }
@@ -201,23 +221,6 @@ public final class Lowered implements Rewrite {
         for (final Xnav kid : Lowered.kids(node)) {
             if (Lowered.hidden(kid)) {
                 out.put(kid.attribute("name").text().get(), kid);
-            }
-        }
-        return out;
-    }
-
-    private static Collection<Xnav> candidates(final Xnav doc) {
-        final Collection<Xnav> out = new ArrayList<>(0);
-        for (final Xnav top : Lowered.kids(doc.element("object"))) {
-            if (top.attribute("base").text().isPresent()) {
-                continue;
-            }
-            for (final Xnav kid : Lowered.kids(top)) {
-                final String name = kid.attribute("name").text().orElse("");
-                if (kid.attribute("base").text().isEmpty()
-                    && !name.isEmpty() && !"λ".equals(name)) {
-                    out.add(kid);
-                }
             }
         }
         return out;

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/nested-arithmetic.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/nested-arithmetic.yaml
@@ -1,15 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
-# Depth decides which pass claims a formation. Only a named attribute of
-# the top object may become an atom outright, so Heron's step loses its
-# body to a sidecar and keeps just its voids. The formations nested
-# deeper keep their shape, and only their bodies leave, each into a
-# synthetic sibling named after its own digest: the cube, the quadratic
-# sample, and Horner's cubic, whose five voids are numbered in the order
-# the carve first meets them, which is why `t` leads. What calls a
-# sibling formation reduces nowhere and stays as written, so `sum` and
-# `rest` print exactly as they were parsed.
+# Depth decides nothing: a named formation becomes an atom wherever it
+# sits, so Heron's step, the cube, the quadratic sample and Horner's
+# cubic all lose their bodies to sidecars and keep just their voids,
+# under their own names. The objects that only hold them — `cubic` and
+# `horner` — declare no void of their own, so they refuse and hand their
+# attributes to the same walk. What calls a lowered formation reduces
+# nowhere and stays as written, so `sum` and `rest` print exactly as
+# they were parsed.
 input: |
   [] > foo
     [n g] > heron
@@ -38,27 +37,16 @@ lowered: |
     sum.plus rest > @
     [] > cubic
       [] > horner
-        [a b c d t] > poly
-          l🌵933af847a7e6 > @
-            t
-            a
-            b
-            c
-            d
-          [] > l🌵933af847a7e6 /Q.number
-            ? > v0 /Q.number
-            ? > v1 /Q.number
-            ? > v2 /Q.number
-            ? > v3 /Q.number
-            ? > v4 /Q.number
-        [t] > sample
-          l🌵63b5710f978f t > @
-          [] > l🌵63b5710f978f /Q.number
-            ? > v0 /Q.number
-      [t] > pow3
-        l🌵425fc1b5fc0f t > @
-        [] > l🌵425fc1b5fc0f /Q.number
-          ? > v0 /Q.number
+        [] > poly /Q.number
+          ? > a /Q.number
+          ? > b /Q.number
+          ? > c /Q.number
+          ? > d /Q.number
+          ? > t /Q.number
+        [] > sample /Q.number
+          ? > t /Q.number
+      [] > pow3 /Q.number
+        ? > t /Q.number
     [] > heron /Q.number
       ? > n /Q.number
       ? > g /Q.number


### PR DESCRIPTION
Closes #8474.

`Lowered.candidates` walked exactly two levels, so in a merged XMIR the candidates were the members of the package object and nothing inside them — which is where every privatized helper keeps its computation.

The walk recurses now, the same shape `Folded.selected` already uses: a named formation is offered to the gate wherever it sits, and one that lowers leaves with its whole body, so nothing inside it is walked afterwards. A formation that refuses hands its own attributes to the same walk, which is how `cubic` and `horner` (no voids of their own) let their nested formations through.

`nested-arithmetic.yaml` is the record of the change. It documented the old limit in prose and in its expected output: the cube, the quadratic sample and Horner's cubic used to keep their shape and lose only their bodies to `l🌵` siblings minted by `Outlined`. They are lowered under their own names now, and the pack says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx)_