### PR TITLE
#8594: Replace dead Maven Central badge links

### DIFF
--- a/eo-integration-tests/src/it/README.md
+++ b/eo-integration-tests/src/it/README.md
@@ -2,7 +2,7 @@
 <!-- markdownlint-disable-next-line line-length -->
 <img alt="logo" src="https://www.yegor256.com/images/books/elegant-objects/cactus.svg" height="100px" />
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/eo-maven-plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-maven-plugin.svg)](https://central.sonatype.com/artifact/org.eolang/eo-maven-plugin)
 
 This directory contains integration tests for eolang-maven-plugin,
 but you can use them as examples of EO-to-Java transformations.

--- a/eo-integration-tests/src/it/fibonacci/README.md
+++ b/eo-integration-tests/src/it/fibonacci/README.md
@@ -13,7 +13,7 @@ The only change you will have to do is setting
 the right versions the `pom.xml`. Use the latest version
 visible in this badge:
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/eo-maven-plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-maven-plugin.svg)](https://central.sonatype.com/artifact/org.eolang/eo-maven-plugin)
 
 Just copy these files to your local directory, change the
 version in `pom.xml` and run `mvn test` (it is assumed that

--- a/eo-maven-plugin/README.md
+++ b/eo-maven-plugin/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD033 MD041 -->
 <img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-maven-plugin.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/eo-maven-plugin)
+[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-maven-plugin.svg)](https://central.sonatype.com/artifact/org.eolang/eo-maven-plugin)
 [![Javadoc](https://www.javadoc.io/badge/org.eolang/eo-maven-plugin.svg)](https://www.javadoc.io/doc/org.eolang/eo-maven-plugin)
 
 This is a

--- a/eo-parser/README.md
+++ b/eo-parser/README.md
@@ -2,7 +2,7 @@
 
 <img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-parser.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/eo-parser)
+[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-parser.svg)](https://central.sonatype.com/artifact/org.eolang/eo-parser)
 [![Javadoc](https://www.javadoc.io/badge/org.eolang/eo-parser.svg)](https://www.javadoc.io/doc/org.eolang/eo-parser)
 
 # eo-parser

--- a/eo-runtime/README.md
+++ b/eo-runtime/README.md
@@ -1,7 +1,7 @@
 <!-- markdownlint-disable MD033 MD041 -->
 <img alt="logo" src="https://www.objectionary.com/cactus.svg" height="100px" />
 
-[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-runtime.svg)](https://maven-badges.herokuapp.com/maven-central/org.eolang/eo-runtime)
+[![Maven Central](https://img.shields.io/maven-central/v/org.eolang/eo-runtime.svg)](https://central.sonatype.com/artifact/org.eolang/eo-runtime)
 [![Javadoc](https://www.javadoc.io/badge/org.eolang/eo-runtime.svg)](https://www.javadoc.io/doc/org.eolang/eo-runtime)
 
 This is runtime for EO.


### PR DESCRIPTION
Closes #8594.

Replaces the five dead `maven-badges.herokuapp.com` badge targets with the corresponding live Maven Central artifact pages on `central.sonatype.com` while keeping the existing Shields.io badge images unchanged.

Verified all three destination artifact pages return HTTP 200:
- `org.eolang:eo-runtime`
- `org.eolang:eo-parser`
- `org.eolang:eo-maven-plugin`

`git diff --check` is clean.
