### PR TITLE
Stop freezing a site on a rewrite that died this pass

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Dispatched.java
@@ -142,6 +142,42 @@ final class Dispatched {
         return found;
     }
 
+    /**
+     * The dispatches nothing else can answer, said as the tables say them.
+     *
+     * <p>A rewrite into what fills a void dies where the filling is not
+     * settled yet, and {@link Filled} answers nothing rather than hand back
+     * the name it was asked about (#8351). Where the passes have stopped
+     * learning, no filling is going to settle either, and the name the tables
+     * give is all there is to say: the {@code leaf} of whatever fills
+     * {@code x}, rooted at the void and true of every caller. Asked last so
+     * that a site is given up on only once, and only about a site no pair
+     * covers, since a name already worked out is not worth replacing with the
+     * one it was worked out from.</p>
+     *
+     * @param pairs The pairs, each name against the one it is a copy of
+     * @return The dispatches nothing rewrote, each against the name the tables
+     *  give it, empty when every one of them is answered already
+     */
+    Map<String, String> guesses(final Map<String, String> pairs) {
+        final Map<String, String> names = new Ends(pairs).names();
+        final Provided owned = new Provided(this.given, names, this.hollows);
+        final Map<String, String> found = new HashMap<>(0);
+        for (final Site dispatch : this.all) {
+            final String made = dispatch.made();
+            final String bearer = dispatch.bearer();
+            if (!bearer.isEmpty() && !pairs.containsKey(made)) {
+                final String kept = owned.attribute(
+                    names.getOrDefault(bearer, bearer), dispatch.name()
+                );
+                if (this.better(kept, "", made)) {
+                    found.put(made, kept);
+                }
+            }
+        }
+        return found;
+    }
+
     private boolean rooted(final String type) {
         return !this.hollows.isEmpty() && new Rooted(this.hollows).covers(type);
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Filled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Filled.java
@@ -53,6 +53,16 @@ import java.util.Map;
  * it up leaves hundreds of names rooted at a void again while settling almost
  * nothing (#8571).</p>
  *
+ * <p>A walk that dies answers nothing at all, rather than handing back the
+ * name it was asked about. The two are not the same question: a void nobody
+ * fills is the answer, while a void this call fills with something the passes
+ * have not settled yet is an answer nobody has worked out. Writing the second
+ * one down as if it were the first froze it, since {@link Dispatched} asks
+ * again only about a name rooted at a void and takes one rooted answer for
+ * another only when the second stands under the first. The {@code if} of a
+ * {@code recovered} is a {@code Φ.bool.if}, which is rooted at a void as well,
+ * so the site kept the name of a void the line above it fills (#8351).</p>
+ *
  * <p>Only the arms of those formations are counted. An argument is relayed to
  * every formation the void might hold, because which one it turns out to be is
  * not known where the argument is written, and a single stray relay among the
@@ -111,8 +121,9 @@ final class Filled {
      * @param answer The type of the attribute, as the table gave it
      * @param bearer The locator of the receiver the question was asked of
      * @param site The locator of the call the question is asked at
-     * @return The type the answer stands for here, or the answer itself when
-     *  no caller says what the void holds
+     * @return The type the answer stands for here, the answer itself when no
+     *  caller says what the void holds, or an empty string when a caller says
+     *  and the walk into what it put there has nowhere to go yet
      */
     String instead(final String answer, final String bearer, final String site) {
         return this.instead(answer, bearer, site, new HashSet<>(0));
@@ -138,7 +149,7 @@ final class Filled {
                 found = this.branch(answer, fillings, bearer, site, seen);
             } else {
                 found = this.asked(
-                    fillings.get(longest), answer.substring(longest.length() + 1), answer
+                    fillings.get(longest), answer.substring(longest.length() + 1)
                 );
             }
         }
@@ -215,9 +226,9 @@ final class Filled {
         final Collection<String> seen
     ) {
         String found = this.asked(
-            handed, answer.substring(Math.min(root.length() + 1, answer.length())), answer
+            handed, answer.substring(Math.min(root.length() + 1, answer.length()))
         );
-        if (found.equals(answer)) {
+        if (found.isEmpty()) {
             found = this.instead(answer, handed, site, seen);
         }
         return found;
@@ -271,7 +282,7 @@ final class Filled {
         }
     }
 
-    private String asked(final String start, final String names, final String back) {
+    private String asked(final String start, final String names) {
         String walked = start;
         int from = 0;
         while (from < names.length() && !walked.isEmpty()) {
@@ -281,9 +292,6 @@ final class Filled {
             }
             walked = this.owned.attribute(walked, names.substring(from, next));
             from = next + 1;
-        }
-        if (walked.isEmpty()) {
-            walked = back;
         }
         return walked;
     }

--- a/eo-inference/src/main/java/org/eolang/inference/Settled.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Settled.java
@@ -15,12 +15,20 @@ import java.util.Map;
  * nothing. Pairs are only ever added, of which there are finitely many, so it
  * settles.</p>
  *
- * <p>There are two things to ask, and the second is asked only when the first
- * has nothing left to say. A dispatch is answered from what the tables hold
+ * <p>There are three things to ask, and each is asked only when the one before
+ * it has nothing left to say. A dispatch is answered from what the tables hold
  * and costs a walk of them; what a void holds is answered from the whole of
  * the program's call sites and costs a table built to be read once, so it is
  * worth asking when a pass would otherwise be the last. Every void it names
  * opens the dispatches rooted at that void, and the passes go round again.</p>
+ *
+ * <p>The third is what to write down about a dispatch neither of them ever
+ * answered. A question asked of a void is rewritten into a question asked of
+ * what fills it, and until the filling settles the rewrite has nowhere to go;
+ * a pass that wrote the unrewritten name down then would freeze a site the
+ * next pass could have answered (#8351). So the name the tables give is asked
+ * for last, once the other two have stopped learning, and a site given up on
+ * that way is one no filling was ever going to settle.</p>
  *
  * @since 0.69.0
  * @todo #8274:90min Settle a chain in fewer passes than it has hops.
@@ -81,6 +89,9 @@ final class Settled {
         Map<String, String> found = this.made.answers(pairs);
         if (found.isEmpty()) {
             found = this.more.from(pairs);
+        }
+        if (found.isEmpty()) {
+            found = this.made.guesses(pairs);
         }
         return found;
     }

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-rewrite-that-dies-this-pass-is-not-an-answer.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-rewrite-that-dies-this-pass-is-not-an-answer.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# `app` asks `m` of what `hold` hands back, which is whatever went into its
+# `value`, and a `step` went in. So the question becomes the `m` of a `step`,
+# and a `step` hands back a `pick`, whose `m` is the answer. The two passes
+# that takes are the whole point: on the first one nobody has settled what a
+# `step` is worth yet, so the rewritten question has no answer and the walk
+# dies. The unrewritten name is not what the site is, it is what the site
+# looks like before anyone has done the work, and writing it down is what
+# kept the answer from ever improving: `Φ.pick.m` is rooted at a void too, so
+# a pair already rooted at `Φ.hold.value` would not give way to it. Two
+# fillings keep `hold`'s void from being worth one name, so the rewrite at the
+# call site is the only way through.
+eo:
+  pick.eo: |
+    [m] > pick
+      m > @
+  maker.eo: |
+    [] > maker
+      pick 7 > pass
+  hold.eo: |
+    [] > hold /A
+      ? > value /A?
+      ? > alternative /A
+  step.eo: |
+    [] > step
+      hold > inner
+        maker
+        0
+      inner.pass > @
+  app.eo: |
+    [] > app
+      hold > held
+        step
+        0
+      held.m > @
+links:
+  - "/links/type[@id='Φ.step.φ']/ref[@loc='Φ.maker.pass']"
+  - "/links/type[@id='Φ.app.φ']/ref[@loc='Φ.pick.m']"


### PR DESCRIPTION
A question asked of a void gets rewritten into the same question asked of what
fills it. On an early pass the filling is not settled yet, so the walk into it
has nowhere to go, and `Filled` used to hand the unrewritten name back. That
name then went into the pairs as the answer, and the site was stuck: a name
rooted at a void gives way only to a name it stands under, and a void rooted
somewhere else never stands under it. `file.eo:115` sat on `Φ.recovered.value.if`
for the rest of the run while `Φ.bool.if` was offered and refused, pass after
pass.

A dead walk now answers nothing, and the name the tables give is asked for last,
once the other two asks have stopped learning:

```java
Map<String, String> found = this.made.answers(pairs);
if (found.isEmpty()) {
    found = this.more.from(pairs);
}
if (found.isEmpty()) {
    found = this.made.guesses(pairs);
}
```

Over `eo-runtime` this moves 99 answers and drops one row, a member of
`Φ.recovered.value` that existed only because the frozen name asked for it. The
headline is unchanged at 87.4% named.

Only one of the 99 gets shorter, and it is the one the ticket names. The other
98 are the same fallback name spelled longer: the expression that produces it
has not changed, but it now runs on the last round rather than the first, so the
receiver it is built on has settled and the name carries more of the program's
own chain. All 98 rested on a void before and rest on one after. `file.eo:115` reads `Φ.bool.if` now.
`directory/deleted.eo` stays rooted at a void as the ticket expects, though at
`Φ.bool.if.called...` rather than at `Φ.directory.deleted.ρ.walk` — reaching the
latter needs the rewrite to walk two hops, through `recovered` into what its own
`value` was bound to at that call, which is a separate hole.

The pack is the reproduction: five files, a void filled two ways so that nothing
can promote it, and a rewrite that only settles on the second pass.

Closes #8351
