### PR TITLE
#8606: Reuse fragile dispatch detector

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -549,17 +549,12 @@ final class Eo implements Iterable<Directive> {
 
     private static Line questioned(final Span span) {
         final Line line;
-        if (Eo.qdot(span.body(), 0)) {
+        if (Tokens.fragileAhead(span.body(), 0)) {
             line = new LnMethod(span);
         } else {
             line = new LnVoid(span);
         }
         return line;
-    }
-
-    private static boolean qdot(final String body, final int idx) {
-        return idx + 1 < body.length()
-            && body.charAt(idx) == '?' && body.charAt(idx + 1) == '.';
     }
 
     private static boolean onlyPhi(final Span span) {
@@ -626,7 +621,7 @@ final class Eo implements Iterable<Directive> {
                 reversed = idx + 1 >= body.length() || body.charAt(idx + 1) == ' ';
                 break;
             }
-            if (Eo.qdot(body, idx)) {
+            if (Tokens.fragileAhead(body, idx)) {
                 reversed = idx + 2 >= body.length() || body.charAt(idx + 2) == ' ';
                 break;
             }
@@ -645,7 +640,7 @@ final class Eo implements Iterable<Directive> {
         final boolean reversed;
         if (root && body.length() >= 2 && body.charAt(1) == '.') {
             reversed = body.length() == 2 || body.charAt(2) == ' ';
-        } else if (root && Eo.qdot(body, 1)) {
+        } else if (root && Tokens.fragileAhead(body, 1)) {
             reversed = body.length() == 3 || body.charAt(3) == ' ';
         } else {
             reversed = false;

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -668,7 +668,7 @@ final class Tokens {
         return single;
     }
 
-    private static boolean fragileAhead(final String body, final int idx) {
+    static boolean fragileAhead(final String body, final int idx) {
         return idx + 1 < body.length() && body.charAt(idx) == '?' && body.charAt(idx + 1) == '.';
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -648,6 +648,10 @@ final class Tokens {
         return idx;
     }
 
+    static boolean fragileAhead(final String body, final int idx) {
+        return idx + 1 < body.length() && body.charAt(idx) == '?' && body.charAt(idx + 1) == '.';
+    }
+
     private static int clamped(final int pos, final Span source) {
         return Math.min(pos, source.text().length() - 1);
     }
@@ -666,10 +670,6 @@ final class Tokens {
             idx = idx + 1;
         }
         return single;
-    }
-
-    static boolean fragileAhead(final String body, final int idx) {
-        return idx + 1 < body.length() && body.charAt(idx) == '?' && body.charAt(idx + 1) == '.';
     }
 
     private static boolean bytesStart(final String body, final int idx) {


### PR DESCRIPTION
Closes #8606.

Removes the duplicate `Eo.qdot()` predicate and reuses `Tokens.fragileAhead()` for the three `Eo` call sites. The helper is widened only from private to package-private, matching the existing package-level reuse of parser token helpers.

The fragile-dispatch expression itself is unchanged, so this is a single-source-of-truth refactoring rather than a behavior change.

`git diff --check` is clean; repository CI will run the parser tests and quality checks.
