### PR TITLE
#8577: collect the whole subtree of a locator

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Rows.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Rows.java
@@ -83,10 +83,13 @@ final class Rows {
         try {
             final MessageDigest sha = MessageDigest.getInstance("SHA-256");
             for (final String locator : new TreeSet<>(locators)) {
-                for (final Map.Entry<String, String> row : rows.tailMap(locator).entrySet()) {
-                    if (!row.getKey().equals(locator)
-                        && !row.getKey().startsWith(String.format("%s.", locator))) {
-                        break;
+                final String prefix = String.format("%s.", locator);
+                final SortedMap<String, String> subtree = rows.subMap(
+                    locator, String.format("%s%c", prefix, Character.MAX_VALUE)
+                );
+                for (final Map.Entry<String, String> row : subtree.entrySet()) {
+                    if (!row.getKey().equals(locator) && !row.getKey().startsWith(prefix)) {
+                        continue;
                     }
                     Rows.feed(sha, row.getKey());
                     Rows.feed(sha, row.getValue());

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/RowsTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/RowsTest.java
@@ -47,6 +47,30 @@ final class RowsTest {
     }
 
     @Test
+    void readsPastAHyphenatedSibling(@Mktmp final Path temp) throws IOException {
+        final String neighbours = "<type id=\"Q.foo\"/><type id=\"Q.foo-bar\"/>";
+        MatcherAssert.assertThat(
+            "a change in a descendant row must reach the digest, a hyphenated sibling hid it",
+            this.digest(
+                temp.resolve("one"),
+                String.format(
+                    "%s<type id=\"Q.foo.inner\"><attr name=\"x\"/></type>", neighbours
+                )
+            ),
+            Matchers.not(
+                Matchers.equalTo(
+                    this.digest(
+                        temp.resolve("two"),
+                        String.format(
+                            "%s<type id=\"Q.foo.inner\"><attr name=\"y\"/></type>", neighbours
+                        )
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
     void framesEveryDigestField(@Mktmp final Path temp) throws IOException {
         final String locator = "Q.φ";
         final Path dir = temp.resolve("framed");


### PR DESCRIPTION
`Rows.digest` walked the sorted map from each locator forward and stopped at
the first key that was neither the locator nor one of its `locator + "."`
descendants. That assumed the rows of one subtree are contiguous, and they are
not: `-` sorts before `.`, so `Q.foo-bar` lands between `Q.foo` and
`Q.foo.inner` and the scan ended before any descendant row was read. Changes
in those rows never reached the transpile cache key, so generated Java was
restored from the cache after `provides.xml` or `links.xml` changed.

The scan now runs over the range that ends past the last descendant and skips
what sorts inside it without belonging to the subtree.

Closes #8577
