### PR TITLE
Ask a bare void read what a dispatch is asked

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -21,6 +21,14 @@ import java.util.Map;
  * attribute is looked for is {@link Provided}'s business — the object itself,
  * its package, or behind its {@code φ}.</p>
  *
+ * <p>A name read off the object the line is written in is the same question
+ * with the receiver left out: {@code if > not} inside {@code [if] > bool}
+ * takes {@code if} from the {@code bool} around it. There is nothing to look
+ * the name up in, since the row already says what the name came out as, but
+ * the arguments of that very application say what the void it came out as
+ * holds — so the application stands in for its own receiver and {@link Filled}
+ * is asked all the same.</p>
+ *
  * <p>Nothing is guessed. A receiver whose type nothing describes is left
  * alone, and so is a receiver that is a void: {@code x.next} inside an object
  * that takes {@code x} is one object in the text and a different one for every
@@ -116,11 +124,16 @@ final class Dispatched {
             final String known = pairs.getOrDefault(made, "");
             if (known.isEmpty() || this.rooted(known)) {
                 final String bearer = dispatch.bearer();
-                final String kept = filled.instead(
-                    owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name()),
-                    bearer,
-                    made
-                );
+                final String kept;
+                if (bearer.isEmpty()) {
+                    kept = filled.instead(known, made, made);
+                } else {
+                    kept = filled.instead(
+                        owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name()),
+                        bearer,
+                        made
+                    );
+                }
                 if (this.better(kept, known, made)) {
                     found.put(made, kept);
                 }

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -83,6 +84,8 @@ public final class Resolved implements Clue {
         final Xmirs world = new Xmirs(xmirs);
         final XML given = new XMLDocument(tables.resolve("provides.xml"));
         final Collection<Site> dispatches = world.dispatches();
+        final Collection<Site> asked = new ArrayList<>(dispatches);
+        asked.addAll(world.reads());
         final Given applied = new Given(world.applications());
         final Map<String, List<String>> args = applied.arguments();
         final Map<String, Map<String, String>> named = applied.named();
@@ -93,11 +96,11 @@ public final class Resolved implements Clue {
         final Woven woven = new Woven(given, applied, receivers, voids, dispatches);
         final Promoted promoted = new Promoted(woven, given, new Said(written), voids);
         final Map<String, String> pairs = new Settled(
-            new Dispatched(given, dispatches, args, named, receivers, voids), promoted
+            new Dispatched(given, asked, args, named, receivers, voids), promoted
         ).from(
             new Settled(
                 new Dispatched(
-                    given, dispatches, args, named, receivers, Collections.emptyList()
+                    given, asked, args, named, receivers, Collections.emptyList()
                 ),
                 promoted
             ).from(written.all())

--- a/eo-inference/src/main/java/org/eolang/inference/Site.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Site.java
@@ -19,7 +19,9 @@ import com.github.lombrozo.xnav.Xnav;
  *
  * <p>The object the name is taken from is the child that is not an argument:
  * {@code x.plus 5} takes {@code plus} from {@code x}, never from the
- * {@code 5}.</p>
+ * {@code 5}. It goes unwritten when the name belongs to the object the line
+ * itself is written in, the way {@code if > not} reads the {@code if} of the
+ * {@code bool} around it, and then there is no such child at all.</p>
  *
  * @since 0.71.0
  */
@@ -51,7 +53,8 @@ final class Site {
     /**
      * The object this dispatch takes its name from.
      *
-     * @return The locator of it
+     * @return The locator of it, empty when the name is read off the object
+     *  this dispatch is written in
      */
     String bearer() {
         return this.dispatch
@@ -64,9 +67,11 @@ final class Site {
     /**
      * The name this dispatch takes.
      *
-     * @return The name, without the dot that says it is a dispatch
+     * @return The name, without what stands before the dot that says a name
+     *  is being taken
      */
     String name() {
-        return new Noted(this.dispatch).says("base").substring(1);
+        final String base = new Noted(this.dispatch).says("base");
+        return base.substring(base.indexOf('.') + 1);
     }
 }

--- a/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Xmirs.java
@@ -149,11 +149,27 @@ final class Xmirs {
      * @throws IOException If a file cannot be read
      */
     Collection<Site> dispatches() throws IOException {
-        final Collection<Site> found = new ArrayList<>(0);
-        for (final XML dispatch : this.matching("//o[starts-with(@base, '.')]")) {
-            found.add(new Site(new Xnav(dispatch.inner())));
-        }
-        return found;
+        return this.sites("//o[starts-with(@base, '.')]");
+    }
+
+    /**
+     * Every application of a name read off the object it is written in.
+     *
+     * <p>{@code if > not} inside {@code [if] > bool} takes the same name from
+     * the same object as {@code b.if} does from outside, only the object goes
+     * unwritten because it is the one the line is written in. The name is
+     * still taken from something, so the question a dispatch asks is worth
+     * asking here too — and when the name is a void, the arguments of this
+     * very application are what say what the void holds.</p>
+     *
+     * @return The applications, file by file, in the order they appear in
+     *  the code
+     * @throws IOException If a file cannot be read
+     */
+    Collection<Site> reads() throws IOException {
+        return this.sites(
+            "//o[starts-with(@base, 'ξ.') and o[starts-with(@as, 'α')]]"
+        );
     }
 
     /**
@@ -247,6 +263,14 @@ final class Xmirs {
         return owner.elements(
             Filter.all(Filter.withName("o"), Filter.not(Filter.hasAttribute("as")))
         );
+    }
+
+    private Collection<Site> sites(final String xpath) throws IOException {
+        final Collection<Site> found = new ArrayList<>(0);
+        for (final XML site : this.matching(xpath)) {
+            found.add(new Site(new Xnav(site.inner())));
+        }
+        return found;
     }
 
     private Collection<XML> matching(final String xpath) throws IOException {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-read-without-a-receiver-is-still-a-question.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-read-without-a-receiver-is-still-a-question.yaml
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: MIT
 ---
 # A name is taken from an object even when the object goes unwritten, because
-# it is the one the line is written in: `choose > taken` inside `[choose] > pick`
-# reads the same void that `p.choose` reads from outside. Both are applied to
-# two arms, both are answered by what the callers put into the void, and there
-# is no reason for the two to end differently. A reader further along already
-# got its answer this way, so the read itself staying a question left the table
-# saying two things about one object.
+# it is the one the line is written in: `choose > taken` inside
+# `[choose] > pick` reads the same void that `p.choose` reads from outside.
+# Both are applied to two arms, both are answered by what the callers put into
+# the void, and there is no reason for the two to end differently. A reader
+# further along already got its answer this way, so the read itself staying a
+# question left the table saying two things about one object.
 eo:
   pick.eo: |
     [choose] > pick

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-read-without-a-receiver-is-still-a-question.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-void-read-without-a-receiver-is-still-a-question.yaml
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A name is taken from an object even when the object goes unwritten, because
+# it is the one the line is written in: `choose > taken` inside `[choose] > pick`
+# reads the same void that `p.choose` reads from outside. Both are applied to
+# two arms, both are answered by what the callers put into the void, and there
+# is no reason for the two to end differently. A reader further along already
+# got its answer this way, so the read itself staying a question left the table
+# saying two things about one object.
+eo:
+  pick.eo: |
+    [choose] > pick
+      choose > taken
+        oak
+        oak
+  yes.eo: |
+    [^] > yes
+      pick > @
+        [^]
+          ? >> left
+          ? >> right
+          left > @
+  no.eo: |
+    [^] > no
+      pick > @
+        [^]
+          ? >> left
+          ? >> right
+          right > @
+  oak.eo: |
+    [] > oak
+      [^ tall] > grows
+        tall > @
+  app.eo: |
+    [] > app
+      yes.taken.grows > @
+        03-
+links:
+  - "/links/type[@id='Φ.pick.taken']/ref[@loc='Φ.oak']"
+  - "/links/type[@id='Φ.app.φ.ρ']/ref[@loc='Φ.pick.taken']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.oak.grows']"


### PR DESCRIPTION
`Dispatched.answers` walked `Xmirs.dispatches()`, which collects only objects
whose base begins with a dot. `if > not` inside `[if] > bool` is the same
choice as the `^.if` three lines above it with the receiver left out, so it
never reached `Filled` — the one thing that turns an answer rooted at a void
into what fills the void. `Xmirs.reads()` collects those applications now, and
`Dispatched` lets the application stand in for its own receiver:

```java
final String bearer = dispatch.bearer();
final String kept;
if (bearer.isEmpty()) {
    kept = filled.instead(known, made, made);
} else {
    kept = filled.instead(
        owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name()),
        bearer,
        made
    );
}
```

There is nothing to look the name up in, since the row already says what came
out — it is `Φ.bool.if` — and the two arms written on that very line say what
it holds. `Φ.bool.not` reads `Φ.bool` and `Φ.bool.φ` reads `Φ.bytes`, both of
which #8551 already gave to `and` and `or`.

Across eo-runtime 143 rows that rested on a void get a name, most of them the
`Φ.bytes.eq` behind `true.eq true`. 153 rows go the other way, and those are
worth a look before this merges: `os.is-windows.if` over two numbers used to
read `Φ.bytes`, and a `posix` call used to read `Φ.win32.return.called`. Both
answers were borrowed from what `bool` puts into its own `if`, reachable
through `Filled.fillings` only while `Φ.bool.φ` was itself the void. With that
gone the rows say `Φ.bool.if` and wait for somebody to read a call's own arms
at the call site, which is what #8469 is about. Rows resting on exactly
`Φ.bool.if` therefore go from 33 to 73, and the report moves from 86.6% to
86.9% named.

One answer I cannot defend: sixteen rows now read `Φ.false`, `Φ.uri.host` and
`Φ.uri.port` among them, where before they read `Φ.bool.if`. `Filled.handed`
walks past the site to other calls of the same object and keeps whichever arms
`Puts.holders` lets through, and there only one of `false`/`true` survives —
at the `not` site itself both do, which is why `Φ.bool.not` joins them to
`Φ.bool` correctly. Filed as #8571.

Closes #8564.
