### PR TITLE
#8189: point the only-phi naming error at the line that names

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Admission.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Admission.java
@@ -80,10 +80,11 @@ final class Admission {
      * Name the level with this suffix's label, when there is one.
      *
      * @param level The level to name
+     * @param line The source line the suffix sits on
      */
-    void name(final Level level) {
+    void name(final Level level, final int line) {
         if (this.label != null) {
-            level.name(this.label, this.test);
+            level.name(this.label, this.test, line);
         }
     }
 

--- a/eo-parser/src/main/java/org/eolang/parser/Eo.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Eo.java
@@ -695,7 +695,7 @@ final class Eo implements Iterable<Directive> {
         }
         if (naming && level.argument() && level.named()) {
             emit.error(
-                level.start(), level.indent(),
+                level.labelled(), level.indent(),
                 level.onlyPhiNamingError()
             );
         }

--- a/eo-parser/src/main/java/org/eolang/parser/Level.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Level.java
@@ -79,6 +79,15 @@ final class Level {
     private Optional<String> label;
 
     /**
+     * The source line of the naming suffix that set {@link #label},
+     * which is the line a §4.5 error about that name belongs on. It is
+     * the line the entry was pushed on until a suffix claims the entry,
+     * and a same-indent {@code .method} continuation moves it to its own
+     * line the way it moves the label (R-6.2.2).
+     */
+    private int labelled;
+
+    /**
      * The source name of the only-phi formation this entry argues
      * (empty when anonymous), or {@code null} when it is not such an
      * argument. Set by {@link Stack} (see {@link #argues(String)});
@@ -189,6 +198,7 @@ final class Level {
         this.parent = parent;
         this.patom = patom;
         this.label = Level.NO_NAME;
+        this.labelled = line;
         this.atom = false;
         this.taken = false;
         this.count = 0;
@@ -214,6 +224,16 @@ final class Level {
      */
     int start() {
         return this.start;
+    }
+
+    /**
+     * Source line of the suffix that named the entry, or the line it was
+     * pushed on while no suffix has named it.
+     *
+     * @return Line of the name
+     */
+    int labelled() {
+        return this.labelled;
     }
 
     /**
@@ -402,9 +422,11 @@ final class Level {
      *  {@code null}
      * @param form Whether the suffix that set this name was a
      *  {@code TEST} or {@code THROWS} form
+     * @param line The source line the suffix sits on
      */
-    void name(final String text, final boolean form) {
+    void name(final String text, final boolean form, final int line) {
         this.label = Optional.of(text);
+        this.labelled = line;
         if (form) {
             this.refusal = "method continuation not allowed on a test attribute";
         }
@@ -507,6 +529,7 @@ final class Level {
         this.bindings = 0;
         this.arg = 0;
         this.label = Level.NO_NAME;
+        this.labelled = this.start;
     }
 
     /**
@@ -610,6 +633,7 @@ final class Level {
 
     private void absorb(final Level other) {
         this.label = other.label;
+        this.labelled = other.labelled;
         this.formation = other.formation;
         this.atom = other.atom;
         this.taken = other.taken;

--- a/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnMethod.java
@@ -124,7 +124,7 @@ final class LnMethod implements Line {
             top.tie();
         }
         if (suffix.present()) {
-            top.name(suffix.label(), suffix.test());
+            top.name(suffix.label(), suffix.test(), this.span.line());
         }
         globals.clearBlanks();
         globals.markEmitted();

--- a/eo-parser/src/main/java/org/eolang/parser/Transition.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Transition.java
@@ -64,7 +64,7 @@ final class Transition {
                 this.span.line(), this.span.indent(), admission.violation()
             );
         }
-        admission.name(level);
+        admission.name(level, this.span.line());
         return level;
     }
 

--- a/eo-parser/src/test/java/org/eolang/parser/AdmissionTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/AdmissionTest.java
@@ -18,7 +18,7 @@ final class AdmissionTest {
     @Test
     void namesTheLevelWhenLabelIsGiven() {
         final Level level = new Stack().push(0, 1, Kind.HEAD, Openness.OPEN);
-        new Admission("nu", false).name(level);
+        new Admission("nu", false).name(level, 1);
         MatcherAssert.assertThat(
             "a level named through a non-null label must be recorded as named",
             level.named(),
@@ -29,7 +29,7 @@ final class AdmissionTest {
     @Test
     void leavesTheLevelUnnamedWhenLabelIsNull() {
         final Level level = new Stack().push(0, 1, Kind.HEAD, Openness.OPEN);
-        new Admission(null, false).name(level);
+        new Admission(null, false).name(level, 1);
         MatcherAssert.assertThat(
             "a level left untouched by a null label must stay unnamed",
             level.named(),

--- a/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
+++ b/eo-parser/src/test/java/org/eolang/parser/LevelTest.java
@@ -65,7 +65,7 @@ final class LevelTest {
         final Level level = new Level(
             0, 1, Kind.BARE_FORMATION, Openness.OPEN, Kind.TOP_LEVEL, false
         );
-        level.name("foo", false);
+        level.name("foo", false, 1);
         MatcherAssert.assertThat(
             "named() must report true once name() has been called",
             level.named(),
@@ -78,7 +78,7 @@ final class LevelTest {
         final Level level = new Level(
             2, 5, Kind.VMETHOD, Openness.OPEN, Kind.BARE_FORMATION, false
         );
-        level.name("intermediate", false);
+        level.name("intermediate", false, 5);
         level.sealed();
         MatcherAssert.assertThat(
             "sealed() must forget the name the replaced chain link carried",

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-naming-error-points-at-the-naming-line.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/only-phi-naming-error-points-at-the-naming-line.yaml
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets: []
+asserts:
+  - /object/errors[count(error)=1]
+  - /object/errors/error[contains(text(),'cannot be a named attribute of only-phi formation')]
+  - /object/errors/error[@line='4']
+input: |
+  [] > main
+    foo > [x] > f
+      bar
+      .baz > z


### PR DESCRIPTION
`Eo.checkNaming` reported the §4.5 violation at `level.start()`, the line the entry was pushed
on. For a vertical method chain that is the head line, while the name in the message came from
a later `.method` line, so the caret `Rows.underlined` draws landed on a line that does not
contain the attribute the message names.

`Level` now keeps the line of the suffix that set the label, next to the label itself: the push
line until a suffix claims the entry, the suffix's own line after that, and `sealed()` drops it
the way it drops the label when a `.method` continuation takes the entry over. The §4.5 error
reports that line.

A pack test for

```
[] > main
  foo > [x] > f
    bar
    .baz > z
```

On master it fails with `FAIL: /object/errors/error[@line='4']`, because the error sits on line
3, which is `bar`.

Closes #8189

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
