### PR TITLE
#8491: read the receiver void through a run of spaces

### DIFF
--- a/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
+++ b/eo-parser/src/main/java/org/eolang/parser/LnVoid.java
@@ -61,9 +61,13 @@ import java.util.regex.Pattern;
 final class LnVoid implements Line {
 
     /**
-     * The shape of a head that declares the formation's receiver.
+     * The shape of a head that declares the formation's receiver. A run
+     * of spaces of any length is admitted around the arrow, the way
+     * {@code Suffix} admits one around every other void name, so that
+     * {@code ?  > ^} is read as the receiver it is rather than sent to
+     * the attribute branch to be refused as a lowercase name.
      */
-    private static final Pattern RECEIVER = Pattern.compile(" > \\^ *");
+    private static final Pattern RECEIVER = Pattern.compile(" +> +\\^ *");
 
     /**
      * The line's source span.

--- a/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/receiver-void-with-extra-spaces.yaml
+++ b/eo-parser/src/test/resources/org/eolang/parser/eo-syntax/receiver-void-with-extra-spaces.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# A run of spaces around the arrow is admitted for every other void name,
+# so the receiver reads the same way instead of being refused as a name
+# that does not start with a lowercase letter (R-3.4.11).
+sheets: []
+asserts:
+  - /object[not(errors)]
+  - //o[@name='ρ' and @base='∅']
+input: |
+  [] > main
+    ?  >  ^
+    ? > x


### PR DESCRIPTION
The receiver form of a vertical void was matched by `" > \^ *"`, which admits exactly one space
on each side of the arrow, while every other void name goes through `Suffix`, whose `skipSpace`
swallows a run of any length. So `?  >  ^` missed the pattern, fell into the attribute branch,
and died with `name must start with a lowercase letter` about `^` — a legal void, and a message
about the wrong thing.

The pattern now admits a run of spaces the way the rest of the class does. Routing the receiver
through a parsed `Suffix` instead, as the issue suggests, is not a spacing change: `Suffix`
refuses `^` at parse time in `checkLowercaseStart`, so it would have to learn a new name shape
first, and that would make `x > ^` legal on every other line too.

A pack test for `?  >  ^`. On master it fails with

```
FAIL: /object[not(errors)]
```

Closes #8491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FQ2UqCcwzZn8F4SrY8tGrD
