### PR TITLE
Remove all missing messages from failure causes

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Causes.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Causes.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The chain of causes of a problem, ready for the log.
@@ -37,12 +38,7 @@ final class Causes implements Iterable<String> {
     @Override
     public Iterator<String> iterator() {
         final List<String> causes = Causes.all(this.problem);
-        for (int pos = 0; pos < causes.size(); ++pos) {
-            if (causes.get(pos) == null) {
-                causes.remove(pos);
-                break;
-            }
-        }
+        causes.removeIf(Objects::isNull);
         int idx = 0;
         while (idx < causes.size()) {
             final String cause = causes.get(idx);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CausesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CausesTest.java
@@ -1,0 +1,64 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Causes}.
+ *
+ * @since 0.71.0
+ */
+final class CausesTest {
+
+    @Test
+    void skipsConsecutiveMissingMessages() {
+        MatcherAssert.assertThat(
+            "message-less wrappers must not hide the real failure",
+            new Causes(
+                new RuntimeException(
+                    null, new RuntimeException(null, new RuntimeException("root failure"))
+                )
+            ),
+            Matchers.contains("root failure")
+        );
+    }
+
+    @Test
+    void skipsMissingMessagesBetweenDistinctFailures() {
+        MatcherAssert.assertThat(
+            "all absent messages must be removed without discarding distinct reasons",
+            new Causes(
+                new RuntimeException(
+                    "outer failure",
+                    new RuntimeException(
+                        null, new RuntimeException(null, new RuntimeException("root"))
+                    )
+                )
+            ),
+            Matchers.contains("outer failure", "root")
+        );
+    }
+
+    @Test
+    void omitsAnEntirelyMessageLessChain() {
+        MatcherAssert.assertThat(
+            "a chain without messages must have no log entries",
+            new Causes(new RuntimeException(null, new RuntimeException())),
+            Matchers.emptyIterable()
+        );
+    }
+
+    @Test
+    void retainsExistingDuplicateFiltering() {
+        MatcherAssert.assertThat(
+            "redundant messages must still collapse to their underlying reason",
+            new Causes(new RuntimeException("wrapped root", new RuntimeException("root"))),
+            Matchers.contains("root")
+        );
+    }
+}


### PR DESCRIPTION
Closes #8578.

Remove every null exception message before comparing causes. Chains with multiple message-less exceptions now preserve the actual error instead of throwing another exception or printing null. Four regression tests cover consecutive and intermediate missing messages, an entirely message-less chain, and existing duplicate filtering.

Validation: Maven-plugin suite passed (1,153 tests, 218 skipped; all four new tests passed without skips), and Qulice passed. Rebased onto master `66991c9c2`, which includes the upstream build fixes. The required full `mvn clean install -Pqulice` passes all six production modules and Qulice. Integration result: 36 tests, 32 passed, three jar-test errors, one skipped. The errors compile generated `EOstring.java` with missing `EOstring$EOregex$EOcompile` and `EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index`, also observed on the separate #8633 branch. Full reactor success is not claimed; the same failure is reproduced from untouched upstream source and tracked in #8649.

@yegor256

