### PR TITLE
Acknowledge the sprintf lints where they belong

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -326,15 +326,6 @@
                 -->
                 <lint>unsorted-metas</lint>
                 <!--
-                @todo #8654:30min Stop skipping the three 'sprintf' lints here.
-                'string/printf.eo:162' hands an argument to a template whose
-                only conversion is an escaped '%%', while line 506 feeds two
-                arguments to '%s' on purpose, to prove that extras are ignored.
-                -->
-                <lint>sprintf-constant-args</lint>
-                <lint>sprintf-without-formatters</lint>
-                <lint>wrong-sprintf-arguments</lint>
-                <!--
                 @todo #8654:30min Stop skipping 'invalid-name-notation' here.
                 The lint holds a name to '[a-z]+(-[a-z]+)*', which leaves no
                 room for the digit in 'bytes/as-u8.eo:12' or in its siblings

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -64,6 +64,9 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint sprintf-constant-args
++unlint sprintf-without-formatters
++unlint wrong-sprintf-arguments
 
 [^ args] > printf
   string > @
@@ -159,7 +162,7 @@
             auto
             acc.concat 25-
           T
-            "The escaped %% conversion does not take flags, width or precision".printf
+            "The escaped %% conversion in the format %s does not take flags, width or precision".printf
               * ^.^
         walk
           plus.
@@ -639,12 +642,24 @@
     "%(s"
     * "Jeff"
 
+  printf. --> stops-on-a-positional-index-before-an-escaped-percent
+    "%1$%s"
+    * "x"
+
+  printf. --> stops-on-a-precision-before-an-escaped-percent
+    "%.2%s"
+    * "x"
+
   printf. --> stops-on-a-precision-with-d
     "%.2d"
     * 5
 
   printf. --> stops-on-a-width-before-an-escaped-percent
     "%5%s"
+    * "x"
+
+  printf. --> stops-on-a-zero-flag-before-an-escaped-percent
+    "%0%s"
     * "x"
 
   printf. --> stops-on-a-zero-flag-with-x

--- a/eo-runtime/src/main/eo/string/scanf.eo
+++ b/eo-runtime/src/main/eo/string/scanf.eo
@@ -31,6 +31,8 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint sprintf-constant-args
++unlint sprintf-without-formatters
 
 [^ read] > scanf
   [^ pattern specifiers] >>


### PR DESCRIPTION
Three `sprintf` lints were switched off for the whole of `eo-runtime` when lints 0.4.9 woke them up. That is far more than the two files that actually need them: only `string/printf.eo` and `string/scanf.eo` were ever reported, so the skips are now `+unlint` metas in those two files and the module is linted again everywhere else.

The suppressions are honest ones. `printf.eo` is where `.printf` is specified, so its tests necessarily hand constant arguments to constant templates, and its negative tests deliberately feed malformed templates such as `"%,s"` or an extra argument to a single `%s`. `scanf.eo` prints its oversized-integer message through `.printf` to unescape a doubled percent, which the lint reads as a template with no conversion.

One of the reported defects was real, though. The error raised for an escaped `%%` carrying flags, width or precision handed the format to a template that had no `%s` to put it in, so the argument was dead and the message never named the input it complained about. It now reads like its siblings and prints the format. Three negative tests cover the paths into it that were untested: a positional index, a precision and a zero flag placed before the escaped percent.

Closes #8662
