### PR TITLE
#8586: read the repeat past the hops the walk consumed

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
@@ -192,7 +192,7 @@ public final class Parsed {
         Term out;
         int next = hops + 1;
         if ("ρ".equals(parts[hops])) {
-            out = Parsed.again(where, path, parts, args);
+            out = Parsed.again(where, path, parts, hops, args);
             next = parts.length;
         } else if (hops == last) {
             out = new Reference(where, this.trail, parts[hops], args, this.tables).term();
@@ -219,8 +219,9 @@ public final class Parsed {
     }
 
     private static Term again(final Scope where, final String path,
-        final String[] parts, final List<Binding> args) {
-        if (where.name().isEmpty() || parts.length != 2 || !parts[1].equals(where.name())) {
+        final String[] parts, final int hops, final List<Binding> args) {
+        if (where.name().isEmpty() || parts.length != hops + 2
+            || !parts[hops + 1].equals(where.name())) {
             throw new IllegalStateException(
                 String.format(
                     "The reference 'ξ.%s' reaches through ρ beyond the formation being lowered",

--- a/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
@@ -326,6 +326,29 @@ final class ParsedTest {
     }
 
     @Test
+    void repeatsTheFormationNamedFromAHelper() {
+        MatcherAssert.assertThat(
+            "a helper naming the formation it belongs to must repeat it, but it didnt",
+            new Parsed(
+                new Xnav("<o base='ξ.a🌵7-4'><o as='α0' base='ξ.x'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                "f",
+                Collections.singletonMap(
+                    "a🌵7-4",
+                    new Xnav(
+                        String.join(
+                            "",
+                            "<o name='a🌵7-4'><o base='∅' name='ρ'/><o base='∅' name='j'/>",
+                            "<o base='ξ.ρ.ρ.f' name='φ'><o as='α0' base='ξ.j'/></o></o>"
+                        )
+                    ).element("o")
+                )
+            ).term().again().get().arguments(),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
     void refusesReachBeyondTheFormation() {
         MatcherAssert.assertThat(
             "a reference past the root through ρ depends on a context the fragment lacks",


### PR DESCRIPTION
Closes #8586.

`Parsed.chained` walks up the enclosing scopes and counts the hops it consumed, then handed the whole path to `again`, which re-indexed from zero with `parts.length != 2` and `parts[1]`. Those two are only right when `hops` is zero, so a helper naming the formation it belongs to — one hop out, spelled `ξ.ρ.ρ.foo` — read as `parts[1] == "ρ"` and was refused as reaching beyond the formation. Mutual recursion between a formation and its helper never lowered, though `Repeat.protocol`, `Program.index("")` and `JavaAtom.rebound` all carry it.

`again` now takes `hops` and looks at `parts[hops + 1]` against a length of `hops + 2`. With `hops` zero that is the old check verbatim, so `readsCallToItselfAsRepeat`, `refusesCallThroughRhoToAnother` and `refusesReachBeyondTheFormation` are untouched — the last of those reaches through two `ρ` from the root, where `hops` is still zero and the length is three, and it is still refused.

`repeatsTheFormationNamedFromAHelper` reproduces it: it raises `The reference 'ξ.ρ.ρ.f' reaches through ρ beyond the formation being lowered` on master and passes here. All 337 tests of `eo-lowering` are green, and `qulice` passes on the module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga

---
_Generated by [Claude Code](https://claude.ai/code/session_01Phy88cN7XAmjevJf6Bcqga)_