### PR TITLE
#8486: ask VoidName for the name a vertical void is emitted under

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -103,7 +103,9 @@ final class LnVoid implements Line {
         this.checkTyped(level, slash);
         globals.clearBlanks();
         globals.markEmitted();
-        emit.object("ρ", "∅", this.span.line(), this.span.indent());
+        emit.object(
+            new VoidName("^").asString(), "∅", this.span.line(), this.span.indent()
+        );
     }
 
     private void attribute(
@@ -128,10 +130,13 @@ final class LnVoid implements Line {
         this.checkTyped(level, slash);
         globals.clearBlanks();
         globals.markEmitted();
-        emit.object(
-            suffix.attribute(this.span.line(), this.span.indent()),
-            "∅", this.span.line(), this.span.indent()
-        );
+        final String name;
+        if (suffix.form() == Suffix.Form.AUTO) {
+            name = suffix.attribute(this.span.line(), this.span.indent());
+        } else {
+            name = new VoidName(suffix.label()).asString();
+        }
+        emit.object(name, "∅", this.span.line(), this.span.indent());
         if (!suffix.handle().isEmpty()) {
             emit.local(suffix.handle());
         }


### PR DESCRIPTION
`VoidName` says of itself that the §9.3 table is the single source of truth for void-name
promotions and that every parameter loop asks it rather than deciding for itself. `LnVoid` was
the one place that did not: the receiver branch wrote the literal `"ρ"` into the emission, and
the attribute branch reached `φ` through `Suffix.attribute`, a second copy of the same mapping.

Both branches now ask `VoidName`. The auto-named form still goes through `Suffix.attribute`,
which is what mints the file-local handle for `? >>` and is not a §9.3 promotion at all.

No behaviour change, so no new test: `VoidName` maps `^` and `@` exactly as the two places it
replaces did, and the 814 parser packs stay green.

Closes #8486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
