### PR TITLE
#8580: keep a classified artifact of the runtime

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithoutRuntime.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/DpsWithoutRuntime.java
@@ -41,10 +41,13 @@ final class DpsWithoutRuntime implements Dependencies {
     // An artifact id is not unique in Maven, so the group has to be read
     // too: a dependency of somebody else named "eo-runtime" is not the
     // runtime this class removes, and dropping it would change the classpath
-    // of a build that asked for nothing of the sort (#8147). This is the
-    // same pair DpsWithRuntime decides by.
+    // of a build that asked for nothing of the sort (#8147). A classifier
+    // names a different artifact of the same coordinates, which is not the
+    // runtime either and has to stay (#8148). These are the same three parts
+    // DpsWithRuntime decides by.
     private static boolean isRuntime(final Dependency dep) {
         return "org.eolang".equals(dep.getGroupId())
-            && "eo-runtime".equals(dep.getArtifactId());
+            && "eo-runtime".equals(dep.getArtifactId())
+            && (dep.getClassifier() == null || dep.getClassifier().isEmpty());
     }
 }

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/DpsWithoutRuntimeTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/DpsWithoutRuntimeTest.java
@@ -33,6 +33,23 @@ final class DpsWithoutRuntimeTest {
     }
 
     @Test
+    void keepsTheClassifiedArtifactOfTheRuntime() {
+        MatcherAssert.assertThat(
+            "a classified artifact of the runtime must stay, but it didnt",
+            new DpsWithoutRuntime(
+                () -> new ListOf<>(
+                    new Dep()
+                        .withGroupId("org.eolang")
+                        .withArtifactId("eo-runtime")
+                        .withClassifier("tests")
+                        .withVersion("0.30.0")
+                ).iterator()
+            ),
+            Matchers.iterableWithSize(1)
+        );
+    }
+
+    @Test
     void keepsTheRuntimeOfSomebodyElse() {
         MatcherAssert.assertThat(
             "a dependency of another group named eo-runtime must stay, but it didnt",


### PR DESCRIPTION
`DpsWithoutRuntime.isRuntime` decided by group and artifact only, while
`DpsWithRuntime.isRuntime` also requires an empty classifier. With
`eo.ignoreRuntime=true` a `org.eolang:eo-runtime:<classifier>:<version>`
dependency was dropped from resolution, so its jar was never unpacked or
placed and its classes went missing with no diagnostic.

Now both classes decide by the same three parts of the coordinates, so a
classified artifact is neither added as the runtime nor removed as one.

Closes #8580
