### PR TITLE
#8588: let a number of the wrong width print structurally

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Numbered.java
+++ b/eo-runtime/src/main/java/org/eolang/Numbered.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Bytes rendered as an EO number literal.
+ *
+ * <p>A number is eight bytes wide and nothing else, so a payload of any
+ * other width denotes no number at all. Handing such bytes to
+ * {@link BytesRaw#asNumber()} fails, and the caller here is the builder
+ * of a failure message, where a second failure buries the first one.
+ * The caller gets an empty result for them and is expected to print the
+ * structural form instead, the way {@link Quoted} answers for text that
+ * is not UTF-8.</p>
+ *
+ * @since 0.77.0
+ */
+final class Numbered implements Supplier<Optional<String>> {
+
+    /**
+     * The bytes of the number.
+     */
+    private final byte[] data;
+
+    /**
+     * Ctor.
+     *
+     * @param data The bytes
+     */
+    Numbered(final byte[] data) {
+        this.data = Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public Optional<String> get() {
+        final Optional<String> result;
+        if (this.data.length == Double.BYTES) {
+            result = Optional.of(new Numeral(new BytesOf(this.data).asNumber()).get());
+        } else {
+            result = Optional.empty();
+        }
+        return result;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -5,6 +5,7 @@
 
 package org.eolang;
 
+import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -92,27 +93,15 @@ public final class PhApplication extends PhOnce {
         final String body = PhApplication.body(binds);
         final Matcher data = PhApplication.DATA.matcher(body);
         final boolean literal = binds.length == 1 && binds[0].first() && data.matches();
-        final String string;
+        final Optional<String> printed;
         if (literal && "Φ.string".equals(head)) {
-            string = PhApplication.string(PhApplication.bytes(data.group(1)));
-        } else {
-            string = null;
-        }
-        final String result;
-        if (string != null) {
-            result = string;
+            printed = new Quoted(PhApplication.bytes(data.group(1))).get();
         } else if (literal && "Φ.number".equals(head)) {
-            result = new Numeral(
-                new BytesOf(PhApplication.bytes(data.group(1))).asNumber()
-            ).get();
+            printed = new Numbered(PhApplication.bytes(data.group(1))).get();
         } else {
-            result = String.format("%s(%s)", head, body);
+            printed = Optional.empty();
         }
-        return result;
-    }
-
-    private static String string(final byte[] bytes) {
-        return new Quoted(bytes).get().orElse(null);
+        return printed.orElseGet(() -> String.format("%s(%s)", head, body));
     }
 
     private static String body(final Bind... binds) {

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -357,7 +357,7 @@ public class PhDefault implements Phi, Cloneable {
             if ("string".equals(name)) {
                 result = new Quoted(raw).get().orElseGet(this::structural);
             } else {
-                result = new Numeral(new BytesOf(raw).asNumber()).get();
+                result = new Numbered(raw).get().orElseGet(this::structural);
             }
         } else {
             result = this.structural();

--- a/eo-runtime/src/test/java/org/eolang/NumberedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/NumberedTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Numbered}.
+ *
+ * @since 0.77.0
+ */
+final class NumberedTest {
+
+    @Test
+    void rendersEightBytesAsLiteral() {
+        MatcherAssert.assertThat(
+            "Eight bytes must render as the number they spell, but they didnt",
+            new Numbered(
+                new byte[] {
+                    (byte) 0x40, (byte) 0x45, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                }
+            ).get(),
+            Matchers.equalTo(Optional.of("42"))
+        );
+    }
+
+    @Test
+    void refusesTooFewBytes() {
+        MatcherAssert.assertThat(
+            "One byte spells no number and must come back empty, but it didnt",
+            new Numbered(new byte[] {(byte) 0x01}).get().isPresent(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void refusesNoBytesAtAll() {
+        MatcherAssert.assertThat(
+            "An empty payload spells no number and must come back empty, but it didnt",
+            new Numbered(new byte[0]).get().isPresent(),
+            Matchers.is(false)
+        );
+    }
+
+    @Test
+    void refusesTooManyBytes() {
+        MatcherAssert.assertThat(
+            "Nine bytes spell no number and must come back empty, but they didnt",
+            new Numbered(new byte[9]).get().isPresent(),
+            Matchers.is(false)
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -55,6 +55,23 @@ final class PhApplicationTest {
     }
 
     @Test
+    void keepsANumberOfTheWrongWidthStructural() {
+        MatcherAssert.assertThat(
+            "one byte spells no number and must render as the application it is, but the renderer threw",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "number"),
+                0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "bytes"),
+                    0,
+                    new PhDefault(new byte[] {(byte) 0x01})
+                )
+            ).φTerm(),
+            Matchers.equalTo("Φ.number(0->Φ.bytes(0->[D> 01-]))")
+        );
+    }
+
+    @Test
     void appliesSeveralBindingsToObject() {
         MatcherAssert.assertThat(
             "PhApplication must bind every pair to the object, but it didnt",

--- a/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhDefaultTest.java
@@ -86,6 +86,17 @@ final class PhDefaultTest {
     }
 
     @Test
+    void printsNumberOfTheWrongWidthStructurally() {
+        final Phi phi = Phi.Φ.take("number").copy();
+        phi.put(0, new PhDefault(new byte[] {(byte) 0x01}));
+        MatcherAssert.assertThat(
+            "Number carrying bytes that are not eight must fall back to its structural φ-term, but it didnt",
+            phi.φTerm(),
+            Matchers.containsString("D> 01-")
+        );
+    }
+
+    @Test
     void comparesTwoObjects() {
         final Phi phi = PhDefaultTest.Int.made();
         MatcherAssert.assertThat(


### PR DESCRIPTION
Closes #8588.

`φTerm()` is what builds a failure message, so it must not fail. Its string branch degrades to the structural form when the bytes are not UTF-8; its number branch handed them to `BytesRaw.asNumber()`, which insists on exactly eight, so a `number` bound to any other width threw `Can't convert 1 bytes to java.lang.Double` from the message builder and buried the failure that actually happened.

`Numbered` answers for bytes the way `Quoted` answers for text: the literal when it can be spelled, empty otherwise. Both call sites — `PhDefault.φTerm()` and `PhApplication.applied()` — now read the same, and `PhApplication` loses the `null` sentinel and the private helper that produced it, since two `Optional` branches say it without one.

Reproduced first: `PhDefaultTest.printsNumberOfTheWrongWidthStructurally` and `PhApplicationTest.keepsANumberOfTheWrongWidthStructural` both raise that `ExFailure` on master and pass here. `NumberedTest` covers the four widths — eight, one, none, nine. 124 tests across the six touched classes are green, and `qulice` passes on `eo-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga

---
_Generated by [Claude Code](https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga)_