### PR TITLE
#8604: Share method-chain link emission

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
@@ -119,6 +119,7 @@ final class ChainEmission {
      * @param line Source line
      * @param links The dispatch chain
      * @param label Name for the last link, or {@code null}
+     * @checkstyle ParameterNumberCheck (3 lines)
      */
     static void links(
         final Emit sink, final int line, final List<MethodChain> links, final String label

--- a/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
@@ -104,12 +104,26 @@ final class ChainEmission {
         final Emit sink, final int line, final Value head,
         final List<MethodChain> links, final String label
     ) {
-        final int last = links.size() - 1;
         if (links.isEmpty()) {
             Emissions.openValue(sink, label, head, line);
         } else {
             Emissions.openValue(sink, null, head, line);
         }
+        ChainEmission.links(sink, line, links, label);
+    }
+
+    /**
+     * Emit dispatch links after an already-open head.
+     *
+     * @param sink The directives sink
+     * @param line Source line
+     * @param links The dispatch chain
+     * @param label Name for the last link, or {@code null}
+     */
+    static void links(
+        final Emit sink, final int line, final List<MethodChain> links, final String label
+    ) {
+        final int last = links.size() - 1;
         for (int idx = 0; idx <= last; idx = idx + 1) {
             final MethodChain chained = links.get(idx);
             sink.close();

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -103,19 +103,10 @@ final class LnTextBlock implements Line {
         } else {
             emit.unnamedObject("Φ.string", this.span.line(), this.span.indent());
             Emissions.bytesCarrier(emit, this.span.line(), this.span.indent(), hex);
-            emit.close();
-            for (int idx = 0; idx < chain.size() - 1; idx = idx + 1) {
-                final MethodChain link = chain.get(idx);
-                emit.unnamedObject(".".concat(link.name()), this.span.line(), link.dot());
-                emit.method(link.fragile());
-                emit.close();
-            }
-            final MethodChain last = chain.get(chain.size() - 1);
-            emit.object(
-                suffix.attribute(this.span.line(), this.span.indent()),
-                ".".concat(last.name()), this.span.line(), last.dot()
+            ChainEmission.links(
+                emit, this.span.line(), chain,
+                suffix.attribute(this.span.line(), this.span.indent())
             );
-            emit.method(last.fragile());
             new Marked(emit, suffix).apply();
         }
     }


### PR DESCRIPTION
Closes #8604.

Extracts the dispatch-link walk from `ChainEmission.link()` into `ChainEmission.links()`, which operates on an already-open head. `ChainEmission.link()` still owns ordinary head emission and delegates the links to that method.

`LnTextBlock` keeps its special `Φ.string`/pre-joined bytes head, then hands the still-open head to the same shared link emitter. This removes its private transcription of link closing, method-object creation, source position, fragile marking, and final-label placement without changing the text-block head semantics.

`git diff --check` is clean; existing `LnTextBlockTest` and `ChainEmissionTest` cases cover chained and unchained output.
