### PR TITLE
Back the walk with plexus DirectoryScanner, keeping NIO globs for the filtering

### DIFF
--- a/eo-maven-plugin/pom.xml
+++ b/eo-maven-plugin/pom.xml
@@ -259,6 +259,17 @@
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-utils</artifactId>
+      <version>4.1.0</version>
+      <!--
+      Provides DirectoryScanner, which Scanned uses to list a directory.
+      maven-core brings it in transitively, but it is used on purpose here,
+      so it is declared, and qulice resolves its type-checking classpath
+      from directly declared dependencies only (#6316)
+      -->
+    </dependency>
+    <dependency>
+      <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-xml</artifactId>
       <version>4.2.0</version>
       <scope>provided</scope>

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Scanned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Scanned.java
@@ -56,10 +56,6 @@ final class Scanned implements Iterable<Path> {
         return files.iterator();
     }
 
-    /**
-     * The files the scanner lets through.
-     * @return Absolute paths of them
-     */
     private Collection<Path> found() {
         final DirectoryScanner scanner = new DirectoryScanner();
         scanner.setBasedir(this.home.toFile());

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Scanned.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Scanned.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import org.codehaus.plexus.util.DirectoryScanner;
+
+/**
+ * Regular files under a directory, found by the scan Maven itself runs.
+ *
+ * <p>A directory a version control system owns, such as {@code .git} or
+ * {@code .svn}, is pruned while the scan is under way, instead of being
+ * walked whole and thrown away afterwards, and so are the backup and
+ * editor droppings the scan excludes by default.</p>
+ *
+ * <p>Only regular files come out. A directory is not one, and neither is a
+ * FIFO, a socket, a device node or a link with nothing at the end of it,
+ * and a goal handed such an entry cannot make an EO program out of it: it
+ * would hash and read it, and reading a FIFO waits for a writer that never
+ * comes. A link to an ordinary file is still found, since such a source
+ * reads exactly like the file it names, while a link to a directory is not
+ * descended into, because the files behind it carry their own names.</p>
+ *
+ * <p>A directory that is not there holds no files, which is what a goal
+ * running before the one that creates it has to see.</p>
+ *
+ * @since 0.73.4
+ */
+final class Scanned implements Iterable<Path> {
+
+    /**
+     * The home.
+     */
+    private final Path home;
+
+    /**
+     * Ctor.
+     * @param dir The directory
+     */
+    Scanned(final Path dir) {
+        this.home = dir;
+    }
+
+    @Override
+    public Iterator<Path> iterator() {
+        final Collection<Path> files = new ArrayList<>(0);
+        if (Files.exists(this.home)) {
+            files.addAll(this.found());
+        }
+        return files.iterator();
+    }
+
+    /**
+     * The files the scanner lets through.
+     * @return Absolute paths of them
+     */
+    private Collection<Path> found() {
+        final DirectoryScanner scanner = new DirectoryScanner();
+        scanner.setBasedir(this.home.toFile());
+        scanner.setIncludes(new String[] {"**"});
+        scanner.setFollowSymlinks(false);
+        scanner.addDefaultExcludes();
+        scanner.scan();
+        final Collection<Path> files = new ArrayList<>(0);
+        for (final String name : scanner.getIncludedFiles()) {
+            files.add(this.home.resolve(name));
+        }
+        return files;
+    }
+}

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/WkDefault.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/WkDefault.java
@@ -4,27 +4,23 @@
  */
 package org.eolang.maven;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.cactoos.list.ListEnvelope;
+import org.cactoos.list.ListOf;
 
 /**
  * Default implementation of {@link Walk}.
  *
- * <p>Only regular files are walked. A directory is not one, and neither is
- * a FIFO, a socket, a device node or a link with nothing at the end of it,
- * and a goal handed such an entry cannot make an EO program out of it: it
- * would hash and read it, and reading a FIFO waits for a writer that never
- * comes. A link to an ordinary file is still walked, since
- * {@link Files#isRegularFile(Path, java.nio.file.LinkOption...)} follows
- * links by default, and such a source reads exactly like the file it names.</p>
+ * <p>The files arrive from {@link Scanned} and this object narrows them
+ * down to the ones a goal asked for. The narrowing stays with
+ * {@link Globbed}, in the syntax the JDK reads, because a glob there says
+ * things the Ant style of the scan cannot: {@code **.eo} reaches through
+ * directories, and {@code EO*$[1-9]*.class} in {@code Unspiling} names a
+ * range of digits, which Ant would read as five literal characters.</p>
  *
  * @since 0.1
  */
@@ -40,7 +36,7 @@ final class WkDefault extends ListEnvelope<Path> implements Walk {
      * @param dir The directory
      */
     WkDefault(final Path dir) {
-        this(dir, WkDefault.list(dir));
+        this(dir, new ListOf<>(new Scanned(dir)));
     }
 
     /**
@@ -83,28 +79,6 @@ final class WkDefault extends ListEnvelope<Path> implements Walk {
             )
             .collect(Collectors.toList())
         );
-    }
-
-    private static List<Path> list(final Path dir) {
-        try {
-            final List<Path> files = new ArrayList<>(0);
-            if (Files.exists(dir)) {
-                files.addAll(WkDefault.regular(dir));
-            }
-            return files;
-        } catch (final IOException ex) {
-            throw new IllegalStateException(
-                String.format("Can't read files in %s folder during a walk", dir),
-                ex
-            );
-        }
-    }
-
-    private static Collection<Path> regular(final Path dir) throws IOException {
-        try (Stream<Path> walk = Files.walk(dir)) {
-            return walk.filter(Files::isRegularFile)
-                .collect(Collectors.toList());
-        }
     }
 
     private Path relative(final Path file) {

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ScannedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ScannedTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Scanned}.
+ * @since 0.73.4
+ */
+@ExtendWith(MktmpResolver.class)
+final class ScannedTest {
+
+    @Test
+    void skipsDirectoryOwnedByVersionControl(@Mktmp final Path temp) throws Exception {
+        new Saved("[] > привет", temp.resolve("привет.eo")).value();
+        new Saved("", temp.resolve(".git/objects/pack/каталог.pack")).value();
+        MatcherAssert.assertThat(
+            "a file inside .git must be pruned by the scan, but it was walked",
+            new Scanned(temp),
+            Matchers.contains(temp.resolve("привет.eo"))
+        );
+    }
+
+    @Test
+    void findsNothingInMissingDirectory(@Mktmp final Path temp) {
+        MatcherAssert.assertThat(
+            "a directory that is not there holds no files, but some were found",
+            new Scanned(temp.resolve("absent")),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void skipsDirectoryReachedThroughALink(@Mktmp final Path temp) throws IOException {
+        Files.createDirectories(temp.resolve("sources"));
+        Files.write(temp.resolve("sources/ωmega.eo"), "[] > omega".getBytes("UTF-8"));
+        Files.createSymbolicLink(temp.resolve("mirror"), temp.resolve("sources"));
+        MatcherAssert.assertThat(
+            "a linked directory must not be descended into, since its files carry their own names",
+            new Scanned(temp),
+            Matchers.contains(temp.resolve("sources/ωmega.eo"))
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/ScannedTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/ScannedTest.java
@@ -6,7 +6,6 @@ package org.eolang.maven;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
-import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
@@ -45,9 +44,8 @@ final class ScannedTest {
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
-    void skipsDirectoryReachedThroughALink(@Mktmp final Path temp) throws IOException {
-        Files.createDirectories(temp.resolve("sources"));
-        Files.write(temp.resolve("sources/ωmega.eo"), "[] > omega".getBytes("UTF-8"));
+    void skipsDirectoryReachedThroughALink(@Mktmp final Path temp) throws Exception {
+        new Saved("[] > omega", temp.resolve("sources/ωmega.eo")).value();
         Files.createSymbolicLink(temp.resolve("mirror"), temp.resolve("sources"));
         MatcherAssert.assertThat(
             "a linked directory must not be descended into, since its files carry their own names",


### PR DESCRIPTION
`WkDefault` walked a directory with `Files.walk()` and filtered afterwards. The walk now runs on `org.codehaus.plexus.util.DirectoryScanner`, the same scanner Maven and its own plugins use, hidden behind a new `Scanned` object so that its setters and its `String[]` never leave that class. `WkDefault` keeps the one job it should have, which is narrowing a listing down to the globs a goal asked for.

The pattern language stays where it is, and `Globbed` keeps doing the filtering with NIO globs. Ant patterns cannot say what the patterns already in this codebase say. `**.eo`, the documented default of `includeSources`, matches `dir/sub/foo.eo` under NIO and does not under Ant, and `**/EO*$[1-9]*.class` in `Unspiling` names a range of digits that Ant reads as five literal characters. There is no general translation from one language to the other, so nothing anybody has written in a `pom.xml` changes meaning here, and the two tests that assert on the message a bad glob produces keep passing, because `Globbed` is still the object that raises it.

The scan answers the other worries on its own. It hands back regular files only, so a FIFO, a link with nothing at the end of it and a directory are all still skipped, while a link to an ordinary file is still walked. Symlinked directories are not descended into, which is what `Files.walk()` did too. What is new is that a directory a version control system owns, such as `.git`, is pruned while the scan is under way instead of being enumerated and then thrown away, and that is what the new test pins down.

I did not measure the effect on build time. None of the directories the goals walk today carry a `.git` inside them, so the pruning is robustness rather than a speed-up, and the honest claim for this change is less code of ours plus glob rules that match the rest of the Maven ecosystem for the scan itself.

Closes #8536
