### PR TITLE
Stop counting a formation's read of its own void as filling it

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -110,7 +110,7 @@ final class Dispatched {
         final Map<String, Map<String, String>> bound = new Copied(
             new Bound(this.args, this.named, this.receivers, pairs, owned).all(),
             pairs,
-            new Lent(owned, this.all, this.args, this.hollows).sites(names)
+            new Lent(owned, this.all, this.args, this.receivers).sites(names)
         ).all();
         final Filled filled = new Filled(
             pairs,

--- a/eo-inference/src/main/java/org/eolang/inference/Lent.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Lent.java
@@ -32,6 +32,14 @@ import java.util.Map;
  * both halves are asked of the tables as they stand, and neither of them is
  * what the refinement wrote (#8508).</p>
  *
+ * <p>A name read without a dot before it is such a call too. The {@code if} of
+ * {@code if > not} is the void of the {@code bool} the line is written in, and
+ * the {@code false} and {@code true} beside it go into whatever fills that
+ * void, never into the void itself. Nothing stands beside the name to say what
+ * it is read off, so {@link Taken} is asked, which is the one answer that
+ * covers a name written after a dot and a name written by itself alike
+ * (#8469).</p>
+ *
  * @since 0.71.0
  */
 final class Lent {
@@ -42,7 +50,7 @@ final class Lent {
     private final Provided owned;
 
     /**
-     * Every dispatch of the program.
+     * Every dispatch and read of the program.
      */
     private final Collection<Site> all;
 
@@ -52,50 +60,58 @@ final class Lent {
     private final Map<String, List<String>> args;
 
     /**
-     * The locator of every void.
+     * What every call takes its attribute from, from {@link Taken}.
      */
-    private final Collection<String> hollows;
+    private final Map<String, String> receivers;
 
     /**
      * Ctor.
      *
      * @param provided What the types certainly have
-     * @param dispatches Every dispatch of the program
+     * @param dispatches Every dispatch and read of the program
      * @param arguments The arguments of every application, from {@link Given}
-     * @param voids The locator of every void, from {@link Hollows}
+     * @param taken What every call takes its attribute from, from {@link Taken}
      */
     Lent(
         final Provided provided,
         final Collection<Site> dispatches,
         final Map<String, List<String>> arguments,
-        final Collection<String> voids
+        final Map<String, String> taken
     ) {
         this.owned = provided;
         this.all = dispatches;
         this.args = arguments;
-        this.hollows = voids;
+        this.receivers = taken;
     }
 
     /**
      * The calls whose answer is one of their own arguments.
      *
      * @param names The name every locator goes by, from {@link Ends}
-     * @return The locator of every dispatch that lands on a void and comes
-     *  back as what it was given, empty when this pass looks into no void
+     * @return The locator of every call that lands on a void and comes back as
+     *  what it was given, empty when this pass looks into no void
      */
     Collection<String> sites(final Map<String, String> names) {
         final Collection<String> found = new HashSet<>(0);
         for (final Site dispatch : this.all) {
             final String made = dispatch.made();
-            final String bearer = dispatch.bearer();
+            final String bearer = this.bearer(dispatch);
             final String given = this.joined(made, names);
             if (!given.isEmpty()
                 && given.equals(names.getOrDefault(made, made))
-                && new Rooted(this.hollows).covers(
+                && this.owned.hollow(
                     this.owned.attribute(names.getOrDefault(bearer, bearer), dispatch.name())
                 )) {
                 found.add(made);
             }
+        }
+        return found;
+    }
+
+    private String bearer(final Site dispatch) {
+        String found = dispatch.bearer();
+        if (found.isEmpty()) {
+            found = this.receivers.getOrDefault(dispatch.made(), "");
         }
         return found;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Provided.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Provided.java
@@ -220,20 +220,15 @@ final class Provided {
         return this.names.getOrDefault(next, next);
     }
 
-    private boolean hollow(final String type) {
-        boolean found = false;
-        String walked = type;
-        while (!walked.isEmpty()) {
-            if (this.hollows.contains(walked)) {
-                found = true;
-                break;
-            }
-            if (!walked.contains(".")) {
-                break;
-            }
-            walked = walked.substring(0, walked.lastIndexOf('.'));
-        }
-        return found;
+    /**
+     * Whether this name is one of the voids, or a name taken off one.
+     *
+     * @param type The name the type goes by
+     * @return True when nothing certain is said about it here, because what it
+     *  is stands where a caller has yet to put anything
+     */
+    boolean hollow(final String type) {
+        return new Rooted(this.hollows).covers(type);
     }
 
     private String kept(final String type, final String name, final Collection<String> walked) {

--- a/eo-inference/src/main/java/org/eolang/inference/Resolved.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Resolved.java
@@ -93,7 +93,7 @@ public final class Resolved implements Clue {
         final Map<String, String> receivers = new Taken(world, written).all();
         final Collection<String> voids = new Hollows(given).all();
         final Map<String, Type> kept = written.others();
-        final Woven woven = new Woven(given, applied, receivers, voids, dispatches);
+        final Woven woven = new Woven(given, applied, receivers, voids, asked);
         final Promoted promoted = new Promoted(woven, given, new Said(written), voids, args);
         final Map<String, String> pairs = new Settled(
             new Dispatched(given, asked, args, named, receivers, voids), promoted

--- a/eo-inference/src/main/java/org/eolang/inference/Woven.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Woven.java
@@ -51,7 +51,7 @@ final class Woven {
     private final Collection<String> hollows;
 
     /**
-     * Every dispatch of the program.
+     * Every dispatch and read of the program.
      */
     private final Collection<Site> all;
 
@@ -62,7 +62,7 @@ final class Woven {
      * @param applications What every application of the program gives
      * @param taken What every dispatch takes its attribute from
      * @param voids The locator of every void
-     * @param dispatches Every dispatch of the program
+     * @param dispatches Every dispatch and read of the program
      */
     Woven(
         final XML provides,
@@ -114,7 +114,7 @@ final class Woven {
                 owned
             ).all(),
             pairs,
-            new Lent(owned, this.all, this.applied.arguments(), this.hollows).sites(names)
+            new Lent(owned, this.all, this.applied.arguments(), this.receivers).sites(names)
         ).all();
     }
 }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-read-of-its-own-void-does-not-fill-it.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-read-of-its-own-void-does-not-fill-it.yaml
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A formation that reads its own void and applies it puts nothing into that
+# void: `choose yes no` inside `[choose] > pick` hands the two arms to
+# whatever a caller has put there, and the callers are the only ones who fill
+# it. The read is answered with a `pick`, since both arms are, and answering
+# it that way is what made it look like a copy of `pick` filling the first
+# void of one, so the arms were written down twice over — once against the
+# void the callers fill, where they never went.
+eo:
+  pick.eo: |
+    [choose] > pick
+      choose > taken
+        yes
+        no
+  yes.eo: |
+    [^] > yes
+      pick > @
+        [^]
+          ? >> left
+          ? >> right
+          left > @
+  no.eo: |
+    [^] > no
+      pick > @
+        [^]
+          ? >> left
+          ? >> right
+          right > @
+links:
+  - "/links/type[@id='Φ.pick.taken']/ref[@loc='Φ.pick'][not(bind)]"
+  - "/links[count(//bind[@void='Φ.pick.choose'])=2]"
+  - "/links/type[@id='Φ.yes.φ']/ref/bind[@void='Φ.pick.choose']/ref[@loc='Φ.yes.φ.α0']"
+  - "/links/type[@id='Φ.no.φ']/ref/bind[@void='Φ.pick.choose']/ref[@loc='Φ.no.φ.α0']"


### PR DESCRIPTION
A formation that reads its own void and applies it was written down as filling
that void. `if > not` inside `[if] > bool` hands `false` and `true` to whatever
a caller has put in `if`, and both arms went into the record twice over — once
against the void itself, where they never went.

`Lent` already knew this rule, for a dotted dispatch. Two things kept it from
reaching a bare read. `Site.bearer()` is empty for a read, so
`attribute("", "if")` came back empty and the condition could never hold. And
`Resolved` built `asked = dispatches + reads` but handed only `dispatches` to
`Woven`, so the pass whose output reaches `links.xml` never saw a read at all.
`Lent` now asks `Taken` when the site names no bearer, since `Taken` is the one
answer that covers a name written after a dot and a name written by itself
alike, and `Resolved` hands over every asked site.

```java
private String bearer(final Site dispatch) {
    String found = dispatch.bearer();
    if (found.isEmpty()) {
        found = this.receivers.getOrDefault(dispatch.made(), "");
    }
    return found;
}
```

`Provided.hollow` was a copy of `Rooted.covers` over the same collection, so it
delegates now, which frees the fourth attribute slot `Lent` needed.

The prescription in the ticket is not what fixes this. It asks that
`Provided.behind` stop the walk where a type's `φ` is a void, but by the time
`Bound` runs the void has already left the pair: a later pass refines
`Φ.bool.if` to `Φ.bool`, rightly, because `if false true` does answer with a
bool, and it is that refined pair `Bound` uses as the application's base.
Written as a stop-set in `Ends` it moved the void-rooted band the wrong way,
9300 to 9465, and broke the ticket's own assertion. The three-file reproduction
in the ticket also passes on master already, since #8564 removed the two
fillings it names, so the new pack is the only failing evidence here.

That pack, `a-read-of-its-own-void-does-not-fill-it.yaml`, is three files:
`pick` reads its own void and applies it to two arms that are both `pick`s,
which is what makes the arms join to the void's own owner and manufacture the
fake filling. On master `Φ.pick.taken` answers `Φ.yes` and carries a bind
`Φ.yes.ρ <- Φ.pick` that nothing wrote; with this change it answers `Φ.pick`
with nothing bound, and the only two fillings of `Φ.pick.choose` are the two
callers. 105 of 105 packs pass, 164 `eo-inference` unit tests pass, qulice is
clean, and the A/B was run both ways.

Over `eo-runtime` 102 rows change their answer, and every answer master gave
was manufactured from that one fake filling. `Φ.file.open.φ` moves from
`Φ.false` to `Φ.bool.if`; `Φ.i64.gt.φ` from `Φ.false` to a void-rooted chain;
`Φ.socket.checked-port.φ` likewise, which takes the whole fabricated
`Φ.socket.htons.* -> Φ.bytes.*` family with it. Six rows under `Φ.bool.if` that
master answered `Φ.bytes.*` disappear. The census of `Φ.bool.if` itself drops
from `['?', 'Φ.false']` to `['?']`.

So the void-rooted band grows rather than shrinks: 9300 to 9391, `Φ.bool.if`
806 to 881. That is the honest number, and it is the point — master answered
those rows only by believing bool's `if` holds a `Φ.false`. Clearing
`Φ.bool.if` now waits on its two real fillings, which are anonymous picker
formations sharing no ancestor, so `Sole` and `Joined` yield nothing and it
stays a union. Two follow-ups deserve tickets: that dead end, and `Branched`
not producing the join-of-arguments answer for an `.if` dispatch, which is why
`Φ.i64.gt.φ` lands on a chain instead of on `Φ.bool`.

Closes #8469.
