### PR TITLE
#8635: move Syscall into org.eolang.sys

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AcceptSyscall.java
@@ -9,8 +9,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Sockaddr;
+import org.eolang.sys.Syscall;
 
 /**
  * Accept syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/AccessSyscall.java
@@ -8,8 +8,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Access syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/BindSyscall.java
@@ -8,8 +8,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Sockaddr;
+import org.eolang.sys.Syscall;
 
 /**
  * Bind syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/CloseSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CloseSyscall.java
@@ -8,7 +8,7 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Close syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ClosedirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ClosedirSyscall.java
@@ -8,8 +8,8 @@ import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Handles;
+import org.eolang.sys.Syscall;
 
 /**
  * Closedir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ConnectSyscall.java
@@ -8,8 +8,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Sockaddr;
+import org.eolang.sys.Syscall;
 
 /**
  * Connect syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/CreatSyscall.java
@@ -7,8 +7,8 @@ package org.eolang.posix;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Creat syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ErrnoSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ErrnoSyscall.java
@@ -8,7 +8,7 @@ import com.sun.jna.Native;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The 'errno' syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/GetenvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/GetenvSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Getenv syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/GetpidSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/GetpidSyscall.java
@@ -7,7 +7,7 @@ package org.eolang.posix;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Getpid syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/GettimeofdaySyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/GettimeofdaySyscall.java
@@ -6,7 +6,7 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Gettimeofday syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/InetAddrSyscall.java
@@ -9,8 +9,8 @@ import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The 'inet_addr' syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ListenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ListenSyscall.java
@@ -8,7 +8,7 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Listen syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/MkdirSyscall.java
@@ -7,8 +7,8 @@ package org.eolang.posix;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Mkdir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/NamedSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/NamedSyscall.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.eolang.ExFailure;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * A POSIX syscall known by its name.

--- a/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/OpenSyscall.java
@@ -7,8 +7,8 @@ package org.eolang.posix;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Open syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/OpendirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/OpendirSyscall.java
@@ -7,9 +7,9 @@ package org.eolang.posix;
 import com.sun.jna.Pointer;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
 import org.eolang.sys.Handles;
+import org.eolang.sys.Syscall;
 
 /**
  * Opendir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -10,7 +10,7 @@ import org.eolang.Expect;
 import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Read syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/ReaddirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReaddirSyscall.java
@@ -10,8 +10,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Handles;
+import org.eolang.sys.Syscall;
 
 /**
  * Readdir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -10,7 +10,7 @@ import org.eolang.Expect;
 import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Recv syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/RenameSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RenameSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Rename syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/RmdirSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RmdirSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Rmdir syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SendSyscall.java
@@ -12,7 +12,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Send syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/SocketSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SocketSyscall.java
@@ -8,7 +8,7 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Socket syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StatSyscall.java
@@ -9,8 +9,8 @@ import com.sun.jna.Structure;
 import java.util.function.ToIntBiFunction;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Stat syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/StrerrorSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/StrerrorSyscall.java
@@ -8,7 +8,7 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The 'strerror' syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/SymlinkSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Symlink syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/UnlinkSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/UnlinkSyscall.java
@@ -6,8 +6,8 @@ package org.eolang.posix;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * Unlink syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/WriteSyscall.java
@@ -12,7 +12,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * Write syscall.

--- a/eo-runtime/src/main/java/org/eolang/sys/Syscall.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/Syscall.java
@@ -3,7 +3,9 @@
  * SPDX-License-Identifier: MIT
  */
 
-package org.eolang;
+package org.eolang.sys;
+
+import org.eolang.Phi;
 
 /**
  * System call that can be made with EO objects ({@link Phi}) as arguments.

--- a/eo-runtime/src/main/java/org/eolang/sys/package-info.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/package-info.java
@@ -10,17 +10,12 @@
  * another way by macOS, and both families of adapters, posix and win32,
  * hand that layout to the kernel. It is theirs, not the runtime's, so it
  * lives here rather than in the root package next to {@code Phi} and
- * {@code Bytes}. The same goes for {@code Handles}, {@code Cstring} and
+ * {@code Bytes}. The same goes for {@code Syscall}, the shape every
+ * adapter takes, and for {@code Handles}, {@code Cstring} and
  * {@code TupleToArray}, which carry a pointer, a text and a tuple of
  * arguments across to C on their behalf.</p>
  *
  * @since 0.77.0
- * @todo #8618:30min Move Syscall here too, together with SyscallTest,
- *  ReadSyscallTest and StatSyscallTest. It serves posix and win32 alone,
- *  yet standing in org.eolang it reads as part of the runtime's public
- *  surface, the way Bytes and PhDefault are. It waits on its own pull
- *  request because sixty-two adapters import it and the diff would not
- *  fit under the two-hundred-line limit alongside this one.
  * @todo #8533:30min Re-parent org.eolang.posix and org.eolang.win32 as
  *  org.eolang.sys.posix and org.eolang.sys.win32, and name the new directories
  *  in sonar.cpd.exclusions in pom.xml, which is the only place outside Java

--- a/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AcceptFuncCall.java
@@ -11,8 +11,8 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.SockaddrIn;
+import org.eolang.sys.Syscall;
 
 /**
  * The socket WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/AccessFuncCall.java
@@ -9,8 +9,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _access function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/BindFuncCall.java
@@ -10,8 +10,8 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.SockaddrIn;
+import org.eolang.sys.Syscall;
 
 /**
  * The socket WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/CloseFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CloseFuncCall.java
@@ -8,7 +8,7 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _close function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/ClosesocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ClosesocketFuncCall.java
@@ -9,7 +9,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The closesocket WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ConnectFuncCall.java
@@ -10,8 +10,8 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.SockaddrIn;
+import org.eolang.sys.Syscall;
 
 /**
  * The 'connect' WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/CreatFuncCall.java
@@ -8,8 +8,8 @@ import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _creat function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/ErrnoFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ErrnoFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt {@code _errno} function call: the raw CRT error code left by the

--- a/eo-runtime/src/main/java/org/eolang/win32/FindCloseFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FindCloseFuncCall.java
@@ -9,8 +9,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Handles;
+import org.eolang.sys.Syscall;
 
 /**
  * The kernel32 FindClose function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/FindFirstFileFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FindFirstFileFuncCall.java
@@ -9,9 +9,9 @@ import com.sun.jna.Pointer;
 import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
 import org.eolang.sys.Handles;
+import org.eolang.sys.Syscall;
 
 /**
  * The kernel32 FindFirstFileW function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/FindNextFileFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FindNextFileFuncCall.java
@@ -9,8 +9,8 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Handles;
+import org.eolang.sys.Syscall;
 
 /**
  * The kernel32 FindNextFileW function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/FtimeFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/FtimeFuncCall.java
@@ -6,7 +6,7 @@ package org.eolang.win32;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _ftime64_s function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/GetFileAttributesFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetFileAttributesFuncCall.java
@@ -8,8 +8,8 @@ import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The kernel32 GetFileAttributesW function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/GetenvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetenvFuncCall.java
@@ -6,8 +6,8 @@ package org.eolang.win32;
 
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt getenv function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/GetpidFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/GetpidFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _getpid function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/InetAddrFuncCall.java
@@ -10,8 +10,8 @@ import java.util.Collections;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The 'inet_addr' WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ListenFuncCall.java
@@ -10,7 +10,7 @@ import org.eolang.Dataized;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * WriteFile kernel32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/MkdirFuncCall.java
@@ -7,8 +7,8 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _mkdir function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/NamedFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/NamedFuncCall.java
@@ -8,7 +8,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * A Win32 function call known by its name.

--- a/eo-runtime/src/main/java/org/eolang/win32/NamedSocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/NamedSocketFuncCall.java
@@ -9,7 +9,7 @@ import java.util.Map;
 import java.util.function.Function;
 import org.eolang.ExFailure;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * A Winsock function call known by its name, split out of {@link NamedFuncCall}

--- a/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/OpenFuncCall.java
@@ -8,8 +8,8 @@ import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _open function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -10,7 +10,7 @@ import org.eolang.Expect;
 import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _read function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -12,7 +12,7 @@ import org.eolang.Expect;
 import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * ReadFile kernel32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RenameFuncCall.java
@@ -7,8 +7,8 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt rename function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RmdirFuncCall.java
@@ -7,8 +7,8 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _rmdir function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SendFuncCall.java
@@ -13,7 +13,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * WriteFile kernel32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/SocketFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/SocketFuncCall.java
@@ -9,7 +9,7 @@ import org.eolang.Data;
 import org.eolang.Int;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The socket WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/Stat64FuncCall.java
@@ -7,8 +7,8 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _stat64 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/UnlinkFuncCall.java
@@ -7,8 +7,8 @@ package org.eolang.win32;
 import com.sun.jna.WString;
 import org.eolang.Data;
 import org.eolang.Phi;
-import org.eolang.Syscall;
 import org.eolang.sys.Cstring;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _unlink function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/WSACleanupFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WSACleanupFuncCall.java
@@ -7,7 +7,7 @@ package org.eolang.win32;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * WSACleanup WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/WSAGetLastErrorFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WSAGetLastErrorFuncCall.java
@@ -8,7 +8,7 @@ import com.sun.jna.Native;
 import org.eolang.Data;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * WSAGetLastError WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/WSAStartupFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WSAStartupFuncCall.java
@@ -8,7 +8,7 @@ import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * WSAStartup WS2_32 function call.

--- a/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/WriteFuncCall.java
@@ -12,7 +12,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.PhDefault;
 import org.eolang.Phi;
-import org.eolang.Syscall;
+import org.eolang.sys.Syscall;
 
 /**
  * The msvcrt _write function call.

--- a/eo-runtime/src/test/java/org/eolang/sys/ReadSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/ReadSyscallTest.java
@@ -2,8 +2,11 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang;
+package org.eolang.sys;
 
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
 import org.eolang.posix.ReadSyscall;
 import org.eolang.win32.ReadFuncCall;
 import org.junit.jupiter.api.Assertions;

--- a/eo-runtime/src/test/java/org/eolang/sys/StatSyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/StatSyscallTest.java
@@ -2,13 +2,16 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang;
+package org.eolang.sys;
 
 import com.sun.jna.Structure;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.ToIntBiFunction;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.Phi;
 import org.eolang.posix.CStdLib;
 import org.eolang.posix.StatSyscall;
 import org.hamcrest.MatcherAssert;

--- a/eo-runtime/src/test/java/org/eolang/sys/SyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/SyscallTest.java
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang;
+package org.eolang.sys;
 
 import codes.ivanov.ephpo.Ephemeral;
 import codes.ivanov.ephpo.EphemeralResolver;
@@ -21,8 +21,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import org.eolang.AtVoid;
+import org.eolang.Atom;
+import org.eolang.Attr;
+import org.eolang.Attrs;
+import org.eolang.Data;
+import org.eolang.Dataized;
+import org.eolang.PhDefault;
+import org.eolang.Phi;
 import org.eolang.posix.CStdLib;
-import org.eolang.sys.SockaddrIn;
 import org.eolang.win32.WSAData;
 import org.eolang.win32.Winsock;
 import org.hamcrest.MatcherAssert;


### PR DESCRIPTION
Closes #8635.

The other half of #8618. `Syscall` serves `posix` and `win32` alone, yet standing in `org.eolang` it read as part of the runtime's public surface, the way `Bytes` and `PhDefault` are. It joins `Handles`, `Cstring` and `TupleToArray` beside `Sockaddr`, and `SyscallTest`, `ReadSyscallTest` and `StatSyscallTest` travel with it.

Only imports change in the sixty-two adapters that implement it — which is why this waited for a pull request of its own: together with #8622 the diff came to 253 lines and `pr-size` caps at 200. This one is 158.

`SyscallTest` also loses its `import org.eolang.sys.SockaddrIn`, now that it sits in that package itself.

The `@todo` that asked for this is gone; the one about re-parenting `org.eolang.posix` and `org.eolang.win32` is #8619 and stays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga

---
_Generated by [Claude Code](https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga)_