### PR TITLE
#8610: Reuse consumed dispatch kind in chain reader

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -415,12 +415,8 @@ final class Tokens {
     List<MethodChain> readChain() {
         final List<MethodChain> chain = new ArrayList<>(0);
         while (!this.atEnd() && this.dispatchAhead()) {
-            final boolean fragile = Tokens.fragileAhead(this.body, this.cursor);
-            int dot = this.span.indent() + this.cursor;
-            if (fragile) {
-                dot = dot + 1;
-            }
-            this.consumeDispatch();
+            final boolean fragile = this.consumeDispatch();
+            final int dot = this.span.indent() + this.cursor - 1;
             final Value name = this.readMethodName();
             chain.add(new MethodChain(name.raw(), dot, fragile));
         }


### PR DESCRIPTION
Closes #8610.

`Tokens.readChain()` now uses the boolean already returned by `consumeDispatch()` instead of scanning the same cursor position with `fragileAhead()` first and then discarding the result returned by `consumeDispatch()`.

After either `.` or `?.` has been consumed, the dispatch dot is always one column behind the cursor, so the source position is calculated uniformly as `indent + cursor - 1`. This removes the duplicate fragile-dispatch probe and the special-case dot adjustment without changing chain semantics.

`git diff --check` is clean; the existing parser chain/fragile-dispatch tests remain the behavioral coverage for this refactoring.
