### PR TITLE
#8608: Let method-chain links emit themselves

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
@@ -111,14 +111,8 @@ final class ChainEmission {
             Emissions.openValue(sink, null, head, line);
         }
         for (int idx = 0; idx <= last; idx = idx + 1) {
-            final MethodChain chained = links.get(idx);
             sink.close();
-            if (idx == last) {
-                sink.object(label, ".".concat(chained.name()), line, chained.dot());
-            } else {
-                sink.unnamedObject(".".concat(chained.name()), line, chained.dot());
-            }
-            sink.method(chained.fragile());
+            links.get(idx).write(sink, line, idx == last ? label : null);
         }
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
@@ -112,7 +112,13 @@ final class ChainEmission {
         }
         for (int idx = 0; idx <= last; idx = idx + 1) {
             sink.close();
-            links.get(idx).write(sink, line, idx == last ? label : null);
+            final String name;
+            if (idx == last) {
+                name = label;
+            } else {
+                name = null;
+            }
+            links.get(idx).write(sink, line, name);
         }
     }
 }

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -105,17 +105,13 @@ final class LnTextBlock implements Line {
             Emissions.bytesCarrier(emit, this.span.line(), this.span.indent(), hex);
             emit.close();
             for (int idx = 0; idx < chain.size() - 1; idx = idx + 1) {
-                final MethodChain link = chain.get(idx);
-                emit.unnamedObject(".".concat(link.name()), this.span.line(), link.dot());
-                emit.method(link.fragile());
+                chain.get(idx).write(emit, this.span.line(), null);
                 emit.close();
             }
-            final MethodChain last = chain.get(chain.size() - 1);
-            emit.object(
-                suffix.attribute(this.span.line(), this.span.indent()),
-                ".".concat(last.name()), this.span.line(), last.dot()
+            chain.get(chain.size() - 1).write(
+                emit, this.span.line(),
+                suffix.attribute(this.span.line(), this.span.indent())
             );
-            emit.method(last.fragile());
             new Marked(emit, suffix).apply();
         }
     }

--- a/eo-parser/src/main/java/org/eolang/parser/MethodChain.java
+++ b/eo-parser/src/main/java/org/eolang/parser/MethodChain.java
@@ -7,9 +7,9 @@ package org.eolang.parser;
 /**
  * One link in a {@code .method.method} chain — §3.5, §3.6.
  *
- * <p>Captures the method name and the source column of the leading
- * dot. Per R-9.1.3, the dot column is the {@code @pos} value emitted
- * for the link's {@code <o>} (not the column of the method name).</p>
+ * <p>Captures the method name, the source column of the leading dot, and
+ * whether the dispatch is fragile. Per R-9.1.3, the dot column is the
+ * {@code @pos} value emitted for the link's {@code <o>}.</p>
  *
  * @since 0.1
  */
@@ -26,8 +26,7 @@ final class MethodChain {
     private final int dot;
 
     /**
-     * Whether this link is a fragile dispatch ({@code ?.} instead of
-     * {@code .}) — R-3.5 / §9.4.
+     * Whether this link is a fragile dispatch ({@code ?.}).
      */
     private final boolean fragile;
 
@@ -35,39 +34,24 @@ final class MethodChain {
      * Ctor.
      *
      * @param ident Method name
-     * @param dot Column of the dot
+     * @param pos Column of the dot
      * @param weak Whether the link is a fragile {@code ?.} dispatch
      */
-    MethodChain(final String ident, final int dot, final boolean weak) {
+    MethodChain(final String ident, final int pos, final boolean weak) {
         this.name = ident;
-        this.dot = dot;
+        this.dot = pos;
         this.fragile = weak;
     }
 
     /**
-     * Whether this link is a fragile {@code ?.} dispatch.
+     * Write this method link to the emitter.
      *
-     * @return True for {@code ?.}, false for plain {@code .}
+     * @param sink Directives sink
+     * @param line Source line
+     * @param label Optional name for the emitted link
      */
-    boolean fragile() {
-        return this.fragile;
-    }
-
-    /**
-     * Method name (no leading dot).
-     *
-     * @return Name
-     */
-    String name() {
-        return this.name;
-    }
-
-    /**
-     * Column of the leading dot.
-     *
-     * @return Dot column
-     */
-    int dot() {
-        return this.dot;
+    void write(final Emit sink, final int line, final String label) {
+        sink.object(label, ".".concat(this.name), line, this.dot);
+        sink.method(this.fragile);
     }
 }

--- a/eo-parser/src/test/java/org/eolang/parser/MethodChainTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/MethodChainTest.java
@@ -4,9 +4,11 @@
  */
 package org.eolang.parser;
 
+import com.jcabi.matchers.XhtmlMatchers;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.xembly.Directives;
+import org.xembly.Xembler;
 
 /**
  * Test case for {@link MethodChain}.
@@ -16,29 +18,40 @@ import org.junit.jupiter.api.Test;
 final class MethodChainTest {
 
     @Test
-    void retainsMethodName() {
+    void writesNamedPlainMethodLink() {
+        final Emit emit = new Emit();
+        emit.object("wrap", null, 1, 0);
+        new MethodChain("bar", 3, false).write(emit, 2, "result");
+        emit.close();
+        emit.close();
         MatcherAssert.assertThat(
-            "name() must round-trip the method identifier without the leading dot",
-            new MethodChain("bar", 3, false).name(),
-            Matchers.equalTo("bar")
+            "plain method link was not emitted from its stored shape",
+            MethodChainTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='wrap']/o[@base='.bar' and @name='result' and @line='2' and @pos='3' and @method='' and not(@fragile)]"
+            )
         );
     }
 
     @Test
-    void retainsDotColumnForPosAttribute() {
+    void writesUnnamedFragileMethodLink() {
+        final Emit emit = new Emit();
+        emit.object("wrap", null, 1, 0);
+        new MethodChain("read", 5, true).write(emit, 3, null);
+        emit.close();
+        emit.close();
         MatcherAssert.assertThat(
-            "dot() must round-trip the column where the leading dot sits per R-9.1.3",
-            new MethodChain("bar", 3, false).dot(),
-            Matchers.equalTo(3)
+            "fragile method link lost its marker or became named",
+            MethodChainTest.render(emit),
+            XhtmlMatchers.hasXPath(
+                "/object/o[@name='wrap']/o[@base='.read' and @line='3' and @pos='5' and @method='' and @fragile='' and not(@name)]"
+            )
         );
     }
 
-    @Test
-    void retainsFragileFlag() {
-        MatcherAssert.assertThat(
-            "fragile() must round-trip the `?.` dispatch marker",
-            new MethodChain("read", 3, true).fragile(),
-            Matchers.equalTo(true)
-        );
+    private static String render(final Emit emit) {
+        return new Xembler(
+            new Directives().add("object").append(emit.directives())
+        ).xmlQuietly();
     }
 }


### PR DESCRIPTION
Closes #8608.

Moves the XMIR emission decision for one method-chain link into `MethodChain` itself. The class now writes its own `.<name>` base, source position, optional name, `@method`, and `@fragile` marker instead of exposing three fields through accessors for callers to reconstruct that shape.

Both duplicated consumers now delegate to it:
- `ChainEmission.link()` uses `MethodChain.write(...)` for intermediate and final links;
- `LnTextBlock` uses the same method for its chain instead of maintaining a second copy of the base/position/fragile emission logic.

The old accessor-only `MethodChainTest` cases are replaced with behavioral tests for a named plain link and an unnamed fragile link, including base, line, position and markers.

`git diff --check` is clean. Maven is not available in this Termux environment, so repository CI will run the parser test/quality matrix.
