### PR TITLE
Read what a void says it holds before counting its callers

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Answers.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Answers.java
@@ -40,6 +40,19 @@ import java.util.Map;
  * that keeps itself stays on the rung where a name rooted at a void belongs,
  * true of every caller and concrete for none.</p>
  *
+ * <p>Where the source says what a void holds, that is what it holds, however
+ * many things the callers were seen putting in it. {@code Φ.number.minus.ρ}
+ * is a {@code Φ.number} because only a {@code Φ.number} declares a
+ * {@code minus} for anybody to call, and {@link Received} wrote that on the
+ * row two passes before anybody asks here. {@code minus} is called from all
+ * over the program, so its callers run past the cap {@link Witnessed} keeps
+ * and the census comes back with nothing that can be named, which was shown
+ * as a void seen too many things to name over the {@code ^} of a file that
+ * says plainly what it takes (#8554). A sighting is the poorer fact of the
+ * two and loses where they disagree. An annotation ending in a question mark
+ * says the value is that type or a termination, and is read here as the type
+ * alone, the way {@link Held} reads it.</p>
+ *
  * <p>Where the void keeps itself, what {@link Seen} found in it goes back
  * beside it, for a reader who is told their object is whatever
  * {@code Φ.bool.and.x} turns out to be and would rather be told that
@@ -139,9 +152,29 @@ final class Answers {
     }
 
     private String sole(final String end) {
-        return new Sole(
-            this.hollows.getOrDefault(end, Collections.emptyList()), this.table.keySet()
-        ).names();
+        String found = this.said(end);
+        if (found.isEmpty()) {
+            found = new Sole(
+                this.hollows.getOrDefault(end, Collections.emptyList()), this.table.keySet()
+            ).names();
+        }
+        return found;
+    }
+
+    private String said(final String hollow) {
+        String found = "";
+        final int last = hollow.lastIndexOf('.');
+        if (last > 0) {
+            for (final Map<String, String> row : this.own(hollow.substring(0, last))) {
+                if (hollow.equals(row.get("type"))) {
+                    found = row.getOrDefault("holds", "").replace("?", "");
+                }
+            }
+        }
+        if (!this.table.containsKey(found)) {
+            found = "";
+        }
+        return found;
     }
 
     private int depth(final String type, final int free) {

--- a/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/AnswersTest.java
@@ -230,10 +230,91 @@ final class AnswersTest {
         );
     }
 
+    @Test
+    void answersAVoidWithWhatItSaysItHolds() {
+        MatcherAssert.assertThat(
+            "a void that says it holds a number must answer that it is one, but it didnt",
+            new Answers(
+                AnswersTest.holding("Φ.number.minus", "ρ", "Φ.number"),
+                Collections.singletonMap(
+                    "Φ.number.minus.ρ", Collections.singletonList(new Unknown())
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.number.minus.ρ", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.number")
+        );
+    }
+
+    @Test
+    void prefersWhatAVoidSaysItHoldsOverWhatWasPutInIt() {
+        final Map<String, Collection<Map<String, String>>> rows =
+            AnswersTest.holding("Φ.number.div", "x", "Φ.number");
+        rows.putAll(AnswersTest.formation("Φ.bytes"));
+        MatcherAssert.assertThat(
+            "a void saying it holds a number cannot be the bytes put there, but it was",
+            new Answers(
+                rows,
+                Collections.singletonMap(
+                    "Φ.number.div.x", Collections.singletonList(new Ref("Φ.bytes"))
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.number.div.x", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.number")
+        );
+    }
+
+    @Test
+    void readsAVoidThatMayTerminateAsTheTypeAlone() {
+        MatcherAssert.assertThat(
+            "a void holding a number or a termination must answer as a number, but it didnt",
+            new Answers(
+                AnswersTest.holding("Φ.number.minus", "ρ", "Φ.number?"),
+                Collections.singletonMap(
+                    "Φ.number.minus.ρ", Collections.singletonList(new Unknown())
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.number.minus.ρ", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.number")
+        );
+    }
+
+    @Test
+    void leavesAVoidHoldingSomethingNoRowMentionsAlone() {
+        MatcherAssert.assertThat(
+            "a void holding what no row mentions has nowhere to send a reader, but it sent them",
+            new Answers(
+                AnswersTest.holding("Φ.number.minus", "ρ", "Φ.nowhere"),
+                Collections.singletonMap(
+                    "Φ.number.minus.ρ", Collections.singletonList(new Unknown())
+                ),
+                Collections.emptyList(),
+                Collections.emptyMap()
+            ).of("Φ.number.minus.ρ", Collections.emptyList()).where(),
+            Matchers.equalTo("Φ.number.minus.ρ")
+        );
+    }
+
     private static Map<String, Collection<Map<String, String>>> formation(final String locator) {
         final Map<String, String> whole = new LinkedHashMap<>(0);
         whole.put("id", locator);
         whole.put("complete", "true");
         return Collections.singletonMap(locator, Collections.singletonList(whole));
+    }
+
+    private static Map<String, Collection<Map<String, String>>> holding(
+        final String owner, final String name, final String held
+    ) {
+        final Map<String, String> hollow = new LinkedHashMap<>(0);
+        hollow.put("name", name);
+        hollow.put("void", "true");
+        hollow.put("type", String.join(".", owner, name));
+        hollow.put("holds", held);
+        final Map<String, Collection<Map<String, String>>> found =
+            new LinkedHashMap<>(AnswersTest.formation("Φ.number"));
+        found.put(owner, Collections.singletonList(hollow));
+        return found;
     }
 }


### PR DESCRIPTION
The page put "void, seen too many things to name" over the `^` of
`number/minus.eo:10`, which is a file that says what it takes. `Answers` asked
`Sole` what the void was worth, `Sole` counts the callers, and `minus` is called
from all over eo-runtime, so the census ran past the cap and came back with
nothing nameable. The row had said `holds="Φ.number"` since `Received` wrote it
two passes earlier, and nothing here read it.

Now it does, and the census answers only where the source says nothing:

```java
private String sole(final String end) {
    String found = this.said(end);
    if (found.isEmpty()) {
        found = new Sole(
            this.hollows.getOrDefault(end, Collections.emptyList()), this.table.keySet()
        ).names();
    }
    return found;
}
```

`said` reads the `holds` cell off the row of the void's owner, drops a trailing
question mark the way `Held` does, and gives nothing back when what it names has
no row of its own for a reader to go and look at.

Over eo-runtime, 729 of the 53,604 answers move: 519 from amber to green, 171
from grey to green, and 39 that were already green change which object they
name. The printed line goes from `85.3% named, 14.7% rooted at a void; depth
70.5%` to `86.6% named, 13.4% rooted at a void; depth 70.8%`. The tables are
untouched — `Answered` feeds the page and the count and nothing else — so
`links.xml` and `provides.xml` come out byte for byte the same.

The 39 are worth a look. Fourteen get sharper, since a void reached through a
formation's own scope now names that scope rather than the object outside it:
`Φ.socket.a🌵53-4.closed-socket.ρ` was `Φ.socket` and is now
`Φ.socket.a🌵53-4`, which is the only thing that declares a `closed-socket`.
The other twenty-five go the other way and name the owner where a sighting had
named an inner formation of it: `Φ.directory.walk.a🌵124-4.ρ` was
`Φ.directory.walk.a🌵95-4.a🌵96-6` and is now `Φ.directory.walk`. Neither is
false, and the owner is the one a reader can find in the file, but if a sighting
should win where it names something inside what the source declares, that is a
line to add rather than one to remove.
