### PR TITLE
Settle a filling that waits on the void it fills

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Freed.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Freed.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * What a void is filled with, where one of the fillings waits on the void.
+ *
+ * <p>{@code directory} keeps a {@code file} void and a {@code tmpfile} that
+ * chooses on the {@code exists} of it, and that {@code tmpfile} is one of the
+ * two things the program ever puts into that void. So what the void holds is
+ * worked out from a filling whose own type is worked out from the void, and
+ * the two wait on each other for as long as the passes run. 1,002 rows of
+ * eo-runtime end at that void and go no further (#8565).</p>
+ *
+ * <p>The choice such a filling stands on is the loose end. One of its arms
+ * terminates and hands nothing back, so a caller holding a value from the
+ * choice got it from the arm that is left, which is what {@link Branched}
+ * already says of a choice whose receiver is known. Reading that arm asks
+ * nothing of the void — only the receiver of the choice does — so the filling
+ * is settled from its arms, stands in the choice in place of itself, and the
+ * void is asked what it holds with nothing left waiting on it. What the
+ * filling itself is worth is settled a pass later, off a void that no longer
+ * waits for it, and the choice then says the same thing again without any of
+ * this.</p>
+ *
+ * <p>It is the body of a filling that is read this way and never a call made
+ * on the void. The {@code fallback} of {@code Φ.tuple.at} is a terminating arm
+ * at every call site of that {@code at}, and the arm left standing there is
+ * the index rather than the element: an application whose arms are all but one
+ * terminating is a choice where a choice is what stands on it, and nothing in
+ * particular anywhere else.</p>
+ *
+ * @since 0.73.0
+ */
+final class Freed {
+
+    /**
+     * What the program was seen putting into every void, from
+     * {@link Fillings}.
+     */
+    private final Map<String, Collection<Type>> told;
+
+    /**
+     * What the links table says.
+     */
+    private final Said table;
+
+    /**
+     * What the types certainly have.
+     */
+    private final Provided owned;
+
+    /**
+     * The arguments of every application, from {@link Given}.
+     */
+    private final Map<String, List<String>> arms;
+
+    /**
+     * Ctor.
+     *
+     * @param witnesses What the program was seen putting into every void,
+     *  from {@link Fillings}
+     * @param said What the links table says
+     * @param provided What the types certainly have
+     * @param arguments The arguments of every application, from {@link Given}
+     */
+    Freed(
+        final Map<String, Collection<Type>> witnesses,
+        final Said said,
+        final Provided provided,
+        final Map<String, List<String>> arguments
+    ) {
+        this.told = witnesses;
+        this.table = said;
+        this.owned = provided;
+        this.arms = arguments;
+    }
+
+    /**
+     * What is put into every void, with the fillings that wait on it settled.
+     *
+     * @return The types put in, by the locator of the void, in the order they
+     *  were seen
+     */
+    Map<String, Collection<Type>> all() {
+        final Map<String, Collection<Type>> found = new LinkedHashMap<>(this.told.size());
+        for (final Map.Entry<String, Collection<Type>> hollow : this.told.entrySet()) {
+            found.put(hollow.getKey(), this.members(hollow.getKey(), hollow.getValue()));
+        }
+        return found;
+    }
+
+    private Collection<Type> members(final String hollow, final Collection<Type> witnesses) {
+        final Forms forms = new Forms(this.table.forms());
+        final Ends ends = new Ends(this.table.all());
+        final Collection<Type> found = new ArrayList<>(witnesses.size());
+        for (final Type one : witnesses) {
+            final String stood = this.stands(hollow, one.names());
+            if (stood.isEmpty()) {
+                found.add(one);
+            } else {
+                found.add(forms.type(ends.name(stood)));
+            }
+        }
+        return found;
+    }
+
+    private String stands(final String hollow, final String member) {
+        final String body = this.owned.body(member);
+        final String answer = this.table.all().getOrDefault(body, "");
+        final String found;
+        if (!body.isEmpty()
+            && (answer.equals(hollow) || answer.startsWith(hollow.concat(".")))) {
+            found = this.sole(body);
+        } else {
+            found = "";
+        }
+        return found;
+    }
+
+    private String sole(final String call) {
+        final Map<String, String> forms = this.table.forms();
+        boolean dead = false;
+        String found = "";
+        for (final String arm : this.arms.getOrDefault(call, Collections.emptyList())) {
+            if (arm.isEmpty()) {
+                continue;
+            }
+            if ("terminator".equals(forms.get(arm))) {
+                dead = true;
+            } else if (found.isEmpty()) {
+                found = arm;
+            } else {
+                found = "";
+                break;
+            }
+        }
+        if (!dead) {
+            found = "";
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Promoted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Promoted.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -58,6 +59,10 @@ import java.util.Map;
  * a void has, what comes back is a {@link Var}, which names nothing a reader
  * could go and look at, and {@link Sole} refuses it.</p>
  *
+ * <p>A filling that waits on the very void it fills is settled first, by
+ * {@link Freed}, so that the two are not left waiting on each other for as
+ * long as the passes run.</p>
+ *
  * @since 0.71.0
  */
 final class Promoted {
@@ -83,6 +88,11 @@ final class Promoted {
     private final Collection<String> hollows;
 
     /**
+     * The arguments of every application, from {@link Given}.
+     */
+    private final Map<String, List<String>> arms;
+
+    /**
      * Ctor.
      *
      * @param woven The rows that follow from a set of pairs
@@ -90,17 +100,21 @@ final class Promoted {
      * @param said What the links table says, as the rules left it, without
      *  which a filling that arrives at a literal is not seen to be one
      * @param voids The locator of every void, from {@link Hollows}
+     * @param arguments The arguments of every application, without which a
+     *  filling that waits on the void it fills is not seen to be a choice
      */
     Promoted(
         final Woven woven,
         final XML provides,
         final Said said,
-        final Collection<String> voids
+        final Collection<String> voids,
+        final Map<String, List<String>> arguments
     ) {
         this.table = woven;
         this.given = provides;
         this.written = said;
         this.hollows = voids;
+        this.arms = arguments;
     }
 
     /**
@@ -117,10 +131,11 @@ final class Promoted {
             this.given, new Ends(pairs).names(), this.hollows
         );
         final Map<String, Collection<String>> asked = this.asked(pairs);
+        final Said said = this.written.with(pairs, this.table.binds(pairs));
         final Map<String, String> found = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Collection<Type>> hollow
-            : new Fillings(
-                this.written.with(pairs, this.table.binds(pairs)), this.given, this.hollows
+            : new Freed(
+                new Fillings(said, this.given, this.hollows).all(), said, owned, this.arms
             ).all().entrySet()) {
             String sole = new Sole(hollow.getValue(), known).names();
             if (sole.isEmpty()) {

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -94,7 +94,7 @@ public final class Resolved implements Clue {
         final Collection<String> voids = new Hollows(given).all();
         final Map<String, Type> kept = written.others();
         final Woven woven = new Woven(given, applied, receivers, voids, dispatches);
-        final Promoted promoted = new Promoted(woven, given, new Said(written), voids);
+        final Promoted promoted = new Promoted(woven, given, new Said(written), voids, args);
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, asked, args, named, receivers, voids), promoted
         ).from(

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-choice-with-one-live-arm-settles-before-the-void-it-reads.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-choice-with-one-live-arm-settles-before-the-void-it-reads.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `temp` reads `exists` off the object in `dir`'s void and chooses on it, so
+# what `temp` is worth looks like it waits on that void. It does not. One arm
+# of the choice terminates and never hands anything back, so the other arm is
+# the whole answer, and reading that arm asks nothing about `exists`. Until
+# `temp` is settled the void has two witnesses and stays a void, `temp` being
+# one of them, and the two wait on each other forever. With `temp` settled off
+# its arms the void is a `leaf`, and `there` and the receiver of the choice
+# both say so.
+eo:
+  leaf.eo: |
+    [path] > leaf
+      path > @
+      path > exists
+  dir.eo: |
+    [file] > dir
+      file > @
+      file.exists > there
+      [^] > temp
+        ^.exists.if > @
+          leaf "tmp"
+          T
+            "no such dir"
+  app.eo: |
+    [] > app
+      outer.temp > @
+      dir > outer
+        inner.temp
+      dir > inner
+        leaf "a"
+links:
+  - "/links/type[@id='Φ.dir.there']/ref[@loc='Φ.leaf.exists']"
+  - "/links/type[@id='Φ.dir.temp.φ.ρ']/ref[@loc='Φ.leaf.exists']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.dir.temp']"


### PR DESCRIPTION
`directory` keeps a `file` void and a `tmpfile` that chooses on the `exists` of
it, and that `tmpfile` is one of the two things the program ever puts into that
void. What the void holds was therefore worked out from a filling whose own type
was worked out from the void, and the two waited on each other for as long as
the passes ran.

The choice the filling stands on is the loose end. One arm terminates and hands
nothing back, so the arm left standing is the whole answer, and reading that arm
asks nothing of the void — only the receiver of the choice does. `Freed` settles
the filling that way, puts it into the union in place of itself, and leaves
nothing waiting on the void:

```java
private String stands(final String hollow, final String member) {
    final String body = this.owned.body(member);
    final String answer = this.table.all().getOrDefault(body, "");
    final String found;
    if (!body.isEmpty()
        && (answer.equals(hollow) || answer.startsWith(hollow.concat(".")))) {
        found = this.sole(body);
    } else {
        found = "";
    }
    return found;
}
```

The claim self-corrects. Once `Φ.directory.file` is `Φ.file`, the next pass
answers `Φ.directory.tmpfile.φ` off a void that no longer waits for it, and the
choice says the same thing again without any of this. It is the body of a
filling that is read this way and never a call made on the void: the `fallback`
of `Φ.tuple.at` is a terminating arm at every call site of that `at`, and the
arm left standing there is the index rather than the element.

Across eo-runtime this settles two fillings and moves 23 answers off a void —
`Φ.directory.file.is-directory` becomes `Φ.file.is-directory`,
`Φ.directory.file.as-path.resolved` becomes `Φ.path.impl.resolved`, and so on.
Nothing moves the other way, and the run still takes 38s. The report goes from
86.9% to 87.0% named.

The 1,002 rows the ticket counts do not all come along. 979 of them rest on
`Φ.directory.file.exists.if`, and with the void named that reads as `.if` on
`Φ.file.exists`, whose own body ends at `Φ.bool.if.code.eq.or` — an `if` whose
arms nobody read at the call site, which is #8469. So this clears the cycle the
ticket names and hands the rest to that one.

Closes #8565.
