### PR TITLE
#8582: Index available binaries for unplacing

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Unplacing.java
@@ -9,7 +9,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
+import java.util.HashSet;
 import java.util.Set;
 
 /**
@@ -68,7 +68,7 @@ final class Unplacing implements Step {
         if (binaries.isEmpty()) {
             Logger.warn(this, "No classes found in %[file]s", this.classes);
         } else {
-            final Collection<Path> available = binaries.excludes(this.keep);
+            final Set<Path> available = new HashSet<>(binaries.excludes(this.keep));
             final int total = new Threaded<>(
                 this.placed.classes(),
                 tojo -> this.unplace(tojo, available)
@@ -95,13 +95,13 @@ final class Unplacing implements Step {
 
     private int unplace(
         final TjPlaced tojo,
-        final Collection<Path> available
+        final Set<Path> available
     ) throws IOException {
         final String related = tojo.related();
         final Path path = Paths.get(tojo.identifier());
         final String hash = new FileHash(path).toString();
         final int total;
-        final boolean inside = available.stream().anyMatch(path::equals);
+        final boolean inside = available.contains(path);
         if (tojo.sameHash(hash)) {
             if (inside) {
                 Logger.debug(


### PR DESCRIPTION
Closes #8582.

Builds a `HashSet<Path>` from the available binaries once before the threaded catalog loop and uses `contains()` for membership checks.

Previously each placed catalog row scanned the full collection with `stream().anyMatch(path::equals)`, making the unplacing membership phase O(placed rows × available binaries). No list ordering is used by this code; the collection is otherwise only queried for its size.

`git diff --check` is clean; repository CI will run the Maven-plugin test and quality matrix.
