### PR TITLE
#8616: Phrase parser assertion failures as claims

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MsgUnderlinedTest.java
@@ -18,7 +18,7 @@ final class MsgUnderlinedTest {
     @Test
     void underlinesWholeLineWhenFromIsNegative() {
         MatcherAssert.assertThat(
-            "a negative from must underline every character of the origin",
+            "a negative from did not underline every character of the origin",
             new MsgUnderlined("hello", -1, 3).formatted(),
             Matchers.equalTo(String.format("hello%n^^^^^"))
         );
@@ -27,7 +27,7 @@ final class MsgUnderlinedTest {
     @Test
     void clampsCaretRunToLineLengthRemainingAfterFrom() {
         MatcherAssert.assertThat(
-            "a length reaching past the line end must be clamped to what remains from position",
+            "a length reaching past the line end was not clamped to what remains from position",
             new MsgUnderlined("0123456789", 8, 5).formatted(),
             Matchers.equalTo(String.format("0123456789%n        ^^"))
         );
@@ -36,7 +36,7 @@ final class MsgUnderlinedTest {
     @Test
     void leavesUnderlineEmptyWhenFromReachesLineEnd() {
         MatcherAssert.assertThat(
-            "a from at the line length must draw no caret since no position is left to underline",
+            "a from at the line length drew a caret although no position was left to underline",
             new MsgUnderlined("abc", 3, 2).formatted(),
             Matchers.equalTo(String.format("abc%n"))
         );

--- a/eo-parser/src/test/java/org/eolang/parser/ParseErrorTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/ParseErrorTest.java
@@ -18,7 +18,7 @@ final class ParseErrorTest {
     @Test
     void retainsLineFromCtor() {
         MatcherAssert.assertThat(
-            "line must round-trip the ctor argument so reporters can quote source location",
+            "line did not round-trip the ctor argument for source-location reporting",
             new ParseError(7, 3, "boom").line(),
             Matchers.equalTo(7)
         );
@@ -27,7 +27,7 @@ final class ParseErrorTest {
     @Test
     void retainsPosFromCtor() {
         MatcherAssert.assertThat(
-            "pos must round-trip the ctor argument with 0-indexed semantics",
+            "pos did not round-trip the ctor argument with 0-indexed semantics",
             new ParseError(1, 12, "boom").pos(),
             Matchers.equalTo(12)
         );
@@ -36,7 +36,7 @@ final class ParseErrorTest {
     @Test
     void exposesMessageThroughGetMessage() {
         MatcherAssert.assertThat(
-            "the canonical message text must be readable via getMessage()",
+            "the canonical message text was not readable via getMessage()",
             new ParseError(1, 0, "unexpected odd indent").getMessage(),
             Matchers.equalTo("unexpected odd indent")
         );


### PR DESCRIPTION
Closes #8616.

Rephrases the six Hamcrest assertion messages in `MsgUnderlinedTest` and `ParseErrorTest` as claims about what went wrong, rather than expectations about what the code should do.

This matches the style already used by neighboring parser tests and makes a failing CI message actionable without opening the test source. Production code and assertions are unchanged.

`git diff --check` is clean.
