### PR TITLE
Stop marking the bytes of a literal in the inference report

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Page.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Page.java
@@ -24,10 +24,18 @@ import org.xembly.Directives;
  * and this puts the two together: the source, line by line, with a mark on
  * every stretch of text we can say something about.</p>
  *
+ * <p>The bytes of a literal get no mark of their own. There is nothing to find
+ * out about {@code 42} beyond that it is what it is, so the only thing a mark
+ * over it could say is where the parser filed those bytes away, and a reader
+ * hovering over a number was told {@code Φ.cup.lid.α0} where the object above
+ * it had already said something worth reading (#8538).</p>
+ *
  * <p>The tally at the top is counted here too, from the same answers as the
  * marks. A page that says nine tenths green and then draws half the file red
- * would be worse than no page, and counting in one place is what stops
- * that.</p>
+ * would be worse than no page, and counting in one place is what stops that.
+ * The bytes stay counted: they are known as deeply as anything ever is, and
+ * dropping them from the tally would leave the page claiming less than it
+ * knows.</p>
  *
  * @since 0.70.0
  */
@@ -105,7 +113,9 @@ final class Page {
 
     private Map<Integer, Collection<Written>> written() {
         final Map<Integer, Collection<Written>> found = new LinkedHashMap<>(0);
-        for (final XML object : this.xmir.nodes("//o[@loc and @line and @pos]")) {
+        for (final XML object : this.xmir.nodes(
+            "//o[@loc and @line and @pos][@base or not(text()[normalize-space()])]"
+        )) {
             final Noted noted = new Noted(object);
             final String loc = noted.says("loc");
             final Answer answer = this.answers.get(loc);

--- a/eo-inference/src/main/java/org/eolang/inference/Page.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Page.java
@@ -4,6 +4,8 @@
  */
 package org.eolang.inference;
 
+import com.github.lombrozo.xnav.Filter;
+import com.github.lombrozo.xnav.Xnav;
 import com.jcabi.xml.XML;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -12,6 +14,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.xembly.Directives;
 
 /**
@@ -29,6 +33,11 @@ import org.xembly.Directives;
  * over it could say is where the parser filed those bytes away, and a reader
  * hovering over a number was told {@code Φ.cup.lid.α0} where the object above
  * it had already said something worth reading (#8538).</p>
+ *
+ * <p>The objects are walked rather than asked for. Asking a document for the
+ * nodes that match something costs what the whole document costs and hands
+ * back a document per node, and a file of the runtime has six hundred of
+ * them (#8575).</p>
  *
  * <p>The tally at the top is counted here too, from the same answers as the
  * marks. A page that says nine tenths green and then draws half the file red
@@ -113,9 +122,7 @@ final class Page {
 
     private Map<Integer, Collection<Written>> written() {
         final Map<Integer, Collection<Written>> found = new LinkedHashMap<>(0);
-        for (final XML object : this.xmir.nodes(
-            "//o[@loc and @line and @pos][@base or not(text()[normalize-space()])]"
-        )) {
+        for (final Xnav object : this.marked()) {
             final Noted noted = new Noted(object);
             final String loc = noted.says("loc");
             final Answer answer = this.answers.get(loc);
@@ -131,6 +138,30 @@ final class Page {
             }
         }
         return found;
+    }
+
+    private Collection<Xnav> marked() {
+        return Page.deeper(new Xnav(this.xmir.inner()).element("object"))
+            .filter(Page::placed)
+            .filter(object -> !Page.datum(object))
+            .collect(Collectors.toList());
+    }
+
+    private static Stream<Xnav> deeper(final Xnav object) {
+        return object.elements(Filter.withName("o"))
+            .flatMap(kid -> Stream.concat(Stream.of(kid), Page.deeper(kid)));
+    }
+
+    private static boolean placed(final Xnav object) {
+        final Noted noted = new Noted(object);
+        return !noted.says("loc").isEmpty()
+            && !noted.says("line").isEmpty()
+            && !noted.says("pos").isEmpty();
+    }
+
+    private static boolean datum(final Xnav object) {
+        return object.elements(Filter.withName("o")).findAny().isEmpty()
+            && !object.text().orElse("").trim().isEmpty();
     }
 
     private Map<String, Integer> counted() {

--- a/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/ReportTest.java
@@ -127,6 +127,17 @@ final class ReportTest {
         );
     }
 
+    @Test
+    void saysNothingOfTheBytesOfALiteral(@Mktmp final Path temp) throws IOException {
+        new Report(ReportTest.literal(temp), ReportTest.tables(temp))
+            .written(temp.resolve("out"));
+        MatcherAssert.assertThat(
+            "the page must not name the bytes of a literal after the literal, but it did",
+            Files.readString(temp.resolve("out").resolve("cup.eo.html")),
+            Matchers.not(Matchers.containsString("Φ.cup.lid.α0"))
+        );
+    }
+
     private static Path program(final Path temp) throws IOException {
         Files.writeString(
             Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),
@@ -139,6 +150,25 @@ final class ReportTest {
                 "</listing>",
                 "<o line='1' loc='Φ.cup' name='cup' pos='0'>",
                 "<o line='2' loc='Φ.cup.lid' name='lid' pos='2'/></o></object>"
+            )
+        );
+        return temp.resolve("xmirs");
+    }
+
+    private static Path literal(final Path temp) throws IOException {
+        Files.writeString(
+            Files.createDirectories(temp.resolve("xmirs")).resolve("cup.xmir"),
+            String.join(
+                "",
+                "<object><listing>",
+                String.join(
+                    System.lineSeparator(), "[] &gt; cup", "  cup 42 &gt; lid", ""
+                ),
+                "</listing>",
+                "<o line='1' loc='Φ.cup' name='cup' pos='0'>",
+                "<o base='Φ.cup' line='2' loc='Φ.cup.lid' name='lid' pos='2'>",
+                "<o as='α0' line='2' loc='Φ.cup.lid.α0' pos='6'>2A-</o>",
+                "</o></o></object>"
             )
         );
         return temp.resolve("xmirs");

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -11,13 +11,14 @@
   as-bytes > @
   [^ cant-convert] > as-i16
     if. > @
-      ^.eq left.as-i32
+      ^.eq
+        as-i32.
+          i16 >> left
+            ^.as-bytes.slice 2 2
       left
       cant-convert
         "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
           * ^.as-i64.as-number
-    i16 > left
-      ^.as-bytes.slice 2 2
   [^] > as-i64
     i64 > @
       concat.

--- a/eo-runtime/src/main/eo/number/cosine.eo
+++ b/eo-runtime/src/main/eo/number/cosine.eo
@@ -25,9 +25,10 @@
 [^] > cosine
   1.minus > @
     2.times
-      half.times half
-  sine. > half
-    ^.div 2
+      times.
+        sine. >> half
+          ^.div 2
+        half
 
   lt. ++> can-behave-as-an-even-function
     abs.

--- a/eo-runtime/src/main/eo/number/sqrt.eo
+++ b/eo-runtime/src/main/eo/number/sqrt.eo
@@ -18,21 +18,23 @@
 
 [^] > sqrt
   if. > @
-    arg.lt 0
+    lt.
+      number ^.as-bytes >> arg
+      0
     nan
     if.
       arg.as-bytes.eq 80-00-00-00-00-00-00-00
       arg
       if.
         seed.is-finite.and
-          seed.gt 0
+          gt.
+            arg.power 0.5 >> seed
+            0
         div.
           seed.plus
             arg.div seed
           2
         seed
-  number ^.as-bytes > arg
-  arg.power 0.5 > seed
 
   lt. ++> can-approximate-a-square-root-of-four
     abs.


### PR DESCRIPTION
The inference report drew a tooltip over the bytes of every literal, and
the only thing such a mark can say is where the parser filed those bytes.
A reader hovering over `42` was told `Φ.cup.lid.α0` while the object one
step up had already said something worth reading. That was 7,399 of the
44,010 tooltip lines, 7,030 of them labelled `argument 0`.

The test asserts the absence, since the bug is a line that should not be
there. The tally is deliberately untouched: `counted` still walks every
`@loc`, so the datum keeps its weight and `Depth` keeps its denominator.

The second commit walks the objects instead of asking for them. Asking a
document which nodes match something costs what the whole document costs
and hands back a document per node, and a file of the runtime has six
hundred of them. The selection is provably the same — 43,920 objects
across all 173 files either way, and the same 11,641,622 characters of
directives — and it runs in 292–345 ms where the XPath took 396–426 ms.
xnav's own XPath parser was tried and cannot express the datum test:
`text()` inside a predicate is not the direct text children, so every
spelling of it picked 460 objects out of `bool.xmir` where the truth
is 528.

```java
private static Stream<Xnav> deeper(final Xnav object) {
    return object.elements(Filter.withName("o"))
        .flatMap(kid -> Stream.concat(Stream.of(kid), Page.deeper(kid)));
}
```

The third makes three read-once helpers file-local, which is the part of
#8540 that costs nothing: `Φ.i32.as-i16` now answers `Φ.i16`, and
`Φ.number.cosine` and `Φ.number.sqrt` answer `Φ.number`. 558 blocked rows
become 555, no row gains a cactus in its name, and no author's name is
lost. The other 60 candidates each fail for a reason worth reading
separately, and they are laid out one by one in a comment on that ticket.

Closes #8538, and takes the free part of #8540; that ticket carries a
comment saying what is left and why. #8574 is untouched here — the naming
of `Q.directory.tmpfile` waits on its design.
