### PR TITLE
Unbreak master: unlint 'redundant-attachment' in string.regex

### DIFF
--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -60,6 +60,17 @@
 # engine counts bytes and converts at the border; a matched block remembers
 # where its bytes end, so `next` neither rescans the text nor parses the
 # pattern again.
+#
+# @todo #7485:30min Stop skipping 'redundant-attachment' here. It complains
+# about three formations, the fallback of `compiled`, the continuation
+# `sought` hands to `run` and the one the parser builds for `\z`, and reads
+# their `>>` names as unreferenced. At least the one in `sought` does reach
+# out of itself, through the receiver its own head declares, and the lint
+# misses it, because a void of the same name masks the reference. Dropping
+# the names breaks the engine and everything built on it, `string.scanf`,
+# `string.as-number` and `path` among them. Remove this directive once
+# objectionary/lints#1301 counts a hop through the receiver as reaching
+# outward even when the head declares a void of the same name.
 
 +architect yegor256@gmail.com
 +home https://github.com/objectionary/eo
@@ -67,6 +78,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint redundant-attachment
 
 [^] > regex
   compile > @


### PR DESCRIPTION
Master is red: [`eo:compile` fails](https://github.com/objectionary/eo/actions/runs/34442379516/job/102759937452) on `eo-runtime` with

```
[ERROR] In 173 XMIR files, we found 3 warnings:
string.regex:836 This object doesn't need to be named, since its auto-generated name is never referenced (redundant-attachment/S)
string.regex:1628 ...
string.regex:682 ...
```

`redundant-attachment` was enabled globally in #8563, which added `+unlint redundant-attachment` to the eight files that trip it. `string.regex` came in through #8505 in parallel, so neither branch saw the other and the merge of the two broke the build.

The first commit adds the same directive to `string/regex.eo`, plus a `@todo` explaining why the lint cannot be obeyed here.

The lint is wrong about at least one of the three formations: the continuation that `sought` hands to `run` reads `^.at`, which reaches out to the `at` of `sought`, but the lint's `outer-refs` masks that reference, because the formation's own head declares a void named `at` too (objectionary/lints#1301).

Verified with `mvn -Dinvoker.skip=true install -pl eo-runtime`, which transpiles the `++>` tests:

| variant | result |
|:--|:--|
| dropping the three `>>` names, as the lint asks | lint and formatter go quiet, then **99 EO tests fail** — `string.regex`, `string.scanf`, `string.as-number` and `path` all break with `the object [] declares no receiver` |
| dropping only the two at 682 and 1628 | 1 fails: `can_tell_the_input_end_anchor_needs_the_end_of_the_text` |
| this patch | `All 173 EO source(s) are formatted canonically`, `Linted 173 out of 173 XMIR program(s): no complaints`, and the only failing tests are the 11 that already fail on `master` in this sandbox (`SyscallTest` cannot get free TCP ports, `MainTest.printsVersion` sees the proxy banner on stdout) |

The second commit is the `Value.java` javadoc line from #8621, ported because `qulice` is red on `master` and therefore on this branch as well: Qulice 0.35.2 added `JavadocEmptyLineBeforeTagCheck`, and `eo-parser` failing it skips every module after it. It no-ops once #8621 merges. `mvn -Pqulice -Deo.skip clean process-classes qulice:check` passes across all eight modules with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RShrL1ZcDYoTqM3Qx9tJGi