### PR TITLE
#8532: index the attributes instead of scanning the siblings

### DIFF
--- a/eo-parser/src/main/resources/org/eolang/parser/parse/validate-attribute-names.xsl
+++ b/eo-parser/src/main/resources/org/eolang/parser/parse/validate-attribute-names.xsl
@@ -11,11 +11,21 @@
   they are a different declaration and are checked elsewhere.
   -->
   <xsl:output encoding="UTF-8" method="xml"/>
+  <!--
+  Every declared attribute, by its owner and its name. The check used to
+  ask each attribute whether a preceding sibling carried the same name,
+  which is one sibling scan per attribute and N squared comparisons for a
+  formation of N attributes (#8532). The index answers the same question
+  by position: a name declared twice has a second member in its group,
+  and keys answer in document order, so "not the first one" is exactly
+  "has a preceding sibling of the same name".
+  -->
+  <xsl:key name="named" match="o[@name][not(@base='∅')]" use="concat(generate-id(..), ' ', @name)"/>
   <xsl:template match="/object">
     <xsl:variable name="errors" as="element()*">
       <xsl:for-each select="descendant-or-self::*[self::object or self::o[not(@base)]]/o[@name and not(@base='∅')]">
         <xsl:variable name="name" select="@name"/>
-        <xsl:if test="preceding-sibling::o[@name=$name and not(@base='∅')]">
+        <xsl:if test="not(. is key('named', concat(generate-id(..), ' ', $name), root(.))[1])">
           <error>
             <xsl:attribute name="check" select="'validate-attribute-names'"/>
             <xsl:attribute name="line" select="if (@line) then @line else 0"/>


### PR DESCRIPTION
Closes #8532.

The check asked every named attribute whether a preceding sibling carried the same name — one sibling scan per attribute, so N²/2 comparisons in a formation of N attributes.

An `xsl:key` on the owner and the name answers the same question by position. Keys answer in document order, so "this node is not the first of its group" is exactly "this node has a preceding sibling of the same name", and the verdict, the message, the line and the order of the errors are unchanged.

## Measurements

One formation holding N bindings, parsed with `EoSyntax`, best of three, Saxon-HE 13.0:

| `<o>` nodes | sheet before | sheet after | whole parse before | whole parse after |
| ---: | ---: | ---: | ---: | ---: |
| 6003 | 3 s | under 500 ms | 4846 ms | 2015 ms |
| 12003 | 12 s | under 500 ms | 12722 ms | 3673 ms |
| 24003 | — | under 500 ms | 46369 ms | 8239 ms |

"Under 500 ms" is where `TrFull` stops warning, so the sheet no longer reports itself at any size tried. What is left of the parse time on such a file is `resolve-local-names` (3 s at 24003 nodes) and `wrap-applications` (848 ms), which are their own tickets.

## Correctness

All 1634 `eo-parser` tests pass, including the four `eo-typos` packs that pin this check: `attribute-declared-twice`, `alias-declared-twice`, `void-declared-twice` and `phi-void-declared-twice`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQotaVaHcaaX74kULAjkkx)_