### PR TITLE
#8583: view an arm answer as the forma of its target

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -120,7 +120,10 @@ public final class JavaAtom {
             }
             lines.add(
                 JavaAtom.returned(
-                    this.values.handed(this.values.expression(first.answer()), first.answer())
+                    this.values.viewed(
+                        this.values.expression(first.answer()), first.answer(),
+                        this.program.carrier()
+                    )
                 )
             );
         }
@@ -183,7 +186,11 @@ public final class JavaAtom {
         }
         out.add("    }");
         out.add("}");
-        out.add(JavaAtom.returned(this.values.handed("out", this.answer())));
+        out.add(
+            JavaAtom.returned(
+                this.values.viewed("out", this.answer(), this.program.carrier())
+            )
+        );
         return out;
     }
 

--- a/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/JavaAtom.java
@@ -203,7 +203,7 @@ public final class JavaAtom {
         final String pad = "        ";
         final List<String> out = this.computed(proto, pad, all, "");
         if (proto.again().isEmpty()) {
-            out.addAll(this.closed("out", proto, pad, true));
+            out.addAll(this.closed("out", proto, pad, true, this.values.forma(this.answer())));
         } else {
             out.addAll(this.rebound(proto.target(), proto.again(), pad));
         }
@@ -276,7 +276,12 @@ public final class JavaAtom {
         final String pad, final Set<Integer> known, final String exit) {
         final List<String> out = this.computed(arm, pad, known, exit);
         if (arm.again().isEmpty()) {
-            out.addAll(this.closed(label, arm, pad, label.equals(exit)));
+            out.addAll(
+                this.closed(
+                    label, arm, pad, label.equals(exit),
+                    this.values.forma(String.format("sym:%s", label))
+                )
+            );
         } else {
             out.addAll(this.rebound(arm.target(), arm.again(), pad));
         }
@@ -284,11 +289,16 @@ public final class JavaAtom {
     }
 
     private List<String> closed(final String label, final Protocol proto,
-        final String pad, final boolean exits) {
+        final String pad, final boolean exits, final String carrier) {
         final List<String> out = new ArrayList<>(2);
         if (proto.reason().isEmpty()) {
             out.add(
-                String.format("%s%s = %s;", pad, label, this.values.expression(proto.answer()))
+                String.format(
+                    "%s%s = %s;", pad, label,
+                    this.values.viewed(
+                        this.values.expression(proto.answer()), proto.answer(), carrier
+                    )
+                )
             );
             if (exits) {
                 out.add(String.format("%sbreak;", pad));

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -292,7 +292,23 @@ public final class Rendering {
      * @return The expression to hand over, wrapped when the formas part
      */
     public String handed(final String local, final String key) {
-        final String carrier = Rendering.carried(this.program.carrier());
+        return this.viewed(local, key, Rendering.carried(this.program.carrier()));
+    }
+
+    /**
+     * The Java expression of a value, seen as the forma another place expects.
+     *
+     * <p>A local and the key it stands under may part, as {@code x!} makes
+     * them part: the local is a double and the key is bytes. Wherever such a
+     * value is handed over, returned or assigned, the bits have to be seen
+     * as the forma of the place that takes them.</p>
+     *
+     * @param local The Java expression of the value, such as {@code s1}
+     * @param key The key that value stands under, such as {@code sym:s1}
+     * @param carrier The forma the place expects, such as {@code bytes}
+     * @return The expression, wrapped when the formas part
+     */
+    public String viewed(final String local, final String key, final String carrier) {
         final String own = this.forma(key);
         final String out;
         if (carrier.equals(own)) {
@@ -304,6 +320,8 @@ public final class Rendering {
             );
         } else if ("bytes".equals(carrier) && "bool".equals(own)) {
             out = String.format("new byte[] {(byte) (%s ? 0xFF : 0x00)}", local);
+        } else if ("number".equals(carrier) && "bytes".equals(own)) {
+            out = String.format("java.nio.ByteBuffer.wrap(%s).getDouble()", local);
         } else {
             throw new IllegalStateException(
                 String.format(

--- a/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Rendering.java
@@ -281,27 +281,12 @@ public final class Rendering {
     }
 
     /**
-     * The Java expression the atom hands to {@code Data.ToPhi}.
-     *
-     * <p>Where the fragment settled into a view of a local rather than
-     * the local itself, as {@code x!} does, the step is a double and the
-     * answer is bytes: the raw bits of the local are those bytes.</p>
-     *
-     * @param local The Java expression of the value, such as {@code s1}
-     * @param key The key that value stands under, such as {@code sym:s1}
-     * @return The expression to hand over, wrapped when the formas part
-     */
-    public String handed(final String local, final String key) {
-        return this.viewed(local, key, Rendering.carried(this.program.carrier()));
-    }
-
-    /**
      * The Java expression of a value, seen as the forma another place expects.
      *
-     * <p>A local and the key it stands under may part, as {@code x!} makes
-     * them part: the local is a double and the key is bytes. Wherever such a
-     * value is handed over, returned or assigned, the bits have to be seen
-     * as the forma of the place that takes them.</p>
+     * <p>Where the fragment settled into a view of a local rather than the
+     * local itself, as {@code x!} does, the step is a double and the key is
+     * bytes. Wherever such a value is handed over, returned or assigned, the
+     * bits have to be seen as the forma of the place that takes them.</p>
      *
      * @param local The Java expression of the value, such as {@code s1}
      * @param key The key that value stands under, such as {@code sym:s1}
@@ -310,23 +295,24 @@ public final class Rendering {
      */
     public String viewed(final String local, final String key, final String carrier) {
         final String own = this.forma(key);
+        final String wanted = Rendering.carried(carrier);
         final String out;
-        if (carrier.equals(own)) {
+        if (wanted.equals(own)) {
             out = local;
-        } else if ("bytes".equals(carrier) && "number".equals(own)) {
+        } else if ("bytes".equals(wanted) && "number".equals(own)) {
             out = String.format(
                 "java.nio.ByteBuffer.allocate(8).putLong(Double.doubleToRawLongBits(%s)).array()",
                 local
             );
-        } else if ("bytes".equals(carrier) && "bool".equals(own)) {
+        } else if ("bytes".equals(wanted) && "bool".equals(own)) {
             out = String.format("new byte[] {(byte) (%s ? 0xFF : 0x00)}", local);
-        } else if ("number".equals(carrier) && "bytes".equals(own)) {
+        } else if ("number".equals(wanted) && "bytes".equals(own)) {
             out = String.format("java.nio.ByteBuffer.wrap(%s).getDouble()", local);
         } else {
             throw new IllegalStateException(
                 String.format(
                     "The answer '%s' carries a %s, which no view renders as a %s",
-                    key, own, carrier
+                    key, own, wanted
                 )
             );
         }

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomForkTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomForkTest.java
@@ -1,0 +1,73 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.lowering;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for the forks of {@link JavaAtom}.
+ *
+ * <p>An arm of a fork answers into the local the fork declares, so the
+ * answer has to be seen as the forma of that local. These pin the Java
+ * text such an arm renders into.</p>
+ *
+ * @since 0.76.0
+ */
+final class JavaAtomForkTest {
+
+    @Test
+    void viewsTheAnswerOfAnArmAsTheFormaOfTheFork() {
+        MatcherAssert.assertThat(
+            "an arm answering a view of a local must be assigned as bytes, but it wasnt",
+            new JavaAtom(
+                new Protocol(
+                    Arrays.asList(
+                        new Application(
+                            "s0", "L_number_equal",
+                            Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
+                        ),
+                        new Fork(
+                            "s2", "L_bool_if", "sym:s0",
+                            new Protocol(
+                                Collections.singletonList(
+                                    new Application(
+                                        "s1", "L_number_plus",
+                                        Arrays.asList(
+                                            "sym:v0", "number:3F-F0-00-00-00-00-00-00"
+                                        )
+                                    )
+                                ),
+                                "sym:s1", "bytes"
+                            ),
+                            new Protocol(
+                                Collections.singletonList(
+                                    new Application(
+                                        "s3", "L_number_times",
+                                        Arrays.asList(
+                                            "sym:v0", "number:40-00-00-00-00-00-00-00"
+                                        )
+                                    )
+                                ),
+                                "sym:s3", "bytes"
+                            )
+                        )
+                    ),
+                    "sym:s2", "bytes"
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "final byte[] s2;",
+                "s2 = java.nio.ByteBuffer.allocate(8)",
+                "s2 = java.nio.ByteBuffer.allocate(8)",
+                "return new Data.ToPhi(s2);"
+            )
+        );
+    }
+}

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -66,6 +66,56 @@ final class JavaAtomTest {
     }
 
     @Test
+    void viewsTheAnswerOfAnArmAsTheFormaOfTheFork() {
+        MatcherAssert.assertThat(
+            "an arm answering a view of a local must be assigned as bytes, but it wasnt",
+            new JavaAtom(
+                new Protocol(
+                    Arrays.asList(
+                        new Application(
+                            "s0", "L_number_equal",
+                            Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
+                        ),
+                        new Fork(
+                            "s2", "L_bool_if", "sym:s0",
+                            new Protocol(
+                                Collections.singletonList(
+                                    new Application(
+                                        "s1", "L_number_plus",
+                                        Arrays.asList(
+                                            "sym:v0", "number:3F-F0-00-00-00-00-00-00"
+                                        )
+                                    )
+                                ),
+                                "sym:s1", "bytes"
+                            ),
+                            new Protocol(
+                                Collections.singletonList(
+                                    new Application(
+                                        "s3", "L_number_times",
+                                        Arrays.asList(
+                                            "sym:v0", "number:40-00-00-00-00-00-00-00"
+                                        )
+                                    )
+                                ),
+                                "sym:s3", "bytes"
+                            )
+                        )
+                    ),
+                    "sym:s2", "bytes"
+                ),
+                Collections.singletonMap("x", "number")
+            ).text(),
+            Matchers.stringContainsInOrder(
+                "final byte[] s2;",
+                "s2 = java.nio.ByteBuffer.allocate(8)",
+                "s2 = java.nio.ByteBuffer.allocate(8)",
+                "return new Data.ToPhi(s2);"
+            )
+        );
+    }
+
+    @Test
     void rendersBodiesAsStateMachine() {
         MatcherAssert.assertThat(
             "bodies resuming one another must run as one loop over a state, but they dont",

--- a/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/JavaAtomTest.java
@@ -66,56 +66,6 @@ final class JavaAtomTest {
     }
 
     @Test
-    void viewsTheAnswerOfAnArmAsTheFormaOfTheFork() {
-        MatcherAssert.assertThat(
-            "an arm answering a view of a local must be assigned as bytes, but it wasnt",
-            new JavaAtom(
-                new Protocol(
-                    Arrays.asList(
-                        new Application(
-                            "s0", "L_number_equal",
-                            Arrays.asList("sym:v0", "number:00-00-00-00-00-00-00-00")
-                        ),
-                        new Fork(
-                            "s2", "L_bool_if", "sym:s0",
-                            new Protocol(
-                                Collections.singletonList(
-                                    new Application(
-                                        "s1", "L_number_plus",
-                                        Arrays.asList(
-                                            "sym:v0", "number:3F-F0-00-00-00-00-00-00"
-                                        )
-                                    )
-                                ),
-                                "sym:s1", "bytes"
-                            ),
-                            new Protocol(
-                                Collections.singletonList(
-                                    new Application(
-                                        "s3", "L_number_times",
-                                        Arrays.asList(
-                                            "sym:v0", "number:40-00-00-00-00-00-00-00"
-                                        )
-                                    )
-                                ),
-                                "sym:s3", "bytes"
-                            )
-                        )
-                    ),
-                    "sym:s2", "bytes"
-                ),
-                Collections.singletonMap("x", "number")
-            ).text(),
-            Matchers.stringContainsInOrder(
-                "final byte[] s2;",
-                "s2 = java.nio.ByteBuffer.allocate(8)",
-                "s2 = java.nio.ByteBuffer.allocate(8)",
-                "return new Data.ToPhi(s2);"
-            )
-        );
-    }
-
-    @Test
     void rendersBodiesAsStateMachine() {
         MatcherAssert.assertThat(
             "bodies resuming one another must run as one loop over a state, but they dont",

--- a/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/RenderingTest.java
@@ -31,6 +31,18 @@ final class RenderingTest {
     }
 
     @Test
+    void viewsBytesAsANumber() {
+        MatcherAssert.assertThat(
+            "bytes assigned where a number is expected must be read back as a double, but they arent",
+            new Rendering(
+                new Protocol(Collections.emptyList(), "sym:v0", "number"),
+                Collections.singletonMap("b", "bytes")
+            ).viewed("v0", "sym:v0", "number"),
+            Matchers.equalTo("java.nio.ByteBuffer.wrap(v0).getDouble()")
+        );
+    }
+
+    @Test
     void carriesStringAsByteArray() {
         MatcherAssert.assertThat(
             "a string must be carried as bytes in Java, but it isnt",


### PR DESCRIPTION
`JavaAtom.closed` assigned the answer of an arm raw, while the local it
assigns to is declared from the fork forma, which is the carrier of the arms.
For an arm answering a view of a local, as `x!` or a bare `.as-bytes` makes it,
the two part: the local is a double and the target is `byte[]`, so the sidecar
body did not compile. The resumed path had the same gap in the other direction.

`Rendering.handed` already bridged that gap for the `return`. It is now
`Rendering.viewed`, which takes the forma the place expects, and `handed` asks
it for the carrier of the program. `closed` asks it for the forma of the local
it assigns to, so an arm answer is seen as the forma of its target.

Closes #8583
