### PR TITLE
#8492: say that a reversed dispatch carries no method attribute

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnReversed.java
@@ -29,9 +29,12 @@ import java.util.List;
  * at close time if no receiver appeared.</li>
  * </ul>
  *
- * <p>Emission: opens {@code <o base='.<name>' method=''>} at the
- * current cursor and stays inside. For horizontal form, the receiver
- * and method args are appended as children before the cursor closes.
+ * <p>Emission: opens {@code <o base='.<name>'>} at the current cursor
+ * and stays inside. There is no {@code @method} on it: per §9.4 a
+ * reversed dispatch opens a chain, while {@code @method} marks a link
+ * that continues one, and R-3.5.3b reads the two apart. For horizontal
+ * form, the receiver and method args are appended as children before
+ * the cursor closes.
  * For vertical form, deeper-indent lines (dispatched through
  * {@link LnApplication} etc.) attach as children automatically.</p>
  *


### PR DESCRIPTION
The class docblock of `LnReversed` said the line opens `<o base='.<name>' method=''>`. It does
not, and must not: `LnReversed.emit` opens the element through `Emit.object`, which writes only
`@name`, `@base`, `@line` and `@pos`, and `LnReversedTest.emitsBaseWithLeadingDotAndNoMethodAttribute`
asserts the absence.

The paragraph now says `<o base='.<name>'>` with no `@method`, and says why: per §9.4 a reversed
dispatch opens a chain while `@method` marks a link that continues one, which is what R-3.5.3b
reads apart.

Documentation only, no behaviour change, so no test comes with it.

Closes #8492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
