### PR TITLE
#8590: read the range under the same lock that checks it

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/EOchunk$EOread.java
+++ b/eo-runtime/src/main/java/org/eolang/EOchunk$EOread.java
@@ -5,6 +5,8 @@
 
 package org.eolang;
 
+import java.util.Optional;
+
 /**
  * Chunk.read object.
  *
@@ -47,8 +49,9 @@ public final class EOchunk$EOread extends PhDefault implements Atom {
 
     private Phi bytes(final int id, final int offset, final int length) {
         final Phi result;
-        if (Heaps.INSTANCE.fits(id, offset, length)) {
-            result = new Data.ToPhi(Heaps.INSTANCE.read(id, offset, length));
+        final Optional<byte[]> data = Heaps.INSTANCE.fetched(id, offset, length);
+        if (data.isPresent()) {
+            result = new Data.ToPhi(data.get());
         } else {
             result = this.take(EOchunk$EOread.FALLBACK);
             result.put(

--- a/eo-runtime/src/main/java/org/eolang/Heaps.java
+++ b/eo-runtime/src/main/java/org/eolang/Heaps.java
@@ -6,6 +6,7 @@
 package org.eolang;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -118,21 +119,23 @@ final class Heaps {
     }
 
     /**
-     * Whether the given range fits inside the allocated block — the
-     * single source of truth for the read-bounds rule.
+     * The bytes of the given range, if it fits inside the allocated block —
+     * the single source of truth for the read-bounds rule.
      *
      * <p>If the block is not allocated, the request is a structural
      * (unpredictable) failure and aborts with {@link ExFailure}, which
      * EO cannot catch. A range that exceeds an allocated block is a
-     * predictable failure, reported as {@code false} so the caller can
-     * fall back rather than read garbage.</p>
+     * predictable failure, reported as an empty answer so the caller can
+     * fall back rather than read garbage. The range is checked and copied
+     * under one hold of the lock, so a resize cannot shrink the block
+     * between the two and take the fallback away from the caller.</p>
      *
      * @param identifier Identifier of the block
      * @param offset Offset to start reading from
      * @param length Length of bytes to read
-     * @return True if the range lies within the allocated block
+     * @return The bytes, or nothing if the range lies outside the block
      */
-    boolean fits(final int identifier, final int offset, final int length) {
+    Optional<byte[]> fetched(final int identifier, final int offset, final int length) {
         this.lock.lock();
         try {
             if (!this.blocks.containsKey(identifier)) {
@@ -141,9 +144,14 @@ final class Heaps {
                     identifier
                 );
             }
-            return offset >= 0
-                && length >= 0
-                && (long) offset + length <= this.blocks.get(identifier).length;
+            final byte[] block = this.blocks.get(identifier);
+            final Optional<byte[]> out;
+            if (offset >= 0 && length >= 0 && (long) offset + length <= block.length) {
+                out = Optional.of(Arrays.copyOfRange(block, offset, offset + length));
+            } else {
+                out = Optional.empty();
+            }
+            return out;
         } finally {
             this.lock.unlock();
         }
@@ -172,15 +180,14 @@ final class Heaps {
                     identifier, length
                 );
             }
-            if (!this.fits(identifier, offset, length)) {
-                throw new ExFailure(
+            return this.fetched(identifier, offset, length).orElseThrow(
+                () -> new ExFailure(
                     "Can't read '%d' bytes from offset '%d', because only '%d' are allocated",
                     length,
                     offset,
                     this.blocks.get(identifier).length
-                );
-            }
-            return Arrays.copyOfRange(this.blocks.get(identifier), offset, offset + length);
+                )
+            );
         } finally {
             this.lock.unlock();
         }

--- a/eo-runtime/src/test/java/org/eolang/HeapsTest.java
+++ b/eo-runtime/src/test/java/org/eolang/HeapsTest.java
@@ -7,6 +7,7 @@ package org.eolang;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Optional;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
@@ -26,6 +27,28 @@ final class HeapsTest {
                 10, idx -> Heaps.INSTANCE.read(idx, 0, 10)
             ),
             "Heaps should successfully read from allocated memory, but it didn't"
+        );
+    }
+
+    @Test
+    void fetchesNothingWhenTheRangeExceedsTheBlock() {
+        MatcherAssert.assertThat(
+            "a range outside the block must be answered as nothing, so the caller can fall back",
+            Heaps.INSTANCE.malloc(
+                8, idx -> Heaps.INSTANCE.fetched(idx, 0, 512)
+            ),
+            Matchers.equalTo(Optional.empty())
+        );
+    }
+
+    @Test
+    void fetchesTheBytesOfARangeThatFits() {
+        MatcherAssert.assertThat(
+            "a range inside the block must be answered with its bytes, but it wasnt",
+            Heaps.INSTANCE.malloc(
+                8, idx -> Heaps.INSTANCE.fetched(idx, 0, 3).get().length
+            ),
+            Matchers.equalTo(3)
         );
     }
 


### PR DESCRIPTION
`chunk.read` asked `Heaps.fits` and then called `Heaps.read`, each taking the
lock on its own. A `resize` in the gap shrank the block, so the read failed with
the very `ExFailure` the check exists to prevent and the `cant-read` fallback
was skipped.

`fits` is now `fetched`, which checks the range and copies the bytes under one
hold of the lock and answers nothing when the range does not fit. `read`
delegates to it, so the bounds rule still lives in one place.

Closes #8590
