### PR TITLE
#8615: Reject null source spans at construction

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Rows.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Rows.java
@@ -4,7 +4,6 @@
  */
 package org.eolang.parser;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -30,7 +29,7 @@ final class Rows {
      * @param lines The source in lines
      */
     Rows(final List<Span> lines) {
-        this.source = new ArrayList<>(lines);
+        this.source = List.copyOf(lines);
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/Rows.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Rows.java
@@ -27,7 +27,7 @@ final class Rows {
      * Ctor.
      *
      * @param lines The source in lines
-     * @checkstyle ConstructorsCodeFreeCheck (2 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (3 lines)
      */
     Rows(final List<Span> lines) {
         this.source = List.copyOf(lines);

--- a/eo-parser/src/main/java/org/eolang/parser/Rows.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Rows.java
@@ -27,7 +27,7 @@ final class Rows {
      * Ctor.
      *
      * @param lines The source in lines
-     * @checkstyle ConstructorsCodeFreeCheck (1 lines)
+     * @checkstyle ConstructorsCodeFreeCheck (2 lines)
      */
     Rows(final List<Span> lines) {
         this.source = List.copyOf(lines);

--- a/eo-parser/src/main/java/org/eolang/parser/Rows.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Rows.java
@@ -27,6 +27,7 @@ final class Rows {
      * Ctor.
      *
      * @param lines The source in lines
+     * @checkstyle ConstructorsCodeFreeCheck (1 lines)
      */
     Rows(final List<Span> lines) {
         this.source = List.copyOf(lines);

--- a/eo-parser/src/test/java/org/eolang/parser/RowsTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/RowsTest.java
@@ -124,8 +124,8 @@ final class RowsTest {
         source.add(null);
         Assertions.assertThrows(
             NullPointerException.class,
-            () -> new Rows(source).underlined(2, 0, "дыра"),
-            "a null span at a valid number is not refused with an exception"
+            () -> new Rows(source),
+            "a null span is not refused when the source rows are copied"
         );
     }
 }


### PR DESCRIPTION
Closes #8615.

`Rows` now takes its defensive snapshot with `List.copyOf(lines)`. Besides preserving the existing isolation from later caller mutations, this rejects a null `Span` at the constructor boundary instead of letting it survive until `underlined()` dereferences it while reporting some unrelated parser error.

The existing null regression test now asserts that construction itself fails, so the failure location is part of the contract.

`git diff --check` is clean; repository CI will run the parser tests and quality checks.
