### PR TITLE
Inline the read-once tmpfile helper

### DIFF
--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -79,32 +79,32 @@
             posix.rdonly.plus posix.creat
             posix.exclusive
           posix.private
-  [^] > tmpfile
-    ^.exists.if > @
-      Q.file touch.as-bytes
-      T
-        "Directory %s does not exist, can't create temporary file".printf
-          * ^.file
-    ^.^.retried > [^] > touch
-      ^.^.path
-      clock.as-number
-      code.
-        os.is-windows.if
-          win32
-            "_getpid"
-            *
-          posix
-            "getpid"
-            *
-      os.is-windows.if
-        clock.as-number.random
-        div.
-          micros.
-            output.
-              posix
-                "gettimeofday"
+  ^.exists.if > [^] > tmpfile
+    Q.file
+      as-bytes.
+        ^.retried
+          ^.path
+          clock.as-number
+          code.
+            os.is-windows.if
+              win32
+                "_getpid"
                 *
-          1000000
+              posix
+                "getpid"
+                *
+          os.is-windows.if
+            clock.as-number.random
+            div.
+              micros.
+                output.
+                  posix
+                    "gettimeofday"
+                    *
+              1000000
+    T
+      "Directory %s does not exist, can't create temporary file".printf
+        * ^.file
   [^ glob] > walk
     [^ accum prefix dir] >> walked
       [^ rest] >> stepped


### PR DESCRIPTION
`tmpfile` published two attributes, its `φ` and a `touch` helper that exactly one line read. The helper declared `[^]`, so reading it off `tmpfile` bound its receiver to `tmpfile`, and `^.^` inside it was the directory — which is what `^` inside `tmpfile` already is. The wrapper carried nothing, so its body moves up a level and loses a hop:

```
  ^.exists.if > [^] > tmpfile
    Q.file
      as-bytes.
        ^.retried
          ^.path
          clock.as-number
```

#8574 asked for the helper to go private rather than away, but that route is closed. `^.^.retried > [^] >> touch` parses, and then the printer folds a single-read handle onto its only reference and keeps the synthetic name it has just orphaned, so `-Deo.autoFix` writes source that `redundant-attachment/S` rejects. That is #8655. Removing the attribute is the stronger move anyway.

The 38 objects under `Φ.directory.tmpfile` in the generated XMIR match master one for one, except that `ξ.touch.as-bytes` becomes `.as-bytes`, `ξ.ρ.ρ.retried` and `ξ.ρ.ρ.path` lose a hop, and the wrapper's own `∅` receiver at `Φ.directory.tmpfile.touch.ρ` is gone. One object fewer and nothing else moved. The five `+can-create-*-tmpfile` tests already in this file walk the whole path.

The ticket also asked for a rename, on the grounds that `touch` does not create a file. It does: `opened` at directory.eo:66 passes `creat` and `exclusive`, and `+can-create-an-empty-tmpfile` asserts the size of what comes back is 0. The name was accurate; it is simply no longer a name.

What the ticket wanted from all this — `Φ.directory.tmpfile` reducing to `Φ.file` — does not arrive here, and the second attribute was never what held it back. The row now carries only `ρ` and `φ` and still answers itself, because the walk lands on `Φ.directory.file.exists.if`, which has no `provides` row at all. Its arms are already decided, `Φ.file` at `φ.α0` and `⊥` at `φ.α1`, so one is live and the other terminates: the moment `if` stops being a dead end this row answers `Φ.file`. That gate is #8469.

Closes #8574.
