### PR TITLE
Count a void's fillings by type, not by locator

### DIFF
--- a/eo-inference/src/main/java/org/eolang/inference/Behaviours.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Behaviours.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.github.lombrozo.xnav.Xnav;
+import com.jcabi.xml.XML;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * The name every type of the program behaves as, as the table says it.
+ *
+ * <p>{@link Behaved} works the name out and {@link Reduced} writes it on the
+ * row, so whoever comes after them has only to read the cell. It is read back
+ * rather than worked out again because the two are the same fact, and a
+ * program whose pages say one thing and whose census counts another has no
+ * answer to give about which of them is the program.</p>
+ *
+ * <p>A row that behaves as itself says nothing and is left out, so what comes
+ * back is the types that go by another name, and a reader who finds nothing
+ * here about a type has the name it came with.</p>
+ *
+ * @since 0.73.0
+ */
+final class Behaviours {
+
+    /**
+     * The provides table.
+     */
+    private final XML table;
+
+    /**
+     * Ctor.
+     *
+     * @param provides The provides table, as {@link Reduced} left it
+     */
+    Behaviours(final XML provides) {
+        this.table = provides;
+    }
+
+    /**
+     * The name every type behaves as.
+     *
+     * @return The name to go by, by the locator of the type, without the types
+     *  that behave as themselves
+     */
+    Map<String, String> all() {
+        final Map<String, String> found = new LinkedHashMap<>(0);
+        for (final Xnav row : new Rows(this.table).all()) {
+            final Noted noted = new Noted(row);
+            final String behaves = noted.says("reduced");
+            if (!behaves.isEmpty()) {
+                found.put(noted.says("id"), behaves);
+            }
+        }
+        return found;
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Counted.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Counted.java
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * What was put into one void, each thing counted once for the type it is.
+ *
+ * <p>{@link Fillings} keeps a filling by the name the walk gave it, which is
+ * the locator of an object, and two objects can be one type: a
+ * {@code Φ.bytes.as-bytes} hands back the object it was dispatched on and is a
+ * {@code Φ.bytes}, so a void filled with one of those here and with a plain
+ * {@code Φ.bytes} there is filled one way twice. Counted apart they leave the
+ * void holding a choice between two names for one thing, which nobody can
+ * answer and which {@link Sole} rightly refuses. {@link Behaved} works out
+ * that name and {@link Reduced} writes it on the row, so the fact is in the
+ * table before anybody counts.</p>
+ *
+ * <p>The counting waits until the walk is over. What is folded together here
+ * is a name, and the objects behind it stay apart for as long as anybody has
+ * business with them: {@link Handed} gives a chunk to the first void of every
+ * formation an atom is handed, and two scopes that behave alike are still two
+ * scopes, each with a void of its own to fill. Fold them early and eleven of
+ * them are left holding nothing.</p>
+ *
+ * @since 0.73.0
+ */
+final class Counted {
+
+    /**
+     * What was put in, by the name the walk gave it, from {@link Fillings}.
+     */
+    private final Map<String, Type> told;
+
+    /**
+     * The name every type behaves as, from {@link Behaviours}.
+     */
+    private final Map<String, String> behaves;
+
+    /**
+     * Ctor.
+     *
+     * @param members What was put in, by the name the walk gave it
+     * @param reduced The name every type behaves as, empty where the table has
+     *  not been asked the question yet
+     */
+    Counted(final Map<String, Type> members, final Map<String, String> reduced) {
+        this.told = members;
+        this.behaves = reduced;
+    }
+
+    /**
+     * What was put in, one member to a type.
+     *
+     * @return The types, in the order they were first seen
+     */
+    Collection<Type> all() {
+        final Map<String, Type> found = new LinkedHashMap<>(0);
+        for (final Map.Entry<String, Type> member : this.told.entrySet()) {
+            found.putIfAbsent(
+                this.behaves.getOrDefault(member.getKey(), member.getKey()),
+                member.getValue()
+            );
+        }
+        return found.values();
+    }
+}

--- a/eo-inference/src/main/java/org/eolang/inference/Fillings.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Fillings.java
@@ -21,8 +21,10 @@ import java.util.Map;
  * <p>What goes in is gathered as a type rather than as a locator, which is
  * what makes the answer worth reading: the {@code φ} of {@code Φ.bytes} is
  * filled 7,752 times and all but a handful of those fillings are literals. As
- * types there are two of them, a datum and a {@code Φ.bytes.as-bytes}; as
- * locators there are 7,752.</p>
+ * types there are two of them, a datum and a {@code Φ.bytes}; as locators
+ * there are 7,752. The handful arrive as a {@code Φ.bytes.as-bytes}, which is
+ * a {@code Φ.bytes} and is counted as one by {@link Counted}, once the walk is
+ * over.</p>
  *
  * <p>Which type a filling is counted as is {@link Landed}'s question, and it
  * has to be asked of the links rather than of {@link Ends} alone. An argument
@@ -123,9 +125,10 @@ final class Fillings {
         while (atoms.fills(placed, walked)) {
             walked = new Carried(placed, handed).all();
         }
+        final Map<String, String> behaves = new Behaviours(this.given).all();
         final Map<String, Collection<Type>> found = new LinkedHashMap<>(0);
         for (final Map.Entry<String, Map<String, Type>> hollow : walked.entrySet()) {
-            found.put(hollow.getKey(), hollow.getValue().values());
+            found.put(hollow.getKey(), new Counted(hollow.getValue(), behaves).all());
         }
         return found;
     }

--- a/eo-inference/src/test/java/org/eolang/inference/BehavioursTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/BehavioursTest.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import com.jcabi.xml.XMLDocument;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Behaviours}.
+ *
+ * @since 0.73.0
+ */
+final class BehavioursTest {
+
+    @Test
+    void readsTheNameATypeBehavesAs() {
+        MatcherAssert.assertThat(
+            "the name on the row must come back against the type, but it didnt",
+            new Behaviours(
+                new XMLDocument("<provides><type id='Φ.alias' reduced='Φ.oak'/></provides>")
+            ).all(),
+            Matchers.hasEntry("Φ.alias", "Φ.oak")
+        );
+    }
+
+    @Test
+    void leavesOutATypeThatBehavesAsItself() {
+        MatcherAssert.assertThat(
+            "a type with no other name to go by must be left out, but it was let in",
+            new Behaviours(
+                new XMLDocument("<provides><type id='Φ.oak'/></provides>")
+            ).all(),
+            Matchers.anEmptyMap()
+        );
+    }
+}

--- a/eo-inference/src/test/java/org/eolang/inference/CountedTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/CountedTest.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+package org.eolang.inference;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link Counted}.
+ *
+ * @since 0.73.0
+ */
+final class CountedTest {
+
+    @Test
+    void countsTwoNamesOfOneTypeOnce() {
+        final Map<String, Type> told = new LinkedHashMap<>(0);
+        told.put("Φ.oak", new Ref("Φ.oak"));
+        told.put("Φ.alias", new Ref("Φ.alias"));
+        MatcherAssert.assertThat(
+            "an alias that behaves as an oak is the oak, but it was counted apart from it",
+            new Counted(told, Collections.singletonMap("Φ.alias", "Φ.oak")).all(),
+            Matchers.hasSize(1)
+        );
+    }
+
+    @Test
+    void keepsTheObjectTheWalkArrivedAt() {
+        MatcherAssert.assertThat(
+            "a filling must stay the object it arrived as, but it was traded for a name",
+            new Counted(
+                Collections.singletonMap("Φ.alias", new Ref("Φ.alias")),
+                Collections.singletonMap("Φ.alias", "Φ.oak")
+            ).all().iterator().next().names(),
+            Matchers.equalTo("Φ.alias")
+        );
+    }
+
+    @Test
+    void countsTwoTypesApart() {
+        final Map<String, Type> told = new LinkedHashMap<>(0);
+        told.put("Φ.oak", new Ref("Φ.oak"));
+        told.put("Φ.elm", new Ref("Φ.elm"));
+        MatcherAssert.assertThat(
+            "an oak and an elm are two things, but they were counted as one",
+            new Counted(told, Collections.emptyMap()).all(),
+            Matchers.hasSize(2)
+        );
+    }
+}

--- a/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-filling-is-counted-as-the-type-it-behaves-as.yaml
+++ b/eo-maven-plugin/src/test/resources/org/eolang/maven/inference-packs/a-filling-is-counted-as-the-type-it-behaves-as.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# An `alias` has no behaviour of its own and the row says so: it is an `oak`.
+# So a void filled with an `oak` at one call site and with an `alias` at
+# another is filled one way twice, and counting the two apart leaves it holding
+# a choice between two names for one thing, which nobody can answer. What goes
+# into a void is counted as the type it behaves as, the way a literal is
+# counted as a datum rather than as the locator it was written at, and the
+# object that stays is the one the first caller wrote, since a name is all that
+# is folded here.
+eo:
+  app.eo: |
+    [] > app
+      inc oak > first
+      inc alias > second
+  inc.eo: |
+    [x] > inc
+      x.leaf > @
+  oak.eo: |
+    [] > oak
+      [] > leaf
+  alias.eo: |
+    [] > alias
+      oak > @
+provides:
+  - "/provides/type[@id='Φ.alias' and @reduced='Φ.oak']"
+  - "//type[@id='Φ.inc']/attr[@void='true']/witnessed[not(union)]/ref[@loc='Φ.oak']"


### PR DESCRIPTION
A void's witnesses were kept by the locator of whatever filled it, while
every other half of the table reports a type by the name it behaves as.
So a void filled with a `Φ.bytes` at one call site and with a
`Φ.bytes.as-bytes` at another looked filled two ways, the census wrote a
union, and `Sole` had nothing to answer with — though the two are one
type and the row says so.

The fold waits until the walk is over. It has to: `Handed` gives a chunk
to the first void of every formation an atom is handed, and two scopes
that behave alike are still two scopes, each with a void of its own.
Folding inside the walk leaves eleven of them holding nothing and hands
two others a chunk nobody put there. So `Forms` is untouched, and the
finished member map goes through `Counted`:

```java
for (final Map.Entry<String, Type> member : this.told.entrySet()) {
    found.putIfAbsent(
        this.behaves.getOrDefault(member.getKey(), member.getKey()),
        member.getValue()
    );
}
```

What is folded is a name; the object that stays is the one the walk
arrived at, so nothing downstream loses a locator it needs.

On eo-runtime: voids answered by one name go 427 to 487, none lost; the
`unknown` cap falls from 67 to 54; the census writes 1,061 members where
it wrote 1,135. `links.xml` comes out byte for byte what it was, since
`Witnessed` runs after `Resolved` and writes only `provides.xml`. 124 of
the report's answers move off a void, among them
`Φ.string.scanf.a🌵267-2.found` to `Φ.tuple` and `Φ.bytes.xor.x` to
`Φ.bytes`.

The pack `a-filling-is-counted-as-the-type-it-behaves-as.yaml` describes
it: an `alias` that is an `oak`, passed where an `oak` was passed before,
and the void left holding one of them.

Closes #8729.
