### PR TITLE
#8492: say that a reversed dispatch emits no @method

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -29,8 +29,12 @@ import java.util.List;
  * at close time if no receiver appeared.</li>
  * </ul>
  *
- * <p>Emission: opens {@code <o base='.<name>' method=''>} at the
- * current cursor and stays inside. For horizontal form, the receiver
+ * <p>Emission: opens {@code <o base='.<name>'>} at the current
+ * cursor and stays inside, with no {@code @method}. That attribute is
+ * what marks an {@code <o>} as a link inside a dispatch chain, and a
+ * reversed dispatch opens a chain rather than continuing one; with
+ * {@code ?.} it carries {@code @fragile=''} and still no
+ * {@code @method} (§9.4). For horizontal form, the receiver
  * and method args are appended as children before the cursor closes.
  * For vertical form, deeper-indent lines (dispatched through
  * {@link LnApplication} etc.) attach as children automatically.</p>


### PR DESCRIPTION
Closes #8492.

The class docblock said the line opens `<o base='.<name>' method=''>`. It does not, and must not.

Three things already agree with each other, and only the docblock disagreed:

- `LnReversed.emit` opens the element through `Emit.object`, which writes `@name`, `@base`, `@line` and `@pos` and nothing else;
- `LnReversedTest.emitsBaseWithLeadingDotAndNoMethodAttribute` asserts the absence outright, with `/object/o[@name='x' and @base='.if' and not(@method)]`;
- §9.4 of `PARSER_SPEC.md` is explicit: "a method link keeps `@method=''` and gains `@fragile=''`; a reversed dispatch carries `@fragile=''` without `@method`".

The paragraph now says what is emitted, and why the difference is load-bearing rather than cosmetic: `@method` is what marks an `<o>` as a link inside a dispatch chain, and a reversed dispatch opens a chain rather than continuing one. R-3.5.3b leans on exactly that difference when it looks for "a method dispatch (`@method`, no `@fragile`) whose immediately-preceding sibling is a childless fragile link".

Comment-only change; no behaviour is touched. `qulice` is green on a fork before opening this.