### PR TITLE
#8589: guard the win32 read and recv buffers too

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Buffer.java
+++ b/eo-runtime/src/main/java/org/eolang/Buffer.java
@@ -2,9 +2,7 @@
  * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-package org.eolang.posix;
-
-import org.eolang.ExFailure;
+package org.eolang;
 
 /**
  * A byte array a syscall reads into.
@@ -15,9 +13,13 @@ import org.eolang.ExFailure;
  * instead, the way {@code write} and {@code send} check the size against the
  * buffer they were given.</p>
  *
+ * <p>Public because the win32 adapters, which live in another package,
+ * read into a buffer of a size the program chose just as the posix ones
+ * do, and both must refuse a size the heap cannot hold.</p>
+ *
  * @since 0.64.0
  */
-final class Buffer {
+public final class Buffer {
 
     /**
      * What the size is, for the failure message.
@@ -35,7 +37,7 @@ final class Buffer {
      * @param subject What the size is, for the failure message
      * @param size How many bytes are wanted
      */
-    Buffer(final String subject, final int size) {
+    public Buffer(final String subject, final int size) {
         this.subject = subject;
         this.size = size;
     }
@@ -45,7 +47,7 @@ final class Buffer {
      *
      * @return The array
      */
-    byte[] it() {
+    public byte[] it() {
         final Runtime runtime = Runtime.getRuntime();
         final long free = Math.min(
             runtime.maxMemory() - runtime.totalMemory() + runtime.freeMemory(),

--- a/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/ReadSyscall.java
@@ -5,6 +5,7 @@
 package org.eolang.posix;
 
 import java.util.Arrays;
+import org.eolang.Buffer;
 import org.eolang.Data;
 import org.eolang.Expect;
 import org.eolang.Int;

--- a/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
+++ b/eo-runtime/src/main/java/org/eolang/posix/RecvSyscall.java
@@ -5,6 +5,7 @@
 package org.eolang.posix;
 
 import java.util.Arrays;
+import org.eolang.Buffer;
 import org.eolang.Data;
 import org.eolang.Expect;
 import org.eolang.Int;

--- a/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/ReadFuncCall.java
@@ -5,6 +5,7 @@
 package org.eolang.win32;
 
 import java.util.Arrays;
+import org.eolang.Buffer;
 import org.eolang.Data;
 import org.eolang.Expect;
 import org.eolang.Int;
@@ -41,7 +42,7 @@ public final class ReadFuncCall implements Syscall {
         final int size = new Natural(
             new Expect<>("the 'size' argument of read", () -> params[1])
         ).it();
-        final byte[] buf = new byte[size];
+        final byte[] buf = new Buffer("the 'size' argument of read", size).it();
         final int count = Msvcrt.INSTANCE._read(
             descriptor, buf, size
         );

--- a/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
+++ b/eo-runtime/src/main/java/org/eolang/win32/RecvFuncCall.java
@@ -6,6 +6,7 @@ package org.eolang.win32;
 
 import com.sun.jna.Pointer;
 import java.util.Arrays;
+import org.eolang.Buffer;
 import org.eolang.Data;
 import org.eolang.Dataized;
 import org.eolang.Expect;
@@ -45,7 +46,7 @@ public final class RecvFuncCall implements Syscall {
         final int size = new Natural(
             new Expect<>("the 'size' argument of recv", () -> params[1])
         ).it();
-        final byte[] buf = new byte[size];
+        final byte[] buf = new Buffer("the 'size' argument of recv", size).it();
         final int received = Winsock.INSTANCE.recv(
             new Pointer(new Dataized(params[0]).asNumber().longValue()),
             buf,

--- a/eo-runtime/src/test/java/org/eolang/BufferTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BufferTest.java
@@ -1,0 +1,44 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Buffer}.
+ *
+ * @since 0.64.0
+ */
+final class BufferTest {
+
+    @Test
+    void refusesSizeTheHeapCannotHold() {
+        MatcherAssert.assertThat(
+            "a size larger than any array must be refused by name, but it wasnt",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new Buffer("the 'size' argument of read", Integer.MAX_VALUE).it(),
+                "a size larger than any array was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'size' argument of read"),
+                Matchers.containsString("Can't allocate")
+            )
+        );
+    }
+
+    @Test
+    void makesArrayOfTheSizeAsked() {
+        MatcherAssert.assertThat(
+            "the array must be as long as the size asked for, but it wasnt",
+            new Buffer("the 'size' argument of recv", 16).it().length,
+            Matchers.equalTo(16)
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/ReadFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/ReadFuncCallTest.java
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.win32;
+
+import org.eolang.Data;
+import org.eolang.ExFailure;
+import org.eolang.Phi;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
+
+/**
+ * Test case for {@link ReadFuncCall}.
+ *
+ * @since 0.74.0
+ */
+final class ReadFuncCallTest {
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsSizeNoArrayCanHoldOnWindowsRead() {
+        MatcherAssert.assertThat(
+            "the 'size' argument of read must be refused by name, the way posix refuses it",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new ReadFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(0), new Data.ToPhi(Integer.MAX_VALUE)
+                ),
+                "a 'size' argument of read beyond any array was expected to fail with ExFailure"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'size' argument of read"),
+                Matchers.containsString("Can't allocate")
+            )
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/win32/RecvFuncCallTest.java
@@ -40,6 +40,25 @@ final class RecvFuncCallTest {
 
     @Test
     @DisabledOnOs({OS.MAC, OS.LINUX})
+    void rejectsSizeNoArrayCanHoldOnWindowsRecv() {
+        MatcherAssert.assertThat(
+            "the 'size' argument of recv must be refused by name, the way posix refuses it",
+            Assertions.assertThrows(
+                ExFailure.class,
+                () -> new RecvFuncCall(Phi.Φ.take("win32").copy()).make(
+                    new Data.ToPhi(0), new Data.ToPhi(Integer.MAX_VALUE), new Data.ToPhi(0)
+                ),
+                "A win32 recv size beyond any array must fail with ExFailure, not OutOfMemoryError"
+            ).getMessage(),
+            Matchers.allOf(
+                Matchers.containsString("'size' argument of recv"),
+                Matchers.containsString("Can't allocate")
+            )
+        );
+    }
+
+    @Test
+    @DisabledOnOs({OS.MAC, OS.LINUX})
     void rejectsNegativeSizeOnWindowsRecv() {
         Assertions.assertThrows(
             ExFailure.class,


### PR DESCRIPTION
`posix.read` and `posix.recv` size their buffer through `Buffer`, which refuses
a size the heap cannot hold and reports it as a catchable `ExFailure`. The
win32 adapters allocated the array directly, so the same EO program died on
Windows with an `OutOfMemoryError` that `PhSafe` rethrows unwrapped and EO
cannot catch.

`Buffer` moved from `org.eolang.posix` to `org.eolang`, where both packages can
reach it, the way `Int` and `Natural` already live, and the two win32 calls now
use it.

Closes #8589
