### PR TITLE
fix(#8336): take the race test's directory from MktmpResolver

### DIFF
--- a/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
+++ b/eo-runtime/src/test/java/org/eolang/EOdirectoryEOmadeRaceTest.java
@@ -5,12 +5,14 @@
 
 package org.eolang;
 
+import com.yegor256.Mktmp;
+import com.yegor256.MktmpResolver;
 import com.yegor256.Together;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.RepeatedTest;
-import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@code directory.made} under concurrency.
@@ -36,12 +38,22 @@ import org.junit.jupiter.api.io.TempDir;
  * gigabytes of heap and minutes of collecting it, for no more of the race than
  * four reach.</p>
  *
+ * <p>The directory is one {@link MktmpResolver} hands out, because it deletes
+ * nothing. Four threads down a three-level path outlive the second of
+ * {@code eo.deadline} that eo-runtime grants a test, so {@link Watched}
+ * interrupts them and reports the skip after a bounded grace, whether they
+ * stopped or not, and one that did not stop is still making those very
+ * directories. A directory JUnit owns is deleted the moment the test's context
+ * closes: on windows that delete meets the {@code mkdir} going on underneath
+ * it, fails, and turns a skip into a broken context (#8336).</p>
+ *
  * @since 0.75.0
  */
+@ExtendWith(MktmpResolver.class)
 final class EOdirectoryEOmadeRaceTest {
 
     @RepeatedTest(10)
-    void makesOneDirectoryFromManyThreadsAtOnce(@TempDir final Path temp) {
+    void makesOneDirectoryFromManyThreadsAtOnce(@Mktmp final Path temp) {
         MatcherAssert.assertThat(
             "every thread racing for the same missing directory must be told it is there, since the one that loses the mkdir is the one the EEXIST branch rescues",
             new Together<>(


### PR DESCRIPTION
The `mvn (windows-2022, 26)` leg of master went red on `ac383360` ([run 34476796275](https://github.com/objectionary/eo/actions/runs/34476796275/job/102869419864)) with one error and nothing else:

```
[ERROR] EOdirectoryEOmadeRaceTest.makesOneDirectoryFromManyThreadsAtOnce(Path)[4]
        » JUnit Failed to close extension context
```

The other three legs were cancelled by fail-fast; this was the only failure in the run.

## Why

The failure mode is the one already written down in the `@todo #8336` of `eo-runtime/src/test/java/org/eolang/Watched.java`: the threads a terminated body leaves behind are interrupted as often as the body is, but never waited for.

`EOdirectoryEOmadeRaceTest` races four threads to `mkdir` the same three-level path, and every one of them builds an object graph of its own, so the test outlives the `eo.deadline` the job grants it (two seconds here). `Watched` interrupts the group and reports the skip after a bounded grace, whether the threads stopped or not — and one that did not stop is still making those very directories. The directory was a JUnit `@TempDir`, which JUnit deletes the moment the test's context closes: on windows that delete meets the `mkdir` going on underneath it, fails, and turns the skip into a broken context. Linux and macos delete without a word, which is why only the windows leg goes red, and why it goes red only on the repetition slow enough to be terminated at the wrong instant.

## What changed

The directory now comes from `MktmpResolver`, which deletes nothing, exactly as `EOfileEOtouchedTest` already takes it for the same reason (#8336):

```java
@ExtendWith(MktmpResolver.class)
final class EOdirectoryEOmadeRaceTest {
    @RepeatedTest(10)
    void makesOneDirectoryFromManyThreadsAtOnce(@Mktmp final Path temp) {
```

plus a javadoc paragraph recording why the directory is that one and not JUnit's. The race the test exists to exercise, the assertion, the thread count and the repetitions are all untouched.

This is the only test in `eo-runtime` that combines `Together` with `@TempDir`, so it is the whole exposure. The `@todo` in `Watched` stays open: waiting for the group to empty is the general fix, and this is the test that was failing because of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165eG1SAterxJqMrzkM668u


---
_Generated by [Claude Code](https://claude.ai/code/session_0165eG1SAterxJqMrzkM668u)_