### PR TITLE
#8689: follow a link while walking a fingerprinted directory

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Fingerprint.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Fingerprint.java
@@ -7,6 +7,7 @@ package org.eolang.maven;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileVisitOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
@@ -102,7 +103,7 @@ final class Fingerprint implements Supplier<String> {
             }
             for (final Path base : this.dirs) {
                 if (Files.isDirectory(base)) {
-                    try (Stream<Path> found = Files.walk(base)) {
+                    try (Stream<Path> found = Files.walk(base, FileVisitOption.FOLLOW_LINKS)) {
                         for (final Path file : found.filter(Files::isRegularFile)
                             .sorted().collect(Collectors.toList())) {
                             final byte[] content = Files.readAllBytes(file);

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/FingerprintTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/FingerprintTest.java
@@ -7,11 +7,14 @@ package org.eolang.maven;
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
@@ -119,6 +122,40 @@ final class FingerprintTest {
             Matchers.not(
                 Matchers.equalTo(new Fingerprint(temp.resolve("second")).get())
             )
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void seesTheFilesBehindADirectoryLink(@Mktmp final Path temp) throws IOException {
+        final long seed = System.nanoTime();
+        new Saved(Long.toHexString(seed), temp.resolve("real/a.txt")).value();
+        Files.createSymbolicLink(temp.resolve("linked"), temp.resolve("real"));
+        MatcherAssert.assertThat(
+            String.format(
+                "a link to a directory was walked but never entered, so nothing under it was hashed, seed=%d",
+                seed
+            ),
+            new Fingerprint(temp.resolve("linked")).get(),
+            Matchers.equalTo(new Fingerprint(temp.resolve("real")).get())
+        );
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void noticesAChangeBehindADirectoryLink(@Mktmp final Path temp) throws IOException {
+        final long seed = System.nanoTime();
+        new Saved(Long.toHexString(seed), temp.resolve("real/a.txt")).value();
+        Files.createSymbolicLink(temp.resolve("linked"), temp.resolve("real"));
+        final String before = new Fingerprint(temp.resolve("linked")).get();
+        new Saved(Long.toHexString(seed + 1L), temp.resolve("real/a.txt")).value();
+        MatcherAssert.assertThat(
+            String.format(
+                "a cache keyed by this fingerprint keeps serving tables built from contents that have changed, seed=%d",
+                seed
+            ),
+            new Fingerprint(temp.resolve("linked")).get(),
+            Matchers.not(Matchers.equalTo(before))
         );
     }
 


### PR DESCRIPTION
`Fingerprint.get()` guarded the directory branch with `Files.isDirectory(base)`, which follows
links, and then walked with `Files.walk(base)`, which does not. A `base` that is a link to a
directory was therefore entered by the guard and not by the walk, nothing under it was hashed,
and the digest stayed the SHA-256 of empty input no matter what the real content did.

The walk now passes `FileVisitOption.FOLLOW_LINKS`, the same way `Sha.java` does since #8228.

Two tests added to `FingerprintTest`, both disabled on Windows like their counterparts in
`ShaTest`: one asserts that a link to a directory fingerprints as the directory itself, the
other that a change behind the link changes the fingerprint. Both fail on master:

```
Tests run: 10, Failures: 2, Errors: 0
```

Closes #8689

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
