### PR TITLE
#8618: move Handles, Cstring and TupleToArray into org.eolang.sys

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -291,6 +291,7 @@ final class Value {
     /**
      * The {@code Q} global-root glyph — R-3.8.1 excludes it from the
      * reversed-head whitelist ({@code @}, {@code ^}, {@code $})?
+     *
      * @return True for {@link Kind#ROOT} whose raw text is {@code Q}
      */
     boolean global() {

--- a/eo-runtime/src/main/java/org/eolang/EOposix$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOposix$EOφ.java
@@ -5,6 +5,7 @@
 package org.eolang;
 
 import org.eolang.posix.NamedSyscall;
+import org.eolang.sys.TupleToArray;
 
 /**
  * Posix syscall.

--- a/eo-runtime/src/main/java/org/eolang/EOwin32$EOφ.java
+++ b/eo-runtime/src/main/java/org/eolang/EOwin32$EOφ.java
@@ -4,6 +4,7 @@
  */
 package org.eolang;
 
+import org.eolang.sys.TupleToArray;
 import org.eolang.win32.NamedFuncCall;
 
 /**

--- a/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
@@ -4,12 +4,12 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Access syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ClosedirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ClosedirSyscall.java
@@ -6,10 +6,10 @@ package org.eolang.posix;
 
 import com.sun.jna.Pointer;
 import org.eolang.Data;
-import org.eolang.Handles;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Handles;
 
 /**
  * Closedir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
@@ -4,11 +4,11 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Creat syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/GetenvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/GetenvSyscall.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Getenv syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
@@ -6,11 +6,11 @@ package org.eolang.posix;
 
 import com.sun.jna.Native;
 import java.util.Collections;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The 'inet_addr' syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
@@ -4,11 +4,11 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Mkdir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
@@ -4,11 +4,11 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Open syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/OpendirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/OpendirSyscall.java
@@ -5,11 +5,11 @@
 package org.eolang.posix;
 
 import com.sun.jna.Pointer;
-import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Handles;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
+import org.eolang.sys.Handles;
 
 /**
  * Opendir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ReaddirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReaddirSyscall.java
@@ -7,11 +7,11 @@ package org.eolang.posix;
 import com.sun.jna.Platform;
 import com.sun.jna.Pointer;
 import org.eolang.Data;
-import org.eolang.Handles;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Handles;
 
 /**
  * Readdir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/RenameSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RenameSyscall.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Rename syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/RmdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RmdirSyscall.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Rmdir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
@@ -7,10 +7,10 @@ package org.eolang.posix;
 import com.sun.jna.Platform;
 import com.sun.jna.Structure;
 import java.util.function.ToIntBiFunction;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Stat syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Symlink syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/UnlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/UnlinkSyscall.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.posix;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * Unlink syscall.

--- a/eo-runtime/src/main/java/org/eolang/sys/Cstring.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/Cstring.java
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
+
+import org.eolang.Dataized;
+import org.eolang.Expect;
+import org.eolang.Natural;
+import org.eolang.Phi;
 
 /**
  * Transform {@link Expect} to text a C function can be given.

--- a/eo-runtime/src/main/java/org/eolang/sys/Handles.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/Handles.java
@@ -3,12 +3,13 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Pointer;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.eolang.ExFailure;
 
 /**
  * Native pointers the runtime keeps on behalf of EO.

--- a/eo-runtime/src/main/java/org/eolang/sys/TupleToArray.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/TupleToArray.java
@@ -3,9 +3,12 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import java.util.function.Supplier;
+import org.eolang.Dataized;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
 
 /**
  * Convert {@code EOtuple} of arguments to Java array.

--- a/eo-runtime/src/main/java/org/eolang/sys/package-info.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/package-info.java
@@ -10,13 +10,17 @@
  * another way by macOS, and both families of adapters, posix and win32,
  * hand that layout to the kernel. It is theirs, not the runtime's, so it
  * lives here rather than in the root package next to {@code Phi} and
- * {@code Bytes}.</p>
+ * {@code Bytes}. The same goes for {@code Handles}, {@code Cstring} and
+ * {@code TupleToArray}, which carry a pointer, a text and a tuple of
+ * arguments across to C on their behalf.</p>
  *
  * @since 0.77.0
- * @todo #8533:30min Move Syscall, Handles, Cstring and TupleToArray here,
- *  together with SyscallTest, ReadSyscallTest and StatSyscallTest. They serve
- *  posix and win32 alone, yet standing in org.eolang they read as part of the
- *  runtime's public surface, the way Bytes and PhDefault are.
+ * @todo #8618:30min Move Syscall here too, together with SyscallTest,
+ *  ReadSyscallTest and StatSyscallTest. It serves posix and win32 alone,
+ *  yet standing in org.eolang it reads as part of the runtime's public
+ *  surface, the way Bytes and PhDefault are. It waits on its own pull
+ *  request because sixty-two adapters import it and the diff would not
+ *  fit under the two-hundred-line limit alongside this one.
  * @todo #8533:30min Re-parent org.eolang.posix and org.eolang.win32 as
  *  org.eolang.sys.posix and org.eolang.sys.win32, and name the new directories
  *  in sonar.cpd.exclusions in pom.xml, which is the only place outside Java

--- a/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
@@ -5,12 +5,12 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _access function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
@@ -5,11 +5,11 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _creat function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/FindCloseFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FindCloseFuncCall.java
@@ -6,11 +6,11 @@ package org.eolang.win32;
 
 import com.sun.jna.Pointer;
 import org.eolang.Data;
-import org.eolang.Handles;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Handles;
 
 /**
  * The kernel32 FindClose function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/FindFirstFileFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FindFirstFileFuncCall.java
@@ -7,11 +7,11 @@ package org.eolang.win32;
 import com.sun.jna.Native;
 import com.sun.jna.Pointer;
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
-import org.eolang.Handles;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
+import org.eolang.sys.Handles;
 
 /**
  * The kernel32 FindFirstFileW function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/FindNextFileFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FindNextFileFuncCall.java
@@ -6,11 +6,11 @@ package org.eolang.win32;
 
 import com.sun.jna.Pointer;
 import org.eolang.Data;
-import org.eolang.Handles;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Handles;
 
 /**
  * The kernel32 FindNextFileW function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/GetFileAttributesFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetFileAttributesFuncCall.java
@@ -5,11 +5,11 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The kernel32 GetFileAttributesW function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/GetenvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetenvFuncCall.java
@@ -4,10 +4,10 @@
  */
 package org.eolang.win32;
 
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt getenv function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -7,11 +7,11 @@ package org.eolang.win32;
 import com.sun.jna.Native;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The 'inet_addr' WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
@@ -5,10 +5,10 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _mkdir function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
@@ -5,11 +5,11 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _open function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
@@ -5,10 +5,10 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt rename function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
@@ -5,10 +5,10 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _rmdir function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
@@ -5,10 +5,10 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _stat64 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
@@ -5,10 +5,10 @@
 package org.eolang.win32;
 
 import com.sun.jna.WString;
-import org.eolang.Cstring;
 import org.eolang.Data;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Cstring;
 
 /**
  * The msvcrt _unlink function call.

--- a/eo-runtime/src/test/java/org/eolang/sys/CstringTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/CstringTest.java
@@ -2,8 +2,12 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang;
+package org.eolang.sys;
 
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Expect;
+import org.eolang.PhTerminator;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/eo-runtime/src/test/java/org/eolang/sys/HandlesTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/HandlesTest.java
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Pointer;
+import org.eolang.ExFailure;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;

--- a/eo-runtime/src/test/java/org/eolang/sys/TupleToArrayTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/TupleToArrayTest.java
@@ -2,8 +2,15 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang;
+package org.eolang.sys;
 
+import org.eolang.AtVoid;
+import org.eolang.Attr;
+import org.eolang.Attrs;
+import org.eolang.Data;
+import org.eolang.ExAbstract;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
Closes #8618.

`Handles`, `Cstring` and `TupleToArray` serve `posix` and `win32` alone, yet standing in `org.eolang` they read as part of the runtime's public surface, the way `Bytes` and `PhDefault` are. They move to `org.eolang.sys`, beside `Sockaddr`, and `CstringTest`, `HandlesTest` and `TupleToArrayTest` move with them. Only imports change in the thirty adapters that use them.

`Syscall` stays where it is, under a new `@todo #8618:30min` in `org/eolang/sys/package-info.java`: sixty-two adapters import it, so moving it here as well makes a 250-line diff and `pr-size` caps a pull request at 200. `SyscallTest`, `ReadSyscallTest` and `StatSyscallTest` travel with it in that follow-up. The second `@todo` in that file, about re-parenting `org.eolang.posix` and `org.eolang.win32`, is #8619 and stays untouched.

The second commit is the one-line javadoc fix from #8621, ported so this branch can pass `qulice` before that one lands; it is a no-op once master carries the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga