### PR TITLE
Say why unit-test-is-not-verb cannot run on eo-runtime

### DIFF
--- a/eo-runtime/pom.xml
+++ b/eo-runtime/pom.xml
@@ -312,10 +312,13 @@
                 -->
                 <lint>many-void-attributes</lint>
                 <!--
-                @todo #8654:30min Stop skipping 'unit-test-is-not-verb' here.
-                Lints 0.4.9 registers a lint that 0.4.8 shipped but never ran,
-                and it wants a test name to open with a verb in singular form,
-                which no 'can-...' name in this module does.
+                The lint hands a test name to OpenNLP and keeps it only when
+                the first word is tagged as a verb in singular form, while
+                'bad-test-name', out of the same jar, requires a positive test
+                to start with 'can-' or 'accepts-'. A modal is not a verb to
+                the tagger, so the two rules contradict each other and all
+                1972 positive tests here fail the second one
+                (objectionary/lints#1441).
                 -->
                 <lint>unit-test-is-not-verb</lint>
                 <!--


### PR DESCRIPTION
The puzzle asked to stop skipping `unit-test-is-not-verb`. It cannot be done from this side, so the entry keeps its explanation and points at the upstream issue instead, in the shape the entries above it already use.

`bad-test-name` requires a positive test to match `^(can|accepts)-`. `unit-test-is-not-verb` hands the same title to OpenNLP and keeps it only when the first word comes back tagged `VBZ`. `can` is a modal and tags as `MD`, so the two lints out of the same jar ask for opposite things, and every one of the 1972 positive tests in this module fails the second. The only spelling that satisfies both is `accepts-`, which says the wrong thing about most of them: `accepts-negate-false` is not what that test asserts.

Worth recording, since the timing is confusing: the check is not new in 0.4.9, it is newly registered. `LtTestNotVerb` ships in the 0.4.8 jar too, but `MonoLints` there holds no reference to it, so it never ran.

Filed as objectionary/lints#1441.

Closes #8660
