### PR TITLE
#8613: Share identifier glyph and clamp checks

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Suffix.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Suffix.java
@@ -376,7 +376,14 @@ final class Suffix {
         }
     }
 
-    private static int clamped(final int pos, final Span span) {
+    /**
+     * Clamp an error column to the last character of the source span.
+     *
+     * @param pos Candidate source column
+     * @param span Source span
+     * @return Column inside the source span
+     */
+    static int clamped(final int pos, final Span span) {
         return Math.min(pos, span.text().length() - 1);
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Tokens.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Tokens.java
@@ -184,7 +184,7 @@ final class Tokens {
         final int start = this.cursor;
         if (this.atEnd()) {
             throw new ParseError(
-                this.span.line(), Tokens.clamped(this.span.indent() + start, this.span),
+                this.span.line(), Suffix.clamped(this.span.indent() + start, this.span),
                 "expected identifier"
             );
         }
@@ -200,19 +200,7 @@ final class Tokens {
             idx = idx + 1;
         }
         final String raw = this.body.substring(start, idx);
-        if (Tokens.cactus(raw)) {
-            throw new ParseError(
-                this.span.line(), this.span.indent() + start,
-                "cactus emoji is reserved for auto-names; not allowed in identifiers"
-            );
-        }
-        final int control = new Scrubbed(raw).found();
-        if (control >= 0) {
-            throw new ParseError(
-                this.span.line(), this.span.indent() + start + control,
-                "control character is not allowed in an identifier"
-            );
-        }
+        Suffix.checkGlyphs(raw, this.span.line(), this.span.indent() + start);
         this.cursor = idx;
         return new Value(Value.Kind.IDENTIFIER, raw, this.span.indent() + start);
     }
@@ -543,7 +531,7 @@ final class Tokens {
         }
         if (this.cursor == start) {
             throw new ParseError(
-                this.span.line(), Tokens.clamped(this.span.indent() + start, this.span),
+                this.span.line(), Suffix.clamped(this.span.indent() + start, this.span),
                 "expected binding label after `:`"
             );
         }
@@ -648,10 +636,6 @@ final class Tokens {
         return idx;
     }
 
-    private static int clamped(final int pos, final Span source) {
-        return Math.min(pos, source.text().length() - 1);
-    }
-
     private static boolean singleToken(final String inside) {
         boolean single = true;
         int idx = 0;
@@ -737,10 +721,6 @@ final class Tokens {
 
     private static boolean terminates(final char glyph) {
         return " \t,.|':;!?[]{}()".indexOf(glyph) >= 0;
-    }
-
-    private static boolean cactus(final String text) {
-        return text.codePoints().anyMatch(cp -> cp == 0x1F335);
     }
 
     private static boolean validBinding(final String text) {


### PR DESCRIPTION
Closes #8613.

Removes the remaining duplicate identifier validation and error-column clamping between `Tokens` and `Suffix`:

- `Tokens.readName()` now delegates cactus/control-character validation to the package-level `Suffix.checkGlyphs()` used by other identifier readers;
- `Tokens` uses the shared `Suffix.clamped()` helper for end-of-line diagnostics;
- the duplicate `Tokens.clamped()` and `Tokens.cactus()` helpers are removed.

`checkBinding()` already used `Suffix.checkGlyphs()` on current master, so this completes the consolidation without changing its behavior.

A post-change search leaves one glyph gate and one clamp implementation for these parser paths. `git diff --check` is clean; repository CI will run parser tests and quality checks.
