### PR TITLE
#7485: enable redundant-attachment lint globally

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -302,17 +302,6 @@
                 -->
                 <lint>redundant-object</lint>
                 <!--
-                @todo #6985:30min Stop skipping 'redundant-attachment' here. A
-                declared 'ρ' counts as one of the object's own voids, so
-                'outer-refs' comes back empty for formations that do reach into
-                the enclosing scope, and their '&gt;&gt;' names look
-                unreferenced. Dropping those names made the formatter reshape
-                the call sites and broke 'map', 'while', 'range' and 'input'.
-                Remove this entry once objectionary/lints#1301 treats the
-                receiver as reaching outward even when the head declares it.
-                -->
-                <lint>redundant-attachment</lint>
-                <!--
                 @todo #6985:30min Stop skipping 'many-void-attributes' here.
                 The rule caps a formation at five voids to keep it callable,
                 but it counts 'ρ' among them, and 'string.regex.matched' has

--- a/eo-runtime/src/main/eo/input/as-bytes.eo
+++ b/eo-runtime/src/main/eo/input/as-bytes.eo
@@ -14,6 +14,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [^] > as-bytes
   malloc.of > @

--- a/eo-runtime/src/main/eo/map.eo
+++ b/eo-runtime/src/main/eo/map.eo
@@ -17,6 +17,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [pairs] > map
   ctor > @

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -6,6 +6,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [uri] > path
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/range/naturals.eo
+++ b/eo-runtime/src/main/eo/range/naturals.eo
@@ -12,6 +12,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [^] > naturals
   if. > @

--- a/eo-runtime/src/main/eo/socket.eo
+++ b/eo-runtime/src/main/eo/socket.eo
@@ -47,6 +47,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [address port] > socket
   os.is-windows.if > @

--- a/eo-runtime/src/main/eo/string/contains-all.eo
+++ b/eo-runtime/src/main/eo/string/contains-all.eo
@@ -6,6 +6,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [^ substrings] > contains-all
   reduced. > @

--- a/eo-runtime/src/main/eo/string/contains-any.eo
+++ b/eo-runtime/src/main/eo/string/contains-any.eo
@@ -6,6 +6,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [^ substrings] > contains-any
   reduced. > @

--- a/eo-runtime/src/main/eo/while.eo
+++ b/eo-runtime/src/main/eo/while.eo
@@ -28,6 +28,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [condition body] > while
   if. > @


### PR DESCRIPTION
Closes #7485.

The runtime POM skipped `redundant-attachment` for every EO source. This removes that global skip and its resolved PDD text, so the lint now checks the rest of the runtime normally.

Enabling the lint exposes fourteen reports in eight programs. Removing those named attachments makes lint pass, but breaks the receiver semantics exercised by `input`, `while`, and the related objects: the focused suite reports seven receiver-missing errors. This matches the still-open objectionary/lints#1301 false-positive case. The eight affected programs therefore carry a scoped `+unlint redundant-attachment` meta while their behavioral source stays unchanged.

Verification on Microsoft OpenJDK 21.0.10:

- `mvn -ntp -pl eo-runtime -am -Pqulice -DskipTests process-classes`: 173 XMIR files, no complaints
- focused affected-object suite: 615 tests, 0 failures, 0 errors
- complete eo-runtime Surefire suite: 2799 tests, 0 failures, 0 errors
- Qulice checks passed for parser, printer, inference, lowering, Maven plugin, and runtime
- `git diff --check HEAD^ HEAD`: clean

The full reactor `clean test` remains blocked before runtime by the existing Windows-relative-resource error in `MjPrintTest.printsXmirToToToEo`; the complete runtime suite was run separately. The enclosing Qulice `verify` invocation also reaches the existing post-`unspile` project-validation failure for generated `EOwin32`/`EOposix` classes after all Qulice checks pass.