### PR TITLE
Unbreak master: the qulice javadoc check and the string.regex lint

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -291,6 +291,7 @@ final class Value {
     /**
      * The {@code Q} global-root glyph — R-3.8.1 excludes it from the
      * reversed-head whitelist ({@code @}, {@code ^}, {@code $})?
+     *
      * @return True for {@link Kind#ROOT} whose raw text is {@code Q}
      */
     boolean global() {

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -679,7 +679,7 @@
         ^.parsed.reason
         indexed ^.parsed.at
     ^.checked > compiled
-      T > [^ reason offset] >>
+      T > [^ reason offset]
         worded offset reason
     flags.as-bytes > fraw
     fraw.size > fsize
@@ -833,7 +833,7 @@
           ^.subj
           at
           unmarked
-          block ^.at caps at > [^ at caps] >>
+          block ^.at caps at > [^ at caps]
       subject txt.as-bytes > subj
       txt.length > total
     [^ txt] > matches
@@ -1625,7 +1625,7 @@
                   index.plus 1
                   opened
                   bits
-                  [^] >>
+                  [^]
                     if. > [^ s at caps k] > run
                       s.size.gt at
                       nothing


### PR DESCRIPTION
Master is red in two independent places, and this unbreaks both.

The daily build dies first in `eo-parser`. Qulice moved to 0.35.2 a few commits ago and its `JavadocEmptyLineBeforeTagCheck` now sees a javadoc in `Value` that was written without an empty line between the description and the `@return` clause, so the module fails the check and everything after it is skipped. I added that one line. I scanned every `.java` file in the repository for the same shape and `Value.global()` was the only one, which matches what the build reported before it stopped.

The second breakage is why `fast` fails on every open pull request right now, including renovate branches that touch nothing but an action version. Compiling `eo-runtime` raises three `redundant-attachment/S` warnings in `string.regex`, at lines 682, 836 and 1628, and `failOnWarning` turns them into a build failure. All three objects carry a `>>` auto-name whose generated name nothing ever references, so the name is dead weight; each one sits in argument position, where an anonymous object is legal, and the lint only fires when the object has no reference reaching out of itself, which is exactly the condition under which the name can go. Dropping the suffix is what the lint asks for. They arrived with the pure-EO `string.regex` rewrite in b92ac4b4a3.

The two fixes are unrelated to each other and sit in separate commits. They travel together because `fast` runs on this branch too, so the javadoc fix cannot go green on its own until the runtime lint is cleared.
