### PR TITLE
fix(#8625): look through a fork when refusing a rebuilt receiver

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Call.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Call.java
@@ -21,8 +21,10 @@ import java.util.List;
  * a call is no receiver, though: its value was dataized into the forma
  * the tables witness, and the object that answered — the one owning the
  * method the datum never had — is gone by then, so a call on it is
- * refused and the fragment stays as written. The method
- * is taken of the receiver with {@code PhDispatch} and applied to the
+ * refused and the fragment stays as written. A fork is no receiver
+ * either when an arm of it, or an arm of an arm, answers with such a
+ * call, since the value of the fork is whatever the taken arm answers.
+ * The method is taken of the receiver with {@code PhDispatch} and applied to the
  * arguments by position with {@code PhApplication}, the way the
  * transpiler spells a call, and the value is dataized into the forma the step
  * carries — a number, a bool, or the bytes of bytes and a string — or
@@ -106,9 +108,17 @@ public final class Call {
         if (key.startsWith("sym:s")) {
             final String kind = this.values.kind(key);
             out = !"tuple".equals(kind) && !"object".equals(kind)
-                && this.values.step(key.substring(4)).atom().charAt(0) == '.';
+                && this.dataized(this.values.step(key.substring(4)));
         }
         return out;
+    }
+
+    private boolean dataized(final Step producer) {
+        return producer.atom().charAt(0) == '.'
+            || producer.branches().stream()
+                .map(Protocol::answer)
+                .filter(answer -> !answer.isEmpty())
+                .anyMatch(this::rebuilt);
     }
 
     private String wrapped(final String key) {

--- a/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/CallTest.java
@@ -159,6 +159,84 @@ final class CallTest {
         );
     }
 
+    @Test
+    void refusesReceiverRebuiltUnderFork() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> CallTest.forked(
+                new Dispatch("s1", "size", Collections.singletonList("sym:v0"), "number"),
+                new Protocol(Collections.emptyList(), "sym:s1", "number"),
+                new Protocol(
+                    Collections.emptyList(), "number:40-00-00-00-00-00-00-00", "number"
+                )
+            ).text(),
+            "the number an arm of a fork was dataized into is no object to dispatch on, but it is"
+        );
+    }
+
+    @Test
+    void refusesReceiverRebuiltUnderNestedFork() {
+        Assertions.assertThrows(
+            IllegalStateException.class,
+            () -> CallTest.forked(
+                new Dispatch("s1", "size", Collections.singletonList("sym:v0"), "number"),
+                new Protocol(
+                    Collections.singletonList(
+                        new Fork(
+                            "s4", "L_bool_if", "sym:v1",
+                            new Protocol(Collections.emptyList(), "sym:s1", "number"),
+                            new Protocol(
+                                Collections.emptyList(), "number:40-08-00-00-00-00-00-00", "number"
+                            )
+                        )
+                    ),
+                    "sym:s4", "number"
+                ),
+                new Protocol(
+                    Collections.emptyList(), "number:40-00-00-00-00-00-00-00", "number"
+                )
+            ).text(),
+            "the number an arm of an arm was dataized into is no object to dispatch on, but it is"
+        );
+    }
+
+    @Test
+    void wrapsDatumOfForkOverOperationsAsReceiver() {
+        MatcherAssert.assertThat(
+            "the value of a fork over operations is the number it is, but it was refused",
+            CallTest.forked(
+                new Application(
+                    "s1", "L_number_plus",
+                    Arrays.asList("sym:v0", "number:3F-F0-00-00-00-00-00-00")
+                ),
+                new Protocol(Collections.emptyList(), "sym:s1", "number"),
+                new Protocol(
+                    Collections.emptyList(), "number:40-00-00-00-00-00-00-00", "number"
+                )
+            ).text(),
+            Matchers.equalTo(
+                "new Dataized(new PhDispatch(new Data.ToPhi(s2), \"further\")).asBool()"
+            )
+        );
+    }
+
+    private static Call forked(final Step first, final Protocol taken, final Protocol other) {
+        final Step fork = new Fork("s2", "L_bool_if", "sym:v1", taken, other);
+        final Step further = new Dispatch(
+            "s3", "further", Collections.singletonList("sym:s2"), "bool"
+        );
+        final Map<String, String> voids = new LinkedHashMap<>(2);
+        voids.put("x", "number");
+        voids.put("f", "bool");
+        return new Call(
+            further,
+            new Rendering(
+                new Protocol(Arrays.asList(first, fork, further), "sym:s3", "bool"),
+                voids
+            )
+        );
+    }
+
     private static Call chained(final Step first, final Step second,
         final Map<String, String> voids) {
         return new Call(


### PR DESCRIPTION
`Call` refused to dispatch on a receiver whose value an earlier call had been dataized into, but it asked only the producing step's own atom, and only a `Dispatch` answers a dot-prefixed one. A `Fork` answers the λ name of `if`, so a receiver naming a fork slipped through and got rewrapped with `Data.ToPhi`, even when the taken arm answered with the value of a real dispatch and the object that owned the method was already gone.

The check now walks a fork to what its arms actually answer, and does it recursively, since an arm may answer another fork. An arm that repeats or fails answers nothing and is skipped. A fork over Java operations still passes, so nothing that was allowed before is refused now.

Three cases in `CallTest` cover it: a fork whose arm answers a dispatch, the same one arm deeper, and a fork over operations that must keep rendering.

Closes #8625
