### PR TITLE
#8655: drop a handle's cactus name when the merge spends it

### DIFF
--- a/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
+++ b/eo-printer/src/main/resources/org/eolang/printer/print/merge-monikers.xsl
@@ -567,11 +567,29 @@
       </xsl:when>
       <xsl:otherwise>
         <o>
-          <xsl:apply-templates select="@*[name() != 'as']|node()"/>
+          <xsl:apply-templates select="@*[name() != 'as'][not(eo:spent-name(.))]|node()"/>
         </o>
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
+  <!--
+  Whether `$attr` is the cactus `@name` of a handle whose last reference this
+  merge has just consumed. A `&gt;&gt;` handle carries the synthetic cactus name
+  the parser mints and, in `@local`, the readable one the author wrote;
+  "restore-local-names" drops `@local` from a handle it expects to be folded
+  away, so a merged binding with a cactus `@name` and no `@local` has neither a
+  readable name nor anything referring to the obfuscated one. Carrying it to the
+  use site made "to-eo-tree" print a nameless `&gt;&gt;`, which
+  `redundant-attachment` refuses, leaving no spelling of the handle both
+  canonical and lint-clean (#8655). A const handle (`42 &gt;&gt;!`) keeps its
+  name even with no readable one: the cactus name is what the `&gt;&gt;!` marker
+  is printed from, and that marker means dataize-once rather than a way to refer
+  to the object.
+  -->
+  <xsl:function name="eo:spent-name" as="xs:boolean">
+    <xsl:param name="attr" as="attribute()"/>
+    <xsl:sequence select="name($attr) = 'name' and starts-with($attr, $eo:cactus-name) and empty($attr/../@local) and empty($attr/../@const)"/>
+  </xsl:function>
   <!--
   Host an applied formation handle (see `eo:applied-handle`): emit the inlined
   handle formation in place of the reference, then a "@pipe" node carrying the

--- a/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-formation.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/eo-packs/print/merge-monikers-formation.yaml
@@ -36,12 +36,15 @@ asserts:
   # No forward "ξ.a🌵….q" reference survives: the dispatch was un-rolled.
   - /object[count(//o[starts-with(@base, 'ξ.a🌵')])=0]
   # The dispatch is now a reversed "q." (base '.q') that keeps its own "@name"
-  # ("φ", i.e. "> @"); its receiver is the inlined anonymous formation.
-  - /object/o[@name='bar']/o[@name='φ' and @base='.q']/o[starts-with(@name, 'a🌵') and not(@base)]
+  # ("φ", i.e. "> @"); its receiver is the inlined anonymous formation. The
+  # merge spends the formation's cactus name — nothing refers to it any more —
+  # so the receiver carries none, rather than the nameless ">>" a surviving
+  # cactus name printed and "redundant-attachment" refused (#8655).
+  - /object/o[@name='bar']/o[@name='φ' and @base='.q']/o[not(@name) and not(@base)]
   # The reversed dispatch keeps its own "5" argument after the receiver.
-  - /object/o[@name='bar']/o[@base='.q']/o[starts-with(@name, 'a🌵')]/following-sibling::o[@as='α0' and @base='Φ.number']
+  - /object/o[@name='bar']/o[@base='.q']/o[not(@name) and not(@base)]/following-sibling::o[@as='α0' and @base='Φ.number']
   # The formation's "$"-recursion stays a bare "ξ".
-  - /object/o[@name='bar']/o[@base='.q']/o[starts-with(@name, 'a🌵')]/o[@name='φ' and @base='ξ']
+  - /object/o[@name='bar']/o[@base='.q']/o[not(@name) and not(@base)]/o[@name='φ' and @base='ξ']
 input: |
   +package foo
 

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/merged-handle-spent-name.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/merged-handle-spent-name.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# A named "&gt;&gt;" handle over an anonymous formation, read once through a
+# dispatch that sits inside an argument block rather than beside the binding.
+# "merge-monikers" folds the handle onto that single reference, which spends the
+# name: nothing refers to it any more, and "restore-local-names" has already
+# dropped the readable "@local". Carrying the cactus "@name" to the use site
+# printed the merged formation as a nameless "&gt;&gt;", which
+# "redundant-attachment" refuses, so no spelling of the handle was both
+# canonical and lint-clean (#8655). It is unnamed now.
+penalties:
+  INDENT: 3
+  BRACKET: 7
+  EXCESS: 1
+  WIDTH: 80
+  STEP: 2
+  SPACE: 7
+origin: |
+  +package foo
+
+  [] > bar
+    Q.stdout > @
+      as-bytes.
+        42.plus 1 > [^] >> shifted
+
+printed: |
+  +package foo
+
+  stdout > [] > bar
+    as-bytes.
+      42.plus 1 > [^]

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-dispatch.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/moniker-dispatch.yaml
@@ -11,7 +11,9 @@
 # as the receiver of a reversed dispatch exactly as a bare reference is inlined
 # as a plain receiver (#5782). The printer drops the standalone `>> auto`
 # binding and rewrites `auto.gte 0` into `gte.` over the inlined block, keeping
-# the dispatch's `0` argument. Without the fix the handle had no bare
+# the dispatch's `0` argument. The merge spends the handle's name — nothing
+# refers to `auto` any more — so the inlined block carries none, rather than the
+# nameless `>>` a surviving cactus name used to print (#8655). Without the fix the handle had no bare
 # reference to land on, so `inline-cactoos` stranded the dispatch on a synthetic
 # `v_` placeholder instead. Only one trailing segment is hostable this way; a
 # multi-segment chain would need nested reversed dispatches and stays expanded.
@@ -35,10 +37,9 @@ origin: |
 printed: |
   +package number
 
-  [num] > abs
-    if. > @
-      gte.
-        number num.as-bytes >>
-        0
-      num
-      num
+  if. > [num] > abs
+    gte.
+      number num.as-bytes
+      0
+    num
+    num

--- a/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-auto-named-handle.yaml
+++ b/eo-printer/src/test/resources/org/eolang/printer/print-packs/yaml/recursive-auto-named-handle.yaml
@@ -14,7 +14,10 @@
 # single-segment dispatch onto a named reference (keeping the "&gt; @"), so the
 # formation is inlined back as the anonymous receiver of the reversed dispatch
 # "q. &gt; @" — no dangling reference — with its "$"-application decoratee in
-# the canonical compact form ("$ &gt; [n] &gt;&gt;"), re-parsing to the same graph.
+# the canonical compact form ("$ &gt; [n]"), re-parsing to the same graph. The
+# merge spends the cactus name, so the receiver carries none: the nameless
+# "&gt;&gt;" it used to print names an object nothing refers to, which
+# "redundant-attachment" refuses (#8655).
 penalties:
   INDENT: 3
   BRACKET: 7
@@ -34,8 +37,7 @@ origin: |
 printed: |
   +package foo
 
-  [] > bar
-    q. > @
-      $ > [n] >>
-        n.minus 1
-      5
+  q. > [] > bar
+    $ > [n]
+      n.minus 1
+    5

--- a/eo-runtime/src/main/eo/directory.eo
+++ b/eo-runtime/src/main/eo/directory.eo
@@ -155,7 +155,7 @@
                 regex.
                   string
                     as-bytes.
-                      "".joined >>
+                      "".joined
                         *
                           "/^"
                           translated 0 "" false false

--- a/eo-runtime/src/main/eo/i16.eo
+++ b/eo-runtime/src/main/eo/i16.eo
@@ -9,16 +9,15 @@
 
 [as-bytes] > i16
   as-bytes > @
-  [^] > as-i32
-    i32 > @
-      concat.
-        if. >>
-          eq.
-            ^.as-bytes.and 80-00
-            00-00
+  i32 > [^] > as-i32
+    concat.
+      if.
+        eq.
+          ^.as-bytes.and 80-00
           00-00
-          FF-FF
-        ^.as-bytes
+        00-00
+        FF-FF
+      ^.as-bytes
   as-i32.as-i64 > as-i64
   as-i64.as-number > as-number
   [^ x cant-divide] > div

--- a/eo-runtime/src/main/eo/i32.eo
+++ b/eo-runtime/src/main/eo/i32.eo
@@ -19,16 +19,15 @@
       cant-convert
         "Can't convert i32 number %d to i16 because it's out of i16 bounds".printf
           * ^.as-i64.as-number
-  [^] > as-i64
-    i64 > @
-      concat.
-        if. >>
-          eq.
-            ^.as-bytes.and 80-00-00-00
-            00-00-00-00
+  i64 > [^] > as-i64
+    concat.
+      if.
+        eq.
+          ^.as-bytes.and 80-00-00-00
           00-00-00-00
-          FF-FF-FF-FF
-        ^.as-bytes
+        00-00-00-00
+        FF-FF-FF-FF
+      ^.as-bytes
   as-i64.as-number > as-number
   [^ x cant-divide] > div
     if. > @

--- a/eo-runtime/src/main/eo/i8.eo
+++ b/eo-runtime/src/main/eo/i8.eo
@@ -10,16 +10,15 @@
 
 [as-bytes] > i8
   as-bytes > @
-  [^] > as-i16
-    i16 > @
-      concat.
-        if. >>
-          eq.
-            ^.as-bytes.and 80-
-            00-
+  i16 > [^] > as-i16
+    concat.
+      if.
+        eq.
+          ^.as-bytes.and 80-
           00-
-          FF-
-        ^.as-bytes
+        00-
+        FF-
+      ^.as-bytes
   as-i16.as-number > as-number
   [^ x cant-divide] > div
     if. > @

--- a/eo-runtime/src/main/eo/u64.eo
+++ b/eo-runtime/src/main/eo/u64.eo
@@ -43,24 +43,21 @@
   lte. > [^ x] > lte
     i64 ^.flip
     i64 x.as-u64.flip
-  [^ x] > minus
-    u64 > @
-      as-bytes.
-        minus. >>
-          i64 ^.as-bytes
-          i64 x.as-u64.as-bytes
-  [^ x] > plus
-    u64 > @
-      as-bytes.
-        plus. >>
-          i64 ^.as-bytes
-          i64 x.as-u64.as-bytes
-  [^ x] > times
-    u64 > @
-      as-bytes.
-        times. >>
-          i64 ^.as-bytes
-          i64 x.as-u64.as-bytes
+  u64 > [^ x] > minus
+    as-bytes.
+      minus.
+        i64 ^.as-bytes
+        i64 x.as-u64.as-bytes
+  u64 > [^ x] > plus
+    as-bytes.
+      plus.
+        i64 ^.as-bytes
+        i64 x.as-u64.as-bytes
+  u64 > [^ x] > times
+    as-bytes.
+      times.
+        i64 ^.as-bytes
+        i64 x.as-u64.as-bytes
 
   eq. ++> can-add-one-to-one
     00-00-00-00-00-00-00-01.as-u64.plus 00-00-00-00-00-00-00-01.as-u64

--- a/eo-runtime/src/main/eo/uri.eo
+++ b/eo-runtime/src/main/eo/uri.eo
@@ -89,7 +89,7 @@
     not. >> has-port
       eq.
         if. >> port-colon-idx
-          host-port.starts-with "[" >>
+          host-port.starts-with "["
           if.
             eq.
               index-of. >> rel-colon


### PR DESCRIPTION
Closes #8655.

A `>>` handle read once through a dispatch that sits inside an argument block was merged onto that reference and carried its synthetic cactus `@name` along. `restore-local-names` had already dropped the readable `@local` from it, so the merged object reached `to-eo-tree` with an obfuscated name nothing refers to and printed as a bare `>>`, which `redundant-attachment` refuses. No spelling of the handle satisfied both gates: the hand-written one was not canonical, the canonical one was not lint-clean.

`merge-monikers` now leaves such a name behind, so the merged object is unnamed at the site it was folded onto, which is what it is. A const handle (`42 >>!`) is excluded: its cactus name is what the `>>!` marker is printed from, and that marker means dataize-once rather than a way to refer to the object.

Six `eo-runtime` sources reformat to the shorter canonical spelling as a result; `mvn -pl eo-runtime process-sources` passes both the format check and the linter on them.

Two packs pinned the old output and are updated with the reason, and `merged-handle-spent-name.yaml` pins the reported shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YLE3PkTV72EUWXbGKpgD9

---
_Generated by [Claude Code](https://claude.ai/code/session_012YLE3PkTV72EUWXbGKpgD9)_