### PR TITLE
Keep the receiver of a call the object it is

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Call.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Call.java
@@ -17,7 +17,11 @@ import java.util.List;
  * wrapped back into an object — a number, a bool and bytes through
  * {@code Data.ToPhi}, a string through the same after the bytes are read
  * as text, since that is what the runtime makes a string of, and a tuple
- * or an object as the {@code Phi} it already is. The method
+ * or an object as the {@code Phi} it already is. A step that is itself
+ * a call is no receiver, though: its value was dataized into the forma
+ * the tables witness, and the object that answered — the one owning the
+ * method the datum never had — is gone by then, so a call on it is
+ * refused and the fragment stays as written. The method
  * is taken of the receiver with {@code PhDispatch} and applied to the
  * arguments by position with {@code PhApplication}, the way the
  * transpiler spells a call, and the value is dataized into the forma the step
@@ -56,7 +60,7 @@ public final class Call {
         final List<String> keys = this.step.keys();
         String call = String.format(
             "new PhDispatch(%s, \"%s\")",
-            this.wrapped(keys.get(0)), this.step.atom().substring(1)
+            this.receiver(keys.get(0)), this.step.atom().substring(1)
         );
         if (keys.size() > 1) {
             final Collection<String> binds = new ArrayList<>(keys.size());
@@ -77,6 +81,30 @@ public final class Call {
             out = String.format("new Dataized(%s).take()", call);
         } else {
             out = call;
+        }
+        return out;
+    }
+
+    private String receiver(final String key) {
+        if (this.rebuilt(key)) {
+            throw new IllegalStateException(
+                String.join(
+                    " ",
+                    String.format("The receiver '%s' of '%s' is the", key, this.step.atom()),
+                    String.format("%s an earlier call was dataized into,", this.values.kind(key)),
+                    "and the object it answered with is gone"
+                )
+            );
+        }
+        return this.wrapped(key);
+    }
+
+    private boolean rebuilt(final String key) {
+        boolean out = false;
+        if (key.startsWith("sym:s")) {
+            final String kind = this.values.kind(key);
+            out = !"tuple".equals(kind) && !"object".equals(kind)
+                && this.values.step(key.substring(4)).atom().charAt(0) == '.';
         }
         return out;
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
@@ -113,31 +113,32 @@ final class CallTest {
 
     @Test
     void refusesReceiverRebuiltFromEarlierCall() {
-        final Step read = new Dispatch(
-            "s1", "read", Arrays.asList("sym:v0", "number:40-24-00-00-00-00-00-00"), "bytes"
-        );
-        final Step size = new Dispatch(
-            "s2", "size", Collections.singletonList("sym:s1"), "number"
-        );
         Assertions.assertThrows(
             IllegalStateException.class,
-            () -> CallTest.chained(read, size, Collections.singletonMap("i", "object")).text(),
+            () -> CallTest.chained(
+                new Dispatch(
+                    "s1", "read",
+                    Arrays.asList("sym:v0", "number:40-24-00-00-00-00-00-00"), "bytes"
+                ),
+                new Dispatch("s2", "size", Collections.singletonList("sym:s1"), "number"),
+                Collections.singletonMap("i", "object")
+            ).text(),
             "the bytes an earlier call was dataized into are no object to dispatch on, but they are"
         );
     }
 
     @Test
     void wrapsDatumOfOperationAsReceiver() {
-        final Step plus = new Application(
-            "s1", "L_number_plus",
-            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
-        );
-        final Step nan = new Dispatch(
-            "s2", "is-nan", Collections.singletonList("sym:s1"), "bool"
-        );
         MatcherAssert.assertThat(
             "the value of a Java operation is the whole of the number it is, but it was refused",
-            CallTest.chained(plus, nan, Collections.singletonMap("x", "number")).text(),
+            CallTest.chained(
+                new Application(
+                    "s1", "L_number_plus",
+                    Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+                ),
+                new Dispatch("s2", "is-nan", Collections.singletonList("sym:s1"), "bool"),
+                Collections.singletonMap("x", "number")
+            ).text(),
             Matchers.equalTo(
                 "new Dataized(new PhDispatch(new Data.ToPhi(s1), \"is-nan\")).asBool()"
             )
@@ -146,15 +147,13 @@ final class CallTest {
 
     @Test
     void holdsObjectOfEarlierCallAsReceiver() {
-        final Step head = new Dispatch(
-            "s1", "head", Collections.singletonList("sym:v0"), "object"
-        );
-        final Step next = new Dispatch(
-            "s2", "next", Collections.singletonList("sym:s1"), "object"
-        );
         MatcherAssert.assertThat(
             "an object an earlier call answered must stay the Phi it is, but it was rebuilt",
-            CallTest.chained(head, next, Collections.singletonMap("q", "tuple")).text(),
+            CallTest.chained(
+                new Dispatch("s1", "head", Collections.singletonList("sym:v0"), "object"),
+                new Dispatch("s2", "next", Collections.singletonList("sym:s1"), "object"),
+                Collections.singletonMap("q", "tuple")
+            ).text(),
             Matchers.equalTo("new PhDispatch(s1, \"next\")")
         );
     }

--- a/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
@@ -10,6 +10,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -106,6 +107,65 @@ final class CallTest {
             ),
             Matchers.endsWith(
                 ", new Bind(0, this.take(\"a\")), new Bind(1, this.take(\"b\")))"
+            )
+        );
+    }
+
+    @Test
+    void refusesReceiverRebuiltFromEarlierCall() {
+        final Step read = new Dispatch(
+            "s1", "read", Arrays.asList("sym:v0", "number:40-24-00-00-00-00-00-00"), "bytes"
+        );
+        final Step size = new Dispatch(
+            "s2", "size", Collections.singletonList("sym:s1"), "number"
+        );
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> CallTest.chained(read, size, Collections.singletonMap("i", "object")).text(),
+            "the bytes an earlier call was dataized into are no object to dispatch on, but they are"
+        );
+    }
+
+    @Test
+    void wrapsDatumOfOperationAsReceiver() {
+        final Step plus = new Application(
+            "s1", "L_number_plus",
+            Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+        );
+        final Step nan = new Dispatch(
+            "s2", "is-nan", Collections.singletonList("sym:s1"), "bool"
+        );
+        MatcherAssert.assertThat(
+            "the value of a Java operation is the whole of the number it is, but it was refused",
+            CallTest.chained(plus, nan, Collections.singletonMap("x", "number")).text(),
+            Matchers.equalTo(
+                "new Dataized(new PhDispatch(new Data.ToPhi(s1), \"is-nan\")).asBool()"
+            )
+        );
+    }
+
+    @Test
+    void holdsObjectOfEarlierCallAsReceiver() {
+        final Step head = new Dispatch(
+            "s1", "head", Collections.singletonList("sym:v0"), "object"
+        );
+        final Step next = new Dispatch(
+            "s2", "next", Collections.singletonList("sym:s1"), "object"
+        );
+        MatcherAssert.assertThat(
+            "an object an earlier call answered must stay the Phi it is, but it was rebuilt",
+            CallTest.chained(head, next, Collections.singletonMap("q", "tuple")).text(),
+            Matchers.equalTo("new PhDispatch(s1, \"next\")")
+        );
+    }
+
+    private static Call chained(final Step first, final Step second,
+        final Map<String, String> voids) {
+        return new Call(
+            second,
+            new Rendering(
+                new Protocol(Arrays.asList(first, second), "sym:s2", second.forma()),
+                voids
             )
         );
     }


### PR DESCRIPTION
A dispatch step used to build its receiver out of whatever Java local the operand settled into. For a void that is fixed already — the atom hands over the object it holds — but a step is still rebuilt with `new Data.ToPhi(...)`, and when that step is itself a call the rebuild is a lie. The call was dataized into the forma the inference tables witness, so what is left is bytes or a number, while the object that answered owned methods the datum never had. Dispatching on the rebuilt datum walks straight into the terminator.

The receiver is asked for separately from the arguments now. A void, a literal, and a step already carried as a `Phi` all pass through as before, since each of them really is the object EO would dispatch on. A step that is itself a call and was dataized into a datum has no object left, so the fragment is refused and stays as written rather than compiling into Java that cannot work. The value of a Java operation is still wrapped: a sum is the whole of the number it is, and nothing was lost when it was computed.

Three cases in `CallTest` pin this down — the refusal, the operation receiver that must keep wrapping, and the object receiver that must stay the `Phi` it is. Worth a follow-up: a fork whose arms answer objects is dataized into its forma the same way, and a call on that fork symbol has the same hole, but the fork is not what this issue names.

Closes #8473
