### PR TITLE
#8588: degrade a number of the wrong width to the structural form

### DIFF
--- a/eo-runtime/src/main/java/org/eolang/Numbered.java
+++ b/eo-runtime/src/main/java/org/eolang/Numbered.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+/**
+ * Bytes rendered as an EO number literal.
+ *
+ * <p>A number is eight bytes wide and nothing else denotes one, so bytes
+ * of any other width are refused here the way {@link Quoted} refuses
+ * bytes that are not valid UTF-8. The caller gets an empty result and is
+ * expected to print the structural form instead, since a renderer that
+ * throws replaces the failure it was called to describe.</p>
+ *
+ * @since 0.75.0
+ */
+final class Numbered implements Supplier<Optional<String>> {
+
+    /**
+     * The bytes of the number.
+     */
+    private final byte[] data;
+
+    /**
+     * Ctor.
+     *
+     * @param data The bytes
+     */
+    Numbered(final byte[] data) {
+        this.data = Arrays.copyOf(data, data.length);
+    }
+
+    @Override
+    public Optional<String> get() {
+        final Optional<String> result;
+        if (this.data.length == Double.BYTES) {
+            result = Optional.of(new Numeral(new BytesOf(this.data).asNumber()).get());
+        } else {
+            result = Optional.empty();
+        }
+        return result;
+    }
+}

--- a/eo-runtime/src/main/java/org/eolang/PhApplication.java
+++ b/eo-runtime/src/main/java/org/eolang/PhApplication.java
@@ -98,13 +98,17 @@ public final class PhApplication extends PhOnce {
         } else {
             string = null;
         }
+        final String number;
+        if (literal && "Φ.number".equals(head)) {
+            number = new Numbered(PhApplication.bytes(data.group(1))).get().orElse(null);
+        } else {
+            number = null;
+        }
         final String result;
         if (string != null) {
             result = string;
-        } else if (literal && "Φ.number".equals(head)) {
-            result = new Numeral(
-                new BytesOf(PhApplication.bytes(data.group(1))).asNumber()
-            ).get();
+        } else if (number != null) {
+            result = number;
         } else {
             result = String.format("%s(%s)", head, body);
         }

--- a/eo-runtime/src/main/java/org/eolang/PhDefault.java
+++ b/eo-runtime/src/main/java/org/eolang/PhDefault.java
@@ -357,7 +357,7 @@ public class PhDefault implements Phi, Cloneable {
             if ("string".equals(name)) {
                 result = new Quoted(raw).get().orElseGet(this::structural);
             } else {
-                result = new Numeral(new BytesOf(raw).asNumber()).get();
+                result = new Numbered(raw).get().orElseGet(this::structural);
             }
         } else {
             result = this.structural();

--- a/eo-runtime/src/test/java/org/eolang/NumberedTest.java
+++ b/eo-runtime/src/test/java/org/eolang/NumberedTest.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang;
+
+import java.util.Optional;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Numbered}.
+ *
+ * @since 0.75.0
+ */
+final class NumberedTest {
+
+    @Test
+    void rendersEightBytesAsANumber() {
+        MatcherAssert.assertThat(
+            "eight bytes must render as the number they denote, but they didnt",
+            new Numbered(
+                new byte[] {
+                    (byte) 0x40, (byte) 0x45, (byte) 0x00, (byte) 0x00,
+                    (byte) 0x00, (byte) 0x00, (byte) 0x00, (byte) 0x00,
+                }
+            ).get(),
+            Matchers.equalTo(Optional.of("42"))
+        );
+    }
+
+    @Test
+    void refusesBytesOfAnotherWidth() {
+        MatcherAssert.assertThat(
+            "bytes that are not eight wide must be refused, so the renderer can fall back",
+            new Numbered(new byte[] {(byte) 0x01}).get(),
+            Matchers.equalTo(Optional.empty())
+        );
+    }
+}

--- a/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhApplicationTest.java
@@ -55,6 +55,23 @@ final class PhApplicationTest {
     }
 
     @Test
+    void keepsANumberOfTheWrongWidthStructural() {
+        MatcherAssert.assertThat(
+            "bytes that are not eight wide denote no number and must render structurally, but they threw",
+            new PhApplication(
+                new PhDispatch(Phi.Φ, "number"),
+                0,
+                new PhApplication(
+                    new PhDispatch(Phi.Φ, "bytes"),
+                    0,
+                    new PhDefault(new byte[] {(byte) 0x01})
+                )
+            ).φTerm(),
+            Matchers.startsWith("Φ.number(0->")
+        );
+    }
+
+    @Test
     void appliesSeveralBindingsToObject() {
         MatcherAssert.assertThat(
             "PhApplication must bind every pair to the object, but it didnt",


### PR DESCRIPTION
`φTerm()` renders a literal from its bytes. The string branch falls back to the
structural form when the bytes are not valid UTF-8, while the number branch went
straight into `BytesRaw.asNumber()`, which throws on anything but eight bytes.
The renderer builds failure messages, so a `number` bound to bytes of another
width replaced the real failure with "Can't convert 1 bytes to
java.lang.Double".

The width check now lives in `Numbered`, a sibling of `Quoted`, and both
`PhDefault` and `PhApplication` fall back to the structural form when it
refuses.

Closes #8588
