### PR TITLE
#8600: Reuse reversed dispatch detector

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -84,7 +84,7 @@ final class Emissions {
     ) {
         final Span span = new Span(tokens.body(), line);
         final Value head = tokens.readValue();
-        if (Emissions.reversedDispatch(tokens, head)) {
+        if (!head.global() && tokens.reversedAhead(head)) {
             final boolean fragile = tokens.consumeDispatch();
             final List<Value> rargs = tokens.readArgs();
             Bindings.checkAllOrNothing(rargs, span);
@@ -439,24 +439,6 @@ final class Emissions {
             Emissions.expression(emit, name, tokens, line);
             tokens.checkEnd("unexpected content inside a parenthesised expression");
         }
-    }
-
-    private static boolean reversedDispatch(final Tokens tokens, final Value head) {
-        final boolean reversed;
-        if (head.reversible() && !head.global() && !tokens.atEnd() && tokens.dispatchAhead()) {
-            final int skip;
-            if (tokens.current() == '?') {
-                skip = 2;
-            } else {
-                skip = 1;
-            }
-            final int probe = tokens.cursor() + skip;
-            reversed = probe >= tokens.body().length()
-                || tokens.body().charAt(probe) == ' ';
-        } else {
-            reversed = false;
-        }
-        return reversed;
     }
 
     private static String reversedHead(final Value head) {


### PR DESCRIPTION
Closes #8600.

Removes the private `Emissions.reversedDispatch()` copy and delegates the shared reversed-dispatch shape test to `Tokens.reversedAhead(head)`.

Current master has one extra `Emissions`-specific rule that was added after the duplicate originally appeared: global heads must not enter this parenthesized reversed-dispatch path. That behavior is preserved explicitly as `!head.global() && tokens.reversedAhead(head)`, so the consolidation does not regress the existing `Q.` rejection semantics.

The parser already has coverage for fragile/plain reversed dispatches and for Q-rooted reversed dispatch rejection inside parenthesized expressions. `git diff --check` is clean.
