### PR TITLE
Answer a call on a void from the arms of the call that landed there

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Branched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Branched.java
@@ -5,6 +5,7 @@
 package org.eolang.inference;
 
 import java.util.Collection;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 
@@ -19,13 +20,15 @@ import java.util.Map;
  * on that void is one of the two arguments, and which one is not known —
  * whichever it is, it is what they both are.</p>
  *
- * <p>Nothing is guessed, since a formation that binds a body of its own is
- * passed over: the call goes into it and what comes back is that body, which
- * is a question for whoever walks a delegation and not for this. A void does
- * go by a name of its own once one thing has been seen in it, though, so the
- * body that was {@code left} yesterday is a {@code Φ.dial} today and reads
- * like a body the formation binds. What the call put in says which it is: a
- * body that is one of the arguments is a void wearing the argument's name.</p>
+ * <p>Nothing is guessed, so one formation that binds a body of its own is the
+ * end of it: the call may be that one, what comes back is then that body, and
+ * a body is a question for whoever walks a delegation and not for this. Where
+ * a void holds a formation of each kind there is no agreement to join, and the
+ * call is left rooted at the void it was. A void does go by a name of its own
+ * once one thing has been seen in it, though, so the body that was
+ * {@code left} yesterday is a {@code Φ.dial} today and reads like a body the
+ * formation binds. What the call put in says which it is: a body that is one
+ * of the arguments is a void wearing the argument's name.</p>
  *
  * <p>An arm rooted at a void this call leaves empty is left out of the
  * agreement. Reading a void nobody filled terminates, so that arm never hands
@@ -78,15 +81,39 @@ final class Branched {
      */
     String names() {
         final Collection<String> handed = new LinkedHashSet<>(0);
-        for (final Map.Entry<String, String> bind : this.binds.entrySet()) {
-            final int dot = bind.getKey().lastIndexOf('.');
-            if (dot > 0
-                && this.hands(bind.getKey().substring(0, dot), bind)
-                && this.stands(bind.getValue())) {
-                handed.add(bind.getValue());
+        for (final Map.Entry<String, Map<String, String>> owner : this.owners().entrySet()) {
+            final Collection<String> given = this.given(owner.getKey(), owner.getValue());
+            if (given.isEmpty()) {
+                handed.clear();
+                break;
             }
+            given.removeIf(arm -> !this.stands(arm));
+            handed.addAll(given);
         }
         return new Joined(handed, this.owned).names();
+    }
+
+    private Map<String, Map<String, String>> owners() {
+        final Map<String, Map<String, String>> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, String> bind : this.binds.entrySet()) {
+            final int dot = bind.getKey().lastIndexOf('.');
+            if (dot > 0) {
+                found.computeIfAbsent(
+                    bind.getKey().substring(0, dot), key -> new LinkedHashMap<>(1)
+                ).put(bind.getKey(), bind.getValue());
+            }
+        }
+        return found;
+    }
+
+    private Collection<String> given(final String owner, final Map<String, String> arms) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        for (final Map.Entry<String, String> arm : arms.entrySet()) {
+            if (this.hands(owner, arm)) {
+                found.add(arm.getValue());
+            }
+        }
+        return found;
     }
 
     private boolean hands(final String owner, final Map.Entry<String, String> bind) {

--- a/eo-inference/src/main/java/org/eolang/inference/Copied.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Copied.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What every application fills of what it is a copy of, and of nothing else.
+ *
+ * <p>{@link Bound} reads the pair of an application to know which voids there
+ * are to fill. That is right for as long as the pair says what the application
+ * copies, and a call answered by a formation a void hands back has a pair that
+ * says something else: the {@code ^.if} of an {@code and} is a copy of the void
+ * {@code Φ.bool.if}, which declares no place for an argument, but its pair
+ * reads {@code Φ.bool} once {@link Branched} has had its say, and a
+ * {@code Φ.bool} does declare one.</p>
+ *
+ * <p>So the {@code FF-.eq x} of that {@code and} lands in the {@code if} of
+ * {@code Φ.bool} and stands there for every reader of that void in the
+ * program, which is a whole library told that a boolean chooses with a
+ * comparison (#8508). {@link Lent} says which calls those are, and what they
+ * put into the voids of their answer is dropped. What they put into the
+ * formations the void holds is kept, since that is where their arguments really
+ * went.</p>
+ *
+ * @since 0.71.0
+ */
+final class Copied {
+
+    /**
+     * What every application fills, from {@link Bound}.
+     */
+    private final Map<String, Map<String, String>> fills;
+
+    /**
+     * The pairs, each name against the one it is a copy of.
+     */
+    private final Map<String, String> pairs;
+
+    /**
+     * The calls that land on a void, from {@link Lent}.
+     */
+    private final Collection<String> lent;
+
+    /**
+     * Ctor.
+     *
+     * @param bound What every application fills, from {@link Bound}
+     * @param links The pairs, each name against the one it is a copy of
+     * @param sites The calls that land on a void, from {@link Lent}
+     */
+    Copied(
+        final Map<String, Map<String, String>> bound,
+        final Map<String, String> links,
+        final Collection<String> sites
+    ) {
+        this.fills = bound;
+        this.pairs = links;
+        this.lent = sites;
+    }
+
+    /**
+     * What every application fills, by the locator of the application.
+     *
+     * @return The objects the voids hold, by the locator of the void, without
+     *  the voids of an answer the call was handed rather than copied
+     */
+    Map<String, Map<String, String>> all() {
+        final Map<String, Map<String, String>> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, Map<String, String>> call : this.fills.entrySet()) {
+            found.put(call.getKey(), this.kept(call.getKey(), call.getValue()));
+        }
+        return found;
+    }
+
+    private Map<String, String> kept(final String call, final Map<String, String> filled) {
+        final Map<String, String> found;
+        if (this.lent.contains(call)) {
+            final String answer = new Ends(this.pairs).name(call).concat(".");
+            found = new LinkedHashMap<>(filled);
+            found.keySet().removeIf(hollow -> hollow.startsWith(answer));
+        } else {
+            found = filled;
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -99,25 +99,47 @@ final class Dispatched {
     Map<String, String> answers(final Map<String, String> pairs) {
         final Map<String, String> names = new Ends(pairs).names();
         final Provided owned = new Provided(this.given, names, this.hollows);
+        final Map<String, Map<String, String>> bound = new Copied(
+            new Bound(this.args, this.named, this.receivers, pairs, owned).all(),
+            pairs,
+            new Lent(owned, this.all, this.args, this.hollows).sites(names)
+        ).all();
         final Filled filled = new Filled(
             pairs,
             owned,
-            new Bound(this.args, this.named, this.receivers, pairs, owned).all(),
+            new Puts(bound, new Holders(bound, pairs).all()),
             this.hollows
         );
         final Map<String, String> found = new HashMap<>(0);
         for (final Site dispatch : this.all) {
             final String made = dispatch.made();
-            if (!pairs.containsKey(made)) {
+            final String known = pairs.getOrDefault(made, "");
+            if (known.isEmpty() || this.rooted(known)) {
                 final String bearer = dispatch.bearer();
                 final String kept = filled.instead(
                     owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name()),
-                    bearer
+                    bearer,
+                    made
                 );
-                if (!kept.isEmpty() && !kept.equals(made)) {
+                if (this.better(kept, known, made)) {
                     found.put(made, kept);
                 }
             }
+        }
+        return found;
+    }
+
+    private boolean rooted(final String type) {
+        return !this.hollows.isEmpty() && new Rooted(this.hollows).covers(type);
+    }
+
+    private boolean better(final String kept, final String known, final String made) {
+        final boolean found;
+        if (kept.isEmpty() || kept.equals(made) || kept.equals(known)) {
+            found = false;
+        } else {
+            found = known.isEmpty() || !this.rooted(kept)
+                || known.startsWith(kept.concat("."));
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -5,9 +5,9 @@
 package org.eolang.inference;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Map;
 
 /**
@@ -36,17 +36,30 @@ import java.util.Map;
  *
  * <p>An answer rooted at a void nothing here fills is not the end of it
  * either. The void may hold a formation that hands back what it is given, in
- * which case the answer is one of the things this call put in, and
- * {@link Branched} says which.</p>
+ * which case the answer is one of the things a call put in, and
+ * {@link Branched} says which. Which call is the question, since the chain a
+ * receiver resolves through reaches other applications of the same object and
+ * their arguments went into their own copies of the void. So the call asked is
+ * the one that landed here — the one that filled a void of a formation this
+ * void holds — and a reader further along the chain learns what that call was
+ * handed (#8508).</p>
+ *
+ * <p>Only the arms of those formations are counted. An argument is relayed to
+ * every formation the void might hold, because which one it turns out to be is
+ * not known where the argument is written, and a single stray relay among the
+ * arms is enough to make {@link Branched} give up on all of them: the
+ * {@code if} of an {@code abs} puts its {@code 0.plus value} into the two
+ * choices of a boolean and into the {@code b} of {@code Φ.bytes.eq} as
+ * well.</p>
  *
  * @since 0.69.0
  */
 final class Filled {
 
     /**
-     * What every application fills, from {@link Bound}.
+     * What the calls of the program put into its voids.
      */
-    private final Map<String, Map<String, String>> fills;
+    private final Puts puts;
 
     /**
      * The pairs, each name against the one it is a copy of.
@@ -68,17 +81,16 @@ final class Filled {
      *
      * @param links The pairs, each name against the one it is a copy of
      * @param provided The provides table, by the name a type goes by
-     * @param bound What every application and every dispatch fills, from
-     *  {@link Bound}
+     * @param bound What the calls of the program put into its voids
      * @param voids The locator of every void, from {@link Hollows}
      */
     Filled(
         final Map<String, String> links,
         final Provided provided,
-        final Map<String, Map<String, String>> bound,
+        final Puts bound,
         final Collection<String> voids
     ) {
-        this.fills = bound;
+        this.puts = bound;
         this.pairs = links;
         this.owned = provided;
         this.hollows = voids;
@@ -89,15 +101,17 @@ final class Filled {
      *
      * @param answer The type of the attribute, as the table gave it
      * @param bearer The locator of the receiver the question was asked of
+     * @param site The locator of the call the question is asked at
      * @return The type the answer stands for here, or the answer itself when
      *  no caller says what the void holds
      */
-    String instead(final String answer, final String bearer) {
-        return this.instead(answer, bearer, new HashSet<>(0));
+    String instead(final String answer, final String bearer, final String site) {
+        return this.instead(answer, bearer, site, new HashSet<>(0));
     }
 
     private String instead(
-        final String answer, final String bearer, final Collection<String> seen
+        final String answer, final String bearer, final String site,
+        final Collection<String> seen
     ) {
         final Map<String, String> fillings = this.fillings(bearer);
         final String found;
@@ -112,7 +126,7 @@ final class Filled {
                 }
             }
             if (longest.isEmpty()) {
-                found = this.branch(answer, fillings, seen);
+                found = this.branch(answer, fillings, bearer, site, seen);
             } else {
                 found = this.asked(
                     fillings.get(longest), answer.substring(longest.length() + 1), answer
@@ -123,28 +137,88 @@ final class Filled {
     }
 
     private String branch(
-        final String answer, final Map<String, String> fillings, final Collection<String> seen
+        final String answer, final Map<String, String> fillings, final String bearer,
+        final String site, final Collection<String> seen
     ) {
         final String root = new Rooted(this.hollows).names(answer);
         String found = answer;
         if (!root.isEmpty()) {
-            final String handed = new Branched(this.owned, fillings, this.hollows).names();
+            final String handed = this.handed(root, fillings, bearer, site);
             if (!handed.isEmpty() && seen.add(handed)) {
-                found = this.through(answer, root, handed, seen);
+                found = this.through(answer, root, handed, site, seen);
+            }
+        }
+        return found;
+    }
+
+    private String handed(
+        final String root, final Map<String, String> fillings, final String bearer,
+        final String site
+    ) {
+        String found = "";
+        for (final String call : this.calls(bearer, site)) {
+            final Map<String, String> arms = this.armed(this.arms(call), root);
+            if (!arms.isEmpty()) {
+                found = new Branched(this.owned, arms, this.hollows).names();
+                if (!found.isEmpty()) {
+                    break;
+                }
+            }
+        }
+        if (found.isEmpty()) {
+            found = new Branched(
+                this.owned, this.armed(fillings, root), this.hollows
+            ).names();
+        }
+        return found;
+    }
+
+    private Map<String, String> armed(final Map<String, String> arms, final String root) {
+        final Collection<String> holders = this.puts.holders(root);
+        final Map<String, String> found = new HashMap<>(0);
+        for (final Map.Entry<String, String> arm : arms.entrySet()) {
+            final int dot = arm.getKey().lastIndexOf('.');
+            if (dot > 0 && holders.contains(arm.getKey().substring(0, dot))) {
+                found.put(arm.getKey(), arm.getValue());
+            }
+        }
+        return found;
+    }
+
+    private Collection<String> calls(final String bearer, final String site) {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        found.add(site);
+        final Collection<String> seen = new HashSet<>(0);
+        String walked = bearer;
+        while (!walked.isEmpty() && seen.add(walked)) {
+            found.add(walked);
+            if (this.pairs.containsKey(walked)) {
+                walked = this.pairs.get(walked);
+            } else {
+                walked = this.owned.body(walked);
             }
         }
         return found;
     }
 
     private String through(
-        final String answer, final String root, final String handed,
+        final String answer, final String root, final String handed, final String site,
         final Collection<String> seen
     ) {
         String found = this.asked(
             handed, answer.substring(Math.min(root.length() + 1, answer.length())), answer
         );
         if (found.equals(answer)) {
-            found = this.instead(answer, handed, seen);
+            found = this.instead(answer, handed, site, seen);
+        }
+        return found;
+    }
+
+    private Map<String, String> arms(final String site) {
+        final Map<String, String> found = new HashMap<>(0);
+        for (final Map.Entry<String, String> fill
+            : this.puts.at(site).entrySet()) {
+            found.put(fill.getKey(), new Ends(this.pairs).name(fill.getValue()));
         }
         return found;
     }
@@ -177,7 +251,7 @@ final class Filled {
         String walked = type;
         while (!walked.isEmpty() && seen.add(walked)) {
             for (final Map.Entry<String, String> fill
-                : this.fills.getOrDefault(walked, Collections.emptyMap()).entrySet()) {
+                : this.puts.at(walked).entrySet()) {
                 found.putIfAbsent(fill.getKey(), new Ends(this.pairs).name(fill.getValue()));
             }
             if (this.pairs.containsKey(walked)) {

--- a/eo-inference/src/main/java/org/eolang/inference/Holders.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Holders.java
@@ -1,0 +1,69 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Which objects each void of a program turns out to hold.
+ *
+ * <p>A void is filled by a caller, and a void of a library object is filled by
+ * every caller there is: the {@code if} of {@code Φ.bool} holds the formation
+ * that hands back its left arm, from {@code Φ.true}, and the one that hands
+ * back its right arm, from {@code Φ.false}. Both of them, since a question
+ * about a boolean is answered by whichever of the two the boolean turns out to
+ * be.</p>
+ *
+ * <p>{@link Bound} says what each call filled, keyed by the call. This says the
+ * same thing keyed by the void, which is what a reader of the void wants to
+ * know and would otherwise have to look for through every call of the
+ * program.</p>
+ *
+ * @since 0.71.0
+ */
+final class Holders {
+
+    /**
+     * What every application fills, from {@link Bound}.
+     */
+    private final Map<String, Map<String, String>> fills;
+
+    /**
+     * The pairs, each name against the one it is a copy of.
+     */
+    private final Map<String, String> pairs;
+
+    /**
+     * Ctor.
+     *
+     * @param bound What every application fills, from {@link Bound}
+     * @param links The pairs, each name against the one it is a copy of
+     */
+    Holders(final Map<String, Map<String, String>> bound, final Map<String, String> links) {
+        this.fills = bound;
+        this.pairs = links;
+    }
+
+    /**
+     * What every void holds, by the locator of the void.
+     *
+     * @return The objects put into a void by any call, by the locator of the
+     *  void, each object under the name it ends up going by
+     */
+    Map<String, Collection<String>> all() {
+        final Map<String, Collection<String>> found = new HashMap<>(0);
+        final Ends ends = new Ends(this.pairs);
+        for (final Map<String, String> filled : this.fills.values()) {
+            for (final Map.Entry<String, String> fill : filled.entrySet()) {
+                found.computeIfAbsent(fill.getKey(), hollow -> new HashSet<>(0))
+                    .add(ends.name(fill.getValue()));
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Lent.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Lent.java
@@ -1,0 +1,116 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The calls whose answer is lent to them rather than copied by them.
+ *
+ * <p>A dispatch is a copy of the attribute it takes, and a pair says so. Not
+ * every dispatch, though: one that lands on a void is a copy of that void, and
+ * what it turns out to be is whatever the callers put there. Where they all put
+ * a formation that hands an argument back, {@link Branched} says the call is
+ * one of its own arguments, and the pair is written with that name — the
+ * {@code ^.if} of an {@code and} comes out a {@code Φ.bool} because both the
+ * {@code Φ.true} and the {@code Φ.false} that {@code Φ.bool.if} may hold answer
+ * with one of the two things given to them.</p>
+ *
+ * <p>The call is still a copy of the void, and of nothing else. One pair cannot
+ * say both, so the second fact is asked for here instead, of two halves: the
+ * attribute the dispatch takes is looked up again, and a call that lands on a
+ * void is a candidate whatever its pair has since been refined to; and its pair
+ * is compared with the one thing its own arguments all are, since that is the
+ * only name an arm can hand back. Nothing is remembered from pass to pass —
+ * both halves are asked of the tables as they stand, and neither of them is
+ * what the refinement wrote (#8508).</p>
+ *
+ * @since 0.71.0
+ */
+final class Lent {
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * Every dispatch of the program.
+     */
+    private final Collection<Site> all;
+
+    /**
+     * The arguments of every application, from {@link Given}.
+     */
+    private final Map<String, List<String>> args;
+
+    /**
+     * The locator of every void.
+     */
+    private final Collection<String> hollows;
+
+    /**
+     * Ctor.
+     *
+     * @param provided What the types certainly have
+     * @param dispatches Every dispatch of the program
+     * @param arguments The arguments of every application, from {@link Given}
+     * @param voids The locator of every void, from {@link Hollows}
+     */
+    Lent(
+        final Provided provided,
+        final Collection<Site> dispatches,
+        final Map<String, List<String>> arguments,
+        final Collection<String> voids
+    ) {
+        this.owned = provided;
+        this.all = dispatches;
+        this.args = arguments;
+        this.hollows = voids;
+    }
+
+    /**
+     * The calls whose answer is one of their own arguments.
+     *
+     * @param names The name every locator goes by, from {@link Ends}
+     * @return The locator of every dispatch that lands on a void and comes
+     *  back as what it was given, empty when this pass looks into no void
+     */
+    Collection<String> sites(final Map<String, String> names) {
+        final Collection<String> found = new HashSet<>(0);
+        for (final Site dispatch : this.all) {
+            final String made = dispatch.made();
+            final String bearer = dispatch.bearer();
+            final String given = this.joined(made, names);
+            if (!given.isEmpty()
+                && given.equals(names.getOrDefault(made, made))
+                && new Rooted(this.hollows).covers(
+                    this.owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name())
+                )) {
+                found.add(made);
+            }
+        }
+        return found;
+    }
+
+    private String joined(final String call, final Map<String, String> names) {
+        final Collection<String> arms = new LinkedHashSet<>(0);
+        for (final String arm : this.args.getOrDefault(call, Collections.emptyList())) {
+            if (!arm.isEmpty()) {
+                arms.add(names.getOrDefault(arm, arm));
+            }
+        }
+        String found = "";
+        if (!arms.isEmpty()) {
+            found = new Joined(arms, this.owned).names();
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Puts.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Puts.java
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * What the calls of a program put into its voids, from both sides.
+ *
+ * <p>The same facts are wanted two ways. What a call is a copy of is answered
+ * by what that one call filled, and what a void holds is answered by what every
+ * call filled. So both sides are kept here, the second worked out once by
+ * {@link Holders} rather than looked for again at every question.</p>
+ *
+ * @since 0.71.0
+ */
+final class Puts {
+
+    /**
+     * What every application fills, from {@link Bound}.
+     */
+    private final Map<String, Map<String, String>> fills;
+
+    /**
+     * What every void holds, from {@link Holders}.
+     */
+    private final Map<String, Collection<String>> holds;
+
+    /**
+     * Ctor.
+     *
+     * @param bound What every application fills, from {@link Bound}
+     * @param holders What every void holds, from {@link Holders}
+     */
+    Puts(
+        final Map<String, Map<String, String>> bound,
+        final Map<String, Collection<String>> holders
+    ) {
+        this.fills = bound;
+        this.holds = holders;
+    }
+
+    /**
+     * What this call fills.
+     *
+     * @param call The locator of the application
+     * @return The objects the voids hold, by the locator of the void, empty
+     *  when this call fills nothing
+     */
+    Map<String, String> at(final String call) {
+        return this.fills.getOrDefault(call, Collections.emptyMap());
+    }
+
+    /**
+     * What this void holds.
+     *
+     * @param hollow The locator of the void
+     * @return The objects any call put into it, empty when nobody fills it
+     */
+    Collection<String> holders(final String hollow) {
+        return this.holds.getOrDefault(hollow, Collections.emptySet());
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -90,7 +90,7 @@ public final class Resolved implements Clue {
         final Map<String, String> receivers = new Taken(world, written).all();
         final List<String> voids = given.xpath("//attr[@void='true']/@type");
         final Map<String, Type> kept = written.others();
-        final Woven woven = new Woven(given, applied, receivers, voids);
+        final Woven woven = new Woven(given, applied, receivers, voids, dispatches);
         final Promoted promoted = new Promoted(woven, given, kept, voids);
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, dispatches, args, named, receivers, voids), promoted

--- a/eo-inference/src/main/java/org/eolang/inference/Woven.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Woven.java
@@ -15,8 +15,9 @@ import java.util.Map;
  * halves of one row, and putting the halves together takes the provides table,
  * every application of the program and the pairs themselves. {@link Refs} joins
  * them, {@link Bound} works out what went where and {@link Provided} says which
- * voids there were to fill; this is the four of them wired up, so that whoever
- * has pairs and wants rows says so in one line.</p>
+ * voids there were to fill and {@link Copied} drops what a call was handed
+ * rather than copied; this is the five of them wired up, so that whoever has
+ * pairs and wants rows says so in one line.</p>
  *
  * <p>Rows are asked for twice over. Once at the end, for the table the build
  * writes down, and once for every provisional table a fact is read off before
@@ -50,23 +51,31 @@ final class Woven {
     private final Collection<String> hollows;
 
     /**
+     * Every dispatch of the program.
+     */
+    private final Collection<Site> all;
+
+    /**
      * Ctor.
      *
      * @param provides The provides table, as {@link Provides} wrote it
      * @param applications What every application of the program gives
      * @param taken What every dispatch takes its attribute from
      * @param voids The locator of every void
+     * @param dispatches Every dispatch of the program
      */
     Woven(
         final XML provides,
         final Given applications,
         final Map<String, String> taken,
-        final Collection<String> voids
+        final Collection<String> voids,
+        final Collection<Site> dispatches
     ) {
         this.given = provides;
         this.applied = applications;
         this.receivers = taken;
         this.hollows = voids;
+        this.all = dispatches;
     }
 
     /**
@@ -77,14 +86,20 @@ final class Woven {
      *  order the pairs came in
      */
     Map<String, Type> rows(final Map<String, String> pairs) {
+        final Map<String, String> names = new Ends(pairs).names();
+        final Provided owned = new Provided(this.given, names, this.hollows);
         return new Refs(
             pairs,
-            new Bound(
-                this.applied.arguments(),
-                this.applied.named(),
-                this.receivers,
+            new Copied(
+                new Bound(
+                    this.applied.arguments(),
+                    this.applied.named(),
+                    this.receivers,
+                    pairs,
+                    owned
+                ).all(),
                 pairs,
-                new Provided(this.given, new Ends(pairs).names(), this.hollows)
+                new Lent(owned, this.all, this.applied.arguments(), this.hollows).sites(names)
             ).all()
         ).all();
     }

--- a/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/FilledTest.java
@@ -33,18 +33,19 @@ final class FilledTest {
         final Provided owned = new Provided(
             rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
         );
+        final Map<String, String> pairs = Map.of("app", "form");
+        final Map<String, Map<String, String>> bound = new Bound(
+            Map.of("app", List.of("value-x", "value-foo")),
+            Collections.emptyMap(), Collections.emptyMap(), pairs, owned
+        ).all();
         MatcherAssert.assertThat(
             "an exact fill of the whole answer must win over a fill of one of its prefixes",
             new Filled(
-                Map.of("app", "form"),
+                pairs,
                 owned,
-                new Bound(
-                    Map.of("app", List.of("value-x", "value-foo")),
-                    Collections.emptyMap(), Collections.emptyMap(),
-                    Map.of("app", "form"), owned
-                ).all(),
+                new Puts(bound, new Holders(bound, pairs).all()),
                 Collections.emptyList()
-            ).instead("Φ.node.x", "app"),
+            ).instead("Φ.node.x", "app", "app"),
             Matchers.equalTo("value-x")
         );
     }
@@ -63,18 +64,19 @@ final class FilledTest {
         final Provided owned = new Provided(
             rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
         );
+        final Map<String, String> pairs = Map.of("app", "form");
+        final Map<String, Map<String, String>> bound = new Bound(
+            Map.of("app", List.of("short-fill", "long-fill")),
+            Collections.emptyMap(), Collections.emptyMap(), pairs, owned
+        ).all();
         MatcherAssert.assertThat(
             "the more specific (longer) filled prefix must win, not whichever the map yields first",
             new Filled(
-                Map.of("app", "form"),
+                pairs,
                 owned,
-                new Bound(
-                    Map.of("app", List.of("short-fill", "long-fill")),
-                    Collections.emptyMap(), Collections.emptyMap(),
-                    Map.of("app", "form"), owned
-                ).all(),
+                new Puts(bound, new Holders(bound, pairs).all()),
                 Collections.emptyList()
-            ).instead("Φ.node.x.y", "app"),
+            ).instead("Φ.node.x.y", "app", "app"),
             Matchers.equalTo("Φ.result")
         );
     }
@@ -90,18 +92,18 @@ final class FilledTest {
         final Provided owned = new Provided(
             rows, Collections.emptyMap(), Collections.emptyList(), Collections.emptyMap()
         );
+        final Map<String, Map<String, String>> bound = new Bound(
+            Map.of("app", List.of("zebra")),
+            Collections.emptyMap(), Collections.emptyMap(), pairs, owned
+        ).all();
         MatcherAssert.assertThat(
             "a filling that sits on a ring must come back under the name the ring goes by, but it didnt",
             new Filled(
                 pairs,
                 owned,
-                new Bound(
-                    Map.of("app", List.of("zebra")),
-                    Collections.emptyMap(), Collections.emptyMap(),
-                    pairs, owned
-                ).all(),
+                new Puts(bound, new Holders(bound, pairs).all()),
                 Collections.emptyList()
-            ).instead("Φ.node.x", "app"),
+            ).instead("Φ.node.x", "app", "app"),
             Matchers.equalTo("alpha")
         );
     }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-filled-two-ways-answers-what-both-branches-hand-back.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-call-on-a-void-filled-two-ways-answers-what-both-branches-hand-back.yaml
@@ -45,5 +45,5 @@ eo:
         05-
 links:
   - "/links/type[@id='Φ.sock.flag']/var"
-  - "/links/type[@id='Φ.sock.φ']/ref[@loc='Φ.choice.pick']"
+  - "/links/type[@id='Φ.sock.φ']/ref[@loc='Φ.sock.impl']"
   - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.sock.impl.listen']"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-choice-whose-arms-agree-only-once-reduced-answers-with-that-name.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-choice-whose-arms-agree-only-once-reduced-answers-with-that-name.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A call on a void answers what its fillings hand back, and both arms of a
+# choice hand back an argument of the call, so the call is one of its own
+# arguments and it does not matter which — as long as the two arguments say
+# the same thing. They seldom say it outright. The `and` of a `bool` picks
+# between what `FF-.eq x` comes back with and a `false`, which are two names
+# until each is reduced to the one thing it stands for, and only then do the
+# arms agree that the answer is a `Φ.bool`. So the reduced name has to be in
+# the tables the passes read again, not painted on at the end for the page.
+# The arms counted are the ones the choices themselves were given: the same
+# argument is relayed to every formation that could take it, and a relay that
+# lands anywhere else is enough to make the arms look as though they
+# disagree.
+eo:
+  bool.eo: |
+    [if] > bool
+      if > @
+        FF-
+        00-
+      ^.if > [^ x] > and
+        FF-.eq x
+        false
+  true.eo: |
+    [^] > true
+      bool > @
+        [^]
+          ? >> left
+          ? >> right
+          left > @
+  false.eo: |
+    [^] > false
+      bool > @
+        [^]
+          ? >> left
+          ? >> right
+          right > @
+  bytes.eo: |
+    [@] > bytes
+      [] > eq /Q.bool
+        ? > ^
+        ? > b
+provides:
+  - "/provides/type[@id='Φ.bytes.eq' and @reduced='Φ.bool']"
+  - "/provides/type[@id='Φ.false' and @reduced='Φ.bool']"
+  - "/provides/type[@id='Φ.bool.and' and @reduced='Φ.bool']"
+links:
+  - "/links/type[@id='Φ.bool.and.φ']/ref[@loc='Φ.bool']"


### PR DESCRIPTION
Closes #8508.

`bool.and` now answers `Φ.bool`, and the ticket's guess about why it did not
was wrong: the reduced name reached `Branched` all along. `Φ.bytes.eq` gets to
`Φ.bool` through its `returns` cell and `Φ.false` through its `φ`, and both are
things `Provided.behind` already reads. What went wrong is that `Branched` was
asked the wrong question. A call rooted at a void whose fillings hand back
their arguments is one of its own arguments — but the arms it was shown were a
merge of everything the receiver's whole chain had filled, and that chain
reaches other applications of the same object, whose arguments went into their
own copies of the void.

So the call that landed on the void is looked for through the formations the
void holds, and only the binds those formations own are counted:

```java
for (final String call : this.calls(bearer, site)) {
    final Map<String, String> arms = this.armed(this.arms(call), root);
    if (!arms.isEmpty()) {
        found = new Branched(this.owned, arms, this.hollows).names();
```

That second half matters as much as the first. An argument is relayed to every
formation that could take it, since which one it will be is not known where the
argument is written, and one stray relay among the arms was enough to make
`Branched` abstain: the `if` of an `abs` puts its `0.plus value` into the two
choices of a boolean and into the `b` of `Φ.bytes.eq` as well.

`Lent` and `Copied` stop the other half of the problem. Once `Φ.bool.and.φ`
answers `Φ.bool`, `Bound` read that row back as what the call *copies* and put
the call's own first argument into the vacant `if` of `Φ.bool`, where every
later reader of that void found it — a hundred bindings in the library table
instead of two. `Holders` and `Puts` work out what each void holds once a pass
rather than at every question, which keeps `eo-runtime` at two minutes.

Across `eo-runtime` the reduced types go from 1265 to 1371 with nothing lost.
`Φ.bool.and`, `Φ.bool.or`, `Φ.number.abs`, `Φ.number.as-char` and
`Φ.chunk.put` now answer with the one thing they are, and around twenty test
objects follow them.

The pack for #8508 is new. One existing pack changed its expectation:
`a-call-on-a-void-filled-two-ways...` asserted that `Φ.sock.φ` comes back as
`Φ.choice.pick`, the void itself, where both of its arms are copies of
`Φ.sock.impl` — which is what its own comment describes and what it now says.

One thing this does not fix, and I will file it separately: a dispatch with
arguments and its application share a locator, so a single links row has to
answer both what the call comes back as and whose voids its arguments fill.
`Lent` and `Copied` work around that rather than removing it.
