### PR TITLE
fix(lowering): wait for the SLF4J binding before capturing the log

### DIFF
--- a/eo-lowering/pom.xml
+++ b/eo-lowering/pom.xml
@@ -55,6 +55,12 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.18</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
       <artifactId>slf4j-reload4j</artifactId>
       <!-- version from parent POM -->
       <scope>test</scope>

--- a/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.parallel.Execution;
 import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.junit.jupiter.api.parallel.ResourceLock;
+import org.slf4j.LoggerFactory;
+import org.slf4j.helpers.SubstituteLogger;
 
 /**
  * Test case for {@link Lowered}.
@@ -32,6 +34,17 @@ import org.junit.jupiter.api.parallel.ResourceLock;
  * a capture of it is a level and an appender set on that object, so two
  * of these tests in flight at once read each other's messages, or none
  * at all. They run in one thread for that reason.</p>
+ *
+ * <p>A capture also has to wait for SLF4J to bind itself to the logging
+ * back-end, which is what {@code bound()} below does. The binding starts
+ * with the first logging call of the JVM, made by whichever test class
+ * happens to run first, and while it is under way SLF4J answers every
+ * other thread with a substitute logger: one that says debug is
+ * enabled, records what it is given instead of passing it on, and
+ * replays the records into the real logger once the binding is done. By
+ * then the appender of the capture is gone, so what {@link Lowered} says
+ * during the binding reaches nobody and the capture comes back
+ * empty.</p>
  *
  * @since 0.76.0
  */
@@ -120,8 +133,15 @@ final class LoweredTest {
         );
     }
 
+    private static void bound() {
+        while (LoggerFactory.getLogger(Lowered.class) instanceof SubstituteLogger) {
+            Thread.onSpinWait();
+        }
+    }
+
     private static List<String> spoken(final Formas formas, final String xmir,
         final Path temp) throws IOException {
+        LoweredTest.bound();
         final List<String> messages = new ArrayList<>(0);
         final Appender appender = new AppenderSkeleton() {
             @Override

--- a/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/LoweredTest.java
@@ -36,8 +36,8 @@ import org.slf4j.helpers.SubstituteLogger;
  * at all. They run in one thread for that reason.</p>
  *
  * <p>A capture also has to wait for SLF4J to bind itself to the logging
- * back-end, which is what {@code bound()} below does. The binding starts
- * with the first logging call of the JVM, made by whichever test class
+ * back-end, which is what the loop below does. The binding starts with
+ * the first logging call of the JVM, made by whichever test class
  * happens to run first, and while it is under way SLF4J answers every
  * other thread with a substitute logger: one that says debug is
  * enabled, records what it is given instead of passing it on, and
@@ -133,15 +133,11 @@ final class LoweredTest {
         );
     }
 
-    private static void bound() {
+    private static List<String> spoken(final Formas formas, final String xmir,
+        final Path temp) throws IOException {
         while (LoggerFactory.getLogger(Lowered.class) instanceof SubstituteLogger) {
             Thread.onSpinWait();
         }
-    }
-
-    private static List<String> spoken(final Formas formas, final String xmir,
-        final Path temp) throws IOException {
-        LoweredTest.bound();
         final List<String> messages = new ArrayList<>(0);
         final Appender appender = new AppenderSkeleton() {
             @Override


### PR DESCRIPTION
## What was failing

[`mvn` on `master`, `macos-15`](https://github.com/objectionary/eo/actions/runs/34204496931/job/101990743999) went red in `eo-lowering`:

```
[ERROR] LoweredTest.countsTheAttributesOfAFormationItCannotShape:71
  a formation of the wrong shape must be counted in the log, but it isnt
Expected: a collection containing (a string containing "Φ.foo.calc"
  and a string containing "3 attribute(s)")
     but: was empty
```

Two lines in the same log say what really happened:

```
log4j:WARN No appenders could be found for logger (org.eolang.lowering.Lowered).
SLF4J(W): A number (1) of logging calls during the initialization phase
  have been intercepted and are now being replayed.
```

## Why

`LoweredTest` captures what `Lowered` says by putting a log4j appender on its
logger. A logging call made while SLF4J is still binding itself to the
back-end never reaches log4j at all: SLF4J hands the calling thread a
`SubstituteLogger`, whose `isDebugEnabled()` answers `true` and whose
`EventRecordingLogger` records the event instead of passing it on. The records
are replayed into the real logger once the binding is done — by then the
appender of the test is gone, which is exactly the `No appenders` warning
above, and the capture the test asserts on is empty.

The binding starts with the first logging call of the JVM, made by whichever
test class the parallel runner happens to start first, so the loss is a race
and the test is flaky rather than broken. `@Execution(SAME_THREAD)` and the
`@ResourceLock` already on the class do not help: the thread it races against
is another test class, not another test of this one.

## The fix

The capture waits for the binding to be done before it runs `Lowered`. A probe
of eight threads that install an appender and log at once loses seven of the
eight messages without the wait, and none of them with it:

```
wait=false lost=7 of 8
wait=true  lost=0 of 8
```

`slf4j-api` is now declared in `eo-lowering/pom.xml` at test scope, since the
test names `SubstituteLogger` directly and `dependency:analyze` (through
`qulice`) asks for it.

## Checks

- `mvn -pl eo-lowering test` — 331 tests, 0 failures
- `mvn -Pqulice -Deo.skip -pl eo-lowering process-classes qulice:check` — clean

## Note, outside this change

`XmirTest` in `eo-printer` and `MjLintTest`/`MjResolveTest` in
`eo-maven-plugin` capture log messages the same way and are open to the same
race. They are untouched here to keep the fix to the failing build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CBnxGqPi33FwRwgmKCyUnN

---
_Generated by [Claude Code](https://claude.ai/code/session_01CBnxGqPi33FwRwgmKCyUnN)_