### PR TITLE
#8597: Round zero elapsed span up to one millisecond

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Millis.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Millis.java
@@ -30,6 +30,6 @@ final class Millis implements Text {
 
     @Override
     public String asString() {
-        return String.valueOf((this.nanos + 999_999L) / 1_000_000L);
+        return String.valueOf(Math.max(1L, (this.nanos + 999_999L) / 1_000_000L));
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/MillisTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MillisTest.java
@@ -16,6 +16,15 @@ import org.junit.jupiter.api.Test;
 final class MillisTest {
 
     @Test
+    void roundsZeroSpanUpToOne() {
+        MatcherAssert.assertThat(
+            "a zero span is not printed as one millisecond",
+            new Millis(0L).asString(),
+            Matchers.equalTo("1")
+        );
+    }
+
+    @Test
     void roundsSubMillisecondSpanUpToOne() {
         MatcherAssert.assertThat(
             "a span of a single nanosecond is not printed as one millisecond",


### PR DESCRIPTION
Closes #8597.

`Millis` promises that a span shorter than one millisecond is rendered as one instead of zero. The arithmetic already rounds positive sub-millisecond spans up, but the zero boundary escaped that rule.

This change clamps the rendered millisecond value to at least `1`, preserving all existing positive-span behavior, and adds a regression test for `new Millis(0L)`.

`git diff --check` is clean; repository CI will run the full parser test/quality matrix.
