### PR TITLE
Refuse a lowered call on the value of another call

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Dispatched.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Dispatched.java
@@ -44,6 +44,17 @@ import java.util.regex.Pattern;
  * complement, {@code as-number} of the same eight bytes reads a
  * double.</p>
  *
+ * <p>The receiver of a call is refused when it is itself the value of a
+ * call the tables witness as a datum. Such a value comes back wrapped
+ * into the carrier of its forma — a string of the very bytes it
+ * dataized to — and the object that answered it is gone, together with
+ * every method of that object: {@code path.posix} answers a formation
+ * whose {@code φ} is a string, so the tables witness a string for it,
+ * and {@code basename} of that string is nowhere to be found. Only a
+ * void, which the atom holds as the object it was given, and a value
+ * the tables witness as nothing at all, which the call leaves as the
+ * object it is, may receive a call.</p>
+ *
  * @since 0.76.0
  */
 public final class Dispatched {
@@ -60,6 +71,13 @@ public final class Dispatched {
      */
     private static final Collection<String> LAZY = new HashSet<>(
         Arrays.asList("if", "and", "or")
+    );
+
+    /**
+     * The formas a call comes back as a datum in, losing the object.
+     */
+    private static final Collection<String> DATA = new HashSet<>(
+        Arrays.asList("number", "string", "bool", "bytes")
     );
 
     /**
@@ -132,6 +150,7 @@ public final class Dispatched {
         );
         Optional<Term> out = Optional.empty();
         if (found.isPresent()) {
+            this.reachable(receiver, method);
             final List<Binding> args = found.get();
             final Shape exact = new Shape(method, receiver, args);
             final List<String> keys = new ArrayList<>(args.size() + 1);
@@ -163,10 +182,30 @@ public final class Dispatched {
             }
             final String label = this.minted.next();
             this.minted.bind(label, forma);
+            this.minted.called(label);
             steps.add(new Dispatch(label, method, keys, forma));
             out = Optional.of(tree.swapped(exact, new Symbol(label, forma)));
         }
         return out;
+    }
+
+    private void reachable(final String receiver, final String method) {
+        if (this.minted.calling(receiver)) {
+            final String carrier = this.minted.carrier(receiver);
+            if (Dispatched.DATA.contains(carrier)) {
+                throw new IllegalStateException(
+                    String.format(
+                        String.join(
+                            " ",
+                            "The receiver of '%s' is the value of a call, which comes",
+                            "back into EO as a %s and not as the object that answered",
+                            "it, so no method of that object can be found on it"
+                        ),
+                        method, carrier
+                    )
+                );
+            }
+        }
     }
 
     private static String forma(final Map<String, String> bindings) {

--- a/eo-lowering/src/main/java/org/eolang/lowering/Minted.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Minted.java
@@ -7,6 +7,7 @@ package org.eolang.lowering;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,10 @@ import java.util.Map;
  * voids: those of the formation first, and those of every body a repeat
  * resumes after them, declared with the formas of the values the first
  * repeat hands over, so it names the carrier of any key — a step by its
- * binding, a void by its position, a literal by its own prefix.</p>
+ * binding, a void by its position, a literal by its own prefix. It also
+ * remembers which of the steps are calls back into EO, since the value
+ * of such a step is the datum the call was dataized into and not the
+ * object that answered it.</p>
  *
  * @since 0.76.0
  */
@@ -52,6 +56,11 @@ public final class Minted {
     private final Map<String, Integer> offsets;
 
     /**
+     * The labels of the steps whose value is a call back into EO.
+     */
+    private final Collection<String> calls;
+
+    /**
      * Ctor.
      *
      * @param inputs The voids of the fragment: names to formas, in order
@@ -71,6 +80,7 @@ public final class Minted {
         this.formas = labels;
         this.bodies = parts;
         this.offsets = starts;
+        this.calls = new HashSet<>(0);
     }
 
     /**
@@ -92,6 +102,25 @@ public final class Minted {
      */
     public void bind(final String label, final String forma) {
         this.formas.put(label, forma);
+    }
+
+    /**
+     * Remember that the value of a label is a call back into EO.
+     *
+     * @param label The label
+     */
+    public void called(final String label) {
+        this.calls.add(label);
+    }
+
+    /**
+     * Whether the value a key names came out of a call back into EO.
+     *
+     * @param key The key, such as {@code sym:s2} or {@code sym:v0}
+     * @return True if the key names a step that is such a call
+     */
+    public boolean calling(final String key) {
+        return key.startsWith("sym:s") && this.calls.contains(key.substring(4));
     }
 
     /**

--- a/eo-lowering/src/main/java/org/eolang/lowering/Minted.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Minted.java
@@ -105,25 +105,6 @@ public final class Minted {
     }
 
     /**
-     * Remember that the value of a label is a call back into EO.
-     *
-     * @param label The label
-     */
-    public void called(final String label) {
-        this.calls.add(label);
-    }
-
-    /**
-     * Whether the value a key names came out of a call back into EO.
-     *
-     * @param key The key, such as {@code sym:s2} or {@code sym:v0}
-     * @return True if the key names a step that is such a call
-     */
-    public boolean calling(final String key) {
-        return key.startsWith("sym:s") && this.calls.contains(key.substring(4));
-    }
-
-    /**
      * Declare the voids of a body a repeat resumes.
      *
      * @param name The name of the helper
@@ -245,6 +226,25 @@ public final class Minted {
             );
         }
         return out;
+    }
+
+    /**
+     * Remember that the value of a label is a call back into EO.
+     *
+     * @param label The label
+     */
+    void called(final String label) {
+        this.calls.add(label);
+    }
+
+    /**
+     * Whether the value a key names came out of a call back into EO.
+     *
+     * @param key The key, such as {@code sym:s2} or {@code sym:v0}
+     * @return True if the key names a step that is such a call
+     */
+    boolean calling(final String key) {
+        return key.startsWith("sym:s") && this.calls.contains(key.substring(4));
     }
 
     private static <T> Map<String, T> first(final T value) {

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/dispatched-receiver.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/dispatched-receiver.yaml
@@ -28,5 +28,6 @@ voids:
 lowered: |
   [] > foo
     calc "z" > @
-    (x.holder "a").tail > [x] > calc
+    tail. > [x] > calc
+      x.holder "a"
 stuck: "is the value of a call"

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/dispatched-receiver.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/lowering-packs/dispatched-receiver.yaml
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# The receiver of the second call is the value of the first one, and the
+# tables of eo:inference witness a string for that value, since `holder`
+# is a formation whose φ is the very string it was given. A call comes
+# back into EO wrapped into the carrier of its forma, so the receiver
+# would be a string of those bytes and the object that answered the
+# first call would be gone, together with `tail` and every other method
+# of it. The reduction refuses the call and the formation stays as
+# written.
+input: |
+  [] > foo
+    [x] > calc
+      (x.holder "a").tail > @
+    calc "z" > @
+prelude:
+  string.eo: |
+    [as-bytes] > string
+      as-bytes > @
+      [^ uri] > holder
+        uri > @
+        [^] > tail
+          ^.uri > @
+unit: calc
+voids:
+  x: string
+lowered: |
+  [] > foo
+    calc "z" > @
+    (x.holder "a").tail > [x] > calc
+stuck: "is the value of a call"


### PR DESCRIPTION
Fixes the `codecov` job, which has been red on `master` with 80 `TestEOpath` errors
([run 34371689087](https://github.com/objectionary/eo/actions/runs/34371689087/job/102534227844)).
It is the only job that runs with `eo.loweringRequired`, so the failure is a lowering bug and
nothing the other jobs can see.

### What breaks

Every failing test dispatches `basename`, `dirname`, `extname`, `normalized` or `resolved` on
`path.posix` or `path.win32`, and dies with

```
org.eolang.ExFailure: the attribute "dirname" is not found in []
  at org.eolang.EOpath$EO$u002Bcan_return_the_current_dirname_of_a_relative_posix_file$EOl$uF335b2368125c280.lambda(...)
```

The frame names an `l🌵…` atom, so `Outlined` carved the whole `eq` subtree of the test body into
one fragment. The tables of `eo:inference` decide the leaf and both calls of it (from
`eo-runtime/target/eo/6-inference/links.xml`):

| locator | chases to |
| --- | --- |
| `…file.φ.ρ.ρ.ρ` (the `path` leaf) | `Φ.path` → `Φ.path.φ` → `Φ.path.impl` → `Φ.path.impl.φ` → `Φ.path.impl.uri`, a void witnessed as `string` |
| `…file.φ.ρ.ρ` (the `.posix` call) | `Φ.path.posix` → … → `string` |
| `…file.φ.ρ` (the `.dirname` call) | `Φ.path.impl.dirname` → `string` |

So the leaf carries, the fragment carves, and the reduction settles into two `Dispatch` steps. A
`Dispatch` dataizes its value into the witnessed forma, and `Call` wraps a `string` step back with
`new Data.ToPhi(new String(s1, java.nio.charset.StandardCharsets.UTF_8))` — so `dirname` is
dispatched on a plain `string`, whose `φ` chain ends in an anonymous formation over bytes, which is
the `[]` of the message. `path.posix` answers a formation whose `φ` is the uri, and the witness
cannot tell that object from the string it dataizes to.

### The fix

This is the hazard e7b5fa02 fixed for `bytes` ("the witness cannot tell the object from its data"),
one position over: the receiver of the next call is exactly where the difference decides which
method a name finds. `Minted` now remembers which steps are calls back into EO, and `Dispatched`
refuses a call whose receiver is such a step's value when the tables witness that value as a datum.
A void, which the atom holds as the object it was given, and a value witnessed as nothing at all,
which the call leaves as the object it is, still receive calls. The fragment around a refused call
stays in EO, the way every other refusal leaves its site as written.

A pack records the refusal.

### Verification

Reproduced and verified locally against the `codecov` job's own configuration, with phino 0.0.115
built from Hackage (GHC 9.6.7 — the `base` in 9.6.6 is below phino's `>=4.18.3.0`):

| check | result |
| --- | --- |
| `TestEOpath` under `-Deo.loweringRequired=true` | 95 tests, 0 failures, 0 errors (was 80 errors) |
| `path.xmir` in `4-lower` | still lowers 8 sites, so the refusal is surgical |
| files in `eo-runtime/target/eo/4-lower` | 16, so the job's `ls .../4-lower/*.xmir` guard holds |
| `LoweringTest` (all packs, phino present) | 208/208 |
| `eo-lowering` | 333/333 |
| `mvn -Pqulice qulice:check`, all modules | green |

The only other failures in that run are the sandbox's, not the diff's: ten `SyscallTest` cases
find no free TCP port in 20000-29999, and `MainTest.printsVersion` reads the `JAVA_TOOL_OPTIONS`
banner the container writes to stdout.

Worth noting for whoever reads the workflows: `fast` also passes `-Deo.loweringRequired=true`, but
with `-Deo.transpileTests=false`, so the EO test objects are never generated there. That is why
this only ever showed up in `codecov`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWcxqi3zTxZtnJvpu8xUVm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWcxqi3zTxZtnJvpu8xUVm)_


---
_Generated by [Claude Code](https://claude.ai/code)_