### PR TITLE
#8579: Avoid debug-only dependency walk

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Placing.java
@@ -115,16 +115,19 @@ final class Placing implements Step {
         }
         final Path dir = this.home.resolve(dep);
         final long copied = new Placing.PlacedDependency(dir, dep, this.rewrite).get();
-        if (copied > 0) {
-            Logger.debug(
-                this, "Placed %d binary file(s) out of %d, found in %s, to %[file]s",
-                copied, new WkDefault(dir).size(), dep, this.classes
-            );
-        } else {
-            Logger.debug(
-                this, "No binary file(s) out of %d were placed from %s, to %[file]s",
-                new WkDefault(dir).size(), dep, this.classes
-            );
+        if (Logger.isDebugEnabled(this)) {
+            final int total = new WkDefault(dir).size();
+            if (copied > 0) {
+                Logger.debug(
+                    this, "Placed %d binary file(s) out of %d, found in %s, to %[file]s",
+                    copied, total, dep, this.classes
+                );
+            } else {
+                Logger.debug(
+                    this, "No binary file(s) out of %d were placed from %s, to %[file]s",
+                    total, dep, this.classes
+                );
+            }
         }
         return copied;
     }


### PR DESCRIPTION
Closes #8579.

Avoids a second eager walk of each resolved dependency directory at normal log levels. `PlacedDependency.get()` already traverses the directory to process binaries; the later `new WkDefault(dir).size()` existed only to fill a DEBUG message, but Java evaluated it even when debug logging was disabled.

The extra size walk is now guarded by `Logger.isDebugEnabled(this)` and computed once for the selected debug branch. INFO-level placement no longer pays for that redundant traversal; debug output is unchanged.

`git diff --check` is clean; repository CI will run the Maven-plugin test and quality matrix.
