### PR TITLE
Log the lowering counts pass by pass

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Lowering.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Lowering.java
@@ -11,6 +11,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
+import org.cactoos.iterable.Mapped;
+import org.cactoos.text.Joined;
 import org.eolang.lowering.Folded;
 import org.eolang.lowering.Formas;
 import org.eolang.lowering.Lowered;
@@ -92,14 +94,15 @@ final class Lowering implements Step {
         final Formas formas = new Formas(this.tables);
         final Path atoms = this.home.resolve(Lowering.ATOMS);
         final Iterable<Rewrite> passes = Arrays.asList(
-            new Lowered(this.phino, formas, atoms),
-            new Outlined(this.phino, formas, atoms),
-            new Folded(this.phino)
+            new Tally(new Lowered(this.phino, formas, atoms), "lowered"),
+            new Tally(new Outlined(this.phino, formas, atoms), "outlined"),
+            new Tally(new Folded(this.phino), "folded")
         );
         Logger.info(
-            this, "Folded or lowered %d fragment(s) in %d XMIR(s), into %[file]s",
+            this, "Modified %d fragment(s) in %d XMIR(s), into %[file]s: %s",
             new Threaded<>(this.sources, tojo -> this.folded(tojo, passes)).total(),
-            this.sources.size(), this.home
+            this.sources.size(), this.home,
+            new Joined(", ", new Mapped<>(Object::toString, passes))
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Tally.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Tally.java
@@ -12,7 +12,6 @@ import org.eolang.lowering.Rewrite;
 /**
  * A lowering pass that adds up, across threads, how many fragments it
  * rewrote, and prints itself as {@code 55 lowered}.
- *
  * @since 0.76.0
  */
 final class Tally implements Rewrite {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Tally.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Tally.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Xnav;
+import java.io.IOException;
+import java.util.concurrent.atomic.LongAdder;
+import org.eolang.lowering.Rewrite;
+
+/**
+ * A lowering pass that adds up, across threads, how many fragments it
+ * rewrote, and prints itself as {@code 55 lowered}.
+ *
+ * @since 0.76.0
+ */
+final class Tally implements Rewrite {
+
+    /**
+     * The pass that rewrites.
+     */
+    private final Rewrite origin;
+
+    /**
+     * The verb saying what the pass did.
+     */
+    private final String verb;
+
+    /**
+     * How many fragments the pass rewrote so far.
+     */
+    private final LongAdder count;
+
+    /**
+     * Ctor.
+     * @param pass The pass that rewrites
+     * @param name The verb saying what the pass did
+     */
+    Tally(final Rewrite pass, final String name) {
+        this(pass, name, new LongAdder());
+    }
+
+    /**
+     * Ctor.
+     * @param pass The pass that rewrites
+     * @param name The verb saying what the pass did
+     * @param sum How many fragments the pass rewrote so far
+     */
+    private Tally(final Rewrite pass, final String name, final LongAdder sum) {
+        this.origin = pass;
+        this.verb = name;
+        this.count = sum;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%d %s", this.count.sum(), this.verb);
+    }
+
+    @Override
+    public int rewrite(final Xnav doc) throws IOException {
+        final int done = this.origin.rewrite(doc);
+        this.count.add(done);
+        return done;
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TallyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TallyTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link Tally}.
- *
  * @since 0.76.0
  */
 final class TallyTest {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/TallyTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/TallyTest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.github.lombrozo.xnav.Xnav;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Random;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Tally}.
+ *
+ * @since 0.76.0
+ */
+final class TallyTest {
+
+    @Test
+    void sumsRewritesOfEveryThread() {
+        final long seed = System.nanoTime();
+        final int hits = new Random(seed).nextInt(9) + 1;
+        final Tally tally = new Tally(doc -> hits, "lowered");
+        new Threaded<>(
+            Collections.nCopies(16, new Xnav("<o base='ξ.x'/>")), tally::rewrite
+        ).total();
+        MatcherAssert.assertThat(
+            String.format("the tally adds up no rewrite of a thread, seed %d", seed),
+            tally.toString(),
+            Matchers.equalTo(String.format("%d lowered", hits * 16))
+        );
+    }
+
+    @Test
+    void returnsWhatThePassRewrote() throws IOException {
+        final long seed = System.nanoTime();
+        final int hits = new Random(seed).nextInt(9) + 1;
+        MatcherAssert.assertThat(
+            String.format("the tally hides what the pass rewrote, seed %d", seed),
+            new Tally(doc -> hits, "folded").rewrite(new Xnav("<o base='ξ.y'/>")),
+            Matchers.equalTo(hits)
+        );
+    }
+}


### PR DESCRIPTION
The lowering step ran its three passes as an anonymous list and reported one number for all of them, so a build where folding improved and outlining regressed read exactly like a build where the opposite happened. Each pass is now wrapped in a `Tally`: it delegates the rewrite, adds what came back to a `LongAdder`, since the passes run over the files in parallel, and prints itself as `55 lowered`. The log line joins the three of them after the total, and the list keeps its order, so an earlier pass still shrinks what a later one sees.

I left the `lowering.txt` marker alone. `MjTranspile` reads it and folds its content into the transpilation cache key, so a per-build count in there would move the key whenever a build lowers a different set of files and would cost every incremental build its cache. If the numbers should survive the log, they need a place that is not the cache key, and that is worth its own issue.

The change is 127 hits, over the band. About thirty of them are the javadoc a new final class has to carry.

Closes #8537