### PR TITLE
Compile the local runtime sources in the JarIT sandbox

### DIFF
--- a/eo-integration-tests/src/test/java/integration/EoSourceRun.java
+++ b/eo-integration-tests/src/test/java/integration/EoSourceRun.java
@@ -126,14 +126,7 @@ final class EoSourceRun implements Proc<Object> {
         this.farea.files().file(".mvn/jvm.config").write(
             String.join(" ", EoSourceRun.FLAGS).getBytes(StandardCharsets.UTF_8)
         );
-        new RuntimeSources(
-            Paths.get(System.getProperty("basedir", System.getProperty("user.dir")))
-                .getParent()
-                .resolve("eo-runtime")
-                .resolve("src")
-                .resolve("main")
-                .resolve("eo")
-        ).exec(this.farea);
+        new RuntimeSources().exec(this.farea);
         new EoMavenPlugin(this.farea)
             .appended()
             .execution("compile")

--- a/eo-integration-tests/src/test/java/integration/JarIT.java
+++ b/eo-integration-tests/src/test/java/integration/JarIT.java
@@ -26,12 +26,23 @@ import org.junit.jupiter.api.extension.ExtendWith;
 /**
  * Integration test that runs simple EO program from packaged jar.
  *
+ * <p>The sandbox compiles the {@code .eo} sources of the runtime that live
+ * in this repository, with the plugin kept offline, and does not pull them
+ * from the remote objectionary. What that remote serves is the lowered
+ * output of the last release: every formation the {@code lower} goal folded
+ * there stands in it as an atom naming a Java class that only the jar of
+ * that release carries, {@code string.regex.compile} among them. The
+ * runtime built here folds a set of its own, so a pulled object asking for
+ * an atom this build does not carry stopped javac in the sandbox, and the
+ * three tests below broke on it every time the two sets diverged.</p>
+ *
  * @since 0.54
- * @todo #5047:30min Re-enable runsProgramWithTwoObjects after next release.
- *  The released string.printf carries a stale "+rt jvm org.eolang:eo-runtime"
- *  meta, so the sandbox skips transpiling it and no EOprintf lands on the
- *  classpath, while eo-runtime ships Java atoms only. Master already dropped
- *  that meta, so drop this annotation once the remote objectionary catches up.
+ * @todo #5047:30min Re-enable runsProgramWithTwoObjects.
+ *  The two objects transpile and land in the jar now that the sandbox
+ *  compiles the local sources of the runtime, but running "examples.app"
+ *  from that jar exits with a non-zero code and prints "Can't overwrite the
+ *  cached attribute org.eolang.AtComposite@...". Find out which object
+ *  overwrites a cached attribute there, fix it, and drop this annotation.
  */
 @SuppressWarnings("JTCOP.RuleAllTestsHaveProductionClass")
 @ExtendWith(MktmpResolver.class)
@@ -202,6 +213,7 @@ final class JarIT {
         for (final ElegantObject object : objects) {
             object.write(farea);
         }
+        new RuntimeSources().exec(farea);
         farea.dependencies().append(
             "org.eolang",
             "eo-runtime",
@@ -216,6 +228,7 @@ final class JarIT {
             .goals("register", "compile", "merge", "transpile")
             .configuration()
             .set("ignoreRuntime", "true")
+            .set("offline", "true")
             .set("failOnWarning", "false")
             .set("skipLinting", "true");
         farea.exec("clean", "compile", "jar:jar");

--- a/eo-integration-tests/src/test/java/integration/RuntimeSources.java
+++ b/eo-integration-tests/src/test/java/integration/RuntimeSources.java
@@ -8,6 +8,7 @@ import com.yegor256.farea.Farea;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -30,6 +31,25 @@ final class RuntimeSources implements Proc<Farea> {
      * Directory with local {@code .eo} sources of the eo-runtime.
      */
     private final Path dir;
+
+    /**
+     * Ctor, taking the sources of the {@code eo-runtime} of this reactor.
+     *
+     * <p>The module the tests run in sits next to {@code eo-runtime}, so the
+     * sources are found one directory up. Every test that compiles the
+     * runtime reaches for them the same way, which is why the path is
+     * spelled here and not at the call sites.</p>
+     */
+    RuntimeSources() {
+        this(
+            Paths.get(System.getProperty("basedir", System.getProperty("user.dir")))
+                .getParent()
+                .resolve("eo-runtime")
+                .resolve("src")
+                .resolve("main")
+                .resolve("eo")
+        );
+    }
 
     /**
      * Ctor.


### PR DESCRIPTION
Fixes the `codecov` job of master, which failed in [run 34446895988](https://github.com/objectionary/eo/actions/runs/34446895988/job/102773551942) on all three enabled `JarIT` tests.

## What broke

The sandbox of `JarIT` pulled the `.eo` sources of the runtime from the remote objectionary and linked them against the `eo-runtime` built in this reactor. What that remote serves is the lowered output of the last release: every formation the `lower` goal folded there stands in the published source as an atom naming a Java class that only the jar of that release carries. `objects/string/regex.eo` at `home@master` is one such file:

```
[] > compile /Q.string.regex.pattern
    [] > matched-from-index /Q.string.regex.pattern.match.matched
```

and `eo-runtime-0.63.1.jar` carries `EOstring$EOregex$EOcompile.class` and `EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index.class` for them. The runtime built here folds a set of its own — after `string.regex` was rewritten in pure EO these two are not in it — so javac stopped in the sandbox:

```
generated-sources/org/eolang/EOstring.java: cannot find symbol
  symbol: class EOstring$EOregex$EOcompile
generated-sources/org/eolang/EOstring.java: cannot find symbol
  symbol: class EOstring$EOregex$EOpattern$EOmatch$EOmatched_from_index
```

The three tests were re-enabled a day earlier in objectionary/eo#8595, and only the `codecov` job runs the integration tests (`mvn.yml` builds with `-PskipITs`), so master went red on the next push. The same skew will return whenever the folded sets diverge, which is why this changes the setup rather than waiting for a release.

## What changed

- `JarIT` plants the local `.eo` sources of `eo-runtime` into the sandbox and keeps the plugin `offline`, exactly the way `SnippetIT` already does through `EoSourceRun`, so the objects and the atoms they ask for come from one place.
- The path to those sources moves into a constructor of `RuntimeSources`; both call sites reach for it the same way.
- `runsProgramWithTwoObjects` stays disabled, with its `@todo` rewritten: the two objects transpile and land in the jar now, but running the program from that jar exits non-zero with `Can't overwrite the cached attribute org.eolang.AtComposite@...`. The old reason (a stale `+rt` meta in the released `string.printf`) no longer applies.

## How it was verified

Locally, with the reactor installed:

- `mvn -pl eo-integration-tests verify -Dit.test=JarIT` → `Tests run: 4, Failures: 0, Errors: 0, Skipped: 1` (the skip being the disabled test; the same command on `master` fails the other three with the `cannot find symbol` above).
- `mvn -pl eo-integration-tests verify -Dit.test=SnippetIT` → `Tests run: 11, Failures: 0, Errors: 0` (covers the `RuntimeSources` refactoring).
- `mvn -Pqulice -Deo.skip -pl eo-integration-tests clean process-classes qulice:check` → `BUILD SUCCESS`.

The local runs had no `phino` installed, so `eo-runtime` was built without lowering; that makes the missing-atom mismatch reproduce exactly as it does on the lowering-enabled `codecov` job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HZ4yqz2PayrDnce77aeaou

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZ4yqz2PayrDnce77aeaou)_