### PR TITLE
#8484: drop the triple-quote guard nothing can reach

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1458,7 +1458,6 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Reversed dispatch whose receiver is not followed by a dot (§3.8) | `reversed dispatch must end with a dot` |
 | Pipe line whose `\|` is glued to the argument list or suffix that follows it (§3.14) | `` a pipe `\|` must be followed by a space before its arguments `` |
 | Test attribute on a pipe application (§3.14) | `a pipe application cannot declare a test attribute` |
-| Text block closer that does not open with `"""` (R-3.11.3) | `text block closer must start with triple-quote` |
 | Text block body line shallower than its opener (R-3.11.2) | `text block body line indented less than opener` |
 | Two or more consecutive blank lines (R-6.5.3) | `consecutive blank lines forbidden — at most one blank may separate two non-blank lines (R-6.5.3)` |
 | First object of the file at an indent other than 0 (§5.2) | `unexpected indentation, the first object must start at indent 0` |

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -25,6 +25,10 @@ import java.util.List;
  * {@code <o base='.<name>'>} links, with the line's outer binding and
  * name suffix attaching to the last link.</p>
  *
+ * <p>The span arrives already checked: {@link Eo} builds this line only
+ * for a body that starts with {@code """}, so the closer is not
+ * checked for that a second time here.</p>
+ *
  * @since 0.1
  */
 final class LnTextBlock implements Line {
@@ -46,12 +50,6 @@ final class LnTextBlock implements Line {
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
         final String body = this.span.body();
-        if (!body.startsWith("\"\"\"")) {
-            throw new ParseError(
-                this.span.line(), this.span.indent(),
-                "text block closer must start with triple-quote"
-            );
-        }
         final Tokens tokens = new Tokens(body, this.span);
         tokens.seek(3);
         final List<MethodChain> chain = tokens.readChain();

--- a/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnTextBlock.java
@@ -49,8 +49,7 @@ final class LnTextBlock implements Line {
 
     @Override
     public void into(final Stack stack, final Globals globals, final Emit emit) {
-        final String body = this.span.body();
-        final Tokens tokens = new Tokens(body, this.span);
+        final Tokens tokens = new Tokens(this.span.body(), this.span);
         tokens.seek(3);
         final List<MethodChain> chain = tokens.readChain();
         final String outer = LnApplication.readOuterBinding(tokens, this.span);


### PR DESCRIPTION
`LnTextBlock.into` opened with a guard that threw `text block closer must start with
triple-quote` when the body did not start with `"""`. Nothing can reach it: the only place
the class is built is `Eo.continueTextBlock`, inside `if (Eo.closesTextBlock(span, globals))`,
and `closesTextBlock` already requires `body.startsWith("\"\"\"")` on that same span.

The five lines are gone and the class javadoc now says the span arrives already checked, so
the next reader does not add the check back.

No test comes with this: the guard was unreachable, so the behaviour before and after is the
same, and there is no input that told the two apart.

Closes #8484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
