### PR TITLE
#8529: index the scope lookups of the last two print sheets

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/inline-cactoos.xsl
@@ -22,6 +22,27 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:variable name="auto" select="concat('a', $eo:cactoos)"/>
   <!--
+  The dotted cactus prefix, hoisted out of the hot functions below: "$auto"
+  is a global variable rather than a literal, so Saxon rebuilds the same
+  concatenation at every call instead of folding it (#8529).
+  -->
+  <xsl:variable name="auto-dot" select="concat('.', $auto)"/>
+  <!--
+  Every reference to a cactus name, by the name it resolves to and by the
+  head segment of that name, which is the same thing for a bare reference
+  ("ξ.ρ.a🌵4-2") and the receiver for a method dispatch
+  ("ξ.ρ.a🌵4-2.seg"). The functions below used to answer "which references
+  name this binding?" with a "$target/..//o[...]" subtree scan, reached from
+  template patterns Saxon evaluates against every "o" node, which made a
+  print quadratic in the size of the largest formation (#8529). The indexes
+  answer the same question without walking anything, as in "merge-monikers"
+  (#6511); the scoping stays where it was, as a predicate on what the index
+  hands back, and keys answer in document order, so "the first reference"
+  and "the second one" keep their meaning.
+  -->
+  <xsl:key name="local-ref" match="o[contains(@base, $auto)]" use="eo:resolved-name(@base)"/>
+  <xsl:key name="local-head" match="o[contains(@base, $auto)]" use="substring-before(concat(eo:resolved-name(@base), '.'), '.')"/>
+  <!--
   A reference resolves to its own auto-name: given a base such as
   `ξ.ρ.a🌵4-2`, everything up to the cactus prefix is stripped, so the
   resolved name is the trailing `a🌵4-2`. This mirrors the `$name`
@@ -70,7 +91,7 @@
     <xsl:param name="target" as="element()"/>
     <xsl:param name="seen" as="element()*"/>
     <xsl:variable name="inner" select="$target/ancestor::o/o[@name=eo:resolved-name($target/@base)][1]"/>
-    <xsl:sequence select="if (contains($target/@base, concat('.', $auto)) and not($target/o) and exists($inner) and not(eo:void($inner)) and not(eo:abstract($inner)) and (every $node in $seen satisfies not($inner is $node))) then eo:alias-target($inner, ($seen, $target)) else $target"/>
+    <xsl:sequence select="if (contains($target/@base, $auto-dot) and not($target/o) and exists($inner) and not(eo:void($inner)) and not(eo:abstract($inner)) and (every $node in $seen satisfies not($inner is $node))) then eo:alias-target($inner, ($seen, $target)) else $target"/>
   </xsl:function>
   <!--
   Inline a reference to an auto-named abstract. A `? >> name` void
@@ -112,7 +133,7 @@
   #5821): its cactus name is likewise dropped so the folded value reads inline
   as `a!`, not as a vertical `a >>!` line.
   -->
-  <xsl:template match="o[contains(@base, concat('.', $auto))]" priority="0">
+  <xsl:template match="o[contains(@base, $auto-dot)]" priority="0">
     <xsl:variable name="name" select="eo:resolved-name(@base)"/>
     <xsl:variable name="target" select="ancestor::o/o[@name=$name][1]"/>
     <xsl:variable name="keep-name" as="xs:boolean" select="exists($target) and (eo:abstract($target) or ($target/@base = '.as-bytes' and $target/o[1]/@base = 'Φ.dataized' and eo:abstract($target/o[1]/o[1])))"/>
@@ -379,7 +400,7 @@
       void alias target, whose own name (or const layout) still matters
       and is handled by the ordinary reference path instead.
       -->
-      <xsl:variable name="ref-name" select="if (contains(@base, concat('.', $auto))) then eo:resolved-name(@base) else ()"/>
+      <xsl:variable name="ref-name" select="if (contains(@base, $auto-dot)) then eo:resolved-name(@base) else ()"/>
       <xsl:variable name="ref-target" select="if (exists($ref-name)) then ancestor::o/o[@name=$ref-name][1] else ()"/>
       <xsl:choose>
         <xsl:when test="exists($ref-target) and not(eo:void($ref-target)) and not(eo:abstract($ref-target)) and not(eo:kept-binding($ref-target, $ref-name))">
@@ -406,7 +427,7 @@
   <xsl:function name="eo:recursive" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+    <xsl:sequence select="exists(key('local-ref', $name, root($target))[contains(@base, $auto-dot)][ancestor::*[. is $target]])"/>
   </xsl:function>
   <!--
   Whether a reference in the auto-named binding's owner reaches it through a
@@ -419,7 +440,7 @@
   <xsl:function name="eo:dispatched" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="exists($target/..//o[contains(@base, concat($name, '.')) and not(ancestor-or-self::o[. is $target])])"/>
+    <xsl:sequence select="exists(key('local-head', $name, root($target))[ancestor::*[. is $target/..]][contains(@base, concat($name, '.'))][not(ancestor-or-self::o[. is $target])])"/>
   </xsl:function>
   <!--
   Whether the auto-named binding `$target` is a dataized-const wrapper: a
@@ -448,7 +469,7 @@
   -->
   <xsl:function name="eo:vertical-const" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
-    <xsl:sequence select="eo:dataized-const($target) and not(eo:abstract($target/o[1]/o[1])) and exists($target//o[contains(@base, concat('.', $auto))])"/>
+    <xsl:sequence select="eo:dataized-const($target) and not(eo:abstract($target/o[1]/o[1])) and exists($target//o[contains(@base, $auto-dot)])"/>
   </xsl:function>
   <!--
   Whether the auto-named abstract formation `$target` is immediately followed
@@ -468,7 +489,7 @@
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
     <xsl:variable name="next" select="$target/following-sibling::o[1]"/>
-    <xsl:sequence select="eo:abstract($target) and exists($next) and contains($next/@base, concat('.', $auto)) and eo:resolved-name($next/@base) = $name and ($next/o or $next/@name)"/>
+    <xsl:sequence select="eo:abstract($target) and exists($next) and contains($next/@base, $auto-dot) and eo:resolved-name($next/@base) = $name and ($next/o or $next/@name)"/>
   </xsl:function>
   <!--
   Whether the single-use auto-named abstract formation `$target` is applied by a
@@ -558,7 +579,7 @@
   <xsl:function name="eo:references" as="element()*">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string"/>
-    <xsl:sequence select="$target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]"/>
+    <xsl:sequence select="key('local-head', $name, root($target))[contains(@base, $auto-dot)][ancestor::*[. is $target/..]][not(ancestor-or-self::o[. is $target])]"/>
   </xsl:function>
   <!--
   Whether more than one reference in the binding's owner reaches the auto-name

--- a/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/restore-local-names.xsl
@@ -58,6 +58,28 @@
   <xsl:output encoding="UTF-8" method="xml"/>
   <xsl:variable name="auto" select="concat('a', $eo:cactoos)"/>
   <!--
+  The dotted cactus prefix, hoisted out of the hot functions below: "$auto"
+  is a global variable rather than a literal, so Saxon rebuilds the same
+  concatenation at every call instead of folding it (#8529).
+  -->
+  <xsl:variable name="auto-dot" select="concat('.', $auto)"/>
+  <!--
+  Every reference to a cactus name, by the name it resolves to, and by the
+  head segment of that name, which is the same thing for a bare reference
+  ("ξ.ρ.a🌵4-2") and the receiver for a method dispatch ("ξ.ρ.a🌵4-2.seg").
+  The functions below used to answer "which references name this binding?"
+  with a "$target/..//o[...]" subtree scan, from template patterns Saxon
+  evaluates against every "o" node, which made a print quadratic in the size
+  of the largest formation (#8529). An index answers the same question
+  without walking anything, the way "merge-monikers" (#6511) and
+  "resolve-local-names" (#6502) already do; the scoping each function
+  enforced by hand stays where it was, as a predicate on what comes back,
+  and keys return nodes in document order, so "the first reference" and
+  "the second one" keep their meaning.
+  -->
+  <xsl:key name="local-ref" match="o[contains(@base, $auto)]" use="eo:resolved-name(@base)"/>
+  <xsl:key name="local-head" match="o[contains(@base, $auto)]" use="substring-before(concat(eo:resolved-name(@base), '.'), '.')"/>
+  <!--
   A reference resolves to its own auto-name: given a base such as
   "ξ.ρ.a🌵4-2", everything up to the cactus prefix is stripped, so the
   resolved name is the trailing "a🌵4-2". Mirrors "inline-cactoos".
@@ -86,7 +108,7 @@
   <xsl:function name="eo:recursive" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="exists($target//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name])"/>
+    <xsl:sequence select="exists(key('local-ref', $name, root($target))[contains(@base, $auto-dot)][ancestor::*[. is $target]])"/>
   </xsl:function>
   <!--
   The references in the binding's owner that resolve to the auto-name "$name"
@@ -96,7 +118,7 @@
   <xsl:function name="eo:references" as="element()*">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="$target/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $name or starts-with(eo:resolved-name(@base), concat($name, '.'))) and not(ancestor-or-self::o[. is $target])]"/>
+    <xsl:sequence select="key('local-head', $name, root($target))[contains(@base, $auto-dot)][ancestor::*[. is $target/..]][not(ancestor-or-self::o[. is $target])]"/>
   </xsl:function>
   <!--
   Whether more than one reference in the binding's owner resolves to the
@@ -174,7 +196,7 @@
   <xsl:function name="eo:applied-receiver" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="eo:abstract($target) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and (o or @name) and not(ancestor-or-self::o[. is $target]) and not(preceding-sibling::o[. is $target])])"/>
+    <xsl:sequence select="eo:abstract($target) and exists(key('local-ref', $name, root($target))[contains(@base, $auto-dot)][ancestor::*[. is $target/..]][o or @name][not(ancestor-or-self::o[. is $target])][not(preceding-sibling::o[. is $target])])"/>
   </xsl:function>
   <!--
   Whether the based "&gt;&gt; name" handle "$target" is itself an application
@@ -193,7 +215,7 @@
   <xsl:function name="eo:reapplied" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="not(eo:abstract($target)) and not(exists($target/@const)) and not($target/@base = '.as-bytes') and exists($target/o) and exists($target/..//o[contains(@base, concat('.', $auto)) and eo:resolved-name(@base) = $name and o and not(ancestor-or-self::o[. is $target])])"/>
+    <xsl:sequence select="not(eo:abstract($target)) and not(exists($target/@const)) and not($target/@base = '.as-bytes') and exists($target/o) and exists(key('local-ref', $name, root($target))[contains(@base, $auto-dot)][ancestor::*[. is $target/..]][o][not(ancestor-or-self::o[. is $target])])"/>
   </xsl:function>
   <!--
   Whether a reference in the auto-named binding's owner reaches it through a
@@ -208,7 +230,7 @@
   <xsl:function name="eo:dispatched" as="xs:boolean">
     <xsl:param name="target" as="element()"/>
     <xsl:param name="name" as="xs:string?"/>
-    <xsl:sequence select="exists($target/../o[contains(@base, concat($name, '.')) and not(. is $target)])"/>
+    <xsl:sequence select="exists(key('local-head', $name, root($target))[contains(@base, concat($name, '.'))][.. is $target/..][not(. is $target)])"/>
   </xsl:function>
   <!--
   Whether "$wrapper" is a dataized-const file-local handle (`a &gt;&gt; b!`,
@@ -232,7 +254,7 @@
   <xsl:function name="eo:const-handle" as="xs:boolean">
     <xsl:param name="wrapper" as="element()*"/>
     <xsl:variable name="value" select="$wrapper/o[@base='Φ.dataized']/o[1]"/>
-    <xsl:sequence select="exists($wrapper) and $wrapper/@base='.as-bytes' and exists($wrapper/@name) and exists($value/@local) and count($wrapper/..//o[contains(@base, concat('.', $auto)) and (eo:resolved-name(@base) = $wrapper/@name or starts-with(eo:resolved-name(@base), concat($wrapper/@name, '.'))) and not(ancestor-or-self::o[. is $wrapper])]) &gt; 1"/>
+    <xsl:sequence select="if (empty($wrapper) or not($wrapper/@base='.as-bytes') or empty($wrapper/@name) or empty($value/@local)) then false() else exists(key('local-head', $wrapper/@name/string(), root($wrapper))[contains(@base, $auto-dot)][ancestor::*[. is $wrapper/..]][not(ancestor-or-self::o[. is $wrapper])][2])"/>
   </xsl:function>
   <!--
   Whether the applied reference "$ref" resolves to a recursive "&gt;&gt;" handle
@@ -246,7 +268,7 @@
   -->
   <xsl:function name="eo:relocated" as="xs:boolean">
     <xsl:param name="ref" as="element()"/>
-    <xsl:sequence select="exists($ref/following-sibling::o[@local and eo:recursive(., @name/string()) and @name = eo:resolved-name($ref/@base)])"/>
+    <xsl:sequence select="exists($ref/following-sibling::o[@name = eo:resolved-name($ref/@base)][@local][eo:recursive(., @name/string())])"/>
   </xsl:function>
   <xsl:key name="void-handle" match="o[@local and (@base=$eo:empty or eo:recursive(., @name/string()) or @pipe)]" use="@name"/>
   <!--
@@ -318,7 +340,7 @@
   that already carries "@pipe" (an already-piped handle round-tripping) is
   left as is.
   -->
-  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and preceding-sibling::o[1][@local and eo:recursive(., @name/string())] and eo:resolved-name(@base) = preceding-sibling::o[1]/@name]">
+  <xsl:template match="o[contains(@base, $auto-dot) and (o or @name) and preceding-sibling::o[1][@local and eo:recursive(., @name/string())] and eo:resolved-name(@base) = preceding-sibling::o[1]/@name]">
     <xsl:copy>
       <xsl:if test="not(@pipe)">
         <xsl:attribute name="pipe"/>
@@ -345,7 +367,7 @@
   siblings ("eo:relocated"); a reference resolving to a different binding still
   prints in place, through the identity template.
   -->
-  <xsl:template match="o[contains(@base, concat('.', $auto)) and (o or @name) and eo:relocated(.)]"/>
+  <xsl:template match="o[contains(@base, $auto-dot) and (o or @name) and eo:relocated(.)]"/>
   <!--
   Re-emit the suppressed reference below the handle. Match the recursive handle,
   copy it, then for each applied reference among its preceding siblings that
@@ -358,7 +380,7 @@
     <xsl:copy>
       <xsl:apply-templates select="node()|@*"/>
     </xsl:copy>
-    <xsl:for-each select="preceding-sibling::o[contains(@base, concat('.', $auto)) and (o or @name) and eo:resolved-name(@base) = current()/@name]">
+    <xsl:for-each select="preceding-sibling::o[contains(@base, $auto-dot) and (o or @name) and eo:resolved-name(@base) = current()/@name]">
       <xsl:copy>
         <xsl:if test="not(@pipe)">
           <xsl:attribute name="pipe"/>


### PR DESCRIPTION
Closes #8529.

`restore-local-names.xsl` and `inline-cactoos.xsl` were the two sheets #6512 left behind. Both answered "which references name this binding?" with a `$target/..//o[...]` subtree scan, reached from template patterns that Saxon evaluates against every `o` node, so a print was quadratic in the size of the largest formation.

Two `xsl:key` indexes answer it now — by the name a reference resolves to, and by the head segment of that name, which is the same thing for a bare reference (`ξ.ρ.a🌵4-2`) and the receiver of a method dispatch (`ξ.ρ.a🌵4-2.seg`) — the same shape #6511 gave `merge-monikers` and #6502 gave `resolve-local-names`. Every scoping predicate the scans enforced by hand stays where it was, as a filter on what the index hands back, and the indexes match on the loose `contains(@base, $auto)` so that a bare cactus base is indexed too and each function keeps stating its own condition. Keys answer in document order, so "the first reference" and "the second one" keep their meaning. The dotted cactus prefix is hoisted into `$auto-dot`, and `eo:relocated` asks `@name = …` before the recursion test rather than after.

## Measurements

One formation holding N bindings, parsed with `EoSyntax` and printed with `Xmir.toEO()`, best of three, Saxon-HE 13.0:

| `<o>` nodes | before | after |
| ---: | ---: | ---: |
| 1803 | 2430 ms | 287 ms |
| 3003 | 6642 ms | 368 ms |
| 6003 | 23429 ms | 646 ms |
| 12003 | — | 1289 ms |

Twice the nodes now costs twice the time. Neither sheet crosses the 500 ms line `TrFull` warns at any more, at any size tried.

## Correctness

Output is byte-identical before and after on all 173 `.eo` sources of `eo-runtime` printed through the whole chain, and the 409 `eo-printer` tests pass.

What is left in that measurement is `validate-attribute-names` in the parse chain — 3 s at 6003 nodes and 12 s at 12003 — which is a parser sheet and a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx)_