### PR TITLE
#8598: Describe ms as source-walk duration

### DIFF
--- a/eo-parser/src/main/resources/XMIR.xsd
+++ b/eo-parser/src/main/resources/XMIR.xsd
@@ -500,8 +500,8 @@
         <xs:appinfo>The amount of milliseconds that were spent on creating this document</xs:appinfo>
         <xs:documentation>
           The element contains a positive integer, which is the number of milliseconds
-          that were spent by the parser to generate this document. This information
-          is valuable for debugging purposes and may be omitted in production systems.
+          spent by the parser walking the EO source into XMIR directives. It does not
+          include building the DOM or applying the canonical XSL transformations.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
Closes #8598.

Corrects the `@ms` schema documentation to describe what `EoSyntax.parsed()` actually measures: the EO source walk that builds XMIR directives.

The timer is intentionally read before `Xembler` builds the DOM and before the canonical XSL train runs, so the previous wording (“time ... to generate this document”) overstated the measurement and could mislead performance diagnosis.

No schema type or parser behavior changes. `git diff --check` is clean.
