### PR TITLE
Write the inference numbers down and compare them on every pull request

### DIFF
--- a/.github/workflows/ladder-comment.yml
+++ b/.github/workflows/ladder-comment.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: ladder-comment
+'on':
+  workflow_run:
+    workflows: ["ladder"]
+    types:
+      - completed
+permissions:
+  pull-requests: write
+concurrency:
+  group: ladder-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+jobs:
+  # This job is handed the write the job that measured could not be given,
+  # because that one builds the code of the branch. Nothing of the branch is
+  # checked out here and nothing from it is run: the three files come out of
+  # the artifact and the only one that is read as anything but text is the
+  # pull request number, which is a number.
+  comment:
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    timeout-minutes: 15
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          name: ladder
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - id: numbers
+        run: |
+          number=$(tr -cd '0-9' < pr-number)
+          if [ -z "${number}" ]; then
+            echo 'The artifact carries no pull request number'
+            exit 1
+          fi
+          echo "pr=${number}" >> "${GITHUB_OUTPUT}"
+          echo "changed=$(tr -d '[:space:]' < changed)" >> "${GITHUB_OUTPUT}"
+      # A branch that moved nothing gets no new comment, only an older one
+      # brought up to date, so that a pull request which never touched the
+      # rules is not told about them.
+      - uses: mshick/add-pr-comment@v3
+        with:
+          issue: ${{ steps.numbers.outputs.pr }}
+          message-id: ladder
+          message-path: ladder.md
+          update-only: ${{ steps.numbers.outputs.changed == 'false' }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ladder-comment.yml
+++ b/.github/workflows/ladder-comment.yml
@@ -8,7 +8,12 @@ name: ladder-comment
     workflows: ["ladder"]
     types:
       - completed
+# The artifact belongs to another run, so reading it needs a scope of its
+# own. A `permissions` block that names one scope silences every scope it
+# does not name, and the download would answer 403.
 permissions:
+  actions: read
+  contents: read
   pull-requests: write
 concurrency:
   group: ladder-comment-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/ladder.yml
+++ b/.github/workflows/ladder.yml
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2016-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: ladder
+'on':
+  pull_request:
+    branches:
+      - master
+    # The numbers can only move when the rules move or when the program they
+    # are read from does. A branch that touches neither would spend two builds
+    # proving that nothing happened.
+    paths:
+      - 'eo-inference/**'
+      - 'eo-parser/**'
+      - 'eo-maven-plugin/src/main/**'
+      - 'eo-runtime/src/main/eo/**'
+permissions:
+  contents: read
+concurrency:
+  group: ladder-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  ladder:
+    timeout-minutes: 60
+    runs-on: ubuntu-24.04
+    steps:
+      # The depth is two, not zero: nothing is read here but the merge commit
+      # and its first parent. A full clone drags in `gh-pages`, which is about
+      # three gigabytes of generated site snapshots.
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v6
+        with:
+          distribution: 'temurin'
+          java-version: 26
+      - uses: actions/cache@v6
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-jdk-26-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-jdk-26-maven-
+      - uses: JesseTG/rm@v1.0.3
+        with:
+          path: ~/.m2/repository/org/eolang
+      - id: ladder
+        run: |
+          # The numbers are of eo-runtime, the only program here big enough for
+          # them to mean anything, and the goal that writes them runs in its
+          # `process-sources` phase. None of its Java is wanted, so the plugin
+          # and what it stands on are installed and that one phase is asked for
+          # afterwards. Both builds clean first, or the second one would read
+          # the XMIR of a source the first one had and this one has not.
+          measure() {
+            git checkout --quiet --force "$1"
+            mvn clean install -ntp --batch-mode --errors -DskipTests -Dinvoker.skip -pl eo-maven-plugin -am
+            mvn clean process-sources -ntp --batch-mode --errors -DskipTests -Deo.transpileTests=false -pl eo-runtime
+            # A base older than the goal that writes the file leaves the
+            # numbers empty, and every one of them then reads as new.
+            cp eo-runtime/target/eo/ladder.txt "$2" 2>/dev/null || : > "$2"
+          }
+          # The base must be the first parent of the merge commit we are
+          # standing on, not `pull_request.base.sha`: the latter is the base
+          # branch tip from the moment the branch was last synced, while the
+          # merge ref is recomputed against the current tip. Comparing the two
+          # makes every commit that landed on master meanwhile look like a
+          # change made by this branch.
+          head=$(git rev-parse HEAD)
+          base=$(git rev-parse "${head}^1")
+          measure "${base}" "${RUNNER_TEMP}/master.txt"
+          measure "${head}" "${RUNNER_TEMP}/branch.txt"
+          # Every line is a number and the name it goes by, the value first, so
+          # that nothing here has to know what any of them mean. Shares are
+          # written with a decimal point and rungs without one, and `awk` takes
+          # the difference of either.
+          declare -A was
+          while read -r total metric; do
+            was["${metric}"]="${total}"
+          done < "${RUNNER_TEMP}/master.txt"
+          rows="${RUNNER_TEMP}/rows.md"
+          : > "${rows}"
+          while read -r total metric; do
+            before="${was["${metric}"]:-}"
+            if [ -z "${before}" ]; then
+              printf '| %s | none | %s | new |\n' "${metric}" "${total}" >> "${rows}"
+            elif [ "${before}" != "${total}" ]; then
+              printf '| %s | %s | %s | %s |\n' "${metric}" "${before}" "${total}" \
+                "$(awk -v was="${before}" -v now="${total}" 'BEGIN { printf "%+g", now - was }')" >> "${rows}"
+            fi
+          done < "${RUNNER_TEMP}/branch.txt"
+          report="${RUNNER_TEMP}/ladder.md"
+          if [ -s "${rows}" ]; then
+            {
+              echo 'These inference numbers moved in this branch. A share is a'
+              echo 'percentage of every object in the program, and the rungs are'
+              echo 'the counts it is made of, which come along because a share on'
+              echo 'its own is a number to game:'
+              echo ''
+              echo '| Number | master | branch | change |'
+              echo '|:--|--:|--:|--:|'
+              cat "${rows}"
+              echo ''
+              echo "They come from \`eo-runtime/target/eo/ladder.txt\`, written by the \`inference\` goal."
+            } > "${report}"
+            echo 'changed=true' >> "${GITHUB_OUTPUT}"
+          else
+            echo 'None of the inference numbers moved in this branch' > "${report}"
+            echo 'changed=false' >> "${GITHUB_OUTPUT}"
+          fi
+          cat "${report}"
+      # Nothing is said on the pull request from here. This job builds the code
+      # of a branch that may come from a fork, and a job that does so must have
+      # a read-only token; the numbers travel to `ladder-comment.yml` instead,
+      # which builds nothing and can be trusted with the write.
+      - env:
+          NUMBER: ${{ github.event.pull_request.number }}
+          CHANGED: ${{ steps.ladder.outputs.changed }}
+        run: |
+          echo "${NUMBER}" > "${RUNNER_TEMP}/pr-number"
+          echo "${CHANGED}" > "${RUNNER_TEMP}/changed"
+      - uses: actions/upload-artifact@v7
+        with:
+          name: ladder
+          path: |
+            ${{ runner.temp }}/ladder.md
+            ${{ runner.temp }}/pr-number
+            ${{ runner.temp }}/changed

--- a/eo-inference/README.md
+++ b/eo-inference/README.md
@@ -97,6 +97,35 @@ empty row for every object would leave all four exactly where they are:
   9728  nothing left to find out
 ```
 
+### written down
+
+The line scrolls past, so the same numbers also go into `target/eo/ladder.txt`,
+beside the tables rather than among them, because they measure us and not the
+program:
+
+```text
+46896 objects
+81.0 named
+17.9 rooted at a void
+1.2 nothing known
+67.2 depth
+548 nothing at all
+8374 a name rooted at a void
+5953 a formation, voids still free
+22293 a formation, nothing left free
+9728 nothing left to find out
+```
+
+One number a line, the value first and the name of it after, so that a shell
+can read it with one `read` and know nothing about what any of it means. The
+rungs go down with the shares and not instead of them, for the reason above.
+
+A pull request that touches the rules, the parser, the plugin or the program
+they are read from is built twice by `.github/workflows/ladder.yml` — once at
+the branch and once at the commit it sits on — and every line that differs
+between the two files is posted on it as a table. A branch that moved nothing
+is told nothing.
+
 ## What it draws
 
 The three numbers say how much of a program we understand without saying which

--- a/eo-inference/src/main/java/org/eolang/inference/Depth.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Depth.java
@@ -16,9 +16,10 @@ import java.util.Map;
  *
  * <p>This reads the tables back and puts every object of the program on the
  * ladder {@link Answers} describes. It is a measurement of ourselves rather than a
- * fact about the program, so it writes nothing: what comes out is meant for the
- * log of the goal, where two builds of the same sources can be compared by
- * anybody, and not for a document beside the tables.</p>
+ * fact about the program, so what comes out is no table: the goal says it in
+ * the log and leaves {@link Ladder#asString()} in a file beside the tables
+ * rather than among them, where two builds of the same sources can be compared
+ * by anybody.</p>
  *
  * @since 0.69.0
  */

--- a/eo-inference/src/main/java/org/eolang/inference/Depth.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Depth.java
@@ -17,7 +17,7 @@ import java.util.Map;
  * <p>This reads the tables back and puts every object of the program on the
  * ladder {@link Answers} describes. It is a measurement of ourselves rather than a
  * fact about the program, so what comes out is no table: the goal says it in
- * the log and leaves {@link Ladder#asString()} in a file beside the tables
+ * the log and leaves {@link Ladder#lines()} in a file beside the tables
  * rather than among them, where two builds of the same sources can be compared
  * by anybody.</p>
  *

--- a/eo-inference/src/main/java/org/eolang/inference/Ladder.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ladder.java
@@ -135,18 +135,18 @@ public final class Ladder {
      *
      * <p>A build that only says them out loud leaves nothing behind: the line
      * scrolls past and the next branch has nothing to be measured against. So
-     * they are written too, one number a line, the value first and the name of
-     * it after — a shape a shell can read with one {@code read} and no
-     * knowledge of what any of it means.</p>
+     * they are handed over a line at a time as well, the value first and the
+     * name of it after — a shape a shell can read with one {@code read} and
+     * no knowledge of what any of it means. What ends a line is left to
+     * whoever writes them down.</p>
      *
-     * <p>The rungs go down with the shares and not instead of them. A share on
+     * <p>The rungs come with the shares and not instead of them. A share on
      * its own is a number to game, and the rungs are what makes the gaming
      * visible, so whoever is handed one of them is handed both.</p>
      *
-     * @return The text, ending in a newline, with never a carriage return in
-     *  it: the file is written on one machine and read on another
+     * @return The lines, four shares and a depth ahead of a rung apiece
      */
-    public String asString() {
+    public Collection<String> lines() {
         final Collection<String> lines = new ArrayList<>(0);
         lines.add(String.format(Locale.ROOT, "%d objects", this.total()));
         lines.add(String.format(Locale.ROOT, "%.1f named", this.named()));
@@ -156,8 +156,7 @@ public final class Ladder {
         for (final Map.Entry<String, Integer> rung : this.counts.entrySet()) {
             lines.add(String.format(Locale.ROOT, "%d %s", rung.getValue(), rung.getKey()));
         }
-        lines.add("");
-        return String.join("\n", lines);
+        return lines;
     }
 
     private int upto(final int rungs) {

--- a/eo-inference/src/main/java/org/eolang/inference/Ladder.java
+++ b/eo-inference/src/main/java/org/eolang/inference/Ladder.java
@@ -4,8 +4,11 @@
  */
 package org.eolang.inference;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -125,6 +128,36 @@ public final class Ladder {
             result = this.share(climbed) / (rung - 1);
         }
         return result;
+    }
+
+    /**
+     * The numbers, written down for somebody to compare them with.
+     *
+     * <p>A build that only says them out loud leaves nothing behind: the line
+     * scrolls past and the next branch has nothing to be measured against. So
+     * they are written too, one number a line, the value first and the name of
+     * it after — a shape a shell can read with one {@code read} and no
+     * knowledge of what any of it means.</p>
+     *
+     * <p>The rungs go down with the shares and not instead of them. A share on
+     * its own is a number to game, and the rungs are what makes the gaming
+     * visible, so whoever is handed one of them is handed both.</p>
+     *
+     * @return The text, ending in a newline, with never a carriage return in
+     *  it: the file is written on one machine and read on another
+     */
+    public String asString() {
+        final Collection<String> lines = new ArrayList<>(0);
+        lines.add(String.format(Locale.ROOT, "%d objects", this.total()));
+        lines.add(String.format(Locale.ROOT, "%.1f named", this.named()));
+        lines.add(String.format(Locale.ROOT, "%.1f rooted at a void", this.rooted()));
+        lines.add(String.format(Locale.ROOT, "%.1f nothing known", this.blank()));
+        lines.add(String.format(Locale.ROOT, "%.1f depth", this.percent()));
+        for (final Map.Entry<String, Integer> rung : this.counts.entrySet()) {
+            lines.add(String.format(Locale.ROOT, "%d %s", rung.getValue(), rung.getKey()));
+        }
+        lines.add("");
+        return String.join("\n", lines);
     }
 
     private int upto(final int rungs) {

--- a/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
@@ -126,6 +126,42 @@ final class LadderTest {
     }
 
     @Test
+    void namesEveryShareInTheTextItWritesDown() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 1);
+        rungs.put("a void", 1);
+        rungs.put("a forma", 2);
+        MatcherAssert.assertThat(
+            "half the objects know their forma and the text must say so by name, but it didnt",
+            new Ladder(rungs).asString(),
+            Matchers.containsString("50.0 named")
+        );
+    }
+
+    @Test
+    void writesEveryRungUnderTheNameItGoesBy() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 3);
+        rungs.put("a forma", 7);
+        MatcherAssert.assertThat(
+            "a share is a number to game, so the rungs must be written down beside it, but werent",
+            new Ladder(rungs).asString(),
+            Matchers.containsString("7 a forma")
+        );
+    }
+
+    @Test
+    void endsEveryLineTheSameWayOnEveryPlatform() {
+        final Map<String, Integer> rungs = new LinkedHashMap<>(0);
+        rungs.put("nothing", 1);
+        MatcherAssert.assertThat(
+            "a file read on one machine and written on another cannot carry a stray return, but it did",
+            new Ladder(rungs).asString(),
+            Matchers.not(Matchers.containsString("\r"))
+        );
+    }
+
+    @Test
     void keepsTheRungsUnaffectedByLaterChangesToTheSourceMap() {
         final Map<String, Integer> rungs = new LinkedHashMap<>(0);
         rungs.put("nothing", 1);

--- a/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
+++ b/eo-inference/src/test/java/org/eolang/inference/LadderTest.java
@@ -126,38 +126,38 @@ final class LadderTest {
     }
 
     @Test
-    void namesEveryShareInTheTextItWritesDown() {
+    void namesEveryShareInTheLinesItHandsOver() {
         final Map<String, Integer> rungs = new LinkedHashMap<>(0);
         rungs.put("nothing", 1);
         rungs.put("a void", 1);
         rungs.put("a forma", 2);
         MatcherAssert.assertThat(
-            "half the objects know their forma and the text must say so by name, but it didnt",
-            new Ladder(rungs).asString(),
-            Matchers.containsString("50.0 named")
+            "half the objects know their forma and a line must say so by name, but none did",
+            new Ladder(rungs).lines(),
+            Matchers.hasItem("50.0 named")
         );
     }
 
     @Test
-    void writesEveryRungUnderTheNameItGoesBy() {
+    void handsOverEveryRungUnderTheNameItGoesBy() {
         final Map<String, Integer> rungs = new LinkedHashMap<>(0);
         rungs.put("nothing", 3);
         rungs.put("a forma", 7);
         MatcherAssert.assertThat(
-            "a share is a number to game, so the rungs must be written down beside it, but werent",
-            new Ladder(rungs).asString(),
-            Matchers.containsString("7 a forma")
+            "a share is a number to game, so the rungs must come along beside it, but they didnt",
+            new Ladder(rungs).lines(),
+            Matchers.hasItem("7 a forma")
         );
     }
 
     @Test
-    void endsEveryLineTheSameWayOnEveryPlatform() {
+    void putsTheValueOfEveryLineAheadOfItsName() {
         final Map<String, Integer> rungs = new LinkedHashMap<>(0);
-        rungs.put("nothing", 1);
+        rungs.put("nothing", 5);
         MatcherAssert.assertThat(
-            "a file read on one machine and written on another cannot carry a stray return, but it did",
-            new Ladder(rungs).asString(),
-            Matchers.not(Matchers.containsString("\r"))
+            "a shell reads the value first and the name after, but the line came the other way round",
+            new Ladder(rungs).lines(),
+            Matchers.hasItem("5 objects")
         );
     }
 

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -136,7 +136,7 @@ final class Inferring implements Step {
     private void measured() throws IOException {
         final Ladder ladder = new Depth(this.prepared, this.tables).ladder();
         final Path numbers = this.tables.resolveSibling("ladder.txt");
-        Files.write(numbers, ladder.asString().getBytes(StandardCharsets.UTF_8));
+        Files.write(numbers, ladder.lines(), StandardCharsets.UTF_8);
         Logger.info(
             this,
             "%d objects: %.1f%% named, %.1f%% rooted at a void, %.1f%% nothing known; depth %.1f%%",

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/Inferring.java
@@ -55,6 +55,14 @@ import org.xembly.Xembler;
  * created have none. That is what the prepared files hold, and they are worth
  * keeping: every row of every table points into them.</p>
  *
+ * <p>How much of the program the rules turned out to say is measured when they
+ * are done and written down in {@code ladder.txt}, beside the tables rather
+ * than among them: it is a number about us and not about the program. Saying
+ * it in the log is not enough, because the line scrolls past and a branch has
+ * then nothing to be measured against — the file is what a workflow reads for
+ * the base and for the branch, to say on the pull request which way we
+ * moved.</p>
+ *
  * @since 0.67.0
  */
 final class Inferring implements Step {
@@ -127,6 +135,8 @@ final class Inferring implements Step {
 
     private void measured() throws IOException {
         final Ladder ladder = new Depth(this.prepared, this.tables).ladder();
+        final Path numbers = this.tables.resolveSibling("ladder.txt");
+        Files.write(numbers, ladder.asString().getBytes(StandardCharsets.UTF_8));
         Logger.info(
             this,
             "%d objects: %.1f%% named, %.1f%% rooted at a void, %.1f%% nothing known; depth %.1f%%",
@@ -135,6 +145,7 @@ final class Inferring implements Step {
         for (final Map.Entry<String, Integer> rung : ladder.rungs().entrySet()) {
             Logger.debug(this, "  %6d  %s", rung.getValue(), rung.getKey());
         }
+        Logger.info(this, "The same numbers are written down in %[file]s", numbers);
     }
 
     private void declared() throws IOException {

--- a/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
+++ b/eo-maven-plugin/src/main/java/org/eolang/maven/MjInference.java
@@ -39,9 +39,11 @@ import org.apache.maven.plugins.annotations.Parameter;
  * them for mistakes.</p>
  *
  * <p>The XMIR prepared for the rules is saved in {@link #prepared} and the
- * tables in {@link #tables}, a document each. Not one of them fails the
- * build. The pages a reader opens are drawn by {@link MjInferenceReport},
- * a goal of its own, from those same two directories.</p>
+ * tables in {@link #tables}, a document each, with {@code ladder.txt} beside
+ * them saying how much of the program they turned out to describe. Not one of
+ * them fails the build. The pages a reader opens are drawn by
+ * {@link MjInferenceReport}, a goal of its own, from those same two
+ * directories.</p>
  *
  * @since 0.67.0
  */

--- a/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
+++ b/eo-maven-plugin/src/test/java/org/eolang/maven/InferringTest.java
@@ -125,6 +125,23 @@ final class InferringTest {
     }
 
     @Test
+    void writesDownHowMuchOfTheProgramWasUnderstood(@Mktmp final Path temp) throws IOException {
+        final Path sources = Files.createDirectories(temp.resolve("yard"));
+        Files.writeString(
+            sources.resolve("oak.xmir"),
+            new EoSyntax(
+                String.join(System.lineSeparator(), "[] > oak", "  [] > leaf", "")
+            ).parsed().toString()
+        );
+        new Inferring(sources, temp.resolve("pre"), temp.resolve("rows")).exec();
+        MatcherAssert.assertThat(
+            "a share read without its rungs is a number to game, so both must be written, but werent",
+            Files.readString(temp.resolve("ladder.txt")),
+            Matchers.containsString("nothing left to find out")
+        );
+    }
+
+    @Test
     void forgetsSourceThatIsGone(@Mktmp final Path temp) throws IOException {
         final Path sources = Files.createDirectories(temp.resolve("shed"));
         Files.writeString(


### PR DESCRIPTION
The `inference` goal has been saying how much of a program its rules understood
for a while now, but it said it into the log. The line scrolls past, nothing is
kept, and the next branch has nothing to be measured against, which is the whole
of the complaint in #8734: it is not clear whether we are moving anywhere.

So the numbers are written down as well, in `eo-runtime/target/eo/ladder.txt`,
beside the tables rather than among them, because they measure us and not the
program:

```text
46896 objects
81.0 named
17.9 rooted at a void
1.2 nothing known
67.2 depth
548 nothing at all
8374 a name rooted at a void
5953 a formation, voids still free
22293 a formation, nothing left free
9728 nothing left to find out
```

One number a line, the value first and the name of it after, so a shell reads it
with one `read` and knows nothing about what any of it means. The five rungs go
down with the four shares and not instead of them: a share on its own is a
number to game, and writing an empty row for every object would leave all four
exactly where they are, while the rungs make that visible.

Two workflows turn the file into a table on the pull request, the same shape
`counts.yml` already uses. `ladder.yml` builds the branch and the first parent of
the merge commit it sits on, diffs the two files and renders the lines that
moved; it carries a read-only token, because it builds code that may come from a
fork, and `counts.yml` says plainly what happens to a build step that does not.
The table travels as an artifact to `ladder-comment.yml`, which builds nothing
and is trusted with the write. The comment has a fixed message id, so it is
edited on every push rather than piled up, and a branch that moved no number
gets no new comment at all — only an older one brought up to date.

Nothing is committed as an expected value, for the reason `counts.yml` gives:
numbers in the repository conflict in every other pull request. The comparison
is always between two builds of the same machine, minutes apart.

This pull request will not get a comment itself. A `workflow_run` workflow only
runs once it is on the default branch, so `ladder-comment.yml` starts working
after the merge; `ladder.yml` will run here and the table it renders can be read
in its log.

Closes #8734
