### PR TITLE
Fold the parts of a fragment phino refuses

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Folded.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Folded.java
@@ -7,8 +7,6 @@ package org.eolang.lowering;
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.w3c.dom.Document;
@@ -27,7 +25,9 @@ import org.w3c.dom.Element;
  * receiver dispatches into the standard library and nowhere else — so no
  * purity analysis is consulted. The walk is top-down and the outermost
  * qualifying fragment wins, since folding it folds everything inside
- * it.</p>
+ * it. A fragment phino refuses is not the end of the walk: the parts
+ * under it are tried in turn, so that an equality it declines to run
+ * still lets the sum beneath it fold.</p>
  *
  * <p>Folding is best-effort per fragment: whatever phino refuses — an
  * error-path expression, a method outside its tables, an exhausted
@@ -52,12 +52,16 @@ public final class Folded implements Rewrite {
 
     @Override
     public int rewrite(final Xnav doc) throws IOException {
-        final Collection<Xnav> found = new ArrayList<>(0);
-        Folded.selected(doc.element("object").element("o"), found);
+        return this.folded(doc.element("object").element("o"));
+    }
+
+    private int folded(final Xnav node) {
         int count = 0;
-        for (final Xnav node : found) {
-            if (this.spliced(node)) {
-                ++count;
+        if (Folded.foldable(node) && this.spliced(node)) {
+            count = 1;
+        } else {
+            for (final Xnav kid : Folded.kids(node)) {
+                count += this.folded(kid);
             }
         }
         return count;
@@ -122,16 +126,6 @@ public final class Folded implements Rewrite {
     private static void cleared(final Element element) {
         while (element.getFirstChild() != null) {
             element.removeChild(element.getFirstChild());
-        }
-    }
-
-    private static void selected(final Xnav node, final Collection<Xnav> out) {
-        if (Folded.foldable(node)) {
-            out.add(node);
-        } else {
-            for (final Xnav kid : Folded.kids(node)) {
-                Folded.selected(kid, out);
-            }
         }
     }
 

--- a/eo-lowering/src/test/java/org/eolang/lowering/FoldedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/FoldedTest.java
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
+import java.nio.file.Path;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+/**
+ * Test case for {@link Folded}.
+ * @since 0.76.0
+ */
+@ExtendWith(MktmpResolver.class)
+final class FoldedTest {
+
+    @Test
+    void foldsSumUnderRefusedEquality(@Mktmp final Path temp) throws Exception {
+        final Phino phino = new Phino("phino", 1000, temp);
+        Assumptions.assumeTrue(phino.suitable());
+        final Xnav doc = new Xnav(
+            String.join(
+                "",
+                "<object><o base='.eq'>",
+                "<o base='.plus'>",
+                "<o base='Φ.number'>",
+                "<o as='α0' base='Φ.bytes'><o as='α0'>3F-F0-00-00-00-00-00-00</o></o>",
+                "</o>",
+                "<o as='α0' base='Φ.number'>",
+                "<o as='α0' base='Φ.bytes'><o as='α0'>3F-F0-00-00-00-00-00-00</o></o>",
+                "</o>",
+                "</o>",
+                "<o as='α0' base='Φ.number'>",
+                "<o as='α0' base='Φ.bytes'><o as='α0'>40-08-00-00-00-00-00-00</o></o>",
+                "</o>",
+                "</o></object>"
+            )
+        );
+        new Folded(phino).rewrite(doc);
+        MatcherAssert.assertThat(
+            "the sum under an equality phino refuses must fold on its own, but it didnt",
+            doc.element("object").element("o").element("o").attribute("base").text().orElse(""),
+            Matchers.equalTo("Φ.number")
+        );
+    }
+}


### PR DESCRIPTION
The miscompile this issue reports is gone already: `L_number_eq` was renamed to `L_number_equal`, a name phino does not own, so a numeric equality parks instead of answering with its receiver. What that rename left behind is the other half of the story, and it is what this changes.

`Folded` walked the document top-down, collected the outermost qualifying fragment, and only afterwards tried to splice what it had collected. The collecting stopped at the fragment, so a fragment phino then refused took its whole subtree down with it. A numeric equality is exactly such a fragment now. `(1.plus 1).eq 2` — the body of `can-add-one-to-one`, one of the seven tests named in the issue — folded nothing at all: the `.eq` refused, and the sum underneath it was never offered to phino, though it is as constant as it ever was.

The walk now splices as it descends. A fragment that folds still wins over everything inside it, and a fragment that refuses is no longer the end of the walk: the parts beneath it are tried in turn. `1.plus 1` folds to two and the equality stays as written, which is what a refusal should cost.

`Folded` had no test file, so there is one now, pinning the descent through a refused equality.

Closes #8472
