### PR TITLE
#8578: drop every message-less cause, not just the first

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Causes.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Causes.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * The chain of causes of a problem, ready for the log.
@@ -37,18 +38,12 @@ final class Causes implements Iterable<String> {
     @Override
     public Iterator<String> iterator() {
         final List<String> causes = Causes.all(this.problem);
-        for (int pos = 0; pos < causes.size(); ++pos) {
-            if (causes.get(pos) == null) {
-                causes.remove(pos);
-                break;
-            }
-        }
+        causes.removeIf(Objects::isNull);
         int idx = 0;
         while (idx < causes.size()) {
             final String cause = causes.get(idx);
             for (int later = idx + 1; later < causes.size(); ++later) {
-                final String another = causes.get(later);
-                if (another != null && cause.contains(another)) {
+                if (cause.contains(causes.get(later))) {
                     causes.remove(idx);
                     idx -= 1;
                     break;

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/CausesTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/CausesTest.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.maven;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Causes}.
+ *
+ * @since 0.62.0
+ */
+final class CausesTest {
+
+    @Test
+    void readsAChainOfTwoMessagelessCauses() {
+        MatcherAssert.assertThat(
+            "a chain of two throwables without a message must still be read, but it wasnt",
+            new Causes(
+                new IllegalStateException(
+                    null,
+                    new IllegalStateException(
+                        null, new IllegalStateException("something went wrong")
+                    )
+                )
+            ),
+            Matchers.contains("something went wrong")
+        );
+    }
+
+    @Test
+    void saysNothingForAMessagelessCause() {
+        MatcherAssert.assertThat(
+            "a throwable without a message must say nothing at all, but it spoke",
+            new Causes(
+                new IllegalStateException(
+                    "outer failure",
+                    new IllegalStateException(null, new IllegalStateException((String) null))
+                )
+            ),
+            Matchers.contains("outer failure")
+        );
+    }
+
+    @Test
+    void dropsACauseRepeatedByAnEarlierOne() {
+        MatcherAssert.assertThat(
+            "a cause repeating a part of an earlier one must be dropped, but it stayed",
+            new Causes(
+                new IllegalStateException(
+                    "the build failed because of a typo", new RuntimeException("a typo")
+                )
+            ),
+            Matchers.contains("a typo")
+        );
+    }
+}


### PR DESCRIPTION
`Causes.iterator` removed the first message-less cause and broke out of the loop, so a second
one stayed in the list. The next loop then null-checked only one side of the comparison and
`cause.contains(another)` threw a `NullPointerException` on a chain of two throwables built
without a message, which replaced the real build failure in the report. With one such throwable
left over, a bare `null` line went into the log.

Now every message-less cause goes at once, with `removeIf`, and the null check the second loop
no longer needs is gone with it.

Three tests in a new `CausesTest`. On master the first errors with

```
java.lang.NullPointerException: Cannot invoke "String.contains(java.lang.CharSequence)" because "cause" is null
```

and the second fails with `not matched: null`.

Closes #8578

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
