### PR TITLE
fix(#8548): read the symbol table of a morph into a protocol

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Table.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Table.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * The symbol table one morph of a fragment leaves, as a protocol.
+ *
+ * <p>The atom writes one row per value the fragment computes: the symbol
+ * it mints, the forma that symbol carries, the λ of the atom that minted
+ * it, and the operands it read, each of them either {@code sym:} and the
+ * symbol of an earlier row or {@code hex:} and the bytes of a literal. A
+ * row minted by {@code void} stands for a void of the fragment instead,
+ * and such rows come in the order the voids are declared; every other row
+ * is one {@link Application} labelled after its symbol, whose literal
+ * operands take the formas the {@link Op} row of its atom declares, since
+ * a row names the forma of its own value alone. The last row is the
+ * answer, since the outermost atom fires last.</p>
+ *
+ * @since 0.76.0
+ * @todo #8548:30min Read the rows of a choice and of a repeat, which are
+ *  the {@link Fork} and the {@link Repeat} this module renders already,
+ *  and write the registry naming the λ functions together with the atom
+ *  that mints these rows, since until they land nothing calls this class.
+ */
+public final class Table {
+
+    /**
+     * The rows, tab-separated, in the order they were recorded.
+     */
+    private final List<String> rows;
+
+    /**
+     * Ctor.
+     *
+     * @param records The rows, tab-separated, in the order recorded
+     */
+    public Table(final List<String> records) {
+        this.rows = records;
+    }
+
+    /**
+     * The protocol the table spells.
+     *
+     * @return The steps in their order, the key of the answer, and the
+     *  forma that answer carries
+     */
+    public Protocol protocol() {
+        final Map<String, String> keys = new HashMap<>(0);
+        final List<Step> steps = new ArrayList<>(0);
+        String answer = "";
+        String forma = "";
+        int voids = 0;
+        for (final String row : this.rows) {
+            final String[] cells = row.split("\t");
+            if ("void".equals(cells[2])) {
+                answer = String.format("sym:v%d", voids);
+                voids += 1;
+            } else {
+                final String label = cells[0].toLowerCase(Locale.ENGLISH);
+                answer = String.format("sym:%s", label);
+                steps.add(new Application(label, cells[2], Table.operands(cells, keys)));
+            }
+            keys.put(cells[0], answer);
+            forma = cells[1];
+        }
+        return new Protocol(steps, answer, forma);
+    }
+
+    private static List<String> operands(final String[] cells, final Map<String, String> keys) {
+        final Op operation = new Op(cells[2]);
+        final List<String> formas = new ArrayList<>(cells.length);
+        formas.add(operation.carrier());
+        formas.addAll(operation.formas());
+        final List<String> out = new ArrayList<>(cells.length - 3);
+        for (int idx = 3; idx < cells.length; ++idx) {
+            final String[] parts = cells[idx].split(":", 2);
+            if ("sym".equals(parts[0])) {
+                if (!keys.containsKey(parts[1])) {
+                    throw new IllegalStateException(
+                        String.format(
+                            "The table reads the symbol '%s' before any row mints it", parts[1]
+                        )
+                    );
+                }
+                out.add(keys.get(parts[1]));
+            } else {
+                out.add(String.format("%s:%s", formas.get(idx - 3), parts[1]));
+            }
+        }
+        return out;
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/TableTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/TableTest.java
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Table}.
+ *
+ * <p>The tables here are written by hand, so the tests need no phino:
+ * they pin the Java that the rows of one morph turn into, which is what
+ * lands in the {@code lambda()} of a generated atom class.</p>
+ *
+ * @since 0.76.0
+ */
+final class TableTest {
+
+    @Test
+    void rendersSquaredDistanceFromItsRows() {
+        final Map<String, String> voids = new LinkedHashMap<>(0);
+        voids.put("α", "number");
+        voids.put("β", "number");
+        MatcherAssert.assertThat(
+            "the rows of a squared distance are not the Java of its atom",
+            new JavaAtom(
+                new Table(
+                    Arrays.asList(
+                        "S1\tnumber\tvoid\tα",
+                        "S2\tnumber\tvoid\tβ",
+                        "S3\tnumber\tL_number_times\tsym:S2\thex:BF-F0-00-00-00-00-00-00",
+                        "S4\tnumber\tL_number_plus\tsym:S1\tsym:S3",
+                        "S7\tnumber\tL_number_times\tsym:S4\tsym:S4"
+                    )
+                ).protocol(),
+                voids
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "final double v0 = new Dataized(this.take(\"α\")).asNumber();",
+                "final double s3 = v1 * Double.longBitsToDouble(0xBFF0000000000000L);",
+                "final double s4 = v0 + s3;",
+                "return new Data.ToPhi(s7);"
+            )
+        );
+    }
+
+    @Test
+    void refusesTheSymbolNoRowMints() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            new Table(
+                Collections.singletonList("S2\tnumber\tL_number_plus\tsym:S1\tsym:S1")
+            )::protocol,
+            "a row reading a symbol nothing minted is not refused"
+        );
+    }
+}


### PR DESCRIPTION
The proposal rebuilds the engine around a single morph under an `--atoms` registry, and one piece of that pipeline needs no phino bump to land: the symbol table the atom writes has to become a `Protocol` before any of it can be rendered as Java. This adds `Table`, which reads those rows — the symbol minted, the forma it carries, the λ that minted it, and the operands it read — and answers the protocol they spell. Voids take their keys in declaration order, and a literal operand takes the forma the `Op` row of its atom declares for that position, since a row names the forma of its own value alone.

The test drives it the whole way down: the rows of the squared distance from the issue go through `Table` into `JavaAtom` and come out as the statements the issue shows, one multiplication by minus one, one addition, one squaring and the return.

Nothing calls `Table` from production yet, and it reads straight-line rows alone. The rows of a choice and of a repeat, which `Fork` and `Repeat` already render, and the registry naming the λ functions together with the atom that mints these rows, are left as a puzzle on the class.

Closes #8548
