### PR TITLE
#8599: Align ms attribute documentation with schema

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -499,7 +499,7 @@
       <xs:annotation>
         <xs:appinfo>The amount of milliseconds that were spent on creating this document</xs:appinfo>
         <xs:documentation>
-          The element contains a positive integer, which is the number of milliseconds
+          The attribute contains a whole number, which is the number of milliseconds
           that were spent by the parser to generate this document. This information
           is valuable for debugging purposes and may be omitted in production systems.
         </xs:documentation>


### PR DESCRIPTION
Closes #8599.

The `ms` declaration already uses the `whole` type, whose schema permits zero. Its documentation said “positive integer” and also called the attribute an element. This PR changes only that prose to “The attribute contains a whole number”, matching the actual XSD contract and the terminology of the declaration.

No schema type or validation behavior changes. `git diff --check` is clean.
