### PR TITLE
#8584: Cache parsed lowering operation table

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Op.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Op.java
@@ -29,6 +29,11 @@ import org.cactoos.text.UncheckedText;
 public final class Op {
 
     /**
+     * Parsed operation table.
+     */
+    private static final List<String[]> TABLE = Op.load();
+
+    /**
      * The λ name, such as {@code L_number_plus}.
      */
     private final String lambda;
@@ -137,6 +142,15 @@ public final class Op {
      *  the forma, the arguments and the Java format
      */
     static List<String[]> table() {
+        return Op.TABLE;
+    }
+
+    /**
+     * Read the operation table from the resource.
+     *
+     * @return Parsed operation rows
+     */
+    private static List<String[]> load() {
         return new UncheckedText(
             new TextOf(new ResourceOf("org/eolang/lowering/ops.tsv", Op.class))
         ).asString().lines()

--- a/eo-lowering/src/main/java/org/eolang/lowering/Op.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Op.java
@@ -145,11 +145,6 @@ public final class Op {
         return Op.TABLE;
     }
 
-    /**
-     * Read the operation table from the resource.
-     *
-     * @return Parsed operation rows
-     */
     private static List<String[]> load() {
         return new UncheckedText(
             new TextOf(new ResourceOf("org/eolang/lowering/ops.tsv", Op.class))

--- a/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
+++ b/eo-lowering/src/test/java/org/eolang/lowering/OpTest.java
@@ -17,6 +17,15 @@ import org.junit.jupiter.api.Test;
 final class OpTest {
 
     @Test
+    void reusesParsedOperationTable() {
+        MatcherAssert.assertThat(
+            "operation table was parsed again instead of reused",
+            Op.table(),
+            Matchers.sameInstance(Op.table())
+        );
+    }
+
+    @Test
     void findsMethodOfLambda() {
         MatcherAssert.assertThat(
             "the λ of addition must dispatch as plus, but it doesnt",


### PR DESCRIPTION
Closes #8584.

Caches the parsed `ops.tsv` table in a static final field instead of reopening and reparsing the classpath resource on every `Op.table()` / `row()` query.

The package-private `table()` API stays unchanged and all existing lookups continue to read the same 17 operation rows. A regression test verifies repeated `table()` calls reuse the same parsed table instance rather than rebuilding it.

`git diff --check` is clean; repository CI will run the lowering tests and quality checks.
