### PR TITLE
Move the sockaddr layout into a package of its own

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
@@ -9,8 +9,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Sockaddr;
 import org.eolang.Syscall;
+import org.eolang.sys.Sockaddr;
 
 /**
  * Accept syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
@@ -8,8 +8,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Sockaddr;
 import org.eolang.Syscall;
+import org.eolang.sys.Sockaddr;
 
 /**
  * Bind syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
@@ -8,8 +8,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Sockaddr;
 import org.eolang.Syscall;
+import org.eolang.sys.Sockaddr;
 
 /**
  * Connect syscall.

--- a/eo-runtime/src/main/java/org/eolang/sys/MacSockaddrIn.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/MacSockaddrIn.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Structure;
 import java.util.Arrays;

--- a/eo-runtime/src/main/java/org/eolang/sys/Padding.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/Padding.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import java.util.Arrays;
 

--- a/eo-runtime/src/main/java/org/eolang/sys/Sockaddr.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/Sockaddr.java
@@ -3,10 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
+import org.eolang.Dataized;
+import org.eolang.Phi;
 
 /**
  * A {@code sockaddr_in} laid out the way the running platform lays it out.

--- a/eo-runtime/src/main/java/org/eolang/sys/SockaddrIn.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/SockaddrIn.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Structure;
 import java.util.Arrays;

--- a/eo-runtime/src/main/java/org/eolang/sys/package-info.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * EO runtime, what the syscall adapters share.
+ *
+ * <p>A {@code sockaddr_in} is laid out one way by Linux and Windows and
+ * another way by macOS, and both families of adapters, posix and win32,
+ * hand that layout to the kernel. It is theirs, not the runtime's, so it
+ * lives here rather than in the root package next to {@code Phi} and
+ * {@code Bytes}.</p>
+ *
+ * @since 0.77.0
+ * @todo #8533:30min Move Syscall, Handles, Cstring and TupleToArray here,
+ *  together with SyscallTest, ReadSyscallTest and StatSyscallTest. They serve
+ *  posix and win32 alone, yet standing in org.eolang they read as part of the
+ *  runtime's public surface, the way Bytes and PhDefault are.
+ * @todo #8533:30min Re-parent org.eolang.posix and org.eolang.win32 as
+ *  org.eolang.sys.posix and org.eolang.sys.win32, and name the new directories
+ *  in sonar.cpd.exclusions in pom.xml, which is the only place outside Java
+ *  that spells the old ones out.
+ */
+package org.eolang.sys;

--- a/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
@@ -11,8 +11,8 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.SockaddrIn;
 import org.eolang.Syscall;
+import org.eolang.sys.SockaddrIn;
 
 /**
  * The socket WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
@@ -10,8 +10,8 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.SockaddrIn;
 import org.eolang.Syscall;
+import org.eolang.sys.SockaddrIn;
 
 /**
  * The socket WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
@@ -10,8 +10,8 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.SockaddrIn;
 import org.eolang.Syscall;
+import org.eolang.sys.SockaddrIn;
 
 /**
  * The 'connect' WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Winsock.java
@@ -9,7 +9,7 @@ import com.sun.jna.Pointer;
 import com.sun.jna.ptr.IntByReference;
 import com.sun.jna.win32.StdCallLibrary;
 import com.sun.jna.win32.W32APIOptions;
-import org.eolang.SockaddrIn;
+import org.eolang.sys.SockaddrIn;
 
 /**
  * Interface definitions for <code>WS2_32.dll</code>.

--- a/eo-runtime/src/test/java/org/eolang/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/SyscallTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import org.eolang.posix.CStdLib;
+import org.eolang.sys.SockaddrIn;
 import org.eolang.win32.WSAData;
 import org.eolang.win32.Winsock;
 import org.hamcrest.MatcherAssert;

--- a/eo-runtime/src/test/java/org/eolang/sys/MacSockaddrInTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/MacSockaddrInTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Structure;
 import org.hamcrest.MatcherAssert;

--- a/eo-runtime/src/test/java/org/eolang/sys/SockaddrInTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/SockaddrInTest.java
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang;
+package org.eolang.sys;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/eo-runtime/src/test/java/org/eolang/sys/package-info.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/package-info.java
@@ -5,6 +5,7 @@
 
 /**
  * Tests for what the syscall adapters share.
+ *
  * @since 0.77.0
  */
 package org.eolang.sys;

--- a/eo-runtime/src/test/java/org/eolang/sys/package-info.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/package-info.java
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+/**
+ * Tests for what the syscall adapters share.
+ * @since 0.77.0
+ */
+package org.eolang.sys;


### PR DESCRIPTION
The `sockaddr_in` layout was sitting in `org.eolang`, next to `Phi`, `Bytes` and `PhDefault`. Nothing in the runtime reads it: `Sockaddr`, `SockaddrIn` and `MacSockaddrIn` exist for `posix` and `win32` alone, and standing in the root package they read as part of the runtime's public surface when they are not. This introduces `org.eolang.sys` and moves them there, with `SockaddrInTest` and `MacSockaddrInTest` following them.

`Padding` moved too, although the issue does not name it. It is package-private, and `bytes()` is package-private as well, so the two structures stop compiling the moment they leave `org.eolang` without it. It belongs with them anyway: it is the padding a `sockaddr_in` ends with and nothing else asks for it. Keeping it package-private inside `org.eolang.sys` was the alternative to widening the root package's surface, which is exactly what the issue is against.

The rest of the move is left as two puzzles in the new package's javadoc. `Syscall` alone is imported by sixty-three adapters, and re-parenting `org.eolang.posix` and `org.eolang.win32` under `org.eolang.sys` touches all eighty of them plus `sonar.cpd.exclusions`; done here it would be a diff nobody could read. The compiler is the only check this kind of change has, so I ran `javac` over the whole runtime and over `SyscallTest`, `StatSyscallTest` and `ReadSyscallTest` before committing.

Closes #8533
