### PR TITLE
#6976: say how the site is built

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,19 @@ You will also need [git] installed and on your `PATH`,
   since some of the quality checks the `qulice` profile runs shell out to it.
 Also, if you have [xcop] installed, make sure it is version `0.8.0`+.
 
+The site is built one module at a time, and only once the artifacts exist:
+
+```bash
+mvn clean install -DskipTests
+mvn clean site -Psite -pl eo-maven-plugin
+```
+
+The `site` lifecycle holds no `package` phase, so no module in the reactor
+  ever produces a jar of its own, and `eo-parser` is never published as a
+  snapshot for one to be downloaded instead.
+A plain `mvn clean site` in a fresh clone therefore has nothing to resolve
+  `org.eolang:eo-parser:1.0-SNAPSHOT` against and stops at `eo-printer`.
+
 A few rules we ask you to follow:
 
 * name your branch after the issue you are working on, e.g. `42`


### PR DESCRIPTION
Closes #6976.

I re-ran all three failures the ticket records, on `be3d5202`:

| command | result today |
|---|---|
| `mvn clean site -Psite -pl eo-maven-plugin` (CI's command, item 3) | **BUILD SUCCESS** |
| `mvn clean site -Psite` (reactor-wide, item 2) | **BUILD SUCCESS** |
| `mvn clean site` with `org.eolang:eo-parser` removed from `~/.m2` (item 1) | fails, exactly as reported |

Items 2 and 3 have since been fixed in place. The `<reporting>` block of the root `pom.xml` now pins `maven-jxr-plugin` to `jxr-no-fork`/`test-jxr-no-fork`, so the aggregate report no longer forks every module's `generate-sources` and `format` is never reached without a manifest. `MjCoverageReport`, `MjInference` and `MjMerge` each carry a documented no-arg constructor now, so doclint has nothing to flag.

Item 1 is Maven's own shape: the `site` lifecycle holds no `package` phase, so no module in the reactor produces a jar of its own, and `eo-parser` is never published as a snapshot for one to be downloaded instead. There is nothing to fix in the build, only something to say, which is what this change does — `README.md` now names the two commands that work and the reason the plain one does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YLE3PkTV72EUWXbGKpgD9

---
_Generated by [Claude Code](https://claude.ai/code/session_012YLE3PkTV72EUWXbGKpgD9)_