### PR TITLE
#8596: Remove vacuous parser timing assertions

### DIFF
--- a/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/EoSyntaxTest.java
@@ -12,7 +12,6 @@ import com.jcabi.xml.XMLDocument;
 import com.yegor256.xsline.Shift;
 import com.yegor256.xsline.TrDefault;
 import com.yegor256.xsline.Train;
-import fixtures.LargeProgram;
 import java.io.IOException;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
@@ -92,30 +91,6 @@ final class EoSyntaxTest {
     }
 
     @Test
-    void measuresRealParsingTime() throws Exception {
-        MatcherAssert.assertThat(
-            "ms attribute is not a measured elapsed time",
-            Long.parseLong(
-                new EoSyntax(
-                    new LargeProgram(30), UnaryOperator.<XML>identity()
-                ).parsed().xpath("/object/@ms").get(0)
-            ),
-            Matchers.greaterThan(0L)
-        );
-    }
-
-    @Test
-    void measuresSubMillisecondParsingTime() throws Exception {
-        final EoSyntax syntax = new EoSyntax(String.format("# Ünïcödé.%n[] > tiny%n"));
-        syntax.parsed();
-        MatcherAssert.assertThat(
-            "ms attribute of a sub-millisecond parse is not rounded up to one",
-            Long.parseLong(syntax.parsed().xpath("/object/@ms").get(0)),
-            Matchers.greaterThan(0L)
-        );
-    }
-
-    @Test
     void reportsMsWithinSaneBound() throws Exception {
         MatcherAssert.assertThat(
             "ms attribute is not within a sane bound for a small program",
@@ -125,19 +100,6 @@ final class EoSyntaxTest {
                 ).parsed().xpath("/object/@ms").get(0)
             ),
             Matchers.lessThan(60_000L)
-        );
-    }
-
-    @Test
-    void measuresParsingTimeOnEveryCall() throws Exception {
-        final EoSyntax syntax = new EoSyntax(
-            new LargeProgram(30), UnaryOperator.<XML>identity()
-        );
-        syntax.parsed();
-        MatcherAssert.assertThat(
-            "second parse of the same syntax does not measure its own elapsed time",
-            Long.parseLong(syntax.parsed().xpath("/object/@ms").get(0)),
-            Matchers.greaterThan(0L)
         );
     }
 


### PR DESCRIPTION
Closes #8596.

Removes the three `EoSyntaxTest` cases whose only timing assertion is `@ms > 0`. That condition is guaranteed by the elapsed-time formatting itself and therefore cannot detect the timing regressions their names claim to cover.

`parsesSimpleCode` still verifies that `@ms` exists, `MillisTest` covers sub-millisecond rounding, and `reportsMsWithinSaneBound` retains a timing assertion that can actually fail on a unit/measurement regression. The now-unused `LargeProgram` import is removed as well.

`git diff --check` is clean.
