### PR TITLE
#8589: guard the win32 read and recv buffers too

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -11,6 +11,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Buffer;
 
 /**
  * Read syscall.

--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -11,6 +11,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Buffer;
 
 /**
  * Recv syscall.

--- a/eo-runtime/src/main/java/org/eolang/sys/Buffer.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/Buffer.java
@@ -2,7 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang.posix;
+package org.eolang.sys;
 
 import org.eolang.ExFailure;
 
@@ -15,9 +15,13 @@ import org.eolang.ExFailure;
  * instead, the way {@code write} and {@code send} check the size against the
  * buffer they were given.</p>
  *
+ * <p>Public because both families of adapters read into a buffer, and
+ * a size the process cannot allocate has to be refused the same way on
+ * either one.</p>
+ *
  * @since 0.64.0
  */
-final class Buffer {
+public final class Buffer {
 
     /**
      * What the size is, for the failure message.
@@ -35,7 +39,7 @@ final class Buffer {
      * @param subject What the size is, for the failure message
      * @param size How many bytes are wanted
      */
-    Buffer(final String subject, final int size) {
+    public Buffer(final String subject, final int size) {
         this.subject = subject;
         this.size = size;
     }
@@ -45,7 +49,7 @@ final class Buffer {
      *
      * @return The array
      */
-    byte[] it() {
+    public byte[] it() {
         final Runtime runtime = Runtime.getRuntime();
         final long free = Math.min(
             runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory(),

--- a/eo-runtime/src/main/java/org/eolang/sys/package-info.java
+++ b/eo-runtime/src/main/java/org/eolang/sys/package-info.java
@@ -10,9 +10,10 @@
  * another way by macOS, and both families of adapters, posix and win32,
  * hand that layout to the kernel. It is theirs, not the runtime's, so it
  * lives here rather than in the root package next to {@code Phi} and
- * {@code Bytes}. The same goes for {@code Handles}, {@code Cstring} and
- * {@code TupleToArray}, which carry a pointer, a text and a tuple of
- * arguments across to C on their behalf.</p>
+ * {@code Bytes}. The same goes for {@code Buffer}, {@code Handles},
+ * {@code Cstring} and {@code TupleToArray}, which size a read and carry
+ * a pointer, a text and a tuple of arguments across to C on their
+ * behalf.</p>
  *
  * @since 0.77.0
  * @todo #8618:30min Move Syscall here too, together with SyscallTest,

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -11,6 +11,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Buffer;
 
 /**
  * The msvcrt _read function call.
@@ -41,7 +42,9 @@ public final class ReadFuncCall implements Syscall {
         final int size = new Natural(
             new Expect<>("the 'size' argument of read", () -> params[1])
         ).it();
-        final byte[] buf = new byte[size];
+        final byte[] buf = new Buffer(
+            "the 'size' argument of read", size
+        ).it();
         final int count = Msvcrt.INSTANCE._read(
             descriptor, buf, size
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -13,6 +13,7 @@ import org.eolang.Int;
 import org.eolang.Natural;
 import org.eolang.Phi;
 import org.eolang.Syscall;
+import org.eolang.sys.Buffer;
 
 /**
  * ReadFile kernel32 function call.
@@ -45,7 +46,9 @@ public final class RecvFuncCall implements Syscall {
         final int size = new Natural(
             new Expect<>("the 'size' argument of recv", () -> params[1])
         ).it();
-        final byte[] buf = new byte[size];
+        final byte[] buf = new Buffer(
+            "the 'size' argument of recv", size
+        ).it();
         final int received = Winsock.INSTANCE.recv(
             new Pointer(new Dataized(params[0]).asNumber().longValue()),
             buf,

--- a/eo-runtime/src/test/java/org/eolang/sys/BufferTest.java
+++ b/eo-runtime/src/test/java/org/eolang/sys/BufferTest.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.sys;
+
+import org.eolang.ExFailure;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Buffer}.
+ *
+ * @since 0.64.0
+ */
+final class BufferTest {
+
+    @Test
+    void makesAnArrayOfTheAskedSize() {
+        MatcherAssert.assertThat(
+            "A size the heap can hold must come back as an array of exactly that many bytes",
+            new Buffer("the 'size' argument of read", 17).it().length,
+            Matchers.equalTo(17)
+        );
+    }
+
+    @Test
+    void makesNothingOutOfNothing() {
+        MatcherAssert.assertThat(
+            "A size of zero must come back as an empty array, not as a failure",
+            new Buffer("the 'size' argument of recv", 0).it().length,
+            Matchers.equalTo(0)
+        );
+    }
+
+    @Test
+    void refusesASizeTheHeapCannotHold() {
+        Assertions.assertThrows(
+            ExFailure.class,
+            () -> new Buffer("the 'size' argument of read", Integer.MAX_VALUE).it(),
+            "A size larger than the heap must fail with ExFailure, not with OutOfMemoryError"
+        );
+    }
+
+    @Test
+    void namesWhatTheSizeWasFor() {
+        MatcherAssert.assertThat(
+            "The failure must name the argument it refused, so the message says what to fix",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Buffer("the 'size' argument of recv", Integer.MAX_VALUE).it()
+            ).getMessage(),
+            Matchers.containsString("the 'size' argument of recv")
+        );
+    }
+}


### PR DESCRIPTION
Closes #8589.

`posix.read` and `posix.recv` size their buffer through `Buffer`, which refuses a size the process cannot allocate and says so as an `ExFailure`. `win32.read` and `win32.recv` asked the JVM straight out with `new byte[size]`, so the same EO program answered with a catchable failure on one platform and an `OutOfMemoryError` on the other — and `PhSafe.through()` rethrows an `Error` unwrapped, so EO could not recover from it at all.

`Buffer` was package-private in `org.eolang.posix`, where win32 could not reach it. It moves to `org.eolang.sys`, beside the rest of what the two families share, and becomes public for the same reason `Handles` is. Both win32 read paths use it now, with the same subject text their posix siblings pass.

`BufferTest` is new and runs on every platform: an askable size comes back as an array of exactly that length, zero comes back empty rather than as a failure, a size past the heap fails with `ExFailure` and not `OutOfMemoryError`, and the message names the argument it refused. The win32 regressions for this live in `RecvFuncCallTest`, which is `@DisabledOnOs({MAC, LINUX})`, so the Windows leg is what exercises the change end to end.

`qulice` passes on `eo-runtime`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga

---
_Generated by [Claude Code](https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga)_