### PR TITLE
Settle the voids without the XML in the middle

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Behaved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Behaved.java
@@ -95,7 +95,7 @@ final class Behaved {
         final Map<String, Collection<Map<String, String>>> rows =
             new Ungrouped(this.table, Collections.emptyMap()).rows();
         final Provided owned = new Provided(
-            this.table, this.names, this.table.xpath("//attr[@void='true']/@type")
+            this.table, this.names, new Hollows(this.table).all()
         );
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final String type : rows.keySet()) {

--- a/eo-inference/src/main/java/org/eolang/inference/Calls.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Calls.java
@@ -37,7 +37,7 @@ final class Calls {
     /**
      * What the links table says.
      */
-    private final Pairs links;
+    private final Said links;
 
     /**
      * The provides table.
@@ -52,7 +52,7 @@ final class Calls {
      * @param provides The provides table, which says where an argument can
      *  land
      */
-    Calls(final Collection<XML> applications, final Pairs table, final XML provides) {
+    Calls(final Collection<XML> applications, final Said table, final XML provides) {
         this.sites = applications;
         this.links = table;
         this.given = provides;

--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -65,7 +65,7 @@ public final class Demanded implements Clue {
         this.origin.follow(xmirs, tables);
         final Path table = tables.resolve("provides.xml");
         final XML given = new XMLDocument(table);
-        final Pairs links = new Pairs(new XMLDocument(tables.resolve("links.xml")));
+        final Said links = new Said(new Pairs(new XMLDocument(tables.resolve("links.xml"))));
         final Map<String, String> names = new Ends(links.all()).names();
         final Collection<String> voids = new Hollows(given).all();
         final Map<String, Collection<String>> into = Demanded.into(links.puts(), names, voids);

--- a/eo-inference/src/main/java/org/eolang/inference/Demanded.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Demanded.java
@@ -67,7 +67,7 @@ public final class Demanded implements Clue {
         final XML given = new XMLDocument(table);
         final Pairs links = new Pairs(new XMLDocument(tables.resolve("links.xml")));
         final Map<String, String> names = new Ends(links.all()).names();
-        final Collection<String> voids = given.xpath("//attr[@void='true']/@type");
+        final Collection<String> voids = new Hollows(given).all();
         final Map<String, Collection<String>> into = Demanded.into(links.puts(), names, voids);
         final Map<String, Map<String, String>> asked = new Asked(
             new XMLDocument(tables.resolve("needs.xml")),

--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -54,14 +54,19 @@ import java.util.Map;
 final class Fillings {
 
     /**
-     * The links table.
+     * What the links table says.
      */
-    private final XML table;
+    private final Said table;
 
     /**
      * The provides table.
      */
     private final XML given;
+
+    /**
+     * The locator of every void.
+     */
+    private final Collection<String> hollows;
 
     /**
      * Ctor.
@@ -70,8 +75,20 @@ final class Fillings {
      * @param provides The provides table, which says where a filling can land
      */
     Fillings(final XML links, final XML provides) {
+        this(new Said(new Pairs(links)), provides, new Hollows(provides).all());
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param links What the links table says, as {@link Resolved} left it
+     * @param provides The provides table, which says where a filling can land
+     * @param voids The locator of every void, from {@link Hollows}
+     */
+    Fillings(final Said links, final XML provides, final Collection<String> voids) {
         this.table = links;
         this.given = provides;
+        this.hollows = voids;
     }
 
     /**
@@ -81,13 +98,12 @@ final class Fillings {
      *  nobody ever fills
      */
     Map<String, Collection<Type>> all() {
-        final Pairs pairs = new Pairs(this.table);
-        final Map<String, String> names = new Ends(pairs.all()).names();
-        final Map<String, String> landings = new Landed(pairs, this.given).all();
-        final Forms forms = new Forms(pairs.forms());
+        final Map<String, String> names = new Ends(this.table.all()).names();
+        final Map<String, String> landings = new Landed(this.table, this.given).all();
+        final Forms forms = new Forms(this.table.forms());
         final Map<String, Map<String, Type>> placed = new LinkedHashMap<>(0);
         final Map<String, Map<String, Type>> handed = new LinkedHashMap<>(0);
-        for (final Map.Entry<String, Collection<String>> bound : pairs.puts().entrySet()) {
+        for (final Map.Entry<String, Collection<String>> bound : this.table.puts().entrySet()) {
             for (final String put : bound.getValue()) {
                 final String end = landings.get(put);
                 if (end == null) {
@@ -100,7 +116,9 @@ final class Fillings {
                 }
             }
         }
-        final Handed atoms = new Handed(this.table, this.given);
+        final Handed atoms = new Handed(
+            this.given, new Provided(this.given, names, this.hollows)
+        );
         Map<String, Map<String, Type>> walked = new Carried(placed, handed).all();
         while (atoms.fills(placed, walked)) {
             walked = new Carried(placed, handed).all();

--- a/eo-inference/src/main/java/org/eolang/inference/Handed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Handed.java
@@ -63,18 +63,11 @@ final class Handed {
     /**
      * Ctor.
      *
-     * @param links The links table, as {@link Resolved} left it
      * @param provides The provides table, which says what an atom hands in
+     * @param rows The provides table, asked what void a place lands in
      */
-    Handed(final XML links, final XML provides) {
-        this(
-            provides.nodes("//attr[@void='true' and @args]"),
-            new Provided(
-                provides,
-                new Ends(new Pairs(links).all()).names(),
-                new Hollows(provides).all()
-            )
-        );
+    Handed(final XML provides, final Provided rows) {
+        this(provides.nodes("//attr[@void='true' and @args]"), rows);
     }
 
     /**

--- a/eo-inference/src/main/java/org/eolang/inference/Handed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Handed.java
@@ -72,7 +72,7 @@ final class Handed {
             new Provided(
                 provides,
                 new Ends(new Pairs(links).all()).names(),
-                provides.xpath("//attr[@void='true']/@type")
+                new Hollows(provides).all()
             )
         );
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Hollows.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Hollows.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+
+/**
+ * The locator of every void of a program.
+ *
+ * <p>Half the rules ask whether a name belongs to a void, and none of them
+ * ask which void is which: {@link Rooted} walks a locator up until one of
+ * these answers, {@link Provided} stops a walk that arrives at one. So what
+ * they want is a set, and being handed a list instead makes every one of those
+ * questions a walk of the whole of it — on {@code eo-runtime} that is 1,593
+ * comparisons per question, asked of 13,325 dispatches on every pass of a
+ * fixpoint that runs more than a hundred of them.</p>
+ *
+ * <p>The order the table wrote them in is kept all the same, since a table
+ * read back the same way twice is a table a reader can diff.</p>
+ *
+ * @since 0.73.0
+ */
+final class Hollows {
+
+    /**
+     * The provides table.
+     */
+    private final XML given;
+
+    /**
+     * Ctor.
+     *
+     * @param provides The provides table, as {@link Provides} wrote it
+     */
+    Hollows(final XML provides) {
+        this.given = provides;
+    }
+
+    /**
+     * The locator of every void the table names.
+     *
+     * @return The locators, in the order the table names them
+     */
+    Collection<String> all() {
+        final Collection<String> found = new LinkedHashSet<>(0);
+        for (final Xnav type : new Rows(this.given).all()) {
+            type.elements(Filter.withName("attr"))
+                .filter(attr -> "true".equals(new Noted(attr).says("void")))
+                .forEach(attr -> found.add(new Noted(attr).says("type")));
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Landed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Landed.java
@@ -39,7 +39,7 @@ final class Landed {
     /**
      * What the links table says.
      */
-    private final Pairs links;
+    private final Said links;
 
     /**
      * The provides table.
@@ -53,7 +53,7 @@ final class Landed {
      * @param provides The provides table, which says what an atom comes back
      *  with and which objects are formations
      */
-    Landed(final Pairs table, final XML provides) {
+    Landed(final Said table, final XML provides) {
         this.links = table;
         this.given = provides;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Promoted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Promoted.java
@@ -26,7 +26,10 @@ import java.util.Map;
  * carries no further facts.</p>
  *
  * <p>{@link Sole} decides what a void is worth and this asks it, of every void
- * at once, off the table {@link Woven} builds from the pairs settled so far.
+ * at once, off what {@link Woven} works out the pairs settled so far to have
+ * put where. That is the table the build goes on to publish, said as
+ * {@link Said} rather than written as a document, since a pass that rendered
+ * it only to read it back would spend most of itself doing so.
  * {@link Shared} is asked where the fillings share an ancestor and {@link
  * Agreed} where they share nothing but their answers, so a void nothing can be
  * called as a whole still carries the dispatches its fillings agree on. Which
@@ -56,15 +59,6 @@ import java.util.Map;
  * could go and look at, and {@link Sole} refuses it.</p>
  *
  * @since 0.71.0
- * @todo #8231:90min Settle the voids without the XML in the middle.
- *  Every pass renders the whole table through {@link Types#asXml()} and
- *  {@link Fillings} reads it straight back out with {@link Pairs}, which
- *  costs about 320ms of a pass on {@code eo-runtime}, and it takes 45
- *  passes there to name 510 voids. Then every void named asks all 11,314
- *  dispatches again from scratch, where only the ones rooted at that void
- *  can have changed. Between them the two turn 7s of inference into 28s.
- *  Let {@link Fillings} take the rows themselves, and ask again only the
- *  dispatches the new name reaches.
  */
 final class Promoted {
 
@@ -79,9 +73,9 @@ final class Promoted {
     private final XML given;
 
     /**
-     * The rows of the links table that are not pairs, from {@link Pairs}.
+     * What the links table says, as the rules left it.
      */
-    private final Map<String, Type> others;
+    private final Said written;
 
     /**
      * The locator of every void.
@@ -93,19 +87,19 @@ final class Promoted {
      *
      * @param woven The rows that follow from a set of pairs
      * @param provides The provides table, which says where a filling can land
-     * @param kept The rows of the links table that are not pairs, without which
-     *  a filling that arrives at a literal is not seen to be one
+     * @param said What the links table says, as the rules left it, without
+     *  which a filling that arrives at a literal is not seen to be one
      * @param voids The locator of every void, from {@link Hollows}
      */
     Promoted(
         final Woven woven,
         final XML provides,
-        final Map<String, Type> kept,
+        final Said said,
         final Collection<String> voids
     ) {
         this.table = woven;
         this.given = provides;
-        this.others = kept;
+        this.written = said;
         this.hollows = voids;
     }
 
@@ -125,7 +119,9 @@ final class Promoted {
         final Map<String, Collection<String>> asked = this.asked(pairs);
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Collection<Type>> hollow
-            : new Fillings(this.links(pairs), this.given).all().entrySet()) {
+            : new Fillings(
+                this.written.with(pairs, this.table.binds(pairs)), this.given, this.hollows
+            ).all().entrySet()) {
             String sole = new Sole(hollow.getValue(), known).names();
             if (sole.isEmpty()) {
                 sole = new Shared(hollow.getValue(), known, owned).names();
@@ -158,12 +154,6 @@ final class Promoted {
             }
         }
         return found;
-    }
-
-    private XML links(final Map<String, String> pairs) {
-        final Map<String, Type> rows = this.table.rows(pairs);
-        rows.putAll(this.others);
-        return new Types(rows).asXml();
     }
 
     private Collection<String> known() {

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -91,7 +91,7 @@ public final class Resolved implements Clue {
         final Collection<String> voids = new Hollows(given).all();
         final Map<String, Type> kept = written.others();
         final Woven woven = new Woven(given, applied, receivers, voids, dispatches);
-        final Promoted promoted = new Promoted(woven, given, kept, voids);
+        final Promoted promoted = new Promoted(woven, given, new Said(written), voids);
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, dispatches, args, named, receivers, voids), promoted
         ).from(

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -88,7 +88,7 @@ public final class Resolved implements Clue {
         final Map<String, Map<String, String>> named = applied.named();
         final Pairs written = new Pairs(new XMLDocument(links));
         final Map<String, String> receivers = new Taken(world, written).all();
-        final List<String> voids = given.xpath("//attr[@void='true']/@type");
+        final Collection<String> voids = new Hollows(given).all();
         final Map<String, Type> kept = written.others();
         final Woven woven = new Woven(given, applied, receivers, voids, dispatches);
         final Promoted promoted = new Promoted(woven, given, kept, voids);

--- a/eo-inference/src/main/java/org/eolang/inference/Said.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Said.java
@@ -1,0 +1,162 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+
+/**
+ * What the links table says.
+ *
+ * <p>{@link Pairs} answers four questions off a document, which is the right
+ * way round once and the wrong way round afterwards. The table is read from
+ * disk once, and then a fixpoint asks the same four questions of a table that
+ * exists only to be asked them: {@link Promoted} weaves the pairs it has
+ * settled into rows, renders the rows into XML and reads the XML straight back
+ * out, and on eo-runtime that round trip is most of a second of every pass of
+ * a fixpoint that runs more than a hundred of them.</p>
+ *
+ * <p>So the four questions are asked of this instead, and a rule that has the
+ * pairs can answer them without a document. Two of them are the pairs
+ * themselves: what an object is a copy of is the pair, and what went into
+ * every void is {@link Bound}'s answer read the other way round. The other two
+ * do not depend on the pairs at all. Which rows are not pairs, and which of
+ * those are answers as they stand, is what the table said when it was read
+ * from disk, and no pass writes a row of either kind. That is why
+ * {@link #with(Map, Map)} takes the first two afresh and keeps the last
+ * two.</p>
+ *
+ * <p>A row that is not a pair wins over one that is, exactly as it does when
+ * the rows are rendered, since a pass writes the rows it worked out first and
+ * puts the ones it knows nothing about over the top. A row is not a pair when
+ * the table gave it some form other than a reference, which is the same thing
+ * {@link Pairs#others()} means by it. The order the pairs came in is kept,
+ * because the first filling of a void is the one that counts.</p>
+ *
+ * @since 0.73.0
+ */
+final class Said {
+
+    /**
+     * What every object is a copy of.
+     */
+    private final Map<String, String> hops;
+
+    /**
+     * What went into every void.
+     */
+    private final Map<String, Collection<String>> given;
+
+    /**
+     * Which form of answer every row holds.
+     */
+    private final Map<String, String> shapes;
+
+    /**
+     * Every object the table answers by itself.
+     */
+    private final Collection<String> plain;
+
+    /**
+     * Ctor.
+     *
+     * @param table The links table, as a clue left it
+     */
+    Said(final Pairs table) {
+        this(table.all(), table.puts(), table.forms(), table.certain());
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param copies What every object is a copy of
+     * @param puts What went into every void
+     * @param forms Which form of answer every row holds
+     * @param certain Every object the table answers by itself
+     */
+    Said(
+        final Map<String, String> copies,
+        final Map<String, Collection<String>> puts,
+        final Map<String, String> forms,
+        final Collection<String> certain
+    ) {
+        this.hops = copies;
+        this.given = puts;
+        this.shapes = forms;
+        this.plain = certain;
+    }
+
+    /**
+     * The same table, saying what these pairs say.
+     *
+     * @param pairs The pairs, each object against the one it is a copy of
+     * @param binds What every copy put into the voids of what it copies, from
+     *  {@link Bound}
+     * @return The table, with the pairs and their binds in place of its own and
+     *  the rows no pass can write kept as they were
+     */
+    Said with(
+        final Map<String, String> pairs,
+        final Map<String, Map<String, String>> binds
+    ) {
+        final Map<String, String> copies = new LinkedHashMap<>(pairs.size());
+        final Map<String, Collection<String>> puts = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, String> pair : pairs.entrySet()) {
+            if (this.other(pair.getKey())) {
+                continue;
+            }
+            copies.put(pair.getKey(), pair.getValue());
+            binds.getOrDefault(pair.getKey(), Collections.emptyMap()).forEach(
+                (hollow, put) -> puts.computeIfAbsent(
+                    hollow, key -> new LinkedHashSet<>(0)
+                ).add(put)
+            );
+        }
+        return new Said(copies, puts, this.shapes, this.plain);
+    }
+
+    /**
+     * Every pair of the table.
+     *
+     * @return The pairs, each name against the one it is a copy of
+     */
+    Map<String, String> all() {
+        return this.hops;
+    }
+
+    /**
+     * What the table says went into every void.
+     *
+     * @return The locators of what went in, by the locator of the void
+     */
+    Map<String, Collection<String>> puts() {
+        return this.given;
+    }
+
+    /**
+     * Which form of answer every row of the table holds.
+     *
+     * @return The form, by the locator of the object the row is about
+     */
+    Map<String, String> forms() {
+        return this.shapes;
+    }
+
+    /**
+     * Every object the table answers by itself.
+     *
+     * @return The locators
+     */
+    Collection<String> certain() {
+        return this.plain;
+    }
+
+    private boolean other(final String object) {
+        return this.shapes.containsKey(object) && !"ref".equals(this.shapes.get(object));
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Settled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Settled.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * opens the dispatches rooted at that void, and the passes go round again.</p>
  *
  * @since 0.69.0
- * @todo #8274:120min Settle a chain in fewer passes than it has hops.
+ * @todo #8274:90min Settle a chain in fewer passes than it has hops.
  *  On eo-runtime this runs 128 passes of {@link Dispatched} and 44 of
  *  {@link Promoted} to settle 41,192 pairs, 77 of the passes adding one pair
  *  apiece, which is 30s of the 40s the tables take to build. The count is the

--- a/eo-inference/src/main/java/org/eolang/inference/Settled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Settled.java
@@ -23,6 +23,20 @@ import java.util.Map;
  * opens the dispatches rooted at that void, and the passes go round again.</p>
  *
  * @since 0.69.0
+ * @todo #8274:120min Settle a chain in fewer passes than it has hops.
+ *  On eo-runtime this runs 128 passes of {@link Dispatched} and 44 of
+ *  {@link Promoted} to settle 41,192 pairs, 77 of the passes adding one pair
+ *  apiece, which is 30s of the 40s the tables take to build. The count is the
+ *  cost and not the pass: of the 18.7s the dispatches take, {@link Bound} is
+ *  9.4s and the rest of what a pass builds 6.5s, while the loop over all
+ *  13,325 dispatches is 2.8s and already asks none but the ones left
+ *  unanswered. So narrowing that loop further buys 7% and would need an index
+ *  of what every answer was read off to be sound, since an answer changes when
+ *  the fillings of a void change and not only when the end of its bearer does.
+ *  What makes the passes is that a chain is read one hop to a pass, and
+ *  bool.eo nests 40 formations that call each other. Read more than one hop, or
+ *  ask again only what a new pair reaches, and mind that both change the order
+ *  the pairs are learnt in, which {@link Dispatched} is not indifferent to.
  */
 final class Settled {
 

--- a/eo-inference/src/main/java/org/eolang/inference/Woven.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Woven.java
@@ -86,21 +86,35 @@ final class Woven {
      *  order the pairs came in
      */
     Map<String, Type> rows(final Map<String, String> pairs) {
+        return new Refs(pairs, this.binds(pairs)).all();
+    }
+
+    /**
+     * What every one of these pairs put into the voids of what it copies.
+     *
+     * <p>This is the half of a row that {@link Bound} works out, and a rule
+     * that reads it does not need the row: {@link Promoted} asks what the
+     * program puts into every void, which is this read the other way round,
+     * and rendering it into a document first only to read it back out again is
+     * a second of every pass of a fixpoint that runs a hundred of them.</p>
+     *
+     * @param pairs The pairs, each object against the one it is a copy of
+     * @return The objects put in, by the locator of the void, by the locator of
+     *  the object that put them there
+     */
+    Map<String, Map<String, String>> binds(final Map<String, String> pairs) {
         final Map<String, String> names = new Ends(pairs).names();
         final Provided owned = new Provided(this.given, names, this.hollows);
-        return new Refs(
-            pairs,
-            new Copied(
-                new Bound(
-                    this.applied.arguments(),
-                    this.applied.named(),
-                    this.receivers,
-                    pairs,
-                    owned
-                ).all(),
+        return new Copied(
+            new Bound(
+                this.applied.arguments(),
+                this.applied.named(),
+                this.receivers,
                 pairs,
-                new Lent(owned, this.all, this.applied.arguments(), this.hollows).sites(names)
-            ).all()
+                owned
+            ).all(),
+            pairs,
+            new Lent(owned, this.all, this.applied.arguments(), this.hollows).sites(names)
         ).all();
     }
 }

--- a/eo-inference/src/test/java/org/eolang/inference/HollowsTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/HollowsTest.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Hollows}.
+ *
+ * @since 0.73.0
+ */
+final class HollowsTest {
+
+    @Test
+    void namesTheVoidsAndNothingElse() {
+        MatcherAssert.assertThat(
+            "the voids of the table must be the ones marked so, but they werent",
+            new Hollows(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides><type id='Φ.oak'>",
+                        "<attr name='leaf' type='Φ.oak.leaf' void='true'/>",
+                        "<attr name='bark' type='Φ.oak.bark'/>",
+                        "<attr name='root' type='Φ.oak.root' void='false'/>",
+                        "</type></provides>"
+                    )
+                )
+            ).all(),
+            Matchers.contains("Φ.oak.leaf")
+        );
+    }
+
+    @Test
+    void keepsTheOrderTheTableNamesThemIn() {
+        MatcherAssert.assertThat(
+            "the voids must come back in the order the table wrote them, but they didnt",
+            new Hollows(
+                new XMLDocument(
+                    String.join(
+                        "",
+                        "<provides>",
+                        "<type id='Φ.elm'>",
+                        "<attr name='leaf' type='Φ.elm.leaf' void='true'/>",
+                        "</type>",
+                        "<type id='Φ.oak'>",
+                        "<attr name='bud' type='Φ.oak.bud' void='true'/>",
+                        "<attr name='leaf' type='Φ.oak.leaf' void='true'/>",
+                        "</type>",
+                        "</provides>"
+                    )
+                )
+            ).all(),
+            Matchers.contains("Φ.elm.leaf", "Φ.oak.bud", "Φ.oak.leaf")
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/SaidTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/SaidTest.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Said}.
+ *
+ * @since 0.73.0
+ */
+final class SaidTest {
+
+    @Test
+    void saysWhatThePairsSay() {
+        MatcherAssert.assertThat(
+            "the pairs handed over must be the ones the table says, but they werent",
+            new Said(new Pairs(new XMLDocument("<links/>"))).with(
+                Collections.singletonMap("Φ.oak", "Φ.tree"),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.hasEntry("Φ.oak", "Φ.tree")
+        );
+    }
+
+    @Test
+    void readsTheBindsTheOtherWayRound() {
+        MatcherAssert.assertThat(
+            "the void must name what went into it, but it didnt",
+            new Said(new Pairs(new XMLDocument("<links/>"))).with(
+                Collections.singletonMap("Φ.oak", "Φ.tree"),
+                Collections.singletonMap(
+                    "Φ.oak", Collections.singletonMap("Φ.tree.seed", "Φ.acorn")
+                )
+            ).puts(),
+            Matchers.hasEntry(Matchers.is("Φ.tree.seed"), Matchers.contains("Φ.acorn"))
+        );
+    }
+
+    @Test
+    void gathersWhatTwoCopiesPutIntoOneVoid() {
+        final Map<String, String> pairs = new LinkedHashMap<>(0);
+        pairs.put("Φ.oak", "Φ.tree");
+        pairs.put("Φ.elm", "Φ.tree");
+        final Map<String, Map<String, String>> binds = new LinkedHashMap<>(0);
+        binds.put("Φ.oak", Collections.singletonMap("Φ.tree.seed", "Φ.acorn"));
+        binds.put("Φ.elm", Collections.singletonMap("Φ.tree.seed", "Φ.samara"));
+        MatcherAssert.assertThat(
+            "the void must name both the objects put into it, but it didnt",
+            new Said(new Pairs(new XMLDocument("<links/>")))
+                .with(pairs, binds)
+                .puts()
+                .get("Φ.tree.seed"),
+            Matchers.contains("Φ.acorn", "Φ.samara")
+        );
+    }
+
+    @Test
+    void dropsThePairARowOfAnotherFormOverwrites() {
+        MatcherAssert.assertThat(
+            "the row the table gave a form of its own must beat the pair, but it didnt",
+            new Said(
+                new Pairs(new XMLDocument("<links><type id='Φ.oak'><data/></type></links>"))
+            ).with(
+                Collections.singletonMap("Φ.oak", "Φ.tree"),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.not(Matchers.hasKey("Φ.oak"))
+        );
+    }
+
+    @Test
+    void keepsThePairARowOfItsOwnKindDoesNot() {
+        MatcherAssert.assertThat(
+            "the pair the table wrote itself must survive the pass, but it didnt",
+            new Said(
+                new Pairs(
+                    new XMLDocument(
+                        "<links><type id='Φ.oak'><ref loc='Φ.tree'/></type></links>"
+                    )
+                )
+            ).with(
+                Collections.singletonMap("Φ.oak", "Φ.plant"),
+                Collections.emptyMap()
+            ).all(),
+            Matchers.hasEntry("Φ.oak", "Φ.plant")
+        );
+    }
+
+    @Test
+    void keepsTheFormsNoPassCanWrite() {
+        MatcherAssert.assertThat(
+            "the form the table gave a row must survive the pass, but it didnt",
+            new Said(
+                new Pairs(
+                    new XMLDocument("<links><type id='Φ.oak'><terminator/></type></links>")
+                )
+            ).with(
+                Collections.singletonMap("Φ.elm", "Φ.tree"),
+                Collections.emptyMap()
+            ).forms(),
+            Matchers.hasEntry("Φ.oak", "terminator")
+        );
+    }
+
+    @Test
+    void keepsWhatTheTableAnswersByItself() {
+        MatcherAssert.assertThat(
+            "the object the table answers by itself must survive the pass, but it didnt",
+            new Said(
+                new Pairs(new XMLDocument("<links><type id='Φ.oak'><data/></type></links>"))
+            ).with(
+                Collections.singletonMap("Φ.elm", "Φ.tree"),
+                Collections.emptyMap()
+            ).certain(),
+            Matchers.contains("Φ.oak")
+        );
+    }
+}


### PR DESCRIPTION
The fixpoint in `Resolved` was 89% of the time it takes to build the inference tables — 58s of 65s on `eo-runtime`. Two things were paying for it, and neither was the algorithm.

The first was `Rooted`. Every dispatch of every pass walks a locator up the dots asking whether each step is a void, and the voids arrived as the `ListWrapper` that `xpath()` hands back — 1,593 entries, scanned linearly, 13,325 times a pass, a hundred passes. `Hollows` is the class the javadocs had been pointing at for two releases without anybody writing it, and it answers a set.

The second is what #8274 asks for. Every pass wove the pairs it had settled into rows, rendered the whole table through `Types.asXml()`, and `Fillings` read the document straight back out with `Pairs` — most of a second of a 1.2s pass. None of it was needed, because a rule that has the pairs has the answers already:

```java
Said with(final Map<String, String> pairs, final Map<String, Map<String, String>> binds)
```

Two of the four questions `Fillings` asks are the pairs themselves — what an object is a copy of is the pair, and what went into every void is `Bound`'s answer read the other way round. The other two do not depend on the pairs at all: which rows are not pairs, and which of those are answers as they stand, is what the table said when it was read from disk, and no pass writes a row of either kind. So `with` takes the first two afresh and keeps the last two.

A `Promoted` pass drops from 1.2s to 0.25s and the whole chain from 65s to 38s. `links.xml`, `provides.xml` and `needs.xml` come out byte-identical to master on `eo-runtime`.

The other half of #8274 — asking again only the dispatches a new name reaches — does not survive being measured, so it moves to a new puzzle on `Settled` rather than getting guessed at. Of the 18.7s the dispatches now take, `Bound` is 9.4s and the rest of what a pass builds is 6.5s; the loop over all 13,325 of them is 2.8s, and it already asks none but the ones left unanswered. Narrowing it further buys 7% and needs an index of what every answer was read off to be sound, since an answer changes when the fillings of a void change and not only when the end of its bearer does. What actually makes the passes is that a chain is read one hop to a pass, and `bool.eo` nests forty formations that call each other.

Closes #8274
