### PR TITLE
Let a bool come back from bytes again

### DIFF
--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -62,7 +62,7 @@ final class EoSourceRun implements Proc<Object> {
      * {@code .mvn/jvm.config} and the same flags on the forked command.
      */
     private static final String[] FLAGS = {
-        "-Xmx1g",
+        "-Xmx4g",
         "-Xss64m",
         "-XX:-HeapDumpOnOutOfMemoryError",
     };

--- a/eo-runtime/src/main/eo/bytes/as-bool.eo
+++ b/eo-runtime/src/main/eo/bytes/as-bool.eo
@@ -1,5 +1,4 @@
-# Bytes as a boolean: TRUE for `FF-` and FALSE for `00-`. Any other bytes
-# terminate, since only those two are booleans.
+# Bytes as a boolean: TRUE when the single byte equals `FF-`, FALSE otherwise.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -9,17 +8,7 @@
 +spdx SPDX-License-Identifier: MIT
 
 [^] > as-bool
-  if. > @
-    ^.eq 00-
-    false
-    if.
-      ^.eq FF-
-      true
-      T
-        "Can't convert %x to bool, only 00- and FF- are booleans".printf
-          * ^
+  ^.eq FF- > @
 
   not. ++> can-convert-bytes-to-a-bool
     FF-.as-bool.eq 00-.as-bool
-
-  01-.as-bool --> stops-on-bytes-that-are-not-a-boolean


### PR DESCRIPTION
Fixes the `OutOfMemoryError` in [ec2 run 34204497031](https://github.com/objectionary/eo/actions/runs/34204497031/job/102009190023) and master's red `snippets` job.

## What is broken

`bytes.as-bool` is what every bool in every EO program is made of. Since #8387 (`d25d3a7`) rewrote it as a chain of `if.`, it does not come back — it allocates until the heap is gone:

```diff
 [^] > as-bool
-  ^.eq FF- > @
+  if. > @
+    ^.eq 00-
+    false
+    if.
+      ^.eq FF-
+      true
+      T
+        "Can't convert %x to bool, only 00- and FF- are booleans".printf
+          * ^
```

`stdout "Hello, world!\n"` prints its line and then eats eight gigabytes. That is why the ec2 job's `SnippetIT` reports 7 failures and 3 errors, every one of them carrying `OutOfMemoryError: Java heap space`, on programs as small as `reads-all-lines`; and why `snippets` on master has been red since the change landed.

It only became visible in ec2 now because ec2 used to die inside eo-runtime and skip `eo-integration-tests` altogether. eo-runtime's own tests stay green because a test that goes over `eo.maxmem` there is reported as **skipped**, so the runaway is absorbed as skips and is only fatal in the sandbox, which has no guard.

## How it was found

By reverting one file at a time against a fixed heap, so every row differs from its neighbour by source alone:

| tree | heap | result | time |
| --- | --- | --- | --- |
| master | 1G | 5/5 fail | |
| all nine `.eo` files changed in `2ca9896..d8c6a64` reverted | 1G | 4/5 fail | |
| the same nine reverted | 6G | 5/5 pass | 74s |
| `number/integral.eo`, `i16.eo`, `i32.eo` restored | 6G | 5/5 pass | |
| **only `bytes/as-bool.eo` reverted** | 6G | **5/5 pass** | 74s |
| master, nothing reverted | 6G | **5/5 fail** | 426s |

The window came from the job's own history: last green `snippets` was run 9284 (`2ca9896`, Sep 6 19:59), and every completed run after it is red.

## What is not known

The change is reverted, which is not the same as saying it was wrong to want. Refusing `01-` as a boolean is worth having; what is not yet known is how to have it.

It is the `if.` that does the damage, not the message it carries. An `as-bool` that keeps both branches and terminates with a plain string — naming no bytes, reaching no `printf` — fails all five snippets just the same. So the tempting explanation, that `string/printf.eo` closes the loop by calling `as-bool` eight times (lines 177, 191, 224, 237, 253, 265 and on), is not the answer either, and neither is anything about the two `? > ^` receiver voids dropped by #8446 in the same window.

Since `as-bool` sits under every bool in the language, a replacement nobody can explain is the same bug in a different shape. Hence the revert, and #8387 wants reopening with the negative result attached: **any `if.`-based `as-bool` runs away, message or no message**, so the validation likely belongs in a Java atom rather than in EO branching.

The revert also drops that commit's `01-.as-bool --> stops-on-bytes-that-are-not-a-boolean`, which goes back to being silently `false`.

## The second commit is mine to correct

#8530 handed the sandbox a gigabyte and called the figure measured. Half of it was: a gigabyte clears the build the sandbox runs first, which parses, lints, merges and transpiles all 174 sources of eo-runtime. It never cleared the *snippet*, and could not have: every snippet was already running away, so there was no passing snippet to measure against. The claim there that the bound "cannot break the green path once the runaway is fixed" rested on nothing.

It could, and it did. With the runaway gone, the README's multiplication table wants more than two gigabytes — it fails at 1G and 2G, passes at 4G and 6G. It gets four, measured against snippets that pass.

## Verified

A clean rebuild of eo-runtime from the reverted source (`BUILD SUCCESS`, which runs the lints with `failOnWarning=true`), then both suites:

```
integration.ReadmeSnippetsIT — Tests run: 5,  Failures: 0, Errors: 0, Skipped: 0
integration.SnippetIT        — Tests run: 11, Failures: 0, Errors: 0, Skipped: 0
```

Zero `OutOfMemoryError` in either log. `SnippetIT` is the suite the ec2 run failed, and it runs in the default profile, not under `-Psnippets`.

Note that `snippets.yml` is `on: push: branches: [master]`, so **no check on this PR exercises any of this** — the runs above are the only pre-merge evidence. `fast` does cover eo-runtime's own tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FjwNADfX9wh4RuzyeNRje4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FjwNADfX9wh4RuzyeNRje4)_