### PR TITLE
#8609: Reuse suffix mark emitter

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/ChainEmission.java
@@ -82,12 +82,7 @@ final class ChainEmission {
             this.emit, this.span.line(), this.head, this.chain,
             this.suffix.attribute(this.span.line(), this.span.indent())
         );
-        if (!this.suffix.handle().isEmpty()) {
-            this.emit.local(this.suffix.handle());
-        }
-        if (this.suffix.constant()) {
-            this.emit.constant();
-        }
+        new Marked(this.emit, this.suffix).apply();
     }
 
     /**

--- a/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnFormation.java
@@ -135,15 +135,10 @@ final class LnFormation implements Line {
             suffix.attribute(this.span.line(), this.span.indent()),
             this.span.line(), this.span.indent()
         );
-        if (!suffix.handle().isEmpty()) {
-            emit.local(suffix.handle());
-        }
         if (!binding.isEmpty()) {
             emit.slot(Emissions.bindingTag(binding));
         }
-        if (suffix.constant()) {
-            emit.constant();
-        }
+        new Marked(emit, suffix).apply();
         int column = this.span.indent() + 1;
         for (final String param : params) {
             emit.voidParam(param, this.span.line(), column);

--- a/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnOnlyPhi.java
@@ -160,12 +160,7 @@ final class LnOnlyPhi implements Line {
             suffix.attribute(this.span.line(), this.span.indent()),
             this.span.line(), this.span.indent()
         );
-        if (!suffix.handle().isEmpty()) {
-            emit.local(suffix.handle());
-        }
-        if (suffix.constant()) {
-            emit.constant();
-        }
+        new Marked(emit, suffix).apply();
         this.emitVoids(emit, params, origin);
         this.emitPhi(emit, tokens, stack.top().openness() == Openness.OPEN);
     }

--- a/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnPipe.java
@@ -92,13 +92,8 @@ final class LnPipe implements Line {
             suffix.attribute(this.span.line(), this.span.indent()),
             this.span.line(), this.span.indent()
         );
-        if (!suffix.handle().isEmpty()) {
-            emit.local(suffix.handle());
-        }
         emit.pipe();
-        if (suffix.constant()) {
-            emit.constant();
-        }
+        new Marked(emit, suffix).apply();
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, this.span.line());
         }

--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -135,15 +135,10 @@ final class LnReversed implements Line {
             suffix.attribute(this.span.line(), this.span.indent()),
             base, this.span.line(), this.span.indent()
         );
-        if (!suffix.handle().isEmpty()) {
-            emit.local(suffix.handle());
-        }
         if (fragile) {
             emit.fragile();
         }
-        if (suffix.constant()) {
-            emit.constant();
-        }
+        new Marked(emit, suffix).apply();
         for (final Value arg : args) {
             Emissions.emitArg(emit, arg, this.span.line());
         }


### PR DESCRIPTION
Closes #8609.

Replaces five hand-written copies of the file-local-handle/const suffix logic with the existing `Marked` abstraction:

- `ChainEmission`
- `LnOnlyPhi`
- `LnReversed`
- `LnPipe`
- `LnFormation`

For the shapes that have their own marker (`@fragile`, `@pipe`, or an inline binding slot), that shape-specific marker is emitted first and `Marked.apply()` then writes the suffix-owned handle/const marks together. `LnVoid` remains intentionally separate because voids reject the const marker and may only carry the handle.

A post-change search shows `suffix.handle()`/`suffix.constant()` are now confined to `Marked` plus the deliberate `LnVoid` exception. `git diff --check` is clean.
