### PR TITLE
#6798: Re-enable two-object JarIT

### DIFF
--- a/eo-integration-tests/src/test/java/integration/JarIT.java
+++ b/eo-integration-tests/src/test/java/integration/JarIT.java
@@ -19,7 +19,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -27,11 +26,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * Integration test that runs simple EO program from packaged jar.
  *
  * @since 0.54
- * @todo #5047:30min Re-enable runsProgramWithTwoObjects after next release.
- *  The released string.printf carries a stale "+rt jvm org.eolang:eo-runtime"
- *  meta, so the sandbox skips transpiling it and no EOprintf lands on the
- *  classpath, while eo-runtime ships Java atoms only. Master already dropped
- *  that meta, so drop this annotation once the remote objectionary catches up.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith(MktmpResolver.class)
@@ -91,7 +85,6 @@ final class JarIT {
     }
 
     @Test
-    @Disabled
     @ExtendWith(WeAreOnline.class)
     @ExtendWith(MayBeSlow.class)
     void runsProgramWithTwoObjects(final @Mktmp Path temp) throws IOException {


### PR DESCRIPTION
Closes #6798.

The remaining `runsProgramWithTwoObjects` disable was explicitly temporary: its PDD says to re-enable the test after the next release because the then-released `string.printf` still carried a stale `+rt jvm org.eolang:eo-runtime` meta while `master` had already removed it.

That release boundary has now passed (`0.63.0` and `0.63.1` were released after the PDD), and current `eo-runtime/src/main/eo/string/printf.eo` no longer contains the stale runtime meta. In addition, merged #8595 has already aligned `JarIT`'s sandbox with the current package layout by running `merge` before `transpile`.

This therefore removes only the obsolete `#5047` PDD, the final `@Disabled` on `runsProgramWithTwoObjects`, and the now-unused `Disabled` import. No test logic is changed.

I don't have Maven installed in this Android/Termux environment, so the repository CI is the integration-test validation source for this Java-only change.
