### PR TITLE
#8611: run the glyph gate on an inline binding label

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -557,18 +557,16 @@ final class Tokens {
      * reject anything that is neither a NAME-initial label nor a plain
      * slot number. Shared by {@link Tokens#readBinding()} and the outer
      * binding of a vertical formation, so both spell the same grammar.
+     * The glyph gate of {@link Suffix#checkGlyphs(String, int, int)} runs
+     * first, since a label is an identifier and a control character in one
+     * reaches xembly and breaks the parse instead of being reported.
      *
      * @param text Binding text, without the leading {@code :}
      * @param span Source span
      * @param pos Source column of the label (for errors)
      */
     static void checkBinding(final String text, final Span span, final int pos) {
-        if (Tokens.cactus(text)) {
-            throw new ParseError(
-                span.line(), pos,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
+        Suffix.checkGlyphs(text, span.line(), pos);
         if (!Tokens.validBinding(text)) {
             throw new ParseError(
                 span.line(), pos,

--- a/eo-parser/src/main/java/org/eolang/parser/Value.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Value.java
@@ -291,6 +291,7 @@ final class Value {
     /**
      * The {@code Q} global-root glyph — R-3.8.1 excludes it from the
      * reversed-head whitelist ({@code @}, {@code ^}, {@code $})?
+     *
      * @return True for {@link Kind#ROOT} whose raw text is {@code Q}
      */
     boolean global() {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-an-inline-binding-label-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-an-inline-binding-label-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'control character is not allowed in an identifier')]
+input: "[] > app\n  foo bar:go\fod > result\n"


### PR DESCRIPTION
Closes #8611.

`foo bar:go␁od > result` used to leave `EoSyntax.parsed()` through xembly:

```
java.lang.IllegalArgumentException: Failed to understand XML content, ATTR(as, good)
```

No `<error>`, no line, no column. `Tokens.checkBinding` ran the cactus half of the identifier gate and not the control-character half, so the label reached `Emit.slot` and `Directives.attr` refused it.

`checkBinding` now calls `Suffix.checkGlyphs`, which is what every other identifier position calls, so the label is reported the way a name or a void parameter already is, at the column the character sits in. The local cactus check was a copy of the one inside `checkGlyphs` and goes with it. §9.9 is unchanged: the canonical text is the one already there.

`control-character-in-an-inline-binding-label-is-rejected.yaml` reproduces it — it errors on master with the exception above and passes here. All 1636 tests of `eo-parser` are green.

The one-line javadoc change in `Value.java` is not mine: it is the fix from #8621 for the `qulice` failure on master, ported so this branch can go green before that one lands. It is a no-op once master carries the same line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga

---
_Generated by [Claude Code](https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga)_