### PR TITLE
#6637: hand every PhCoverage wrapper of a class one set of hits

### DIFF
--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjCoverageReport.java
@@ -49,12 +49,12 @@ import org.eolang.parser.EoSyntax;
  * <p>The raw hits are read one line at a time and never held together in
  * memory. What the report keeps out of them is one counter per line of
  * source, so its own size is bounded by the manifest, but the file the
- * runtime appends to is not: every {@code PhCoverage} wrapper starts with
- * a dedup set of its own, so a location touched through many instances of
- * the same object is appended once per instance (#6508), and a whole test
- * suite leaves gigabytes of duplicates behind for the few thousand
- * distinct locations in them. Reading that file into a list first is what
- * killed the {@code eo-runtime} coverage build with an
+ * runtime appends to is not: a location is written once per generated
+ * class per JVM, so every surefire fork appends its own copy of the few
+ * thousand distinct locations, and while every {@code PhCoverage} wrapper
+ * still started a dedup set of its own (#6508), a whole test suite left
+ * gigabytes of duplicates behind. Reading that file into a list first is
+ * what killed the {@code eo-runtime} coverage build with an
  * {@code OutOfMemoryError} once it outgrew the 4Gb heap
  * {@code .mvn/jvm.config} gives Maven.</p>
  *

--- a/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
+++ b/eo-maven-plugin/src/main/resources/org/eolang/maven/transpile/to-java.xsl
@@ -214,10 +214,24 @@
     </xsl:if>
     <xsl:text> {</xsl:text>
     <xsl:value-of select="eo:eol(1)"/>
+    <xsl:call-template name="hits"/>
     <xsl:apply-templates select="." mode="ctors"/>
     <xsl:apply-templates select="nested"/>
     <xsl:text>}</xsl:text>
     <xsl:value-of select="eo:eol(0)"/>
+  </xsl:template>
+  <!--
+  The set of hits every PhCoverage wrapper of the class shares. A wrapper
+  is built anew each time the attribute holding it is composed, so a set
+  of its own would let the same location reach the file once per instance
+  of the object (#6508). One static set per class outlives them all, and
+  the nested classes read it as well.
+  -->
+  <xsl:template name="hits">
+    <xsl:if test="$coverage='true'">
+      <xsl:text>private static final java.util.Set&lt;String&gt; HITS = java.util.concurrent.ConcurrentHashMap.newKeySet();</xsl:text>
+      <xsl:value-of select="eo:eol(1)"/>
+    </xsl:if>
   </xsl:template>
   <!-- Nested classes for anonymous abstract objects -->
   <xsl:template match="nested">
@@ -681,7 +695,7 @@
       <xsl:value-of select="$name"/>
       <xsl:text> = new PhCoverage(</xsl:text>
       <xsl:value-of select="$name"/>
-      <xsl:text>, "</xsl:text>
+      <xsl:text>, HITS, "</xsl:text>
       <xsl:value-of select="eo:literal(@loc)"/>
       <xsl:text>:</xsl:text>
       <xsl:value-of select="@line"/>
@@ -795,6 +809,7 @@
       </xsl:otherwise>
     </xsl:choose>
     <xsl:value-of select="eo:eol(1)"/>
+    <xsl:call-template name="hits"/>
     <xsl:apply-templates select="." mode="testing-ctors"/>
     <xsl:apply-templates select="." mode="tests"/>
     <xsl:apply-templates select="nested"/>

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/MjTranspileTest.java
@@ -320,6 +320,30 @@ final class MjTranspileTest {
     }
 
     @Test
+    void handsOneSetOfHitsToEveryPhCoverageWrapperOfAClass(@Mktmp final Path temp)
+        throws Exception {
+        MatcherAssert.assertThat(
+            "the class must declare one static set of hits and hand it to every PhCoverage wrapper, but it didnt",
+            new TextOf(
+                new FakeMaven(temp)
+                    .withProgram(MjTranspileTest.program())
+                    .with("coverage", true)
+                    .execute(new PpTranspile())
+                    .result()
+                    .get(MjTranspileTest.compiled())
+            ).asString(),
+            Matchers.allOf(
+                Matchers.stringContainsInOrder(
+                    "public final class EOmain",
+                    "private static final java.util.Set<String> HITS",
+                    "new PhCoverage("
+                ),
+                Matchers.not(Matchers.matchesRegex("(?s).*new PhCoverage\\(\\w+, \".*"))
+            )
+        );
+    }
+
+    @Test
     void excludesThrowingCasesFromPhCoverageWhenTrackingEnabled(@Mktmp final Path temp)
         throws Exception {
         MatcherAssert.assertThat(

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/keeps-the-set-of-hits-out-of-a-class-by-default.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/transpile-packs/keeps-the-set-of-hits-out-of-a-class-by-default.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+sheets:
+  - /org/eolang/parser/parse/set-locators.xsl
+  - /org/eolang/maven/transpile/set-original-names.xsl
+  - /org/eolang/maven/transpile/classes.xsl
+  - /org/eolang/maven/transpile/attrs.xsl
+  - /org/eolang/maven/transpile/data.xsl
+  - /org/eolang/maven/transpile/to-java.xsl
+asserts:
+  - /object[not(errors)]
+  - //java[contains(text(), 'new PhSafe(')]
+  - //java[not(contains(text(), 'HITS'))]
+input: |
+  [] > main
+    42.plus 43 > @

--- a/eo-runtime/src/main/java/org/eolang/PhCoverage.java
+++ b/eo-runtime/src/main/java/org/eolang/PhCoverage.java
@@ -19,11 +19,15 @@ import java.util.concurrent.ConcurrentHashMap;
  * An object that records a coverage hit of its source location when
  * it is touched, and delegates everything to the origin.
  *
- * <p>The transpiler emits it around every located object. Recording is
- * enabled by the {@code eo.coverageFile} system property: on the first
- * touch, one {@code loc:line:pos} line is appended, at most once per
- * wrapper per configured destination; without the property every hit is
- * a silent no-op. The property
+ * <p>The transpiler emits it around every located object and hands all
+ * the wrappers of one generated class the same set of hits, since a
+ * wrapper is built anew each time the attribute holding it is composed,
+ * and a set of its own would let one location reach the file once per
+ * instance of the object. Recording is enabled by the
+ * {@code eo.coverageFile} system property: on the first touch, one
+ * {@code loc:line:pos} line is appended, at most once per set per
+ * configured destination; without the property every hit is a silent
+ * no-op. The property
  * is re-read on every touch (not cached at class load), since this
  * class is now instantiated around every located object in every EO
  * program: the very first one touched anywhere in the JVM would
@@ -37,26 +41,20 @@ import java.util.concurrent.ConcurrentHashMap;
  * program).</p>
  *
  * @since 0.58
- * @todo #6508:30min Let one set of hits span the whole program. Every wrapper
- *  the transpiler builds starts with an empty set of its own, so a location
- *  touched through many instances of the same object is appended to the file
- *  once per instance, the file fills up with duplicates, and every wrapper
- *  pays for a set it shares with nobody. The generated code should hand the
- *  same set to every wrapper it builds.
  */
 public final class PhCoverage implements Phi {
 
     /** The origin. */
     private final Phi origin;
 
-    /** Locations written by this object and its copies, per destination. */
+    /** Locations written by every wrapper sharing this set, per destination. */
     private final Set<String> hits;
 
     /** The location to write, as {@code loc:line:pos}. */
     private final String record;
 
     /**
-     * Ctor.
+     * Ctor, with a set of hits of its own.
      *
      * @param phi The origin
      * @param mark The location to write, as {@code loc:line:pos}
@@ -66,7 +64,7 @@ public final class PhCoverage implements Phi {
     }
 
     /**
-     * Ctor.
+     * Ctor, with a set of hits shared with other wrappers.
      *
      * @param phi The origin
      * @param seen Locations written already, per destination

--- a/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
+++ b/eo-runtime/src/test/java/org/eolang/PhCoverageTest.java
@@ -12,6 +12,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hamcrest.MatcherAssert;
@@ -70,6 +72,34 @@ final class PhCoverageTest {
                 "every location, hit repeatedly and through a copy, must be recorded exactly once",
                 Files.readAllLines(hits, StandardCharsets.UTF_8),
                 Matchers.containsInAnyOrder("Φ.foo:7:3", "Φ.bar:9:5")
+            );
+        } finally {
+            if (before == null) {
+                System.clearProperty("eo.coverageFile");
+            } else {
+                System.setProperty("eo.coverageFile", before);
+            }
+        }
+    }
+
+    @Test
+    void recordsALocationOnceAcrossWrappersSharingASet(@Mktmp final Path temp)
+        throws Exception {
+        final Path hits = temp.resolve("hits.txt");
+        final String before = System.getProperty("eo.coverageFile");
+        System.setProperty("eo.coverageFile", hits.toString());
+        try {
+            final Set<String> shared = ConcurrentHashMap.newKeySet();
+            new Dataized(
+                new PhCoverage(new PhDefault(new byte[] {(byte) 0x2A}), shared, "Φ.shared:5:9")
+            ).take();
+            new Dataized(
+                new PhCoverage(new PhDefault(new byte[] {(byte) 0x2B}), shared, "Φ.shared:5:9")
+            ).take();
+            MatcherAssert.assertThat(
+                "a location hit through two wrappers sharing one set must be recorded once, but it wasnt",
+                Files.readAllLines(hits, StandardCharsets.UTF_8),
+                Matchers.contains("Φ.shared:5:9")
             );
         } finally {
             if (before == null) {


### PR DESCRIPTION
Closes #6637

Every `PhCoverage` wrapper the transpiler built started a set of hits of its own, and a wrapper is built anew each time the attribute holding it is composed, so one location reached `eo.coverageFile` once per instance of the object. `to-java.xsl` now declares one static set per generated class and hands it to every wrapper, so a location is written once per class per JVM. The puzzle text is removed from `PhCoverage`.

@yegor256 Could you please take a look

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKVckkJjdzaRapxQ3rKJWH
