### PR TITLE
Say what many-void-attributes is waiting for

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -302,13 +302,12 @@
                 -->
                 <lint>redundant-object</lint>
                 <!--
-                @todo #6985:30min Stop skipping 'many-void-attributes' here.
                 The rule caps a formation at five voids to keep it callable,
-                but it counts 'ρ' among them, and 'string.regex.pattern.yes'
-                has five real ones. Writing the receiver down did not add an
-                argument, so the cap now bites any head honest enough to
-                declare what it already had. Remove this entry once
-                objectionary/lints#1299 leaves the receiver out of the count.
+                but it counts the receiver 'ρ' among them, so a head that
+                writes '^' down is charged for an argument it never gained
+                (objectionary/lints#1299). Of the two formations it reports in
+                'string/regex.eo', only 'members' at line 1444 truly carries
+                six; 'closed' at line 1818 carries five and its receiver.
                 -->
                 <lint>many-void-attributes</lint>
                 <!--


### PR DESCRIPTION
The puzzle asked to stop skipping `many-void-attributes` once `objectionary/lints#1299` leaves the receiver out of the void count. That issue is still open, so the skip cannot go, and PDD refiles the same unactionable task every time the file is touched. The entry keeps its explanation and the upstream link, in the shape the three entries above it already use, and drops the `@todo`.

The text is now accurate about what the lint actually reports today. Of the two formations it names in `string/regex.eo`, `members` at line 1444 really does carry six voids and would be flagged with or without the receiver; `closed` at line 1818 carries five and its `^`, so it is there only because `ρ` is counted. When the upstream fix lands, `members` is the single thing standing between this module and the lint, and that is a task worth its own issue rather than a note nobody can act on.

Closes #8659
