### PR TITLE
#8603: end a name at a slash in the NAME token too

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -164,7 +164,7 @@ The parser recognises the following lexical tokens:
 | --- | --- |
 | `META` | `+` `NAME` followed by zero or more space-separated parts; each part is one or more non-whitespace characters. Parts may contain `:`, `.`, `-`, `/`, e.g. `+rt jvm a.b.c:lib:1.0.0`. |
 | `COMMENTARY` | `#` followed by the rest of the line. |
-| `NAME` | `[a-z]` followed by characters other than space, line break, tab, `,`, `.`, `\|`, `'`, `:`, `;`, `!`, `?`, `]`, `[`, `}`, `{`, `)`, `(`, `🌵`. |
+| `NAME` | `[a-z]` followed by characters other than space, line break, tab, `,`, `.`, `\|`, `'`, `:`, `;`, `!`, `?`, `/`, `]`, `[`, `}`, `{`, `)`, `(`, `🌵`. The slash is excluded for the same reason `!` and `?` are: it opens an atom signature (§6.3), so a name ends where it starts. |
 | `PHI` | `@` |
 | `RHO` | `^` |
 | `ROOT` | `Q` |

--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -64,7 +64,7 @@ final class Suffix {
      * but a token boundary.
      */
     private static final Pattern NAME = Pattern.compile(
-        "[a-z][^ \\t,.|':;!?\\[\\]{}()]*"
+        "[a-z][^ \\t,.|':;!?/\\[\\]{}()]*"
     );
 
     /**

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/slash-inside-a-callback-argument-type-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/slash-inside-a-callback-argument-type-is-rejected.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors/error[contains(text(),'type must be a dotted path of NAME tokens')]
+input: |
+  [] > foo /number
+    ? > cb /{a/b}

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/slash-inside-a-callback-argument-type-is-rejected.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/slash-inside-a-callback-argument-type-is-rejected.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
+# yamllint disable rule:line-length
 sheets: []
 asserts:
   - /object/errors/error[contains(text(),'type must be a dotted path of NAME tokens')]


### PR DESCRIPTION
The `NAME` token in §2.3 excluded `!` and `?`, both of which end a name because
they open something else, but not `/`, which opens an atom signature. The
parser has always ended a name there, so `[] > foo/bar` reads as an atom named
`foo`, while `Suffix.NAME`, the pattern a dotted type path is checked against,
admitted a slash inside a segment. A callback argument list took that route:
`? > cb /{a/b}` passed the check and emitted `a/b` as a type.

The token in §2.3 now excludes `/` and the pattern matches it, so the class no
longer disagrees with itself about the character.

Closes #8603
