### PR TITLE
#8496: give the pipe predecessor condition its row in 9.9

### DIFF
--- a/eo-parser/PARSER_SPEC.md
+++ b/eo-parser/PARSER_SPEC.md
@@ -1458,6 +1458,7 @@ R-9.9.1. Every error condition in this spec has a single canonical text — **in
 | Reversed dispatch whose receiver is not followed by a dot (§3.8) | `reversed dispatch must end with a dot` |
 | Pipe line whose `\|` is glued to the argument list or suffix that follows it (§3.14) | `` a pipe `\|` must be followed by a space before its arguments `` |
 | Test attribute on a pipe application (§3.14) | `a pipe application cannot declare a test attribute` |
+| Pipe whose predecessor is missing, unnamed, or not a formation or pipe (§3.14) | `a pipe must follow a named formation or another pipe` |
 | Text block closer that does not open with `"""` (R-3.11.3) | `text block closer must start with triple-quote` |
 | Text block body line shallower than its opener (R-3.11.2) | `text block body line indented less than opener` |
 | Two or more consecutive blank lines (R-6.5.3) | `consecutive blank lines forbidden — at most one blank may separate two non-blank lines (R-6.5.3)` |


### PR DESCRIPTION
R-5.2.4a, R-5.2.5a and R-5.2.11a all send the reader to the canonical-text table for
`a pipe must follow a named formation or another pipe`, and the table had no row for it. The
message is thrown once, from `LnPipe.precheck`, for all three rules.

One row added next to the other two pipe texts. R-9.9.1 says the table assigns a text to each
condition, so the pointer in those three rules now leads somewhere.

Specification only, no code change, so no test comes with it.

Closes #8496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
