### PR TITLE
Flatten the deep expressions so too-deep-object can run

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -342,12 +342,13 @@
                 -->
                 <lint>invalid-name-notation</lint>
                 <!--
-                @todo #8654:30min Stop skipping 'too-deep-object' and
-                'broad-scope' here. 'number.eq' nests sixteen levels against a
-                maximum of twelve, and 'number.integral:46' keeps 'subsection'
-                wider than the single object that reads it.
+                'broad-scope' asks for a private attribute read by one sibling
+                to move inside it, which for a recursive head means computing
+                it again on every step: 'i64.div' hoists 'bit' and 'dividend'
+                out of 'looped' on purpose. Thirty-four of its forty-six
+                reports sit in 'string/regex.eo', whose objects share one
+                vocabulary across the whole parser, and #8654 holds the rest.
                 -->
-                <lint>too-deep-object</lint>
                 <lint>broad-scope</lint>
               </skipSourceLints>
               <!--

--- a/eo-runtime/src/main/eo/bool.eo
+++ b/eo-runtime/src/main/eo/bool.eo
@@ -16,6 +16,7 @@
 +version 0.0.0
 +spdx SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
 +spdx SPDX-License-Identifier: MIT
++unlint too-deep-object
 
 [if] > bool
   if > @

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -76,10 +76,10 @@
               read.
                 tee.
                   input
-                    Q.source.tee m2.to-output
+                    ^.source.tee m2.to-output
                   ^.m1.to-output
                 5
               ^.m1.write 5 2A-
               ^.m1
+          input 01-02-03-04-05.as-input > source
       01-02-03-04-05-2A
-    input 01-02-03-04-05.as-input > source

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -76,8 +76,7 @@
               seq * > @
                 read.
                   tee.
-                    input
-                      source.tee m2.to-output
+                    input (source.tee m2.to-output)
                     ^.m1.to-output
                   5
                 ^.m1.write 5 2A-

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -75,9 +75,11 @@
             seq * > [^ m2] >>
               read.
                 tee.
-                  input ((input 01-02-03-04-05.as-input).tee m2.to-output)
+                  input
+                    Q.source.tee m2.to-output
                   ^.m1.to-output
                 5
               ^.m1.write 5 2A-
               ^.m1
       01-02-03-04-05-2A
+    input 01-02-03-04-05.as-input > source

--- a/eo-runtime/src/main/eo/input/tee.eo
+++ b/eo-runtime/src/main/eo/input/tee.eo
@@ -72,14 +72,15 @@
         [m1]
           malloc.of > @
             5
-            seq * > [^ m2] >>
-              read.
-                tee.
-                  input
-                    ^.source.tee m2.to-output
-                  ^.m1.to-output
-                5
-              ^.m1.write 5 2A-
-              ^.m1
-          input 01-02-03-04-05.as-input > source
+            [^ m2] >>
+              seq * > @
+                read.
+                  tee.
+                    input
+                      source.tee m2.to-output
+                    ^.m1.to-output
+                  5
+                ^.m1.write 5 2A-
+                ^.m1
+              input 01-02-03-04-05.as-input > source
       01-02-03-04-05-2A

--- a/eo-runtime/src/main/eo/number/eq.eo
+++ b/eo-runtime/src/main/eo/number/eq.eo
@@ -74,27 +74,18 @@
   not. ++> can-tell-it-does-not-equal-an-integer-when-positive-infinity
     pinf.eq 42
 
-  eq. ++> can-tell-it-does-not-equal-nan-or-infinities-when-a-float-under-load
-    and.
+  ++> can-tell-it-does-not-equal-nan-or-infinities-when-a-float-under-load
+    eq. > @
+      first.and again
+      true
+    and. > again
       and.
         and.
           and.
             and.
-              and.
-                and.
-                  and.
-                    and.
-                      and.
-                        and.
-                          eq. (0.eq nan) false
-                          eq. (0.eq pinf) false
-                        eq. (0.eq ninf) false
-                      eq. (42.5.eq nan) false
-                    eq. (42.5.eq pinf) false
-                  eq. (42.5.eq ninf) false
-                eq.
-                  0.eq nan
-                  false
+              eq.
+                0.eq nan
+                false
               eq.
                 0.eq pinf
                 false
@@ -110,7 +101,29 @@
       eq.
         42.5.eq ninf
         false
-    true
+    and. > first
+      and.
+        and.
+          and.
+            and.
+              eq.
+                0.eq nan
+                false
+              eq.
+                0.eq pinf
+                false
+            eq.
+              0.eq ninf
+              false
+          eq.
+            42.5.eq nan
+            false
+        eq.
+          42.5.eq pinf
+          false
+      eq.
+        42.5.eq ninf
+        false
 
   eq. ++> can-tell-it-does-not-equal-nan-or-infinities-when-an-integer
     and.

--- a/eo-runtime/src/main/eo/number/random.eo
+++ b/eo-runtime/src/main/eo/number/random.eo
@@ -30,27 +30,32 @@
     35 > shift1
     17 > shift3
     clock.as-bytes > tbytes
+  as-i64. > high
+    and.
+      as-bytes.
+        ^.as-i64.div 67108864.as-i64
+      00-00-00-00-03-FF-FF-FF
+  as-i64. > low
+    ^.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF
+  as-i64. > lowered
+    low.times 25214903917.as-i64
   random. > next
     as-number.
       as-i64.
         and.
           as-bytes.
             plus.
-              plus.
-                as-i64.
-                  left.
-                    and.
-                      as-bytes.
-                        ((^.as-i64.div 67108864.as-i64).as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
-                          25214903917.as-i64
-                      00-00-00-00-03-FF-FF-FF
-                    26
-                as-i64.
-                  (^.as-i64.as-bytes.and 00-00-00-00-03-FF-FF-FF).as-i64.times
-                    25214903917.as-i64
+              shifted.plus lowered
               11.as-i64
           00-1F-FF-FF-FF-FF-FF-FF
   clocked clock > pseudo
+  as-i64. > shifted
+    left.
+      and.
+        as-bytes.
+          high.times 25214903917.as-i64
+        00-00-00-00-03-FF-FF-FF
+      26
 
   not. ++> can-differ-between-two-draws
     eq.

--- a/eo-runtime/src/main/eo/path.eo
+++ b/eo-runtime/src/main/eo/path.eo
@@ -122,6 +122,10 @@
             normalized.size.eq 0
             "."
             string normalized
+      if. > closing
+        trailing.and rooted.not
+        ^.separator
+        --
       concat. > core!
         ^.drive.concat
           ^.is-absolute.if
@@ -179,16 +183,8 @@
                   ^.drive.size.gt 0
                   ^.is-absolute.not
               core.concat
-                ".".concat
-                  if.
-                    trailing.and rooted.not
-                    ^.separator
-                    --
-              core.concat
-                if.
-                  trailing.and rooted.not
-                  ^.separator
-                  --
+                ".".concat closing
+              core.concat closing
       and. > rooted
         core.size.gt 0
         eq.

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -253,6 +253,24 @@
         number dollar
         1
       index.plus 1
+    if. > guarded!
+      precise.as-bool.and
+        64-.eq conv
+      T
+        "A precision of %d can't be applied to the %%d conversion".printf
+          *
+            number precision
+      if.
+        zero.as-bool.and
+          not.
+            or.
+              64-.eq conv
+              66-.eq conv
+        T
+          "The zero flag can't be applied to the %s conversion, only to %%d and %%f".printf
+            *
+              string conv
+        converted guarded
     positional.as-bool.if > idx!
       minus.
         digits-value
@@ -346,24 +364,6 @@
                   number idx
                   1
                 ^.args.length
-          if.
-            precise.as-bool.and
-              64-.eq conv
-            T
-              "A precision of %d can't be applied to the %%d conversion".printf
-                *
-                  number precision
-            if.
-              zero.as-bool.and
-                not.
-                  or.
-                    64-.eq conv
-                    66-.eq conv
-              T
-                "The zero flag can't be applied to the %s conversion, only to %%d and %%f".printf
-                  *
-                    string conv
-              converted
     digits-value > width!
       number digits
       number dot

--- a/eo-runtime/src/main/eo/string/printf.eo
+++ b/eo-runtime/src/main/eo/string/printf.eo
@@ -270,7 +270,7 @@
           "The zero flag can't be applied to the %s conversion, only to %%d and %%f".printf
             *
               string conv
-        converted guarded
+        converted
     positional.as-bool.if > idx!
       minus.
         digits-value
@@ -364,6 +364,7 @@
                   number idx
                   1
                 ^.args.length
+          guarded
     digits-value > width!
       number digits
       number dot

--- a/eo-runtime/src/main/eo/string/regex.eo
+++ b/eo-runtime/src/main/eo/string/regex.eo
@@ -1336,21 +1336,30 @@
                     index.plus 1
                     opened
                     bits
-                  if.
-                    b.eq 7B-
-                    yes index opened bits empty --
-                    r.ok.if
-                      if.
-                        r.at.as-bytes.eq index.as-bytes
-                        escaped (index.plus 1) opened bits
-                        yes
-                          r.at
-                          opened
-                          bits
-                          plain bits r.text
-                          r.text
-                      r
+                  brace
       byte index > b
+      if. > brace
+        b.eq 7B-
+        yes
+          index
+          opened
+          bits
+          empty
+          --
+        r.ok.if
+          if.
+            r.at.as-bytes.eq index.as-bytes
+            escaped
+              index.plus 1
+              opened
+              bits
+            yes
+              r.at
+              opened
+              bits
+              plain bits r.text
+              r.text
+          r
       scanned > r
         index
         bits
@@ -1514,22 +1523,23 @@
                 no
                   s.at.plus 1
                   "Illegal character range"
-                u.ok.if
-                  if.
-                    u.preset.or
-                      gt.
-                        key s.from
-                        key u.from
-                    no
-                      u.at.plus -1
-                      "Illegal character range"
-                    span u.at s.from u.from
-                  u
+                ranged
             s
         s
       byte s.at > d
       byte > n
         s.at.plus 1
+      u.ok.if > ranged
+        if.
+          u.preset.or
+            gt.
+              key s.from
+              key u.from
+          no
+            u.at.plus -1
+            "Illegal character range"
+          span u.at s.from u.from
+        u
       single index mode > s
       single > u
         s.at.plus 1
@@ -1656,59 +1666,57 @@
                   refused index e
       byte index > e
       e.or 20- > l
-    if. > [^ index e] >> refused
-      or.
-        e.eq 70-
-        e.eq 50-
-      no
-        index.plus -1
-        "Unicode property classes are not supported"
-      if.
-        e.eq 75-
+    [^ index e] >> refused
+      if. > @
+        or.
+          e.eq 70-
+          e.eq 50-
         no
           index.plus -1
-          "Unicode escapes are not supported"
+          "Unicode property classes are not supported"
         if.
-          e.eq 63-
+          e.eq 75-
           no
             index.plus -1
-            "Control escapes are not supported"
+            "Unicode escapes are not supported"
           if.
-            e.eq 30-
+            e.eq 63-
             no
               index.plus -1
-              "Octal escapes are not supported"
+              "Control escapes are not supported"
             if.
-              or.
-                e.eq 6B-
-                gt.
-                  digit e
-                  0
+              e.eq 30-
               no
                 index.plus -1
-                "Back references are not supported"
+                "Octal escapes are not supported"
               if.
                 or.
-                  e.eq 47-
-                  or.
-                    e.eq 52-
-                    or.
-                      e.eq 68-
-                      or.
-                        e.eq 76-
-                        or.
-                          e.eq 58-
-                          e.eq 4E-
+                  e.eq 6B-
+                  gt. (digit e) 0
                 no
                   index.plus -1
-                  string
-                    concat.
-                      "The escape sequence '\\".as-bytes.concat
-                        e
-                      "' is not supported".as-bytes
-                no
-                  index
-                  "Illegal/unsupported escape sequence"
+                  "Back references are not supported"
+                unsupported.if
+                  no (index.plus -1) message
+                  no
+                    index
+                    "Illegal/unsupported escape sequence"
+      string > message
+        concat.
+          "The escape sequence '\\".as-bytes.concat
+            e
+          "' is not supported".as-bytes
+      or. > unsupported
+        e.eq 47-
+        or.
+          e.eq 52-
+          or.
+            e.eq 68-
+            or.
+              e.eq 76-
+              or.
+                e.eq 58-
+                e.eq 4E-
     [^ index opened bits] >> group
       if. > @
         b.eq 3F-


### PR DESCRIPTION
`too-deep-object` reported 102 objects in `eo-runtime`, and the puzzle asked for it and `broad-scope` to come off the skip list. This takes the first one off.

Forty of those reports were expressions grown past twelve levels, and each is now cut at the joint that made it deep. `number/eq.eo` holds the twelve comparisons of its under-load test in two halves, `first` and `again`, still written out separately so the repetition the test is named for still happens. `string/printf.eo` gives the tail of its conversion cascade a name, `guarded`. `string/regex.eo` does the same three times: `brace` for the `{` branch of `atom`, `ranged` for the range branch of `entry`, and, inside `refused`, `unsupported` for the list of escape letters and `message` for the sentence built from one. `refused` had to stop being a glued head to hold them. `number/random.eo` names the two halves of its LCG step, `path.eo` names the separator it appends twice, and the `tee` test names the input it reads from.

The remaining sixty-two are all one test, `can-nest-formations-that-call-each-other`, whose forty nested formations are the thing under test; `bool.eo` carries `+unlint too-deep-object` for them.

`broad-scope` stays, and the entry now says why rather than asking again. It wants a private attribute read by a single sibling to move inside it, which for a recursive head means recomputing it on every step: `i64.div` hoists `bit` and `dividend` out of `looped` deliberately. Thirty-four of its forty-six reports are in `string/regex.eo`, where the parser objects share one vocabulary, and #8654 holds the rest.

Worth knowing for whoever picks that up: the two lints pull against each other. Naming a sub-expression is the cure for depth, and a name read in one place is what `broad-scope` objects to; `input/tee.eo` gains a `redundant-object` report for exactly that reason, on a lint this module already skips.

This is 280 lines. The flattening and the removal of the entry cannot land separately, since the lint fails the build until the last of the forty is gone.

Closes #8664
