### PR TITLE
#8611: check the glyphs of an inline binding label

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -563,12 +563,7 @@ final class Tokens {
      * @param pos Source column of the label (for errors)
      */
     static void checkBinding(final String text, final Span span, final int pos) {
-        if (Tokens.cactus(text)) {
-            throw new ParseError(
-                span.line(), pos,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
+        Suffix.checkGlyphs(text, span.line(), pos);
         if (!Tokens.validBinding(text)) {
             throw new ParseError(
                 span.line(), pos,

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-binding-label-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/control-character-in-a-binding-label-is-rejected.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'control character is not allowed in an identifier')]
+input: "[] > main\n  foo bar:go\u0001od > result\n"


### PR DESCRIPTION
`Tokens.checkBinding` ran the cactus half of the identifier gate and left the
control-character half out, so a control character inside an inline binding
label reached xembly and aborted the parse with an `IllegalArgumentException`
that named neither line nor position.

It now runs `Suffix.checkGlyphs`, the same check every other identifier
position runs, so the character is reported as a parse error at its column.

Closes #8611
