### PR TITLE
Cache recursive logarithm helper values

### DIFF
--- a/eo-runtime/src/main/eo/number/ln.eo
+++ b/eo-runtime/src/main/eo/number/ln.eo
@@ -69,8 +69,10 @@
       if. > @
         level.eq 0
         e
-        prev.times prev
-      ^.epow > prev
+        times.
+          number prev
+          number prev
+      ^.epow > prev!
         level.minus 1
     [m] > series
       2.times > @
@@ -95,8 +97,10 @@
       if. > @
         level.eq 0
         1
-        prev.plus prev
-      ^.step > prev
+        plus.
+          number prev
+          number prev
+      ^.step > prev!
         level.minus 1
   number ^.as-bytes > n
 

--- a/eo-runtime/src/test/java/org/eolang/DataizedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/DataizedTest.java
@@ -8,6 +8,10 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link Dataized}.
@@ -15,6 +19,32 @@ import org.junit.jupiter.api.Test;
  * @since 0.22
  */
 final class DataizedTest {
+
+    // Exercise the logarithm even when EO test transpilation is disabled.
+    // The lowered power ladder must reach its base case (#8561).
+    @ParameterizedTest
+    @ValueSource(doubles = {1.0, 2.0, 3.0, 20.0, 1.0e300, 1.0e-300})
+    @Timeout(30L)
+    void finishesLogarithm(final double input) {
+        MatcherAssert.assertThat(
+            "A logarithm must finish with the expected value rather than exhaust memory",
+            new Dataized(new Data.ToPhi(input).take("ln")).asNumber(),
+            Matchers.closeTo(Math.log(input), 1.0e-9)
+        );
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+        "-1.0, NaN", "0.0, -Infinity", "Infinity, Infinity",
+        "-Infinity, NaN", "NaN, NaN"
+    })
+    void keepsLogarithmLimitingCases(final double input, final double expected) {
+        MatcherAssert.assertThat(
+            "Logarithm limiting cases must return before evaluating the power ladder",
+            new Dataized(new Data.ToPhi(input).take("ln")).asNumber(),
+            Matchers.equalTo(expected)
+        );
+    }
 
     @Test
     void failsWithLocationThroughPhSafe() {


### PR DESCRIPTION
With Phino lowering enabled, `3.ln`, `20.ln` and extreme finite inputs exhaust the heap: the generated continuation calls `epow(level - 1)` before reaching the atom containing the level-zero guard.

Cache `prev` in both recursive helpers and convert its bytes back to numbers at the arithmetic sites. This preserves the existing power ladder while avoiding that evaluation order. Java regression tests exercise six finite inputs even when EO test transpilation is disabled, plus the zero and non-finite limiting cases.

Validation with Java 21 and Phino 0.0.115:

- The unchanged lowered runtime exhausts memory; all six finite probes return correct results after the change. All 12 existing logarithm tests pass with no skips. `DataizedTest` (19 tests) and `MainTest` (12 tests) also pass with no skips.
- Qulice static checks pass. The full `mvn clean install -Pqulice -Deo.loweringRequired=true` build is not green locally: the first six modules pass, but the runtime has 80 `TestEOpath` errors. The unchanged base reproduces the same 80 errors with identical test names and messages; integration tests were not reached. The path fix is tracked separately in #8587. No path changes or check exclusions are included.

Closes #8561. @yegor256
