### PR TITLE
#8585: Log outline refusal reasons

### DIFF
--- a/eo-lowering/src/main/java/org/eolang/lowering/Outlined.java
+++ b/eo-lowering/src/main/java/org/eolang/lowering/Outlined.java
@@ -6,6 +6,7 @@ package org.eolang.lowering;
 
 import com.github.lombrozo.xnav.Filter;
 import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.log.Logger;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -123,6 +124,10 @@ public final class Outlined implements Rewrite {
             }
         } catch (final IllegalStateException | IOException ex) {
             carrier = "";
+            Logger.debug(
+                this, "The application at %s refused to outline: %s",
+                site.getAttribute("loc"), ex.getMessage()
+            );
         }
         final boolean done = !carrier.isEmpty();
         if (done) {


### PR DESCRIPTION
Closes #8585.

Mirrors the refusal diagnostics already used by `Lowered`: when outlining catches an `IllegalStateException` or `IOException`, it still treats the refusal as normal and leaves the application unchanged, but now logs the application's `loc` and the exception message at DEBUG level.

This preserves the existing best-effort behavior while making legitimate refusals distinguishable from subprocess/IO failures during diagnosis.

`git diff --check` is clean; repository CI will run lowering tests and quality checks.
