### PR TITLE
#8591: report an escape at the body line that holds it

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -4,6 +4,7 @@
  */
 package org.eolang.parser;
 
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 
 /**
@@ -65,10 +66,7 @@ final class LnTextBlock implements Line {
         } else {
             Blanks.checkPlain(this.span, globals, emit);
         }
-        final byte[] joined = new Unescaped(
-            String.join(String.valueOf('\n'), globals.tbody()),
-            this.span.line(), this.span.indent()
-        ).bytes();
+        final byte[] joined = this.decoded(globals.tbody());
         this.transition(stack, suffix);
         Bindings.observeChild(stack, outer, this.span);
         this.emit(emit, suffix, chain, joined);
@@ -78,6 +76,21 @@ final class LnTextBlock implements Line {
         globals.closeTextBlock();
         globals.clearBlanks();
         globals.markEmitted();
+    }
+
+    private byte[] decoded(final List<String> lines) {
+        final int first = this.span.line() - lines.size();
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (int idx = 0; idx < lines.size(); idx = idx + 1) {
+            if (idx > 0) {
+                out.write('\n');
+            }
+            final byte[] bytes = new Unescaped(
+                lines.get(idx), first + idx, this.span.indent()
+            ).bytes();
+            out.write(bytes, 0, bytes.length);
+        }
+        return out.toByteArray();
     }
 
     private void transition(final Stack stack, final Suffix suffix) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/escape-in-a-text-block-is-reported-on-its-own-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/escape-in-a-text-block-is-reported-on-its-own-line.yaml
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-line: 3
-message: |-
-  backslash at the end of the text has nothing to escape
+sheets: []
+asserts:
+  - /object/errors/error[@line='4' and contains(text(),'\p')]
 input: |
-  [] > example
+  [] > main
     """
-    x\
+    ok line
+    bad escape here: \p
+    filler
     """ > @


### PR DESCRIPTION
`LnTextBlock` joined the body lines and unescaped them as one string, with the
span of the closing `"""` line, so a bad escape was reported at the closer.
In a long block that is many lines away from the escape it names.

The body is now unescaped line by line, each with its own line, so the error
lands where the escape is. The typo pack for a trailing backslash moved from
the closer's line to the body line for the same reason.

Closes #8591
