### PR TITLE
#8602: Unify argument emission path

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -171,26 +171,14 @@ final class Emissions {
      * @param line Source line
      */
     static void emitArg(final Emit emit, final Value value, final int line) {
-        final List<MethodChain> tail = value.chain();
-        if (tail.isEmpty()) {
-            Emissions.openValue(emit, null, value, line);
-            if (value.bound()) {
-                emit.slot(Emissions.bindingTag(value.binding()));
-            }
-            if (value.constant()) {
-                emit.constant();
-            }
-            emit.close();
-        } else {
-            ChainEmission.link(emit, line, value, tail, null);
-            if (value.bound()) {
-                emit.slot(Emissions.bindingTag(value.binding()));
-            }
-            if (value.constant()) {
-                emit.constant();
-            }
-            emit.close();
+        ChainEmission.link(emit, line, value, value.chain(), null);
+        if (value.bound()) {
+            emit.slot(Emissions.bindingTag(value.binding()));
         }
+        if (value.constant()) {
+            emit.constant();
+        }
+        emit.close();
     }
 
     /**


### PR DESCRIPTION
Closes #8602.

`Emissions.emitArg()` now delegates to `ChainEmission.link()` for both chained and unchained values. `ChainEmission.link()` already handles an empty chain by calling `Emissions.openValue()` with the supplied label, so the previous branch duplicated the same binding, const, and close tail in both arms.

This removes the redundant condition and duplicated emission logic without changing the generated structure.

`git diff --check` is clean; existing parser emission tests cover chained and unchained arguments.
