### PR TITLE
#8620: let number and string take @ as their void, like bytes

### DIFF
--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -12,7 +12,7 @@ written in the source. That formation is where the answer is looked for, and an
 FQN is the whole of what this module means by a type:
 
 ```eo
-[as-bytes] > number      # Φ.number.as-bytes is a Φ.bytes
+[@] > number             # Φ.number.φ is a Φ.bytes
   [x] > plus             # Φ.number.plus.x is a Φ.number
   [x] > minus
     $.^.plus ($.x.times -1) > @      # Φ.number.minus.@ is a Φ.number
@@ -53,7 +53,7 @@ about them is asking nothing. So does a termination.
 
 Whether the formation still has voids free does not matter here. Knowing that
 something is a `Φ.number` is knowing which object it is, even before knowing
-what went into its `as-bytes`.
+what went into its `φ`.
 
 ### rooted at a void
 

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -291,6 +291,7 @@ final class Value {
     /**
      * The {@code Q} global-root glyph — R-3.8.1 excludes it from the
      * reversed-head whitelist ({@code @}, {@code ^}, {@code $})?
+     *
      * @return True for {@link Kind#ROOT} whose raw text is {@code Q}
      */
     boolean global() {

--- a/eo-runtime/src/main/eo/number.eo
+++ b/eo-runtime/src/main/eo/number.eo
@@ -9,8 +9,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > number
-  as-bytes > @
+[@] > number
   as-i32.as-i16 > as-i16
   $.as-i64.as-i32 > as-i32
   [] > div /Q.number

--- a/eo-runtime/src/main/eo/string.eo
+++ b/eo-runtime/src/main/eo/string.eo
@@ -23,8 +23,7 @@
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
 
-[as-bytes] > string
-  as-bytes > @
+[@] > string
 
   not. ++> can-compare-a-string-with-nan
     nan.eq "друг"

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -353,7 +353,7 @@ public class PhDefault implements Phi, Cloneable {
         final String name = this.oname();
         final String result;
         if (this.literal(name)) {
-            final byte[] raw = this.loaded().get("as-bytes").get().delta();
+            final byte[] raw = this.loaded().get(Phi.PHI).get().delta();
             if ("string".equals(name)) {
                 result = new Quoted(raw).get().orElseGet(this::structural);
             } else {
@@ -475,8 +475,8 @@ public class PhDefault implements Phi, Cloneable {
 
     private boolean literal(final String name) {
         return ("number".equals(name) || "string".equals(name))
-            && this.loaded().containsKey("as-bytes")
-            && !"?".equals(this.loaded().get("as-bytes").φTerm());
+            && this.loaded().containsKey(Phi.PHI)
+            && !"?".equals(this.loaded().get(Phi.PHI).φTerm());
     }
 
     private String structural() {

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -63,7 +63,25 @@ final class PhDefaultTest {
         MatcherAssert.assertThat(
             "Number without injected bytes must fall back to its structural φ-term, but it didnt",
             Phi.Φ.take("number").φTerm(),
-            Matchers.containsString("as-bytes->?")
+            Matchers.containsString("φ->?")
+        );
+    }
+
+    @Test
+    void printsFilledNumberAsLiteral() {
+        MatcherAssert.assertThat(
+            "Number with injected bytes must print as the literal it stands for, but it didnt",
+            new Data.ToPhi(42.5).φTerm(),
+            Matchers.equalTo("42.5")
+        );
+    }
+
+    @Test
+    void printsFilledStringAsLiteral() {
+        MatcherAssert.assertThat(
+            "String with injected bytes must print as the literal it stands for, but it didnt",
+            new Data.ToPhi("привет").φTerm(),
+            Matchers.equalTo("\"привет\"")
         );
     }
 


### PR DESCRIPTION
Closes #8620.

`number` and `string` now open with `[@]`, the way `bytes` already does.

One deviation from the issue: neither object binds `@ > as-bytes`. The `anemic-getter` lint refuses it — *"the object `as-bytes` is a redundant getter, it just renames `φ` without adding anything, use `φ` directly instead"* — and it is right. Nothing is lost by dropping the binding: `as-bytes` is not an attribute of `number` any more, so the dispatch reaches the decoratee, and `bytes.as-bytes` (`bytes/as-bytes.eo`, the identity mapping) hands the chain back unchanged. `42.as-bytes` answers what it always did, which the 525 tests of `TestEOnumber`, the 530 of `TestEOstring` and the 122 of `TestEObytes` confirm.

`PhDefault` printed a literal by reading the `as-bytes` void; it reads the decoratee now. `printsUnsetNumberStructurally` asserted on `as-bytes->?` and asserts on `φ->?`; two tests are added for the filled case, which the issue asked to cover.

`eo-inference/README.md` sketched `number` in its old shape, so its two lines follow.

The one-line javadoc change in `Value.java` is not mine: it is the fix from #8621 for the `qulice` failure on master, ported so this branch can go green before that one lands. It is a no-op once master carries the same line.

`i8`, `i16`, `i32` and `i64` still open with `[as-bytes]`. As the issue says, that is a follow-up, not a widening of this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga