### PR TITLE
#8586: read the path left after the hops the walk consumed

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Parsed.java
@@ -192,7 +192,7 @@ public final class Parsed {
         Term out;
         int next = hops + 1;
         if ("ρ".equals(parts[hops])) {
-            out = Parsed.again(where, path, parts, args);
+            out = Parsed.again(where, path, parts, hops, args);
             next = parts.length;
         } else if (hops == last) {
             out = new Reference(where, this.trail, parts[hops], args, this.tables).term();
@@ -219,8 +219,9 @@ public final class Parsed {
     }
 
     private static Term again(final Scope where, final String path,
-        final String[] parts, final List<Binding> args) {
-        if (where.name().isEmpty() || parts.length != 2 || !parts[1].equals(where.name())) {
+        final String[] parts, final int hops, final List<Binding> args) {
+        if (where.name().isEmpty() || parts.length != hops + 2
+            || !parts[hops + 1].equals(where.name())) {
             throw new IllegalStateException(
                 String.format(
                     "The reference 'ξ.%s' reaches through ρ beyond the formation being lowered",

--- a/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/ParsedTest.java
@@ -326,6 +326,29 @@ final class ParsedTest {
     }
 
     @Test
+    void resumesTheFormationNamedFromAHelper() {
+        MatcherAssert.assertThat(
+            "a helper naming the formation it belongs to must resume it, but it doesnt",
+            new Parsed(
+                new Xnav("<o base='ξ.a🌵7-4'><o as='α0' base='ξ.x'/></o>").element("o"),
+                Collections.singletonMap("x", "number"),
+                "foo",
+                Collections.singletonMap(
+                    "a🌵7-4",
+                    new Xnav(
+                        String.join(
+                            "",
+                            "<o name='a🌵7-4'><o base='∅' name='ρ'/><o base='∅' name='j'/>",
+                            "<o base='ξ.ρ.ρ.foo' name='φ'><o as='α0' base='ξ.j'/></o></o>"
+                        )
+                    ).element("o")
+                )
+            ).term().phi(),
+            Matchers.stringContainsInOrder("a0 ↦ ", "Sym_v0", "λ ⤍ L_self")
+        );
+    }
+
+    @Test
     void refusesReachBeyondTheFormation() {
         MatcherAssert.assertThat(
             "a reference past the root through ρ depends on a context the fragment lacks",


### PR DESCRIPTION
`Parsed.chained` counts the hops it walks up through the enclosing scopes, but
`again` re-indexed the path from zero, so it only read the reference right when
no hop had been taken. A helper naming the formation it belongs to spells it
`ξ.ρ.ρ.foo`, which was refused, and mutual recursion between a formation and its
helper never lowered even though the rest of the machinery handles it.

`again` now reads the part of the path left after those hops.

Closes #8586
