### PR TITLE
#6677: clear the six bugs Sonar holds the gate on

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Dependencies.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Dependencies.java
@@ -29,6 +29,16 @@ interface Dependencies extends Iterable<Dep> {
     final class Fake implements Dependencies {
 
         /**
+         * The source of the random parts of a fake dependency.
+         *
+         * <p>One instance serves every call: a {@link SecureRandom} seeds
+         * itself from the operating system, and building a new one per
+         * dependency pays for that seeding again and, on a machine short of
+         * entropy, blocks while it waits for more.</p>
+         */
+        private static final Random RANDOM = new SecureRandom();
+
+        /**
          * Dependencies.
          */
         private final Collection<Dep> dependencies;
@@ -90,7 +100,7 @@ interface Dependencies extends Iterable<Dep> {
             return Dependencies.Fake.dep(
                 UUID.randomUUID().toString(),
                 UUID.randomUUID().toString(),
-                String.valueOf(new SecureRandom().nextInt(Integer.MAX_VALUE)),
+                String.valueOf(Dependencies.Fake.RANDOM.nextInt(Integer.MAX_VALUE)),
                 scope
             );
         }
@@ -110,12 +120,9 @@ interface Dependencies extends Iterable<Dep> {
         }
 
         private static Dep randDep() {
-            final Random rand = new SecureRandom();
-            return Dependencies.Fake.dep(
-                UUID.randomUUID().toString(),
-                UUID.randomUUID().toString(),
-                String.valueOf(rand.nextInt(Integer.MAX_VALUE)),
-                    new String[]{"test", "compiled", "runtime"}[rand.nextInt(3)]
+            final String[] scopes = {"test", "compiled", "runtime"};
+            return Dependencies.Fake.randDep(
+                scopes[Dependencies.Fake.RANDOM.nextInt(scopes.length)]
             );
         }
 

--- a/eo-runtime/src/main/java/org/eolang/BytesRaw.java
+++ b/eo-runtime/src/main/java/org/eolang/BytesRaw.java
@@ -202,7 +202,7 @@ final class BytesRaw implements Bytes {
             } else {
                 byte dst = (byte) (bytes[source] << mod);
                 if (source + 1 < bytes.length) {
-                    dst |= (byte) (bytes[source + 1] >>> (Byte.SIZE - mod) & carry & 0xFF);
+                    dst |= (byte) ((bytes[source + 1] & 0xFF) >>> (Byte.SIZE - mod) & carry);
                 }
                 bytes[index] = dst;
             }
@@ -219,7 +219,7 @@ final class BytesRaw implements Bytes {
             } else {
                 byte dst = (byte) ((0xFF & bytes[source]) >>> mod);
                 if (source - 1 >= 0) {
-                    dst |= (byte) (bytes[source - 1] << (Byte.SIZE - mod) & carry & 0xFF);
+                    dst |= (byte) ((bytes[source - 1] & 0xFF) << (Byte.SIZE - mod) & carry);
                 }
                 bytes[index] = dst;
             }

--- a/eo-runtime/src/main/java/org/eolang/ExAbstract.java
+++ b/eo-runtime/src/main/java/org/eolang/ExAbstract.java
@@ -58,7 +58,7 @@ public abstract class ExAbstract extends RuntimeException {
      * @param stack Whether the Java stack trace is worth recording, which it
      *  is not for an exception thrown as control flow
      */
-    public ExAbstract(final String cause, final Throwable root, final boolean stack) {
+    protected ExAbstract(final String cause, final Throwable root, final boolean stack) {
         super(cause, root, true, stack);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/ExAbstract.java
+++ b/eo-runtime/src/main/java/org/eolang/ExAbstract.java
@@ -47,6 +47,18 @@ public abstract class ExAbstract extends RuntimeException {
      * @param root Root cause exception
      */
     public ExAbstract(final String cause, final Throwable root) {
-        super(cause, root);
+        this(cause, root, true);
+    }
+
+    /**
+     * Ctor.
+     *
+     * @param cause Exception cause
+     * @param root Root cause exception
+     * @param stack Whether the Java stack trace is worth recording, which it
+     *  is not for an exception thrown as control flow
+     */
+    public ExAbstract(final String cause, final Throwable root, final boolean stack) {
+        super(cause, root, true, stack);
     }
 }

--- a/eo-runtime/src/main/java/org/eolang/ExAgain.java
+++ b/eo-runtime/src/main/java/org/eolang/ExAgain.java
@@ -10,7 +10,8 @@ package org.eolang;
  * <p>{@link PhAgain} throws it when the call it wraps is forced, and the
  * nearest {@link PhLoop} catches it and carries on with the object it holds,
  * instead of letting the Java stack grow by one more level per iteration.
- * It is control flow rather than an error, so it records no stack trace.
+ * It is control flow rather than an error, so it asks {@link Throwable} for
+ * no stack trace at all, rather than throwing the recorded one away after.
  * One that escapes every loop is a defect of the transpiler, and
  * {@link Main} reports it with the message set here.</p>
  *
@@ -34,7 +35,7 @@ public final class ExAgain extends ExAbstract {
      * @param phi The next copy of the formation
      */
     public ExAgain(final Phi phi) {
-        super("A tail call was forced outside of its loop");
+        super("A tail call was forced outside of its loop", null, false);
         this.next = phi;
     }
 
@@ -45,10 +46,5 @@ public final class ExAgain extends ExAbstract {
      */
     public Phi next() {
         return this.next;
-    }
-
-    @Override
-    public Throwable fillInStackTrace() {
-        return this;
     }
 }

--- a/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
+++ b/eo-runtime/src/test/java/org/eolang/BytesOfTest.java
@@ -122,7 +122,9 @@ final class BytesOfTest {
         "0xFF000000,   8, 0x00FF0000",
         "0xFF000000,  16, 0x0000FF00",
         "0xFF000000,  24, 0x000000FF",
-        "0x000000FF,   8, 0x00000000"
+        "0x000000FF,   8, 0x00000000",
+        "0x00000080,  -1, 0x00000100",
+        "0x0000FF80,  -4, 0x000FF800"
     })
     void checksShift(final long num, final int bits, final long expected) {
         MatcherAssert.assertThat(

--- a/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
+++ b/eo-runtime/src/test/java/org/eolang/posix/GettimeofdaySyscallTest.java
@@ -24,7 +24,7 @@ final class GettimeofdaySyscallTest {
     void reportsSecondsCloseToCurrentWallClockTime() {
         MatcherAssert.assertThat(
             "gettimeofday must report seconds close to the current wall-clock time, not a value corrupted by a mismatched NativeLong/Java long field width",
-            new Dataized(this.output().take("seconds")).asNumber().doubleValue(),
+            new Dataized(this.output().take("seconds")).asNumber(),
             Matchers.closeTo(System.currentTimeMillis() / 1000.0, 5.0)
         );
     }


### PR DESCRIPTION
Closes #6677.

`new_reliability_rating` is still 3 (C) against A on `master` — I re-read the gate today and the other four conditions pass, so reliability is the whole of it. The list of open `BUG` issues is down to six from the eleven the ticket names, and this closes all six, which should take the rating to A.

| where | what Sonar says | what this does |
|---|---|---|
| `Dependencies.java:93,113` (CRITICAL ×2) | Save and re-use this `Random` | one `SecureRandom` for the class, instead of one per fake dependency — each new one re-seeds from the OS and can block for entropy. `randDep()` now delegates to `randDep(scope)` rather than repeating it |
| `BytesRaw.java:205,222` (MAJOR ×2) | Prevent `int` promotion by adding `& 0xff` | the operand is masked before the shift. The masks that already sat after the shift (`& carry`, `& 0xFF`) make the old expressions produce the same byte, so no behaviour changes — but the reader had to prove that, and the checker could not |
| `ExAgain.java:51` (MAJOR) | Make this method `synchronized` to match the parent | `fillInStackTrace` is gone. Asking `Throwable` for no stack trace at construction is what the override was imitating, and it costs no monitor on a path taken once per loop iteration. Adding `synchronized` instead trades this bug for PMD's `AvoidSynchronizedAtMethodLevel` |
| `GettimeofdaySyscallTest.java:27` (MINOR) | Remove the unboxing from `Double` | the `Double` goes to `closeTo` whole, rather than being unboxed and boxed again |

`shift` had no case for a sub-byte left shift over a byte with its high bit set — the one shape the promotion on line 205 could have spoiled — so `BytesOfTest` gets two rows that cover it. They pass before and after, as expected.

`mvn -Pqulice -Deo.skip clean process-classes qulice:check` is clean on both modules, and the `eo-runtime` unit tests around the touched classes pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012YLE3PkTV72EUWXbGKpgD9

---
_Generated by [Claude Code](https://claude.ai/code/session_012YLE3PkTV72EUWXbGKpgD9)_