### PR TITLE
#8581: Reuse placed catalog lookup for debug logging

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -199,26 +199,32 @@ final class Placing implements Step {
             } else {
                 res = true;
                 if (tojo.isPresent() && Logger.isDebugEnabled(this)) {
-                    if (!Files.exists(target)) {
-                        Logger.debug(
-                            this,
-                            "The file %[file]s has been placed to %[file]s, but now it's gone, replacing",
-                            file, target
-                        );
-                    } else if (new Unchecked<>(
-                        () -> Files.size(target) != Files.size(file)
-                    ).value()) {
-                        Logger.debug(
-                            this,
-                            "File %[file]s (%[size]s) was already placed at %[file]s (%[size]s!) by %s, replacing",
-                            file, file.toFile().length(),
-                            target, target.toFile().length(),
-                            tojo.get().dependency()
-                        );
-                    }
+                    this.printLogInfoAboutBinary(file, target, tojo.get());
                 }
             }
             return res;
+        }
+
+        private void printLogInfoAboutBinary(
+            final Path file, final Path target, final TjPlaced tojo
+        ) {
+            if (!Files.exists(target)) {
+                Logger.debug(
+                    this,
+                    "The file %[file]s has been placed to %[file]s, but now it's gone, replacing",
+                    file, target
+                );
+            } else if (new Unchecked<>(
+                () -> Files.size(target) != Files.size(file)
+            ).value()) {
+                Logger.debug(
+                    this,
+                    "File %[file]s (%[size]s) was already placed at %[file]s (%[size]s!) by %s, replacing",
+                    file, file.toFile().length(),
+                    target, target.toFile().length(),
+                    tojo.dependency()
+                );
+            }
         }
 
         private void placeBinary(final Path file) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -175,7 +175,6 @@ final class Placing implements Step {
                 .excludes(Placing.this.exclude)
                 .stream()
                 .filter(this::isNotAlreadyPlaced)
-                .peek(this::printLogInfoAboutBinary)
                 .peek(this::placeBinary)
                 .count();
         }
@@ -199,38 +198,27 @@ final class Placing implements Step {
                 res = false;
             } else {
                 res = true;
+                if (tojo.isPresent() && Logger.isDebugEnabled(this)) {
+                    if (!Files.exists(target)) {
+                        Logger.debug(
+                            this,
+                            "The file %[file]s has been placed to %[file]s, but now it's gone, replacing",
+                            file, target
+                        );
+                    } else if (new Unchecked<>(
+                        () -> Files.size(target) != Files.size(file)
+                    ).value()) {
+                        Logger.debug(
+                            this,
+                            "File %[file]s (%[size]s) was already placed at %[file]s (%[size]s!) by %s, replacing",
+                            file, file.toFile().length(),
+                            target, target.toFile().length(),
+                            tojo.get().dependency()
+                        );
+                    }
+                }
             }
             return res;
-        }
-
-        private void printLogInfoAboutBinary(final Path file) {
-            final Path target = Placing.this.classes.resolve(
-                this.dir.relativize(file)
-            );
-            final Optional<TjPlaced> tojo = Placing.this.placed.find(target);
-            if (tojo.isPresent()) {
-                if (!Files.exists(target)) {
-                    Logger.debug(
-                        this,
-                        "The file %[file]s has been placed to %[file]s, but now it's gone, replacing",
-                        file, target
-                    );
-                }
-                if (
-                    Files.exists(target)
-                        && new Unchecked<>(
-                            () -> Files.size(target) != Files.size(file)
-                        ).value()
-                ) {
-                    Logger.debug(
-                        this,
-                        "File %[file]s (%[size]s) was already placed at %[file]s (%[size]s!) by %s, replacing",
-                        file, file.toFile().length(),
-                        target, target.toFile().length(),
-                        tojo.get().dependency()
-                    );
-                }
-            }
         }
 
         private void placeBinary(final Path file) {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -208,21 +208,23 @@ final class Placing implements Step {
         private void printLogInfoAboutBinary(
             final Path file, final Path target, final TjPlaced tojo
         ) {
-            if (!Files.exists(target)) {
+            if (Files.exists(target)) {
+                if (new Unchecked<>(
+                    () -> Files.size(target) != Files.size(file)
+                ).value()) {
+                    Logger.debug(
+                        this,
+                        "File %[file]s (%[size]s) was already placed at %[file]s (%[size]s!) by %s, replacing",
+                        file, file.toFile().length(),
+                        target, target.toFile().length(),
+                        tojo.dependency()
+                    );
+                }
+            } else {
                 Logger.debug(
                     this,
                     "The file %[file]s has been placed to %[file]s, but now it's gone, replacing",
                     file, target
-                );
-            } else if (new Unchecked<>(
-                () -> Files.size(target) != Files.size(file)
-            ).value()) {
-                Logger.debug(
-                    this,
-                    "File %[file]s (%[size]s) was already placed at %[file]s (%[size]s!) by %s, replacing",
-                    file, file.toFile().length(),
-                    target, target.toFile().length(),
-                    tojo.dependency()
                 );
             }
         }


### PR DESCRIPTION
Closes #8581.

Reuses the `TjsPlaced.find(target)` result already obtained by `isNotAlreadyPlaced()` for the replacement diagnostics, instead of running a second full catalog lookup in a following stream `peek()`.

The diagnostic branch now also checks `Logger.isDebugEnabled(this)` before doing filesystem existence/size work, so INFO-level builds no longer pay for debug-only stats. Placement/filter behavior is unchanged.

`git diff --check` is clean; repository CI will run the Maven-plugin tests and quality checks.
