### PR TITLE
#8487: keep the receiver out of the all-or-nothing group

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/Emissions.java
+++ b/eo-parser/src/main/java/org/eolang/parser/Emissions.java
@@ -87,9 +87,11 @@ final class Emissions {
         if (Emissions.reversedDispatch(tokens, head)) {
             final boolean fragile = tokens.consumeDispatch();
             final List<Value> rargs = tokens.readArgs();
-            Bindings.checkAllOrNothing(rargs, span);
             if (!rargs.isEmpty()) {
                 Bindings.checkReceiver(rargs.get(0), span);
+                Bindings.checkAllOrNothing(
+                    rargs.subList(1, rargs.size()), span
+                );
             }
             emit.object(name, ".".concat(Emissions.reversedHead(head)), line, head.pos());
             if (fragile) {

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bound-reversed-application-inside-paren-group.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/bound-reversed-application-inside-paren-group.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+# The receiver of a reversed dispatch is the target, not an argument, so it
+# stays out of the all-or-nothing group (R-6.6.3). The same expression is
+# legal on a line, and must be legal inside parentheses too.
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@base='Φ.false.if' and o[@base='Φ.number' and @as='a']]
+  - //o[@base='Φ.false.if' and o[@base='Φ.number' and @as='b']]
+input: |
+  [] > main
+    q.f (if. false 1:a 2:b) > z


### PR DESCRIPTION
`Emissions.expression` handed the whole argument list of a reversed dispatch to
`Bindings.checkAllOrNothing`, receiver included. R-6.6.3 keeps the receiver out of that group:
it is the dispatch target, it may never carry a binding, so it always read as unbound, became
the group's head, and every bound argument after it disagreed with it.

So `if. false 1:a 2:b > second` parsed clean on a line and the same expression came back as
`argument bindings must be all-or-nothing` inside parentheses. The two checks also ran in the
wrong order, so a real receiver binding was reported as an all-or-nothing failure at the wrong
token.

The two calls are now split the way `LnReversed.into` already splits them: the receiver goes
to `checkReceiver` first, the rest to `checkAllOrNothing`.

A pack test for `q.f (if. false 1:a 2:b) > z`. On master it fails with

```
FAIL: /object[not(errors)]
```

Closes #8487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
